### PR TITLE
Update ProcessMaker XSD

### DIFF
--- a/public/definitions/ProcessMaker.xsd
+++ b/public/definitions/ProcessMaker.xsd
@@ -101,7 +101,7 @@
     <xsd:complexType name="tPmMessageEventDefinition">
         <xsd:complexContent>
             <xsd:extension base="bpmn:tMessageEventDefinition">
-                <xsd:attribute name="dataName" type="xsd:string" use="optional"/>
+                <xsd:attribute name="variableName" type="xsd:string" use="optional"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>


### PR DESCRIPTION
Resolves #1942 

This change is required to validate the Change the reference in the Intermediate Catch event from Data Name to Variable Name. (https://github.com/ProcessMaker/spark-modeler/issues/356)
\