### PR TITLE
Add mock magic variables

### DIFF
--- a/resources/js/processes/screen-builder/mockMagicVariables.js
+++ b/resources/js/processes/screen-builder/mockMagicVariables.js
@@ -1,0 +1,60 @@
+const mockMagicVariables = {
+    _user: {
+        id: 1,
+        fax: "723.743.8058 x00631",
+        cell: "585.620.0749",
+        city: "Donnaland",
+        email: "lauretta.okuneva@robel.com",
+        media: [],
+        phone: "1-316-934-1911 x762",
+        state: "WV",
+        title: "Customer Service Representative",
+        avatar: "",
+        postal: "97304-3230",
+        status: "ACTIVE",
+        address: "8547 Marielle Hills",
+        country: "US",
+        fullname: "admin admin",
+        language: "en",
+        lastname: "admin",
+        timezone: "America/Los_Angeles",
+        username: "admin",
+        birthdate: "1962-10-23",
+        firstname: "admin",
+        created_at: "2019-07-19T08:13:13-07:00",
+        deleted_at: null,
+
+        expires_at: null,
+        updated_at: "2019-07-19T08:14:35-07:00",
+        loggedin_at: "2019-07-19T08:14:35-07:00",
+        datetime_format: "m/d/Y H:i",
+        is_administrator: true
+    },
+    _request: {
+        id: 1,
+        name: "Pet adoption",
+        status: "ACTIVE",
+        process: {
+            id: 1,
+            name: "Pet adoption",
+            status: "ACTIVE",
+            user_id: 1,
+            created_at: "2019-03-25T10:50:46-07:00",
+            deleted_at: null,
+            updated_at: "2019-07-19T08:15:18-07:00",
+            description: "Pet rescue",
+            cancel_screen_id: null,
+            pause_timer_start: 0,
+            process_category_id: 1,
+            has_timer_start_events: false
+        },
+        user_id: 1,
+        created_at: "2019-07-19T08:15:24-07:00",
+        process_id: 1,
+        updated_at: "2019-07-19T08:15:24-07:00",
+        callable_id: "ProcessId",
+        initiated_at: "2019-07-19T08:15:24-07:00"
+    }
+};
+
+export default mockMagicVariables;

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -58,7 +58,9 @@
               :config="config"
               :computed="computed"
               :custom-css="customCSS"
-              v-on:css-errors="cssErrors = $event"/>
+              v-on:css-errors="cssErrors = $event"
+              :mock-magic-variables="mockMagicVariables"
+            />
           </b-col>
 
           <b-col class="overflow-hidden h-100 preview-inspector p-0">
@@ -149,6 +151,7 @@
   import "@processmaker/vue-form-elements/dist/vue-form-elements.css";
   import VueJsonPretty from 'vue-json-pretty';
   import MonacoEditor from "vue-monaco";
+  import mockMagicVariables from './mockMagicVariables';
 
   // Bring in our initial set of controls
   import globalProperties from "@processmaker/screen-builder/src/global-properties";
@@ -194,6 +197,7 @@ import formTypes from "./formTypes";
           lineNumbers: 'off',
           minimap: false,
         },
+        mockMagicVariables,
       };
     },
     components: {


### PR DESCRIPTION
This PR adds mock magic variable data to the screen builder. Related issue: https://github.com/ProcessMaker/screen-builder/issues/294.

For this to work, the related PR on screen-builder must be merged and published: https://github.com/ProcessMaker/screen-builder/pull/296.