### PR TITLE
Register FileDownload component

### DIFF
--- a/resources/js/processes/screen-builder/typeDisplay.js
+++ b/resources/js/processes/screen-builder/typeDisplay.js
@@ -2,6 +2,8 @@ import {renderer, FormBuilderControls} from "@processmaker/screen-builder";
 import FileDownload from "./components/file-download.vue";
 import {FormHtmlEditor} from "@processmaker/vue-form-elements";
 
+Vue.component("FileDownload", FileDownload);
+
 const {
     FormMultiColumn,
     FormText,


### PR DESCRIPTION
New PR for https://github.com/ProcessMaker/processmaker/pull/1982.

This PR registers the `FileDownload` component to be used with the display form type. This component is already registered in the form type.

**How to test:**
1. Create a display form, and drag a FileDownload component onto it.
2. Save the form and use it in a process. 
3. View the form and ensure the FileDownload component renders.