### PR TITLE
Task List: Sort by Request

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -322,11 +322,11 @@ class TaskController extends Controller
         $orderedTasks = collect([]);
 
         foreach($orderedRequests as $item) {
-            $element= $tasksList->first(function ($value, $key) use($item) {
+            $elements = $tasksList->filter(function ($value, $key) use($item) {
                 return $value->process_request_id == $item->id;
             });
 
-            $orderedTasks->push($element);
+            $orderedTasks = $orderedTasks->merge($elements);
         }
 
         return $orderedTasks;


### PR DESCRIPTION
Resolves #2209 

- When sorting by request, just the first task of a request was added to the request list. Now all rows are added.


