### PR TITLE
Fix scrollbar issue with Edge and Firefox in Modeler and Screen Builder

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-container id="modeler-app" class="h-100 container p-0">
+  <b-container id="modeler-app" class="container p-0">
     <b-card no-body class="h-100 border-top-0">
-      <b-card-body class="overflow-hidden position-relative p-0 vh-100">
+      <b-card-body class="overflow-hidden position-relative p-0 h-100">
         <modeler ref="modeler" @validate="validationErrors = $event" />
       </b-card-body>
 

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -35,7 +35,7 @@
       </b-card-header>
 
       <!-- Card Body -->
-      <b-card-body class="overflow-auto p-0" id="screen-builder-container">
+      <b-card-body class="overflow-auto p-0 h-100" id="screen-builder-container">
         <!-- Vue-form-builder -->
         <vue-form-builder
           class="m-0"

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -61,7 +61,7 @@
   <div class="d-flex flex-grow-1 flex-column" style="overflow: hidden;">
     @include('layouts.navbar')
     @yield('breadcrumbs')
-    <div class="flex-grow-1 d-flex flex-column overflow-hidden" id="mainbody">
+    <div class="flex-grow-1 d-flex flex-column overflow-hidden h-100" id="mainbody">
       <div class="main flex-grow-1 h-100">
         @yield('content')
       </div>


### PR DESCRIPTION
In Safari and Firefox the modeler page was rendering extra height to the container of the modeler which caused a scrollbar. The expect behaviour is no scrollbar is present and the modeler app would take 100 percent of the height of the viewport. This applies to screen-builder pages.

Issue in Modeler Repo https://github.com/ProcessMaker/modeler/issues/505
Issue in Screen-Builder Repo https://github.com/ProcessMaker/screen-builder/issues/337

**Chrome**
<img width="1792" alt="Screen Shot 2019-08-14 at 4 06 27 PM" src="https://user-images.githubusercontent.com/26545455/63052849-62a3ce00-beae-11e9-806d-9d7adecfd3c4.png">

**Safari**
<img width="1792" alt="Screen Shot 2019-08-14 at 4 06 10 PM" src="https://user-images.githubusercontent.com/26545455/63052888-6fc0bd00-beae-11e9-8bd4-4e2d39bedea7.png">


**Firefox**
<img width="1792" alt="Screen Shot 2019-08-14 at 4 06 53 PM" src="https://user-images.githubusercontent.com/26545455/63052815-5586df00-beae-11e9-860b-4e5068b777ad.png">