### PR TITLE
Add node packages to about page

### DIFF
--- a/ProcessMaker/Http/Controllers/AboutController.php
+++ b/ProcessMaker/Http/Controllers/AboutController.php
@@ -14,11 +14,20 @@ class AboutController extends Controller
      */
     public function index()
     {
-        $path = base_path('vendor/processmaker');
-        $directories = \File::directories($path);
+        $vendor_path = base_path('vendor/processmaker');
+        $node_path = base_path('node_modules/@processmaker');
+        
+        $vendor_directories = \File::directories($vendor_path);
+        $node_directories = \File::directories($node_path);
+        
         $packages = array();
-        foreach($directories as $directory) {
-            $content = json_decode(file_get_contents($path . '/' . basename($directory) . '/composer.json'));
+
+        foreach($vendor_directories as $directory) {
+            $content = json_decode(file_get_contents($vendor_path . '/' . basename($directory) . '/composer.json'));
+            array_push($packages, $content);
+        }
+        foreach($node_directories as $directory) {
+            $content = json_decode(file_get_contents($node_path . '/' . basename($directory) . '/package.json'));
             array_push($packages, $content);
         }
         return view('about.index', compact('packages'));

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -35,7 +35,9 @@
             <li class="list-group-item">
                 <h6><i class="fas fa-puzzle-piece mr-2"></i>{{ ucfirst(trans($package->name)) }}</h6>
                 <small>
-                  <div>{{ $package->description }}</div>
+                  @if (isset($package->description))
+                    <div>{{ $package->description }}</div>
+                  @endif
                   @if (isset($package->version))
                     <div><strong>Version:</strong> {{ $package->version }}</div>
                   @endif


### PR DESCRIPTION
Displays installed Node Packages on the about page. 

![Screen Shot 2019-11-04 at 9 26 11 AM](https://user-images.githubusercontent.com/52755494/68142902-2dbf7a00-fee5-11e9-99fc-026fd0ff1094.png)

closes #2478 