### PR TITLE
Fix request summary permissions

### DIFF
--- a/ProcessMaker/Policies/ProcessRequestPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestPolicy.php
@@ -36,12 +36,20 @@ class ProcessRequestPolicy
         if ($processRequest->user_id == $user->id) {
             return true;
         }
+
         if ($processRequest->hasUserParticipated($user)) {
-            if ($processRequest->status !== 'COMPLETED') {
-                return true;
-            }
+            return true;
         }
-        if($user->can('view-all_requests')){
+
+        if ($user->hasPermission('edit-request_data')) {
+                return true;
+        }
+
+        if ($processRequest->process->usersCanEditData->where('id', $user->id)->count() > 0) {
+            return true;
+        }
+
+        if ($user->can('view-all_requests')) {
             return true;
         }
     }
@@ -59,6 +67,7 @@ class ProcessRequestPolicy
             return true;
         }
         return $user->can('cancel', $processRequest->process)
+            || $user->hasPermission('edit-request_data')
             || $user->can('editData', $processRequest->process);
     }    
 

--- a/ProcessMaker/Policies/ProcessRequestPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestPolicy.php
@@ -36,6 +36,11 @@ class ProcessRequestPolicy
         if ($processRequest->user_id == $user->id) {
             return true;
         }
+        if ($processRequest->hasUserParticipated($user)) {
+            if ($processRequest->status !== 'COMPLETED') {
+                return true;
+            }
+        }
         if($user->can('view-all_requests')){
             return true;
         }

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -526,8 +526,47 @@ class ProcessRequestsTest extends TestCase
         $response = $this->apiCall('get', $url);
         $response->assertStatus(200);
 
+        // Participant can still see the data when completed
         $request->update(['status' => 'COMPLETED']);
         $response = $this->apiCall('get', $url);
+        $response->assertStatus(200);
+    }
+
+    public function testUserCanEditCompletedData() {
+        $user = factory(User::class)->create();
+        $this->user = $user;
+
+        $process = factory(Process::class)->create();
+        $request = factory(ProcessRequest::class)->create([
+            'status' => 'COMPLETED',
+            'data' => ['foo' => 'bar'],
+            'process_id' => $process->id,
+        ]);
+        
+        $url = route('api.requests.update', $request);
+
+        $response = $this->apiCall('put', $url, ['data' => ['foo' => '123']]);
         $response->assertStatus(403);
+
+        $editAllRequestsData = Permission::where('name', 'edit-request_data')->first();
+        $user->permissions()->attach($editAllRequestsData);
+        $user->refresh();
+        session()->forget('permissions');
+
+        $response = $this->apiCall('put', $url, ['data' => ['foo' => '123']]);
+        $response->assertStatus(204); 
+        
+        $user->permissions()->detach($editAllRequestsData);
+        $user->refresh();
+        session()->forget('permissions');
+
+        $response = $this->apiCall('put', $url, ['data' => ['foo' => '123']]);
+        $response->assertStatus(403);
+
+        // Add process level permission
+        $process->usersCanEditData()->sync([$user->id => ['method' => 'EDIT_DATA']]);
+        
+        $response = $this->apiCall('put', $url, ['data' => ['foo' => '123']]);
+        $response->assertStatus(204);
     }
 }


### PR DESCRIPTION
Fixes #2438 

- Allow participants to view request details
- Allow users with process-specific data edit permission to view data tab