### PR TITLE
Fix Safari export adds .html

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScreenController.php
@@ -63,6 +63,14 @@ class ScreenController extends Controller
     }
 
 
+    /**
+     * Download the JSON definition of the screen
+     *
+     * @param Screen $screen
+     * @param string $key
+     *
+     * @return stream
+     */
     public function download(Screen $screen, $key)
     {
         $fileName = snake_case($screen->title) . '.json';
@@ -73,7 +81,9 @@ class ScreenController extends Controller
         } else {
             return response()->streamDownload(function () use ($fileContents) {
                 echo $fileContents;
-            }, $fileName);
+            }, $fileName, [
+                'Content-type' => 'application/json',
+            ]);
         }
     }
 }

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -173,6 +173,14 @@ class ProcessController extends Controller
         return view('processes.import');
     }
 
+    /**
+     * Download the JSON definition of the process
+     *
+     * @param Process $process
+     * @param string $key
+     *
+     * @return stream
+     */
     public function download(Process $process, $key)
     {
         $fileName = snake_case($process->name) . '.json';
@@ -183,7 +191,9 @@ class ProcessController extends Controller
         } else {
             return response()->streamDownload(function () use ($fileContents) {
                 echo $fileContents;
-            }, $fileName);
+            }, $fileName, [
+                'Content-type' => 'application/json',
+            ]);
         }
     }
 


### PR DESCRIPTION
Resolves #2132 

This PR includes:

- Add missing JSON header when exports a process
- Add missing JSON header when exports a screen
