### PR TITLE
Styles are lost in circle CI builds

### DIFF
--- a/tests/Feature/Api/CssOverrideTest.php
+++ b/tests/Feature/Api/CssOverrideTest.php
@@ -21,33 +21,6 @@ class CssOverrideTest extends TestCase
     private $originalSidebarCss = '';
     private $originalQueueCss = '';
 
-    /**
-     * Verifies that the bootstrap styles can be modified
-     */
-    public function testCssOverride()
-    {
-        $this->markTestSkipped();
-        chdir(app()->basePath());
-
-        // backup of original colors
-        $this->originalColors = file_get_contents("resources/sass/_colors.scss");
-        $this->originalAppCss = file_get_contents("public/css/app.css");
-        $this->originalSidebarCss = file_get_contents("public/css/sidebar.css");
-        $this->originalQueueCss = file_get_contents("public/css/admin/queues.css");
-
-        $response = $this->actingAs($this->user, 'api')
-            ->call('POST', '/api/1.0/customize-ui', $this->cssValues($this->testColor));
-
-        // Validate that the operation was successful
-        $response->assertStatus(201);
-
-        // Validate that the style was set in the compiled css:
-        $file = file_get_contents("public/css/app.css");
-
-        $this->assertStringContainsString($this->testColor, $file);
-
-    }
-
 
     /**
      * Verifies that the bootstrap styles are validated
@@ -69,19 +42,6 @@ class CssOverrideTest extends TestCase
 
         //Validate that the error does a redirection
         $response->assertStatus(302);
-    }
-
-    public function tearDown()
-    {
-        if ($this->getName() === 'testCssOverride')
-        {
-            //restore original colors
-            file_put_contents('resources/sass/_colors.scss', $this->originalColors);
-            file_put_contents('public/css/app.css', $this->originalAppCss);
-            file_put_contents('public/css/sidebar.css', $this->originalSidebarCss );
-            file_put_contents('public/css/admin/queues.css', $this->originalQueueCss);
-        }
-        parent::tearDown();
     }
 
     private function cssValues($testColor)


### PR DESCRIPTION
Resolves #2209  

The problem was caused by a rogue test that restored the app.css empty instead of the original content. The test and the restoring process were removed.
