### PR TITLE
Allow PMQL searches of data belonging to a task's parent request

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -161,6 +161,22 @@ class TaskController extends Controller
                             $query->where('process_request_tokens.status', $value);
                         };
                     }
+                    
+                    if (stripos($expression->field->field(), 'data.') === 0) {
+                        $field = $expression->field->field();
+                        $operator = $expression->operator;
+                        $value = $expression->value->value();
+                        if (is_string($value)) {
+                            $value = '"' . $value . '"';
+                        }
+                        
+                        $pmql = "$field $operator $value";
+                        
+                        return function($query) use ($pmql) {
+                            $requests = ProcessRequest::pmql($pmql)->get();
+                            $query->whereIn('process_request_id', $requests->pluck('id'));
+                        };
+                    }
                 });
             }
 


### PR DESCRIPTION
## Changes
- Adds a data alias for PMQL searches of tasks to allow parent request data to be searched

Closes #2020.