### PR TITLE
Fixed the improper sentence structure seen when deleting API tokens.

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -54,7 +54,7 @@
   "Archived Processes": "Archived Processes",
   "Are you ready to begin?": "Are you ready to begin?",
   "Are you sure to delete the group ": "Are you sure to delete the group ",
-  "Are you sure to delete the token ": "Are you sure to delete the token ",
+  "Are you sure you want to delete the token ": "Are you sure you want to delete the token ",
   "Are you sure you want cancel this request ?": "Are you sure you want cancel this request ?",
   "Are you sure you want to archive the process ": "Are you sure you want to archive the process ",
   "Are you sure you want to archive the process": "Are you sure you want to archive the process ",

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -709,7 +709,7 @@
           deleteToken(tokenId) {
             ProcessMaker.confirmModal(
               this.$t("Caution!"),
-              this.$t("Are you sure to delete the token ") + tokenId.substr(0, 7) +
+              this.$t("Are you sure you want to delete the token ") + tokenId.substr(0, 7) +
               this.$t("? Any services using it will no longer have access."),
               "",
               () => {


### PR DESCRIPTION
Updates will be needed for FR/DE/ES in "package-translate"