### PR TITLE
Import screen builder to fix component reference

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -4,7 +4,7 @@ import Echo from "laravel-echo";
 import VueRouter from "vue-router";
 import datetime_format from "../js/data/datetime_formats.json"
 import translator from "./modules/lang.js"
-
+import ScreenBuilder from '@processmaker/screen-builder';
 
 window.__ = translator;
 window._ = require("lodash");
@@ -33,6 +33,7 @@ window.Vue = require("vue");
 
 window.Vue.use(BootstrapVue);
 window.Vue.use(VueRouter);
+window.Vue.use(ScreenBuilder);
 
 /**
  * Setup Translations


### PR DESCRIPTION
Related issue: https://github.com/ProcessMaker/screen-builder/issues/273.

Ensures vue-form-renderer is registered and available to components that need it (required for record list).