### PR TITLE
Css override uses a wrong url for the OpenSans font

### DIFF
--- a/ProcessMaker/Jobs/CompileSass.php
+++ b/ProcessMaker/Jobs/CompileSass.php
@@ -81,7 +81,7 @@ class CompileSass implements ShouldQueue
     {
         chdir(app()->basePath());
         $file = file_get_contents("public/css/app.css");
-        $file = str_replace('url("./fonts/','url("/fonts/vendor/npm-font-open-sans/', $file );
+        $file = preg_replace('/\.\/fonts(\/[A-Za-z]+\/)OpenSans\-/m', '/fonts/OpenSans-', $file);
         $file = str_replace('public/css/precompiled/vue-multiselect.min.css','css/precompiled/vue-multiselect.min.css', $file );
         $file = str_replace('url("../webfonts/','url("/fonts/', $file );
         $file = str_replace('url("../fonts/','url("/fonts/', $file );


### PR DESCRIPTION
Resolves #2205 

The directory where OpenSans fonts are searched has been fixed. 
This fix was already merged in this PR:

 https://github.com/ProcessMaker/processmaker/pull/2206/files 

but it was reverted by this commit:

https://github.com/ProcessMaker/processmaker/commit/7012016d33748bdefa909b5ca3f03662bc7afe2f