### PR TITLE
Add default to submit button

### DIFF
--- a/resources/js/processes/screen-builder/typeForm.js
+++ b/resources/js/processes/screen-builder/typeForm.js
@@ -77,6 +77,12 @@ initialControls.push({
     }
 });
 
+// The submit button has by default the 'submit' value
+let submitButton = initialControls.find(x => x.control.label === "Submit");
+if (submitButton) {
+    submitButton.control.config.fieldValue = "submit";
+}
+
 ProcessMaker.EventBus.$on("screen-builder-init", (manager) => {
     for (let i = 0; i < initialControls.length; i++) {
         // Load of additional properties for inspector


### PR DESCRIPTION
Resolves #2059 

- Before registering the screen builder controls, the submit button value is set to 'submit' by default.

Before the enhancement:
![image](https://user-images.githubusercontent.com/14875032/61482688-39545880-a969-11e9-9de3-28cba525fe84.png)

After the enhancement:
![image](https://user-images.githubusercontent.com/14875032/61482709-43765700-a969-11e9-8545-d65c9942251a.png)


