### PR TITLE
Loading indicator appears even if unrelated API call is made

### DIFF
--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="data-table">
     <data-loading
-            :for="/processes/"
+            :for="/\/processes\?page|\/processes\?status/"
             v-show="shouldShowLoader"
             :empty="$t('No Data Available')"
             :empty-desc="$t('')"


### PR DESCRIPTION
Resolves #2361 

The regular expression used to determine if the loading icon is shown was modified to be more specific so it won't be confused with the start new processes url.

