### PR TITLE
Add ability to parse mustache syntax for timeDuration

### DIFF
--- a/database/processes/templates/IntermediateTimerEventMustache.bpmn
+++ b/database/processes/templates/IntermediateTimerEventMustache.bpmn
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1550514924091" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1550514924091" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <process id="PROCESS_1" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:description/>
+      <yaoqiang:pageFormat height="841.8897637795276" imageableHeight="831.8897637795276" imageableWidth="588.1102362204724" imageableX="5.0" imageableY="5.0" orientation="0" width="598.1102362204724"/>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <startEvent id="_2" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_8</outgoing>
+      <outputSet/>
+    </startEvent>
+    <task completionQuantity="1" id="_3" isForCompensation="false" name="Task 1" startQuantity="1">
+      <incoming>_8</incoming>
+      <outgoing>_9</outgoing>
+    </task>
+    <intermediateCatchEvent id="_5" name="Intermediate Catch Event" parallelMultiple="false">
+      <incoming>_9</incoming>
+      <outgoing>_10</outgoing>
+      <outputSet/>
+      <timerEventDefinition>
+        <timeDuration>{{ interval }}</timeDuration>
+      </timerEventDefinition>
+    </intermediateCatchEvent>
+    <task completionQuantity="1" id="_6" isForCompensation="false" name="Task2" startQuantity="1">
+      <incoming>_10</incoming>
+      <outgoing>_11</outgoing>
+    </task>
+    <sequenceFlow id="_8" sourceRef="_2" targetRef="_3"/>
+    <sequenceFlow id="_9" sourceRef="_3" targetRef="_5"/>
+    <sequenceFlow id="_10" sourceRef="_5" targetRef="_6"/>
+    <sequenceFlow id="_11" sourceRef="_6" targetRef="_7"/>
+    <endEvent id="_7" name="End Event">
+      <incoming>_11</incoming>
+      <inputSet/>
+    </endEvent>
+  </process>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-PROCESS_1" name="Untitled Diagram" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="PROCESS_1">
+      <bpmndi:BPMNShape bpmnElement="_2" id="Yaoqiang-_2">
+        <dc:Bounds height="32.0" width="32.0" x="99.0" y="100.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="69.0" x="80.5" y="141.1"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" id="Yaoqiang-_3">
+        <dc:Bounds height="55.0" width="85.0" x="242.0" y="91.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="44.0" x="262.5" y="111.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_5" id="Yaoqiang-_5">
+        <dc:Bounds height="32.0" width="32.0" x="272.0" y="196.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="149.0" x="213.5" y="237.1"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_6" id="Yaoqiang-_6">
+        <dc:Bounds height="55.0" width="85.0" x="245.0" y="310.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="40.0" x="267.5" y="330.6"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_7" id="Yaoqiang-_7">
+        <dc:Bounds height="32.0" width="32.0" x="457.0" y="328.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="62.0" x="442.0" y="369.1"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_11" id="Yaoqiang-_11">
+        <di:waypoint x="330.0" y="338.0"/>
+        <di:waypoint x="457.0" y="344.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="390.5" y="331.85"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_9" id="Yaoqiang-_9">
+        <di:waypoint x="288.0" y="146.5"/>
+        <di:waypoint x="288.0" y="196.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="285.0" y="162.1"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_10" id="Yaoqiang-_10">
+        <di:waypoint x="288.0" y="228.5"/>
+        <di:waypoint x="288.0" y="310.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="285.0" y="260.1"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_8" id="Yaoqiang-_8">
+        <di:waypoint x="131.0" y="116.5"/>
+        <di:waypoint x="242.0" y="119.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.8" width="6.0" x="183.5" y="108.35"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/Feature/Api/IntermediateTimerEventTest.php
+++ b/tests/Feature/Api/IntermediateTimerEventTest.php
@@ -9,6 +9,8 @@ use ProcessMaker\Models\ScheduledTask;
 use Tests\Feature\Shared\ResourceAssertionsTrait;
 use Tests\TestCase;
 use Tests\Feature\Shared\RequestHelper;
+use Carbon\Carbon;
+use ProcessMaker\Models\ProcessRequest;
 
 /**
  * Test the process execution with requests
@@ -97,5 +99,39 @@ class IntermediateTimerEventTest extends TestCase
 
         // If no exception has been thrown, this assertion will be executed
         $this->assertTrue(true);
+    }
+
+    public function testScheduleIntermediateTimerEventWithMustacheSyntax()
+    {
+        $data = [];
+        $data['bpmn'] = Process::getProcessTemplate('IntermediateTimerEventMustache.bpmn');
+        $process = factory(Process::class)->create($data);
+        $definitions = $process->getDefinitions();
+        $startEvent = $definitions->getEvent('_2');
+        $request = WorkflowManager::triggerStartEvent($process, $startEvent, ['interval' => 'PT8M']);
+        $task1 = $request->tokens()->where('element_id', '_3')->first();
+        WorkflowManager::completeTask($process, $request, $task1, []); // moves to timer event I guess
+
+        // Time travel 5 minutes into the future
+        Carbon::setTestNow(Carbon::now()->addMinute(5));
+
+        // Re-schedule events for artisan call
+        $schedule = app()->make(\Illuminate\Console\Scheduling\Schedule::class);
+        $scheduleManager = new TaskSchedulerManager();
+        $scheduleManager->scheduleTasks($schedule);
+        \Artisan::call('schedule:run');
+
+        $iteToken = $request->tokens()->where('element_id', '_5')->firstOrFail();
+        $this->assertEquals('ACTIVE', $iteToken->status); // Not enough time has passed
+        
+        // Time travel 5 more minutes into the future
+        Carbon::setTestNow(Carbon::now()->addMinute(5));
+
+        // Re-schedule events for artisan call
+        $scheduleManager->scheduleTasks($schedule);
+        \Artisan::call('schedule:run');
+
+        $iteToken->refresh();
+        $this->assertEquals('CLOSED', $iteToken->status);
     }
 }


### PR DESCRIPTION
Previously, the BPMN could only accept hard-coded durations for timerEventDefinition, for example:
```
<bpmn:timeDuration>PT1H</bpmn:timeDuration>
```
This update allows the definition to include mustache syntax where the ISO 8601 duration is taken off the data object instead. For example

```
<bpmn:timeDuration>{{ my_interval }}</bpmn:timeDuration>
```
With the data object:
```
["my_interval" => "PT1H"]
```

NOTE that I had to change one reference of `new \DateTime()` to `Carbon::now()` so I could mock the the current time in the test (I think we should actually be using Carbon instead of DateTime everywhere in the system)