### PR TITLE
API Tokens Returns Same ALWAYS

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserTokenController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserTokenController.php
@@ -57,7 +57,7 @@ class UserTokenController extends Controller
             throw new AuthorizationException(__('Not authorized to update this user.'));
         }
 
-        $tokens = $this->tokenRepository->forUser($request->user()->getKey());
+        $tokens = $this->tokenRepository->forUser($user->id);
 
         $results =  $tokens->load('client')->filter(function ($token) {
             return $token->client->personal_access_client && ! $token->revoked;

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -682,7 +682,7 @@
           loadTokens() {
             ProcessMaker.apiClient({
               method: 'GET',
-              url: '/users/' + this.currentUserId + '/tokens',
+              url: '/users/' + {{ $user->id }} + '/tokens',
             })
               .then((result) => {
                 this.apiTokens = result.data.data
@@ -691,7 +691,7 @@
           generateToken() {
             ProcessMaker.apiClient({
               method: 'POST',
-              url: '/users/' + this.currentUserId + '/tokens',
+              url: '/users/' + {{ $user->id }} + '/tokens',
               data: {
                 name: 'API Token',
                 scopes: []


### PR DESCRIPTION
Resolves #2128 

- Now API uses the specified user instead of the user that executes the request
- The front-end calls the endpoints using the edited user id (before it was using the current logged user id)

