### PR TITLE
Sorting 500

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -61,7 +61,10 @@ class ScreenController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Screen::nonSystem();
+        $query = Screen::nonSystem()
+                    ->select('screens.*')
+                    ->where('key', null)
+                    ->leftJoin('screen_categories as category', 'screens.screen_category_id', '=', 'category.id');
         $include = $request->input('include', '');
 
         if ($include) {

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -65,7 +65,11 @@ class ScriptController extends Controller
     public function index(Request $request)
     {
         // Do not return results when a key is set. Those are for connectors.
-        $query = Script::nonSystem()->where('key', null);
+        $query = Script::nonSystem()
+                    ->select('scripts.*')
+                    ->where('key', null)
+                    ->leftJoin('script_categories as category', 'scripts.script_category_id', '=', 'category.id');
+
         $include = $request->input('include', '');
 
         if ($include) {
@@ -89,6 +93,7 @@ class ScriptController extends Controller
                     ->orWhere('language', 'like', $filter);
             });
         }
+
 
         $response =
             $query->orderBy(


### PR DESCRIPTION
Resolves #2426 

The order by failed because the built query had not a join with the categories table (like is the case in the processes list). This join has been added.

