### PR TITLE
Refactor timeout modal and add config for seconds before to display it

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -76,7 +76,8 @@ window.ProcessMaker.navbar = new Vue({
       sessionShow: false,
       sessionTitle: "",
       sessionMessage: "",
-      sessionTime: ""
+      sessionTime: "",
+      sessionWarnSeconds: ""
     };
   },
   methods: {
@@ -141,10 +142,11 @@ window.ProcessMaker.alert = function (msg, variant, showValue = 5, stayNextScree
 };
 
 // Setup our login modal
-window.ProcessMaker.sessionModal = function (title, message, time) {
+window.ProcessMaker.sessionModal = function (title, message, time, warnSeconds) {
   ProcessMaker.navbar.sessionTitle = title || __("Session Warning");
   ProcessMaker.navbar.sessionMessage = message || __("Your session is about to expire.");
   ProcessMaker.navbar.sessionTime = time;
+  ProcessMaker.navbar.sessionWarnSeconds = warnSeconds;
   ProcessMaker.navbar.sessionShow = true;
 };
 

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -211,17 +211,29 @@ if (userID) {
     // Session timeout
     let timeoutScript = document.head.querySelector("meta[name=\"timeout-worker\"]").content;
     window.ProcessMaker.AccountTimeoutLength = parseInt(document.head.querySelector("meta[name=\"timeout-length\"]").content);
+    window.ProcessMaker.AccountTimeoutWarnSeconds = parseInt(document.head.querySelector("meta[name=\"timeout-warn-seconds\"]").content);
     window.ProcessMaker.AccountTimeoutWorker = new Worker(timeoutScript);
     window.ProcessMaker.AccountTimeoutWorker.addEventListener('message', function (e) {
         if (e.data.method === 'countdown') {
-            window.ProcessMaker.sessionModal('Session Warning', '<p>Your user session is expiring. If your session expires, all of your unsaved data will be lost.</p><p>Would you like to stay connected?</p>', e.data.data.time);
+            window.ProcessMaker.sessionModal(
+                'Session Warning',
+                '<p>Your user session is expiring. If your session expires, all of your unsaved data will be lost.</p><p>Would you like to stay connected?</p>',
+                e.data.data.time,
+                window.ProcessMaker.AccountTimeoutWarnSeconds
+            );
         }
         if (e.data.method === 'timedOut') {
             window.location = '/logout';
         }
     });
 
-    window.ProcessMaker.AccountTimeoutWorker.postMessage({ method: 'start', data: { timeout: window.ProcessMaker.AccountTimeoutLength } });
+    window.ProcessMaker.AccountTimeoutWorker.postMessage({
+        method: 'start',
+        data: {
+            timeout: window.ProcessMaker.AccountTimeoutLength,
+            warnSeconds: window.ProcessMaker.AccountTimeoutWarnSeconds
+        }
+    });
 }
 
 window.Echo = new Echo({
@@ -237,7 +249,13 @@ if (userID) {
         })
         .listen('.SessionStarted', (e) => {
             let lifetime = parseInt(e.lifetime);
-            window.ProcessMaker.AccountTimeoutWorker.postMessage({ method: 'start', data: { timeout: lifetime } });
+            window.ProcessMaker.AccountTimeoutWorker.postMessage({
+                method: 'start',
+                data: {
+                    timeout: lifetime,
+                    warnSeconds: window.ProcessMaker.AccountTimeoutWarnSeconds
+                }
+            });
             window.ProcessMaker.closeSessionModal();
         });
 }

--- a/resources/js/components/Session.vue
+++ b/resources/js/components/Session.vue
@@ -9,7 +9,7 @@
               <div class="modal-body mb-1">
                 <span v-html="message"></span>
                  <div class="progress">
-                <div class="progress-bar progress-bar-striped" role="progressbar" :style="{width: time + '%'}"><span align="left" class="pl-2">{{moment().startOf('day').seconds(time).format('mm:ss')}}</span></div>
+                <div class="progress-bar progress-bar-striped" role="progressbar" :style="{width: percentage + '%'}"><span align="left" class="pl-2">{{moment().startOf('day').seconds(time).format('mm:ss')}}</span></div>
               </div>
               </div>
 
@@ -26,11 +26,19 @@
 <script>
 
     export default {
-        props: ["title", "message", "time"],
+        props: ["title", "message", "time", "warnSeconds"],
         data() {
             return {
               errors: {},
               disabled: false
+            }
+        },
+        computed: {
+            percentage() {
+                if (this.time === "" || this.warnSeconds === "") {
+                    return 0;
+                }
+                return Math.round((this.time / this.warnSeconds) * 100);
             }
         },
         methods: {
@@ -43,7 +51,13 @@
                   .post("/keep-alive", {}, {baseURL: ''})
                   .then(() => {
                     this.disabled = false;
-                    ProcessMaker.AccountTimeoutWorker.postMessage({method: 'start', data: {timeout: ProcessMaker.AccountTimeoutLength}});
+                    ProcessMaker.AccountTimeoutWorker.postMessage({
+                        method: 'start',
+                        data: {
+                            timeout: ProcessMaker.AccountTimeoutLength,
+                            warnSeconds: ProcessMaker.AccountTimeoutWarnSeconds,
+                        }
+                    });
                     this.onClose();
                   })
                   .catch(error => {

--- a/resources/js/leave-warning.js
+++ b/resources/js/leave-warning.js
@@ -5,7 +5,7 @@ if (window.ProcessMaker) {
     const {AccountTimeoutWorker, EventBus} = window.ProcessMaker;
 
     AccountTimeoutWorker && AccountTimeoutWorker.addEventListener("message", (event) => {
-        if (event.data.method === "timedOut") {
+        if (event.data.method === "countdown" && event.data.data.time < 3) {
             isTimedOut = true;
         }
     });
@@ -16,10 +16,10 @@ if (window.ProcessMaker) {
 
 window.addEventListener("beforeunload", (event) => {
     if (isTimedOut || noUnsavedChanges) {
-        event.preventDefault();
         return;
     }
-
+    
+    event.preventDefault();
     let confirmationMessage = __("Are you sure you want to leave?");
     event.returnValue = confirmationMessage; // Gecko, Trident, Chrome 34+
 

--- a/resources/js/timeout.js
+++ b/resources/js/timeout.js
@@ -16,7 +16,8 @@ self.start = function (data) {
   clearInterval(self.interval);
   self.interval = setInterval(function () {
     self.time--;
-    if (self.time < 55 && self.time > 0) {
+    
+    if (self.time < data.warnSeconds && self.time > 0) {
       self.postMessage({ method: 'countdown', data: { time: self.time } });
     }
 

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -20,6 +20,7 @@
     <meta name="broadcasting-key" content="{{config('broadcasting.key')}}">
     <meta name="timeout-worker" content="{{ mix('js/timeout.js') }}">
     <meta name="timeout-length" content="{{ config('session.lifetime') }}">
+    <meta name="timeout-warn-seconds" content="60">
     @endif
     @if(Session::has('_alert'))
       <meta name="alert" content="show">

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -12,7 +12,7 @@
                             :variant="confirmVariant" :callback="confirmCallback"
                             @close="confirmShow=false">
         </confirmation-modal>
-        <session-modal id="sessionModal" v-show='sessionShow' :title="sessionTitle" :message="sessionMessage" :time="sessionTime"
+        <session-modal id="sessionModal" v-show='sessionShow' :title="sessionTitle" :message="sessionMessage" :time="sessionTime" :warn-seconds="sessionWarnSeconds"
                 @close="sessionShow=false">
         </session-modal>
         <div v-if="alerts.length > 0" class="alert-wrapper">


### PR DESCRIPTION
Fixes #1524 

- Refactor modal code
- Make seconds before timeout warning appears configurable in meta tag. It's hard coded for now. This is mostly for making development easier.
- Fix how we handle the 'beforeunload' event that prevents the browser from navigating away from unsaved processes and screens.