### PR TITLE
BugFix: Add FormImage to Screen Builder Display-type

### DIFF
--- a/resources/js/processes/screen-builder/typeDisplay.js
+++ b/resources/js/processes/screen-builder/typeDisplay.js
@@ -12,6 +12,7 @@ const {
 const TableControl = FormBuilderControls.find(control => control.rendererBinding === "FormMultiColumn");
 const RichTextControl = FormBuilderControls.find(control => control.rendererBinding === "FormHtmlEditor");
 let FormRecordList = FormBuilderControls.find(control => control.rendererBinding === "FormRecordList");
+const FormImage = FormBuilderControls.find(control => control.rendererBinding === "FormImage");
 
 // Remove editable inspector props
 FormRecordList.control.inspector = FormRecordList.control.inspector.filter(prop => prop.field !== "editable" && prop.field !== "form");
@@ -19,7 +20,8 @@ FormRecordList.control.inspector = FormRecordList.control.inspector.filter(prop 
 let controlsDisplay = [
   RichTextControl,
   TableControl,
-  FormRecordList
+  FormRecordList,
+  FormImage
 ];
 
 controlsDisplay.push({


### PR DESCRIPTION
The PR fixes the issue of the FormImage control not displaying for the Screen Builder type Display.

![Screen Shot 2019-11-13 at 3 41 44 PM](https://user-images.githubusercontent.com/52755494/68813970-5f92b800-062c-11ea-9720-20af2da81415.png)

closes [#443](https://github.com/ProcessMaker/screen-builder/issues/433)


