### PR TITLE
Fix leave warning for modeler

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -82,6 +82,7 @@ export default {
             this.process.updated_at = response.data.updated_at;
             // Now show alert
             ProcessMaker.alert(this.$t('The process was saved.'), 'success');
+            window.ProcessMaker.EventBus.$emit('save-changes');
           })
           .catch((err) => {
             const message = err.response.data.message;
@@ -96,7 +97,10 @@ export default {
   mounted() {
     ProcessMaker.$modeler = this.$refs.modeler;
 
-    window.ProcessMaker.EventBus.$on('modeler-change', this.refreshSession);
+    window.ProcessMaker.EventBus.$on('modeler-change', () => {
+      this.refreshSession();
+      window.ProcessMaker.EventBus.$emit('new-changes');
+    });
   },
 };
 </script>


### PR DESCRIPTION
Fixes https://github.com/ProcessMaker/spark-modeler/issues/431.

Video of fix: https://www.dropbox.com/s/g2y6wgrjopiobhv/leave_warning_working_modeler.mov?dl=0.

