### PR TITLE
File Upload URL

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -145,7 +145,6 @@ class ProcessRequestFileController extends Controller
      */
     public function show(Request $laravel_request, ProcessRequest $request, Media $file)
     {
-//        return $request->getMedia()->where('id', $file_id)->first();
         $path = Storage::disk('public')->getAdapter()->getPathPrefix() .
             $file->id . '/' .
             $file->file_name;

--- a/tests/Feature/Api/ProcessRequestFileTest.php
+++ b/tests/Feature/Api/ProcessRequestFileTest.php
@@ -36,18 +36,18 @@ class ProcessRequestFileTest extends TestCase
         $this->assertEquals($response->json()['data'][0]['file_name'], 'photo.jpg');
     }
 
-    
+
     /**
      * Test file upload associated with a process request id
      *
-     * 
-     */ 
+     *
+     */
     public function testFileUploadWithProcessRequestID()
     {
         //create a request
         $process_request = factory(ProcessRequest::class)->create();
 
-        //post photo id with the request 
+        //post photo id with the request
         $response = $this->apiCall('POST', '/requests/' . $process_request->id . '/files', [
             'file' => File::image('photo.jpg')
         ]);
@@ -57,13 +57,13 @@ class ProcessRequestFileTest extends TestCase
     }
 
     /**
-     * test update of an existing file 
+     * test update of an existing file
      */
     public function testFileUpdate()
     {
         //create a request
         $process_request = factory(ProcessRequest::class)->create();
-        // upload file 
+        // upload file
         $fileUpload = File::image('photo.jpg');
 
         $fileUploadUpdate= File::image('updatedFile.jpg');
@@ -82,13 +82,13 @@ class ProcessRequestFileTest extends TestCase
     }
 
     /**
-     * test delete of Media attached to a request 
+     * test delete of Media attached to a request
      */
-    public function testDeleteFile() 
+    public function testDeleteFile()
     {
         //create a request
         $process_request = factory(ProcessRequest::class)->create();
-        // upload file 
+        // upload file
         $fileUpload = File::image('HEEEEy.jpg');
         $process_request->addMedia($fileUpload)->toMediaCollection();
         //delete the file
@@ -118,8 +118,8 @@ class ProcessRequestFileTest extends TestCase
         $response = $this->apiCall('GET', '/requests/' . $process_request->id . '/files/' . $file2->id);
         $response->assertStatus(200);
         $this->assertEquals(
-            $response->headers->get('content-disposition'),
-            'attachment; filename="photo2.jpg"'
+            'attachment; filename=photo2.jpg',
+            $response->headers->get('content-disposition')
         );
     }
 }

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -473,7 +473,7 @@ class ProcessRequestsTest extends TestCase
     /**
      * Verifies that a file uploaded in a request can be downloaded
      */
-    public function testDownload()
+    public function testFileDownload()
     {
         // We create a fake file to upload
         $testFileName = 'test.txt';
@@ -482,6 +482,12 @@ class ProcessRequestsTest extends TestCase
 
         // Create a request
         $request = factory(ProcessRequest::class)->create();
+
+        // Crate a user without administrator privileges
+        $user = factory(User::class)->create([
+            'status' => 'ACTIVE',
+            'is_administrator' => false,
+        ]);
 
         // Add the file to the request
         $addedMedia = $request->addMedia($fileUpload)->toMediaCollection('local');


### PR DESCRIPTION
Resolves #2058 

- The url already existed and is  api/1.0/requests/1/files/1
- The way that the files are returned was improved and made compatible to how the api/1.0/files endpoints works
- Test to validate that the file download works was added
- It was verified that files can be downloded by: super administratoras and request's participants.


