### PR TITLE
Added linked task id for when task name is empty

### DIFF
--- a/resources/js/requests/components/RequestDetail.vue
+++ b/resources/js/requests/components/RequestDetail.vue
@@ -9,8 +9,15 @@
                       :fields="fields"
                       :data="data"
                       data-path="data"
-                      pagination-path="meta">
-
+                      pagination-path="meta"
+            >
+                <template slot="ids" slot-scope="props">
+                    <b-link v-if="isEditable(props.rowData)"
+                            @click="onAction('edit', props.rowData, props.rowIndex)">
+                        #{{props.rowData.id}}
+                    </b-link>
+                    <span v-else>#{{props.rowData.id}}</span>
+                </template>
                 <template slot="name" slot-scope="props">
                     <b-link v-if="isEditable(props.rowData)"
                             @click="onAction('edit', props.rowData, props.rowIndex)">
@@ -49,6 +56,12 @@
           }
         ],
         fields: [
+          {
+            name: "__slot:ids",
+            title: "#",
+            field: "id",
+            sortField: "id"
+          },
           {
             title: () => this.$t("TASK"),
             name: "__slot:name",
@@ -151,7 +164,7 @@
 </script>
 
 <style lang="scss" scoped>
-    /deep/ tr td:nth-child(2) {
+    /deep/ tr td:nth-child(3) {
         padding: 6px 10px;
     }
 </style>


### PR DESCRIPTION
Resolves https://github.com/ProcessMaker/modeler/issues/501
There is a related pr on https://github.com/ProcessMaker/modeler/pull/517 that doesn't rely on this pr.

Currently, the tasks list links the task id as well as the task name. 
<img width="929" alt="Screen Shot 2019-08-14 at 10 27 43 AM" src="https://user-images.githubusercontent.com/6653340/63029236-2fe1e180-be7e-11e9-9a30-26ee3ea8c280.png">

Made the request details similar. So if the task name was empty, you can still get to the task.
<img width="780" alt="Screen Shot 2019-08-13 at 4 59 25 PM" src="https://user-images.githubusercontent.com/6653340/63029022-d24d9500-be7d-11e9-8034-fa9e6f97388e.png">