### PR TITLE
Improve file download permissions

### DIFF
--- a/ProcessMaker/Policies/MediaPolicy.php
+++ b/ProcessMaker/Policies/MediaPolicy.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace ProcessMaker\Policies;
+
+use ProcessMaker\Models\User;
+use ProcessMaker\Models\Media;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class MediaPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Run before all methods to determine if the
+     * user is an admin and can do everything.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @return mixed
+     */    
+    public function before(User $user)
+    {
+        if ($user->is_administrator) {
+            return true;
+        }        
+    }
+
+    /**
+     * Determine whether the user can view the media.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @param  \ProcessMaker\Models\Media  $media
+     * @return mixed
+     */
+    public function view(User $user, Media $media)
+    {
+        if ($user->hasPermission('view-files')) {
+            return true;
+        }
+
+        return $user->can('view', $media->model);
+    }
+
+    /**
+     * Determine whether the user can create media.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        if ($user->hasPermission('create-files')) {
+            return true;
+        }
+        
+        $request = request();
+        
+        $class = $request->input('model');
+        $modelId = $request->input('model_id');
+        
+        if ($class && $modelId && class_exists($class)) {
+            $model = new $class;
+            $model = $model->find($modelId);
+            
+            if ($model) {
+                if ($user->can('create', $model)) {
+                    return true;
+                }
+                
+                if ($user->can('update', $model)) {
+                    return true;
+                }
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the media.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @param  \ProcessMaker\Models\Media  $media
+     * @return mixed
+     */
+    public function update(User $user, Media $media)
+    {
+        if ($user->hasPermission('update-files')) {
+            return true;
+        }
+        
+        return $user->can('update', $media->model);
+    }
+
+    /**
+     * Determine whether the user can delete the media.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @param  \ProcessMaker\Models\Media  $media
+     * @return mixed
+     */
+    public function delete(User $user, Media $media)
+    {
+        if ($user->hasPermission('delete-files')) {
+            return true;
+        }
+        
+        return $user->can('update', $media->model);
+    }
+}

--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Providers;
 
+use ProcessMaker\Models\Media;
+use ProcessMaker\Policies\MediaPolicy;
 use ProcessMaker\Models\Notification;
 use ProcessMaker\Models\User;
 use ProcessMaker\Policies\NotificationPolicy;
@@ -35,6 +37,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
+        Media::class => MediaPolicy::class,
         Notification::class => NotificationPolicy::class,
         Process::class => ProcessPolicy::class,
         ProcessRequest::class => ProcessRequestPolicy::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -115,11 +115,11 @@ Route::group(
 
     // Files
     Route::get('files', 'FileController@index')->name('files.index')->middleware('can:view-files');
-    Route::get('files/{file}', 'FileController@show')->name('files.show')->middleware('can:view-files');
-    Route::get('files/{file}/contents', 'FileController@download')->name('files.download')->middleware('can:view-files');
-    Route::post('files', 'FileController@store')->name('files.store')->middleware('can:create-files');
-    Route::put('files/{file}', 'FileController@update')->name('files.update')->middleware('can:edit-files');
-    Route::delete('files/{file}', 'FileController@destroy')->name('files.destroy')->middleware('can:delete-files');
+    Route::get('files/{file}', 'FileController@show')->name('files.show')->middleware('can:view,file');
+    Route::get('files/{file}/contents', 'FileController@download')->name('files.download')->middleware('can:view,file');
+    Route::post('files', 'FileController@store')->name('files.store')->middleware('can:create,ProcessMaker\Models\Media');
+    Route::put('files/{file}', 'FileController@update')->name('files.update')->middleware('can:update,file');
+    Route::delete('files/{file}', 'FileController@destroy')->name('files.destroy')->middleware('can:delete,file');
 
     // Notifications
     Route::get('notifications', 'NotificationController@index')->name('notifications.index');  //Already filtered in controller


### PR DESCRIPTION
## Changes
- Adds a MediaPolicy that ensures files uploaded as part of a collection or other model will inherit that model's permissions

## Notes
- Relies on a corresponding PR in collections ([processmaker/collections#110](https://github.com/ProcessMaker/package-collections/pull/110)) which also includes unit tests