### PR TITLE
Starting Requests with Data

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -828,11 +828,29 @@ class ProcessController extends Controller
      *           type="string",
      *         )
      *     ),
+     *      @OA\RequestBody(
+     *         description="data that will be stored as part of the created request",
+     *         required=false,
+     *         @OA\JsonContent(
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="stringField",
+     *                     type="string",
+     *                     example="string example"
+     *                 ),
+     *                 @OA\Property(
+     *                     property="integerField",
+     *                     type="string",
+     *                     example="1"
+     *                 )
+     *             )
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="success",
      *         @OA\JsonContent(ref="#/components/schemas/processRequest")
      *     ),
+     *
      * )
      */
     public function triggerStartEvent(Process $process, Request $request)

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -226,7 +226,7 @@ class ProcessTest extends TestCase
 
         $initialData = [
             'Field1' => 'Value of Field 1',
-            'Field2' => 'Value of Field 2'
+            'Field2' => 'htt://www.files.com'
         ];
 
         $response = $this->apiCall('POST', $route . '?event=StartEventUID', $initialData);
@@ -235,9 +235,15 @@ class ProcessTest extends TestCase
         // Verify that the initial data was stored
         $response = $this->apiCall('GET',
             route('api.requests.show', ['request'=>$response->getData()->process_id ]) . '?include=data');
+
+        // Assert structure
         $response->assertJsonStructure([
             'data' => ['Field1', 'Field2']
         ]);
+
+        // Assert that stored values are correct
+        $this->assertEquals($initialData['Field1'], $response->getData()->data->Field1);
+        $this->assertEquals($initialData['Field2'], $response->getData()->data->Field2);
     }
 
     /**

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Permission;
@@ -217,6 +218,7 @@ class ProcessTest extends TestCase
      */
     public function testCreateRequest()
     {
+        $this->withoutExceptionHandling();
         // Load the process to be used in the test
         $process = factory(Process::class)->create([
             'bpmn' => Process::getProcessTemplate('SingleTask.bpmn')
@@ -233,17 +235,17 @@ class ProcessTest extends TestCase
         $this->assertStatus(201, $response);
 
         // Verify that the initial data was stored
-        $response = $this->apiCall('GET',
-            route('api.requests.show', ['request'=>$response->getData()->process_id ]) . '?include=data');
+        $requestRoute =route('api.requests.show', ['request'=>$response->getData()->id]) . '?include=data';
+        $requestResponse = $this->apiCall('GET',$requestRoute );
 
         // Assert structure
-        $response->assertJsonStructure([
+        $requestResponse->assertJsonStructure([
             'data' => ['Field1', 'Field2']
         ]);
 
         // Assert that stored values are correct
-        $this->assertEquals($initialData['Field1'], $response->getData()->data->Field1);
-        $this->assertEquals($initialData['Field2'], $response->getData()->data->Field2);
+        $this->assertEquals($initialData['Field1'], $requestResponse->getData()->data->Field1);
+        $this->assertEquals($initialData['Field2'], $requestResponse->getData()->data->Field2);
     }
 
     /**

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -211,6 +211,35 @@ class ProcessTest extends TestCase
         $this->assertStatus(201, $response);
     }
 
+
+    /**
+     * Verifies that a new request can be created
+     */
+    public function testCreateRequest()
+    {
+        // Load the process to be used in the test
+        $process = factory(Process::class)->create([
+            'bpmn' => Process::getProcessTemplate('SingleTask.bpmn')
+        ]);
+
+        $route = route('api.process_events.trigger', $process);
+
+        $initialData = [
+            'Field1' => 'Value of Field 1',
+            'Field2' => 'Value of Field 2'
+        ];
+
+        $response = $this->apiCall('POST', $route . '?event=StartEventUID', $initialData);
+        $this->assertStatus(201, $response);
+
+        // Verify that the initial data was stored
+        $response = $this->apiCall('GET',
+            route('api.requests.show', ['request'=>$response->getData()->process_id ]) . '?include=data');
+        $response->assertJsonStructure([
+            'data' => ['Field1', 'Field2']
+        ]);
+    }
+
     /**
      * Test to verify that the list dates are in the correct format (yyyy-mm-dd H:i+GMT)
      */


### PR DESCRIPTION
Resolves #2154

- Added a test that verifies that a request can be started with data.
- Sawagger documentation was updated
- The process list API returns the process_id:

![image](https://user-images.githubusercontent.com/14875032/62490249-e8c96180-b796-11e9-869b-72d2704d99f0.png)


