### PR TITLE
Add env for disabling telescope

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,4 @@ BROADCASTER_HOST=https://processmaker.local.processmaker.com:6001
 LARAVEL_ECHO_SERVER_AUTH_HOST=https://processmaker.local.processmaker.com
 LARAVEL_ECHO_SERVER_PORT=6001
 LARAVEL_ECHO_SERVER_DEBUG=false
+TELESCOPE_ENABLED=false

--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -87,7 +87,9 @@ class Install extends Command
         }
         $this->info(__("This application installs a new version of ProcessMaker."));
         $this->info(__("You must have your database credentials available in order to continue."));
-        $this->confirm(__("Are you ready to begin?"));
+        if (!$this->confirm(__("Are you ready to begin?"))) {
+            return;
+        }
         $this->checkDependencies();
         do {
             $this->fetchDatabaseCredentials();
@@ -123,6 +125,10 @@ class Install extends Command
             FILTER_VALIDATE_URL
         )
             || ($this->env['APP_URL'][strlen($this->env['APP_URL']) - 1] == '/')));
+
+        // Set telescope enabled
+        $this->env['TELESCOPE_ENABLED'] = $this->choice('Enable Telescope Debugging', ['true', 'false'], 'false');
+
         // Set broadcaster url
         $this->env['BROADCASTER_HOST'] = $this->env['APP_URL'] . ':6001';
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,6 +30,7 @@
       <env name="APP_KEY" value="base64:x80I9vQNxwllSuwBkTwfUa5qkgPTRdwqHCPSz7zHi1U=" />
       <env name="TESTING_VERBOSE" value="false" />
       <env name="POPULATE_DATABASE" value="true" />
+      <env name="TELESCOPE_ENABLED" value="false" />
 
       <!-- Caching config -->
       <env name="CACHE_DRIVER" value="array" />


### PR DESCRIPTION
Fixes #2371 

No changes were needed to the service provider since telescope already looks for `TELESCOPE_ENABLED` env var.

Note that telescope will log its own events until [this fix](https://github.com/laravel/telescope/pull/720) is released.