### PR TITLE
Wrong Logo post Install

### DIFF
--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -106,7 +106,7 @@ class Setting extends Model implements HasMedia
     public static function getLogin()
     {
         //default login
-        $url = asset(env('MAIN_LOGO_PATH', '/img/processmaker_login.png'));
+        $url = asset(env('LOGIN_LOGO_PATH', '/img/processmaker_login.png'));
         //custom login
         $setting = self::byKey('css-override');
         if ($setting) {


### PR DESCRIPTION
Resolves #2315 

- Change default variable logo to login.

![image](https://user-images.githubusercontent.com/1747025/63861553-1f029700-c979-11e9-8c69-c74314258ee3.png)
