### PR TITLE
Collections file upload & download, Swagger documentation

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Horizon\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
+use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Models\Media;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -29,23 +30,14 @@ class FileController extends Controller
      * @return ApiCollection
      *
      * @OA\Get(
-     *     path="/requests/{request_id}/files",
-     *     summary="Returns the list of files associated to a request",
+     *     path="/files",
+     *     summary="Returns the list of files",
      *     operationId="getFiles",
      *     tags={"Files"},
      *     @OA\Parameter(ref="#/components/parameters/filter"),
      *     @OA\Parameter(ref="#/components/parameters/order_by"),
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
      *     @OA\Parameter(ref="#/components/parameters/per_page"),
-     *     @OA\Parameter(
-     *         description="ID of the request",
-     *         in="path",
-     *         name="request_id",
-     *         required=true,
-     *         @OA\Schema(
-     *           type="string",
-     *         )
-     *     ),
      *
      *     @OA\Response(
      *         response=200,
@@ -95,7 +87,7 @@ class FileController extends Controller
      * @return \Illuminate\Http\Response
      *
      * @OA\Post(
-     *     path="/requests/{request_id}/files",
+     *     path="/files",
      *     summary="Save a new media file",
      *     operationId="createFile",
      *     tags={"Files"},
@@ -113,15 +105,6 @@ class FileController extends Controller
      *         description="Name of the class of the model",
      *         required=false,
      *         @OA\Schema(type="string"),
-     *     ),
-     *      @OA\Parameter(
-     *         description="ID of the request",
-     *         in="path",
-     *         name="request_id",
-     *         required=true,
-     *         @OA\Schema(
-     *           type="string",
-     *         )
      *     ),
      *     @OA\RequestBody(
      *       required=true,
@@ -189,15 +172,16 @@ class FileController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * Get a single media file.
      *
      * @param Media $file
-     * @return \Illuminate\Http\Response
+     *
+     * @return ResponseFactory|Response
      *
      * @OA\Get(
-     *     path="/requests/{request_id}/files/{file_id}",
-     *     summary="Get a file uploaded to a request",
-     *     operationId="getFilesById",
+     *     path="/files/{file_id}",
+     *     summary="Get the metadata of a file",
+     *     operationId="getFileById",
      *     tags={"Files"},
      *     @OA\Parameter(
      *         description="ID of the file to return",
@@ -208,10 +192,33 @@ class FileController extends Controller
      *           type="string",
      *         )
      *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successfully found the file",
+     *         @OA\JsonContent(ref="#/components/schemas/groups")
+     *     ),
+     * )
+     */
+    public function show(Media $file)
+    {
+        return new ApiResource($file);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param Media $file
+     * @return \Illuminate\Http\Response
+     *
+     * @OA\Get(
+     *     path="/files/{file_id}/contents",
+     *     summary="Get the contents of a file",
+     *     operationId="getFileContentsById",
+     *     tags={"Files"},
      *     @OA\Parameter(
-     *         description="ID of the request",
+     *         description="ID of the file to return",
      *         in="path",
-     *         name="request_id",
+     *         name="file_id",
      *         required=true,
      *         @OA\Schema(
      *           type="string",
@@ -219,12 +226,13 @@ class FileController extends Controller
      *     ),
      *     @OA\Response(
      *         response=200,
-     *         description="Successfully found the group",
-     *         @OA\JsonContent(ref="#/components/schemas/groups")
+     *         description="Successfully found the file",
+     *         @OA\MediaType(
+     *             mediaType="application/octet-stream")
      *     ),
      * )
      */
-    public function show(Media $file)
+    public function download(Media $file)
     {
         $path = Storage::disk('public')->getAdapter()->getPathPrefix() .
                 $file->id . '/' .
@@ -241,7 +249,7 @@ class FileController extends Controller
      * @return \Illuminate\Http\Response
      *
      * @OA\Put(
-     *     path="/requests/{request_id}/files/{file_id}",
+     *     path="/files/{file_id}",
      *     summary="Update a media file",
      *     operationId="updateFile",
      *     tags={"Files"},
@@ -300,7 +308,7 @@ class FileController extends Controller
      * @internal param int $id
      *
      * @OA\Delete(
-     *     path="/requests/{request_id}",
+     *     path="/files/{file_id}",
      *     summary="Delete a media file",
      *     operationId="deleteFile",
      *     tags={"Files"},

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -38,9 +38,52 @@ class ProcessRequestFileController extends Controller
     ];
 
     use HasMediaTrait;
-    /*
-    * return list of Process Request files
-    */
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param Request $request
+     *
+     * @return ApiCollection
+     *
+     * @OA\Get(
+     *     path="/requests/{request_id}/files",
+     *     summary="Returns the list of files associated with a request",
+     *     operationId="getRequestFiles",
+     *     tags={"Request Files"},
+     *     @OA\Parameter(ref="#/components/parameters/filter"),
+     *     @OA\Parameter(ref="#/components/parameters/order_by"),
+     *     @OA\Parameter(ref="#/components/parameters/order_direction"),
+     *     @OA\Parameter(ref="#/components/parameters/per_page"),
+     *     @OA\Parameter(
+     *         description="ID of the request",
+     *         in="path",
+     *         name="request_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="list of files",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/media"),
+     *             ),
+     *             @OA\Property(
+     *                 property="meta",
+     *                 type="object",
+     *                 allOf={@OA\Schema(ref="#/components/schemas/metadata")},
+     *             ),
+     *         ),
+     *     ),
+     * )
+     */
     public function index(Request $laravel_request, ProcessRequest $request)
      {
 		//Retrieve media from ProcessRequest
@@ -62,18 +105,53 @@ class ProcessRequestFileController extends Controller
 	        return new ResourceCollection($filtered);
 		}
      }
-
-     /**
-      * Chunk uploading behavior
-      * @param FileReceiver $receiver The Chunk FileReceiver
-      * @return JsonResponse
-      */
-
+     
+    /**
+     * Display the specified resource.
+     *
+     * @param Media $file
+     * @return \Illuminate\Http\Response
+     *
+     * @OA\Get(
+     *     path="/requests/{request_id}/files/{file_id}",
+     *     summary="Get a file uploaded to a request",
+     *     operationId="getRequestFilesById",
+     *     tags={"Request Files"},
+     *     @OA\Parameter(
+     *         description="ID of the file to return",
+     *         in="path",
+     *         name="file_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\Parameter(
+     *         description="ID of the request",
+     *         in="path",
+     *         name="request_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successfully found the group",
+     *         @OA\JsonContent(ref="#/components/schemas/groups")
+     *     ),
+     * )
+     */
     public function show(Request $laravel_request, ProcessRequest $request, $file_id)
     {
         return $request->getMedia()->where('id', $file_id)->first();
     }
 
+    /**
+     * Chunk uploading behavior
+     * @param FileReceiver $receiver The Chunk FileReceiver
+     * @return JsonResponse
+     */
     private function chunk(FileReceiver $receiver, ProcessRequest $request, Request $laravel_request)
     {
             // Perform a chunk upload
@@ -112,8 +190,59 @@ class ProcessRequestFileController extends Controller
     }
 
     /**
-     * save media file to db
-    */
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     *
+     * @OA\Post(
+     *     path="/requests/{request_id}/files",
+     *     summary="Save a new media file to a request",
+     *     operationId="createRequestFile",
+     *     tags={"Request Files"},
+     *
+     *      @OA\Parameter(
+     *         name="media_id",
+     *         in="query",
+     *         description="ID of the model to which the file will be associated",
+     *         required=false,
+     *         @OA\Schema(type="integer"),
+     *     ),
+     *      @OA\Parameter(
+     *         name="media",
+     *         in="query",
+     *         description="Name of the class of the model",
+     *         required=false,
+     *         @OA\Schema(type="string"),
+     *     ),
+     *      @OA\Parameter(
+     *         description="ID of the request",
+     *         in="path",
+     *         name="request_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\RequestBody(
+     *       required=true,
+     *       @OA\JsonContent(
+     *              @OA\Property(property="file", type="string", format="byte"),
+     *      )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="success",
+     *         @OA\JsonContent(
+     *              @OA\Property(property="id", type="string"),
+     *              @OA\Property(property="model_id", type="string"),
+     *              @OA\Property(property="file_name", type="string"),
+     *              @OA\Property(property="mime_type", type="string")
+     *             ),
+     *         )
+     *     ),
+     * )
+     */
     public function store(Request $laravel_request, FileReceiver $receiver, ProcessRequest $request)
     {
         //delete it and upload the new one 
@@ -127,7 +256,55 @@ class ProcessRequestFileController extends Controller
     }
 
     /**
-     * update existing file
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param Media $file
+     *
+     * @return \Illuminate\Http\Response
+     *
+     * @OA\Put(
+     *     path="/requests/{request_id}/files/{file_id}",
+     *     summary="Update a request's media file",
+     *     operationId="updateRequestFile",
+     *     tags={"Request Files"},
+     *
+     *     @OA\Parameter(
+     *         description="ID of the file to update",
+     *         in="path",
+     *         name="file_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *      @OA\Parameter(
+     *         description="ID of the request",
+     *         in="path",
+     *         name="request_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\RequestBody(
+     *       required=true,
+     *       @OA\JsonContent(
+     *              @OA\Property(property="file", type="string", format="byte"),
+     *      )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="success",
+     *         @OA\JsonContent(
+     *              @OA\Property(property="id", type="string"),
+     *              @OA\Property(property="model_id", type="string"),
+     *              @OA\Property(property="file_name", type="string"),
+     *              @OA\Property(property="mime_type", type="string")
+     *             ),
+     *         )
+     *     ),
+     * )
      */
     public function update(Request $laravel_request, ProcessRequest $request)
     {
@@ -138,7 +315,32 @@ class ProcessRequestFileController extends Controller
     }
 
     /**
-     * delete an existing file 
+     * Remove the specified resource from storage.
+     *
+     * @param Media $file
+     * @return \Illuminate\Http\Response
+     *
+     * @internal param int $id
+     *
+     * @OA\Delete(
+     *     path="/requests/{request_id}",
+     *     summary="Delete all media associated with a request",
+     *     operationId="deleteRequestFile",
+     *     tags={"Request Files"},
+     *     @OA\Parameter(
+     *         description="ID of the request",
+     *         in="path",
+     *         name="request_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=204,
+     *         description="success"
+     *     ),
+     * )
      */
     public function destroy(Request $laravel_request, ProcessRequest $request)
     {

--- a/resources/js/processes/screen-builder/components/file-download.vue
+++ b/resources/js/processes/screen-builder/components/file-download.vue
@@ -1,15 +1,21 @@
 <template>
     <div>
-        <template  v-if="loaded && files.data && files.data.length !== 0">
-            <div v-for="file in files.data">
-                <b-btn class="mb-2" variant="primary" @click="onClick(file)">
-                    <i class="fas fa-file-download"></i> {{$t('Download')}}
-                </b-btn>
-                {{file.file_name}}
-            </div>
-        </template>
+        <div v-if="loading">
+            <i class="fas fa-cog fa-spin text-muted"></i>
+            {{$t('Loading...')}}
+        </div>
         <div v-else>
-            {{$t('No files available for download')}}
+          <template v-if="! loading && files.data && files.data.length !== 0">
+              <div v-for="file in files.data">
+                  <b-btn class="mb-2" variant="primary" @click="onClick(file)">
+                      <i class="fas fa-file-download"></i> {{$t('Download')}}
+                  </b-btn>
+                  {{file.file_name}}
+              </div>
+          </template>
+          <div v-else>
+              {{$t('No files available for download')}}
+          </div>
         </div>
     </div>
 </template>
@@ -19,52 +25,147 @@
     export default {
         data() {
             return {
-                loaded: false,
+                fileType: null,
+                loading: true,
                 files: {},
-                requestId: null
+                requestId: null,
+                collectionId: null,
+                recordId: null,
+                listEndpoint: null,
+                downloadEndpoint: null
             };
         },
         props: ['name'],
         beforeMount() {
-            this.getRequestId();
+            this.getFileType();
+            
+            if (this.fileType == 'request') {
+              this.getRequestId();
+            }
+            
+            if (this.fileType == 'collection') {
+              this.getCollectionInfo();
+            }
         },
         mounted() {
-            this.getFiles();
+          if (this.fileType == 'request') {
+            this.getRequestFiles();
+          }
+          
+          if (this.fileType == 'collection') {
+            this.getCollectionFiles();
+          }
         },
         methods: {
             onClick(file) {
-                ProcessMaker.apiClient({
-                    baseURL: "/",
-                    url: "/request/" + this.requestId + "/files/" + file.id,
-                    method: "GET",
-                    responseType: "blob" // important
-                }).then(response => {
-                    //axios needs to be told to open the file
-                    const url = window.URL.createObjectURL(new Blob([response.data]));
-                    const link = document.createElement("a");
-                    link.href = url;
-                    link.setAttribute("download", file.file_name);
-                    document.body.appendChild(link);
-                    link.click();
-                });
+                if (this.fileType == 'request') {
+                    this.downloadRequestFile(file);
+                }
+                
+                if (this.fileType == 'collection') {
+                    this.downloadCollectionFile(file);
+                }
+            },
+            downloadRequestFile(file) {
+              ProcessMaker.apiClient({
+                  baseURL: "/",
+                  url: "/request/" + this.requestId + "/files/" + file.id,
+                  method: "GET",
+                  responseType: "blob" // important
+              }).then(response => {
+                  //axios needs to be told to open the file
+                  const url = window.URL.createObjectURL(new Blob([response.data]));
+                  const link = document.createElement("a");
+                  link.href = url;
+                  link.setAttribute("download", file.file_name);
+                  document.body.appendChild(link);
+                  link.click();
+              });
+            },
+            downloadCollectionFile(file) {
+              ProcessMaker.apiClient({
+                  url: "/files/" + file.id + "/contents",
+                  method: "GET",
+                  responseType: "blob" // important
+              }).then(response => {
+                  //axios needs to be told to open the file
+                  const url = window.URL.createObjectURL(new Blob([response.data]));
+                  const link = document.createElement("a");
+                  link.href = url;
+                  link.setAttribute("download", file.file_name);
+                  document.body.appendChild(link);
+                  link.click();
+              });
+            },            
+            getFileType() {
+              if (document.head.querySelector('meta[name="request-id"]')) {
+                this.fileType = 'request';
+              }
+              
+              if (document.head.querySelector('meta[name="collection-id"]')) {
+                this.fileType = 'collection';
+              }
             },
             getRequestId() {
                 let node = document.head.querySelector('meta[name="request-id"]');
                 if (node === null) {
+                    this.loading = false;
                     return;
                 }
                 this.requestId = node.content;
             },
-            getFiles() {
+            getCollectionInfo() {
+              let collectionNode = document.head.querySelector('meta[name="collection-id"]');
+              if (collectionNode === null) {
+                  this.loading = false;
+                  return;
+              }
+              this.collectionId = collectionNode.content;
+              
+              let recordNode = document.head.querySelector('meta[name="record-id"]');
+              if (recordNode === null) {
+                  this.loading = false;
+                  return;
+              }
+              this.recordId = recordNode.content;
+            },
+            getRequestFiles() {
                 if (this.requestId === null) {
+                    this.loading = false;
                     return;
                 }
                 ProcessMaker.apiClient
                     .get("requests/" + this.requestId + "/files?name=" + this.name)
                     .then(response => {
                         this.files = response.data;
-                        this.loaded = true;
+                        this.loading = false;
                     });
+            },
+            getCollectionFiles() {
+              if (this.collectionId === null || this.recordId === null) {
+                  this.loading = false;
+                  return;
+              }
+              
+              let id = null;
+              
+              ProcessMaker.apiClient
+                  .get("collections/" + this.collectionId + '/records/' + this.recordId)
+                  .then(response => {
+                      if (response.data.data[this.name]) {
+                        let id = response.data.data[this.name].id;
+                        ProcessMaker.apiClient
+                            .get("files/" + id)
+                            .then(response => {
+                                this.files = {data: [response.data]};
+                                this.loading = false;
+                            });  
+                      } else {
+                        this.loading = false;
+                        return;
+                      }
+                  });
+              
             }
         }
     };

--- a/routes/api.php
+++ b/routes/api.php
@@ -116,6 +116,7 @@ Route::group(
     // Files
     Route::get('files', 'FileController@index')->name('files.index')->middleware('can:view-files');
     Route::get('files/{file}', 'FileController@show')->name('files.show')->middleware('can:view-files');
+    Route::get('files/{file}/contents', 'FileController@download')->name('files.download')->middleware('can:view-files');
     Route::post('files', 'FileController@store')->name('files.store')->middleware('can:create-files');
     Route::put('files/{file}', 'FileController@update')->name('files.update')->middleware('can:edit-files');
     Route::delete('files/{file}', 'FileController@destroy')->name('files.destroy')->middleware('can:delete-files');

--- a/tests/Feature/Api/FilesTest.php
+++ b/tests/Feature/Api/FilesTest.php
@@ -93,7 +93,7 @@ class FilesTest extends TestCase
       $model = factory(User::class)->create();
       $addedMedia = $model->addMedia($fileUpload)->toMediaCollection('local');
 
-      $response = $this->apiCall('GET', self::API_TEST_URL . '/' . $addedMedia->id);
+      $response = $this->apiCall('GET', self::API_TEST_URL . '/' . $addedMedia->id . '/contents');
 
       // Validate the header status code
       $response->assertStatus(200);


### PR DESCRIPTION
## Changes
- Updated file upload and download components to handle collections as well as requests
- Added `/files/{file-id}/contents` route to allow direct downloads of files, differentiated from `/files/{file-id}` which displays file metadata
- Updated Swagger docs of File API controller
- Added Swagger docs to the separate Process Request File API controller

Closes #2061.