### PR TITLE
Fix Request Empty Data

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -43,7 +43,7 @@
                                     {{__('Summary')}}
                                 </a>
                             </li>
-                            @if ($request->status === 'COMPLETED')
+                            @if ($request->status === 'COMPLETED' && !$request->errors)
                                 @can('editData', $request)
                                     <li>
                                         <a id="editdata-tab" data-toggle="tab" href="#editdata" role="tab"


### PR DESCRIPTION
The data tab will only display if the request is completed and does not have errors.

closes #2191  #2229 