### PR TITLE
Datasource endpoints are not in Core

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/DataSourcesController.php
+++ b/ProcessMaker/Http/Controllers/Api/DataSourcesController.php
@@ -42,7 +42,7 @@ class DataSourcesController extends Controller
      *             @OA\Property(
      *                 property="data",
      *                 type="array",
-     *                 @OA\Items(ref="#/components/schemas/dataSource"),
+     *                 @OA\Items(@OA\JsonContent()),
      *             ),
      *             @OA\Property(
      *                 property="meta",
@@ -116,7 +116,17 @@ class DataSourcesController extends Controller
      *     @OA\Response(
      *         response=200,
      *         description="Successfully found the Data Source",
-     *         @OA\JsonContent(ref="#/components/schemas/dataSource")
+     *         @OA\JsonContent(
+     *          @OA\Property(property="id", type="string", format="id"),
+     *          @OA\Property(property="name", type="string"),
+     *          @OA\Property(property="description", type="string"),
+     *          @OA\Property(property="endpoints", type="string"),
+     *          @OA\Property(property="mappings", type="string"),
+     *          @OA\Property(property="authtype", type="string"),
+     *          @OA\Property(property="credentials", type="string"),
+     *          @OA\Property(property="status", type="string"),
+     *          @OA\Property(property="data_source_category_id", type="string"),
+     *          )
      *     ),
      * )
      */
@@ -135,6 +145,11 @@ class DataSourcesController extends Controller
      * @param Request $httpRequest
      *
      * @return Response
+     *
+     * @OA\Schema(
+     *   schema="DataSourceCallParameters",
+     *   @OA\Property(property="endpoint", type="string")
+     * ),
      *
      * @OA\Post(
      *     path="request/{request_id}/data_source/{data_source_id}",
@@ -161,12 +176,14 @@ class DataSourcesController extends Controller
      *     ),
      *     @OA\RequestBody(
      *       required=true,
-     *       @OA\JsonContent()
+     *       @OA\JsonContent(
+     *          @OA\Property(property="config", ref="#/components/schemas/DataSourceCallParameters")
+     *       )
      *     ),
      *     @OA\Response(
      *         response=200,
      *         description="success",
-     *         @OA\JsonContent(ref="#/components/schemas/dataSource")
+     *         @OA\JsonContent()
      *     ),
      * )
      */

--- a/ProcessMaker/Http/Controllers/Api/DataSourcesController.php
+++ b/ProcessMaker/Http/Controllers/Api/DataSourcesController.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use Laravel\Horizon\Http\Controllers\Controller;
+use ProcessMaker\Http\Resources\ApiCollection;
+use ProcessMaker\Http\Resources\ApiResource;
+use ProcessMaker\Models\ProcessRequest;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use ProcessMaker\Packages\Connectors\DataSources\Models\DataSource;
+use ProcessMaker\Packages\Connectors\DataSources\Jobs\DataSource as DataSourceJob;
+use ProcessMaker\Exception\HttpResponseException;
+
+
+class DataSourcesController extends Controller
+{
+
+    /**
+     * Get the list of records of a Data Source
+     *
+     * @param Request $request
+     *
+     * @return ApiCollection
+     *
+     * @OA\Get(
+     *     path="/data_sources",
+     *     summary="Returns all Data Sources that the user has access to",
+     *     operationId="getDataSources",
+     *     tags={"Data Sources"},
+     *     @OA\Parameter(ref="#/components/parameters/filter"),
+     *     @OA\Parameter(ref="#/components/parameters/order_by"),
+     *     @OA\Parameter(ref="#/components/parameters/order_direction"),
+     *     @OA\Parameter(ref="#/components/parameters/per_page"),
+     *     @OA\Parameter(ref="#/components/parameters/include"),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="list of Data Sources",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/dataSource"),
+     *             ),
+     *             @OA\Property(
+     *                 property="meta",
+     *                 type="object",
+     *                 allOf={@OA\Schema(ref="#/components/schemas/metadata")},
+     *             ),
+     *         ),
+     *     ),
+     * )
+     */
+    public function index(Request $request)
+    {
+        $query = DataSource::nonSystem()
+            ->select('data_sources.*')
+            ->leftJoin('data_source_categories as category', 'data_sources.data_source_category_id', '=', 'category.id');
+
+        $include = $request->input('include', '');
+
+        if ($include) {
+            $include = explode(',', $include);
+            $count = array_search('categoryCount', $include);
+            if ($count !== false) {
+                unset($include[$count]);
+                $query->withCount('category');
+            }
+            if ($include) {
+                $query->with($include);
+            }
+        }
+
+        $filter = $request->input('filter', '');
+
+        if (!empty($filter)) {
+            $filter = '%' . $filter . '%';
+            $query->where(function ($query) use ($filter) {
+                $query->where('data_sources.name', 'like', $filter)
+                    ->orWhere('description', 'like', $filter)
+                    ->orWhere('authtype', 'like', $filter);
+            });
+        }
+        $response =
+            $query->orderBy(
+                $request->input('order_by', 'id'),
+                $request->input('order_direction', 'ASC')
+            )->paginate($request->input('per_page', 10));
+
+        return new ApiCollection($response);
+    }
+
+    /**
+     * Get a single Data Source.
+     *
+     * @param DataSource $dataSource
+     *
+     * @return ApiResource
+     *
+     * @OA\Get(
+     *     path="/data_sources/data_source_id",
+     *     summary="Get single Data Source by ID",
+     *     operationId="getDataSourceById",
+     *     tags={"Data Sources"},
+     *     @OA\Parameter(
+     *         description="ID of Data Source to return",
+     *         in="path",
+     *         name="data_source_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successfully found the Data Source",
+     *         @OA\JsonContent(ref="#/components/schemas/dataSource")
+     *     ),
+     * )
+     */
+    public function show(DataSource $dataSource)
+    {
+        return new ApiResource($dataSource);
+    }
+
+
+
+    /**
+     * Execute a data Source endpoint
+     *
+     * @param ProcessRequest $request
+     * @param DataSource $dataSource
+     * @param Request $httpRequest
+     *
+     * @return Response
+     *
+     * @OA\Post(
+     *     path="request/{request_id}/data_source/{data_source_id}",
+     *     summary="execute Data Source",
+     *     operationId="executeDataSource",
+     *     tags={"Data Sources"},
+     *     @OA\Parameter(
+     *         description="ID of the request in whose context the datasource will be executed",
+     *         in="path",
+     *         name="request_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\Parameter(
+     *         description="ID of DataSource to be run",
+     *         in="path",
+     *         name="data_source_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\RequestBody(
+     *       required=true,
+     *       @OA\JsonContent()
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="success",
+     *         @OA\JsonContent(ref="#/components/schemas/dataSource")
+     *     ),
+     * )
+     */
+    public function executeDataSource(ProcessRequest $request, DataSource $dataSource, Request $httpRequest)
+    {
+        $config= $httpRequest->json()->get('config');
+        try {
+            $response = $dataSource->request($request->data, $config);
+            return response($response, 200);
+        } catch (HttpResponseException $exception) {
+            return response($exception->body, $exception->status);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -154,6 +154,13 @@ Route::group(
     Route::put('comments/{comment}', 'CommentController@update')->name('comments.update')->middleware('can:edit-comments');
     Route::delete('comments/{comment}', 'CommentController@destroy')->name('comments.destroy')->middleware('can:delete-comments');
 
+
+    //DataSources
+    Route::get('data_sources', 'DataSourcesController@index')->name('data-sources.index')->middleware('can:view-data-sources');
+    Route::get('data_sources/{data_source}', 'DataSourcesController@show')->name('data-sources.show')->middleware('can:view-data-sources');
+    Route::post('requests/{request}/data_sources/{data_source}', 'DataSourcesController@executeDataSource');
+
+
     //UI customization
     Route::post('customize-ui', 'CssOverrideController@store')->name('customize-ui.store');
 


### PR DESCRIPTION
Resolves #2516 

The endpoints added to core are the 3 main ones and can be used outside the data-sources package:

- data_sources -> the list of data sources
- data_sources/{data_source} -> GET 
- data_sources/{data_source} -> PUT/POST
- data_sources/{data_source} -> information of a data source
- data_sources/{data_source}/test -> test of a data source
- requests/{request}/data_sources/{data_source} -> execution of a data source




