### PR TITLE
Add default value to specialAssignmentsListGetter

### DIFF
--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -186,8 +186,8 @@
         return this.typeAssignmentExpression === "group";
       },
       specialAssignmentsListGetter () {
-        const value = _.get(this.node, "assignmentRules", '[]');
-        return JSON.parse(value) || [];
+        const value = this.node.get('assignmentRules') || '[]';
+        return JSON.parse(value);
       },
     },
     methods: {

--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -186,7 +186,7 @@
         return this.typeAssignmentExpression === "group";
       },
       specialAssignmentsListGetter () {
-        const value = _.get(this.node, "assignmentRules");
+        const value = _.get(this.node, "assignmentRules", '[]');
         return JSON.parse(value) || [];
       },
     },


### PR DESCRIPTION
This PR fixes the console error `Error in render: "SyntaxError: Unexpected token u in JSON at position 0"` 
The Assignment Rules accordion renders but when creating a new rule a console error is thrown.

```
TypeError: Cannot read property 'content' of undefined
    at VueComponent.saveSpecialAssignment (initialLoad.js:336498)
    at invokeWithErrorHandling (vendor.js:97653)
    at HTMLButtonElement.invoker (vendor.js:97978)
    at HTMLButtonElement.original._wrapper (vendor.js:103331)
```

Fixes #2483 