### PR TITLE
Added missing API schema "deleted_at"

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -57,6 +57,7 @@ use DOMElement;
  *       @OA\Schema(
  *           @OA\Property(property="user_id", type="string", format="id"),
  *           @OA\Property(property="id", type="string", format="id"),
+ *           @OA\Property(property="deleted_at", type="string", format="date-time"),
  *           @OA\Property(property="created_at", type="string", format="date-time"),
  *           @OA\Property(property="updated_at", type="string", format="date-time"),
  *       )


### PR DESCRIPTION
* As noted in https://processmaker.atlassian.net/browse/FOUR-425, `deleted_at` was missing in the API documentation for `GET /process` requests