### PR TITLE
Fix Selection Category Modal Object Error

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -262,10 +262,6 @@ class ScreenController extends Controller
             $newScreen->description = $request->input('description');
         }
 
-        if( $request->has('screen_category_id')) {
-            $newScreen->screen_category_id = $request->input('screen_category_id');
-        } 
-
         $newScreen->saveOrFail();
         return new ApiResource($newScreen);
     }

--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -262,6 +262,10 @@ class ScreenController extends Controller
             $newScreen->description = $request->input('description');
         }
 
+        if( $request->has('screen_category_id')) {
+            $newScreen->screen_category_id = $request->input('screen_category_id');
+        } 
+
         $newScreen->saveOrFail();
         return new ApiResource($newScreen);
     }

--- a/resources/js/processes/categories/components/CategorySelect.vue
+++ b/resources/js/processes/categories/components/CategorySelect.vue
@@ -53,7 +53,6 @@
       content: {
         handler() {
           this.$emit("input", this.content.id);
-          this.$emit("update:duplicateScreenCategory", this.content);
         }
       },
       value: {

--- a/resources/js/processes/categories/components/CategorySelect.vue
+++ b/resources/js/processes/categories/components/CategorySelect.vue
@@ -53,6 +53,7 @@
       content: {
         handler() {
           this.$emit("input", this.content.id);
+          this.$emit("update:duplicateScreenCategory", this.content);
         }
       },
       value: {

--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -109,8 +109,14 @@
           </select>
         </div>
         <div class="form-group">
-          <label for="description">{{$t('Category')}}</label>
-          <input type="text" class="form-control" id="category" v-model="dupScreen.category" />
+          <category-select 
+          :label="$t('Category')" 
+          api-get="screen_categories" 
+          api-list="screen_categories" 
+          v-model="dupScreen.screen_category_id"
+          :errors="errors.screen_category_id"
+          @update:duplicateScreenCategory="updateCategory">
+          </category-select>
         </div>
         <div class="form-group">
           <label for="description">{{$t('Description')}}</label>
@@ -138,7 +144,8 @@ export default {
       dupScreen: {
         title: "",
         type: "",
-        category: "",
+        category: {},
+        screen_category_id: "",
         description: ""
       },
       errors: [],
@@ -230,6 +237,7 @@ export default {
           this.dupScreen.title = data.title + " Copy";
           this.dupScreen.type = data.type;
           this.dupScreen.category = data.category;
+          this.dupScreen.screen_category_id = data.category.id;
           this.dupScreen.description = data.description;
           this.dupScreen.id = data.id;
           this.showModal();
@@ -285,6 +293,10 @@ export default {
           this.data = this.transform(response.data);
           this.loading = false;
         });
+    },
+    updateCategory(value) {
+      this.dupScreen.category = value;
+      this.dupScreen.screen_category_id = this.dupScreen.category.id;
     }
   },
 

--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -109,14 +109,8 @@
           </select>
         </div>
         <div class="form-group">
-          <category-select 
-          :label="$t('Category')" 
-          api-get="screen_categories" 
-          api-list="screen_categories" 
-          v-model="dupScreen.screen_category_id"
-          :errors="errors.screen_category_id"
-          @update:duplicateScreenCategory="updateCategory">
-          </category-select>
+          <label for="description">{{$t('Category')}}</label>
+          <input type="text" class="form-control" id="category" v-model="dupScreen.category" />
         </div>
         <div class="form-group">
           <label for="description">{{$t('Description')}}</label>
@@ -144,8 +138,7 @@ export default {
       dupScreen: {
         title: "",
         type: "",
-        category: {},
-        screen_category_id: "",
+        category: "",
         description: ""
       },
       errors: [],
@@ -237,7 +230,6 @@ export default {
           this.dupScreen.title = data.title + " Copy";
           this.dupScreen.type = data.type;
           this.dupScreen.category = data.category;
-          this.dupScreen.screen_category_id = data.category.id;
           this.dupScreen.description = data.description;
           this.dupScreen.id = data.id;
           this.showModal();
@@ -293,10 +285,6 @@ export default {
           this.data = this.transform(response.data);
           this.loading = false;
         });
-    },
-    updateCategory(value) {
-      this.dupScreen.category = value;
-      this.dupScreen.screen_category_id = this.dupScreen.category.id;
     }
   },
 


### PR DESCRIPTION
**Issue:**
The category selection in the duplicate screen modal was displaying and object in the input field.

**Fix:**
Converted the category input field to a dropdown and allow the user to select a category for the duplicate screen.

![Screen Shot 2019-09-18 at 9 19 09 AM](https://user-images.githubusercontent.com/52755494/65166337-6b2f7d00-d9f5-11e9-8b01-670b5eb04fdb.png)


closes #2378 