### PR TITLE
Update copy to match spec

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -379,7 +379,7 @@
     "Leave the password blank to keep the current password:": "Leave the password blank to keep the current password:",
     "Left": "Left",
     "light": "light",
-    "Line Input": "Line Inputs",
+    "Line Input": "Line Input",
     "Link": "Link",
     "List Label": "List Label",
     "List Name": "List Name",


### PR DESCRIPTION
This PR updates the copy for the line input control to match the spec in https://docs.google.com/document/d/1xLekCTfdXJ8H_qlGs1mmEVO2UjRXIY-x73csCytDzsA/edit#.

This PR is required to complete the changes in https://github.com/ProcessMaker/screen-builder/pull/329.

Screenshot of fix:
<img width="323" alt="Screen Shot 2019-08-08 at 3 42 45 PM" src="https://user-images.githubusercontent.com/7561061/62732773-2f1afc80-b9f3-11e9-8df0-359bb93c9ab2.png">
