### PR TITLE
Changed the $table-bg background variable to transparent

### DIFF
--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -78,7 +78,7 @@ $breadcrumb-separator: '>';
 //table
 // $table-cell-padding:            10px !default;
 // $table-condensed-cell-padding:  5px !default;
-$table-bg: $light !default;
+$table-bg: transparent !default;
 $table-bg-accent: #f9f9f9 !default;
 $table-bg-hover: $grey-bg !default;
 $table-bg-active: $table-bg-hover !default;


### PR DESCRIPTION
Table background-color was inheriting the background-color: #fff. Updated the $table-bg variable to transparent allowing the table to inherit theme colors.

Closes #1830 