### PR TITLE
Add our own personal access token management api endpoints and have passport lookup by username for grants that need username

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserTokenController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserTokenController.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Api;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use ProcessMaker\Exception\ReferentialIntegrityException;
+use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Http\Resources\ApiCollection;
+use ProcessMaker\Http\Resources\UserTokenResource as UserTokenResource;
+use ProcessMaker\Models\User;
+use Laravel\Passport\TokenRepository;
+use Laravel\Passport\Passport;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+
+class UserTokenController extends Controller
+{
+    /**
+     * The token repository implementation.
+     *
+     * @var \Laravel\Passport\TokenRepository
+     */
+    protected $tokenRepository;
+
+    /**
+     * The validation factory implementation.
+     *
+     * @var \Illuminate\Contracts\Validation\Factory
+     */
+    protected $validation;
+
+    /**
+     * Create a controller instance.
+     *
+     * @param  \Laravel\Passport\TokenRepository  $tokenRepository
+     * @param  \Illuminate\Contracts\Validation\Factory  $validation
+     * @return void
+     */
+    public function __construct(TokenRepository $tokenRepository, ValidationFactory $validation)
+    {
+        $this->validation = $validation;
+        $this->tokenRepository = $tokenRepository;
+    }
+
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     *
+     *     @OA\Get(
+     *     path="/users",
+     *     summary="Returns all tokens for the specified user",
+     *     operationId="getUserTokens",
+     *     tags={"Tokens"},
+     *     @OA\Parameter(ref="#/components/parameters/order_by"),
+     *     @OA\Parameter(ref="#/components/parameters/order_direction"),
+     *     @OA\Parameter(ref="#/components/parameters/per_page"),
+     *     @OA\Parameter(ref="#/components/parameters/include"),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="list of user tokens",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/users"),
+     *             ),
+     *             @OA\Property(
+     *                 property="meta",
+     *                 type="object",
+     *                 ref="#/components/schemas/metadata",
+     *             ),
+     *         ),
+     *     ),
+     * )
+     */
+    public function index(Request $request, User $user)
+    {
+        if (!Auth::user()->can('view', $user)) {
+            throw new AuthorizationException(__('Not authorized to update this user.'));
+        }
+
+        $tokens = $this->tokenRepository->forUser($request->user()->getKey());
+
+        $results =  $tokens->load('client')->filter(function ($token) {
+            return $token->client->personal_access_client && ! $token->revoked;
+        })->values();
+
+        // Paginate
+        $page = Paginator::resolveCurrentPage() ?: 1;
+        $perPage = $request->input('per_page', 10);
+        $results = new LengthAwarePaginator($results->forPage($page, $perPage), $results->count(), $perPage, $page);
+
+        return new ApiCollection($results);
+    }
+
+    /**
+     * Create a new personal access token for the user.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Laravel\Passport\PersonalAccessTokenResult
+     */
+    public function store(Request $request, User $user)
+    {
+        if (!Auth::user()->can('edit', $user)) {
+            throw new AuthorizationException(__('Not authorized to update this user.'));
+        }
+
+        $this->validation->make($request->all(), [
+            'name' => 'required|max:255',
+            'scopes' => 'array|in:'.implode(',', Passport::scopeIds()),
+        ])->validate();
+
+        $token =  $user->createToken(
+            $request->name, $request->scopes ?: []
+        );
+
+        return new UserTokenResource($token);
+
+    }
+
+    /**
+     * Show a personal access token for the user
+     */
+    public function show(Request $request, User $user, $tokenId)
+    {
+        if (!Auth::user()->can('view', $user)) {
+            throw new AuthorizationException(__('Not authorized to update this user.'));
+        }
+
+        $token = $this->tokenRepository->findForUser(
+            $tokenId, $user->getKey()
+        );
+
+        if (is_null($token)) {
+            return new Response('', 404);
+        }
+       return new UserTokenResource($token);
+    }
+
+    /**
+     * Delete the given token for a user
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $tokenId
+     * @return \Illuminate\Http\Response
+     */
+
+    public function destroy(Request $request, User $user, $tokenId)
+    {
+        if (!Auth::user()->can('edit', $user)) {
+            throw new AuthorizationException(__('Not authorized to update this user.'));
+        }
+
+        $token = $this->tokenRepository->findForUser(
+            $tokenId, $user->getKey()
+        );
+
+        if (is_null($token)) {
+            return abort(404);
+        }
+
+        $token->revoke();
+
+        return response([], 204);
+    }
+
+
+}

--- a/ProcessMaker/Http/Controllers/Api/UserTokenController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserTokenController.php
@@ -49,38 +49,7 @@ class UserTokenController extends Controller
 
 
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     *
-     *     @OA\Get(
-     *     path="/users",
-     *     summary="Returns all tokens for the specified user",
-     *     operationId="getUserTokens",
-     *     tags={"Tokens"},
-     *     @OA\Parameter(ref="#/components/parameters/order_by"),
-     *     @OA\Parameter(ref="#/components/parameters/order_direction"),
-     *     @OA\Parameter(ref="#/components/parameters/per_page"),
-     *     @OA\Parameter(ref="#/components/parameters/include"),
-     *
-     *     @OA\Response(
-     *         response=200,
-     *         description="list of user tokens",
-     *         @OA\JsonContent(
-     *             type="object",
-     *             @OA\Property(
-     *                 property="data",
-     *                 type="array",
-     *                 @OA\Items(ref="#/components/schemas/users"),
-     *             ),
-     *             @OA\Property(
-     *                 property="meta",
-     *                 type="object",
-     *                 ref="#/components/schemas/metadata",
-     *             ),
-     *         ),
-     *     ),
-     * )
+     * Display listing of access tokens for the specified user
      */
     public function index(Request $request, User $user)
     {

--- a/ProcessMaker/Http/Resources/UserTokenResource.php
+++ b/ProcessMaker/Http/Resources/UserTokenResource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ProcessMaker\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class UserTokenResource extends ApiResource
+{
+
+}

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -305,4 +305,16 @@ class User extends Authenticatable implements HasMedia
         }
         return false;
     }
+
+    /**
+     * Find the user instance for the given username.
+     * This ensures we are utilizing our username field for grants for oauth.
+     *
+     * @param  string  $username
+     * @return \App\User
+     */
+    public function findForPassport($username)
+    {
+        return $this->where('username', $username)->first();
+    }
 }

--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -50,7 +50,14 @@ class AuthServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerPolicies();
-        Passport::routes();
+        Passport::routes(function ($router) {
+            $router->forAuthorization();
+            $router->forAccessTokens();
+            $router->forTransientTokens();
+            $router->forClients();
+            // Do NOT add routes for managing personal access tokens
+            // As this is handled by our OWN api endpoints
+        });
 
         Gate::before(function ($user) {
             if ($user->is_administrator) {

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -302,10 +302,6 @@
                             </div>
                         </div>
                         <div class="tab-pane fade" id="nav-tokens" role="tabpanel" aria-labelledby="nav-tokens-tab">
-                            <div v-if="!isCurrentUser">
-                                {{__('Only the logged in user can create API tokens')}}
-                            </div>
-                            <div v-if="isCurrentUser">
                                 <table class="table">
                                     <thead>
                                     <tr>
@@ -346,7 +342,6 @@
                                 <button class="btn btn-secondary float-right" @click="generateToken">
                                     {{__('Generate New Token')}}
                                 </button>
-                            </div>
                         </div>
                     </div>
                 </div>
@@ -687,25 +682,24 @@
           loadTokens() {
             ProcessMaker.apiClient({
               method: 'GET',
-              url: '/oauth/personal-access-tokens',
-              baseURL: '/'
+              url: '/users/' + this.currentUserId + '/tokens',
             })
               .then((result) => {
-                this.apiTokens = result.data
+                this.apiTokens = result.data.data
               })
           },
           generateToken() {
             ProcessMaker.apiClient({
               method: 'POST',
-              url: '/oauth/personal-access-tokens',
-              baseURL: '/',
+              url: '/users/' + this.currentUserId + '/tokens',
               data: {
                 name: 'API Token',
                 scopes: []
               }
             })
               .then((result) => {
-                this.newToken = result.data;
+                this.newToken = result.data.token;
+                this.newToken.accessToken = result.data.accessToken;
                 this.loadTokens();
                 ProcessMaker.alert(this.$t('Access token generated successfully'), "success");
               })
@@ -719,8 +713,7 @@
               () => {
                 ProcessMaker.apiClient({
                   method: 'DELETE',
-                  url: '/oauth/personal-access-tokens/' + tokenId,
-                  baseURL: '/',
+                  url: '/users/' + this.currentUserId + '/tokens/' + tokenId,
                 })
                   .then((result) => {
                     this.loadTokens();

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,12 @@ Route::group(
     Route::post('users', 'UserController@store')->name('users.store')->middleware('can:create-users');
     Route::put('users/{user}', 'UserController@update')->name('users.update'); //Permissions handled in the controller
     Route::delete('users/{user}', 'UserController@destroy')->name('users.destroy')->middleware('can:delete-users');
+    // User personal access tokens
+    Route::get('users/{user}/tokens', 'UserTokenController@index')->name('users.tokens.index'); //Permissions handled in the controller
+    Route::get('users/{user}/tokens/{tokenId}', 'UserTokenController@show')->name('users.tokens.show'); //Permissions handled in the controller
+    Route::post('users/{user}/tokens', 'UserTokenController@store')->name('users.tokens.store'); // Permissions handled in the controller
+    Route::delete('users/{user}/tokens/{tokenId}', 'UserTokenController@destroy')->name('users.tokens.destroy'); // Permissions handled in the controller
+
 
     // Groups
     Route::get('groups', 'GroupController@index')->name('groups.index')->middleware('can:view-groups');

--- a/tests/Feature/Api/UserTokensTest.php
+++ b/tests/Feature/Api/UserTokensTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+use Tests\Feature\Shared\RequestHelper;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Http\UploadedFile;
+use Carbon\Carbon;
+
+class UserTokensTest extends TestCase
+{
+
+    use RequestHelper;
+
+    public function setUpWithPersonalAccessClient()
+    {
+        $this->withPersonalAccessClient();
+    }
+
+    /**
+     * Get a list of User tokens without query parameters.
+     */
+    public function testListTokensWithEmptyTokens()
+    {
+        $user = $this->user;
+        $response = $this->apiCall('GET', "/users/" . $user->id . "/tokens");
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        // Verify count
+        $this->assertEquals(0, $response->json()['meta']['total']);
+    }
+
+    /**
+     * Get a list of User tokens without query parameters for another user.
+     */
+    public function testListTokensWithEmptyTokensForOtherUser()
+    {
+        $user = factory(User::class)->create();
+        $response = $this->apiCall('GET', "/users/" . $user->id . "/tokens");
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        // Verify count
+        $this->assertEquals(0, $response->json()['meta']['total']);
+    }
+
+    public function testPermissionDeniedForUserWithoutViewPermissions()
+    {
+        $this->debug = false;
+        $user = factory(User::class)->create();
+        $this->user = $user;
+        
+        $targetUser = factory(User::class)->create();
+
+        $response = $this->apiCall('GET', "/users/" . $targetUser->id . "/tokens");
+        $response->assertStatus(403);
+
+    }
+
+
+    /**
+     * Test validation failure
+     */
+    public function testTokenCreateValidationError()
+    {
+        $user = $this->user;
+        $response = $this->apiCall('POST', "/users/" . $user->id . "/tokens");
+
+        //Validate the header status code
+        $response->assertStatus(422);
+    }
+
+    public function testPermissionDeniedForUserWithoutEditPermissionsForCreatingToken()
+    {
+        $this->debug = false;
+        $user = factory(User::class)->create();
+        $this->user = $user;
+        
+        $targetUser = factory(User::class)->create();
+
+        $response = $this->apiCall('POST', "/users/" . $targetUser->id . "/tokens");
+        $response->assertStatus(403);
+
+    }
+
+
+
+    /**
+     * Test creation of a user token with a default expire of 1 year
+     */
+    public function testCreateTokenDefaultExpire()
+    {
+        $now =  new Carbon();
+        $user = $this->user;
+        $response = $this->apiCall('POST', "/users/" . $user->id . "/tokens", [
+            'name' => 'Test Token'
+        ]);
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        $responseObj = $response->decodeResponseJson();
+
+        // Verify if the token expires_at is 1 year into the future, just check the dates, not seconds
+        $checkDate = $now->addYear()->startOfDay();
+
+        $expireDate = (new Carbon($responseObj['token']['expires_at']))->startOfDay();
+
+        $this->assertTrue($checkDate->equalTo($expireDate));
+    }
+
+    public function testListingWithExistingToken()
+    {
+        $user = $this->user;
+        $response = $this->apiCall('POST', "/users/" . $user->id . "/tokens", [
+            'name' => 'Test Token'
+        ]);
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        $response = $this->apiCall('GET', "/users/" . $user->id . "/tokens");
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        // Verify count
+        $this->assertEquals(1, $response->json()['meta']['total']);
+    }
+
+    public function testShowToken()
+    {
+        $user = $this->user;
+        $response = $this->apiCall('POST', "/users/" . $user->id . "/tokens", [
+            'name' => 'Test Token'
+        ]);
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        $responseObj = $response->decodeResponseJson();
+        $response = $this->apiCall('GET', "/users/" . $user->id . "/tokens/" . $responseObj['token']['id']);
+
+        //Validate the header status code
+        $response->assertStatus(200);
+    }
+
+    public function testPermissionDeniedForUserWithoutViewPermissionsForViewingToken()
+    {
+        $this->debug = false;
+
+        $targetUser = factory(User::class)->create();
+
+
+        $user = $this->user;
+        $response = $this->apiCall('POST', "/users/" . $user->id . "/tokens", [
+            'name' => 'Test Token'
+        ]);
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        $responseObj = $response->decodeResponseJson();
+
+        $targetUser = $user;
+        $user = factory(User::class)->create();
+        $this->user = $user;
+
+        $response = $this->apiCall('GET', "/users/" . $targetUser->id . "/tokens/" . $responseObj['token']['id']);
+
+        //Validate the header status code
+        $response->assertStatus(403);
+    }
+
+    public function testRevokeTokenForUser()
+    {
+        $user = $this->user;
+        $response = $this->apiCall('POST', "/users/" . $user->id . "/tokens", [
+            'name' => 'Test Token'
+        ]);
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        $responseObj = $response->decodeResponseJson();
+
+        $response = $this->apiCall('DELETE', "/users/" . $user->id . "/tokens/" . $responseObj['token']['id']);
+
+        //Validate the header status code
+        $response->assertStatus(204);
+
+        // Verify that listing is 0
+        $response = $this->apiCall('GET', "/users/" . $user->id . "/tokens");
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        // Verify count
+        $this->assertEquals(0, $response->json()['meta']['total']);
+    }
+
+    public function testPermissionDeniedForUserWithoutEditPermissionsForDeletingToken()
+    {
+        $this->debug = false;
+
+        $targetUser = factory(User::class)->create();
+
+
+        $user = $this->user;
+        $response = $this->apiCall('POST', "/users/" . $user->id . "/tokens", [
+            'name' => 'Test Token'
+        ]);
+
+        //Validate the header status code
+        $response->assertStatus(200);
+
+        $responseObj = $response->decodeResponseJson();
+
+        $targetUser = $user;
+        $user = factory(User::class)->create();
+        $this->user = $user;
+
+        $response = $this->apiCall('DELETE', "/users/" . $targetUser->id . "/tokens/" . $responseObj['token']['id']);
+
+        //Validate the header status code
+        $response->assertStatus(403);
+    }
+
+   
+
+    public function test404WithRevokeOfUnknownToken()
+    {
+        $user = $this->user;
+        $response = $this->apiCall('DELETE', "/users/" . $user->id . "/tokens/12345");
+        //Validate the header status code
+        $response->assertStatus(404);
+
+    }
+}


### PR DESCRIPTION
Add our own personal access token management api endpoints and have passport lookup by username for grants that need username

How to test:
- Run test cases
- Create a sample user
- Manage api access tokens in UI for sample user

