### PR TITLE
Fix query to get ACTIVE Intermediate Timer Events

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -299,8 +299,7 @@ class ProcessRequestController extends Controller
      */
     public function destroy(ProcessRequest $request)
     {
-        try
-        {
+        try {
             $request->delete();
             return response([], 204);
         } catch (\Exception $e) {
@@ -328,7 +327,7 @@ class ProcessRequestController extends Controller
         // Get token and data
         $token = $request->tokens()->where('element_id', $event)->where('status', 'ACTIVE')->first();
         if (!$token) {
-            return abort(400, __('Not found'));
+            return abort(404, __('Token not found in catch event :element_id', ['element_id' => $event]));
         }
 
         // Check IPs whitelist

--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -263,10 +263,11 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
             return;
         }
 
-        $catch = $request->tokens()->where('element_id', $config->element_id)->first();
-
+        $catches = $request->tokens()
+            ->where('element_id', $config->element_id)
+            ->where('status', 'ACTIVE')->get();
         $executed = false;
-        if ($catch && $catch->status == 'ACTIVE') {
+        foreach($catches as $catch) {
             WorkflowManager::completeCatchEvent($process, $request, $catch, []);
             $executed = true;
         }


### PR DESCRIPTION
Resolves #2079 

This PR fixes the timer event for a loop process:

![image](https://user-images.githubusercontent.com/8028650/60833969-811af900-a18d-11e9-9dd9-bb2deb125329.png)
