### PR TITLE
Fix bug with New Environment Variable form fields not resetting on modal close

### DIFF
--- a/resources/js/processes/environment-variables/index.js
+++ b/resources/js/processes/environment-variables/index.js
@@ -1,11 +1,16 @@
 import Vue from "vue";
 import VariablesListing from "./components/VariablesListing";
 
-// Bootstrap our Variables listing
 new Vue({
     el: "#process-variables-listing",
     data: {
-        filter: ""
+        filter: "",
+        addEnvVariable: {
+            errors: {},
+            name: '',
+            description: '',
+            value: '',
+        }
     },
     components: {
         VariablesListing
@@ -28,6 +33,31 @@ new Vue({
                     direction: "desc"
                 }
             ]);
+        },
+        onClose() {
+            this.addEnvVariable.name = '';
+            this.addEnvVariable.description = '';
+            this.addEnvVariable.value = '';
+            this.addEnvVariable.errors = {};
+        },
+        onSubmit(bvModalEvt) {
+            bvModalEvt.preventDefault();
+            this.addEnvVariable.errors = {};
+            ProcessMaker.apiClient.post('environment_variables', {
+              name: this.addEnvVariable.name,
+              description: this.addEnvVariable.description,
+              value: this.addEnvVariable.value
+            })
+            .then(response => {
+                ProcessMaker.alert(this.$t('The environment variable was created.'), 'success');
+                this.reload();
+                this.$refs.createEnvironmentVariable.hide();
+            })
+            .catch(error => {
+                if (error.response.status === 422) {
+                  this.addEnvVariable.errors = error.response.data.errors
+                }
+            });
         }
     }
 });

--- a/resources/views/processes/environment-variables/index.blade.php
+++ b/resources/views/processes/environment-variables/index.blade.php
@@ -29,8 +29,7 @@
             </div>
             <div class="col-8" align="right">
                 @can('create-environment_variables')
-                    <button type="button" id="create_envvar" class="btn btn-secondary" data-toggle="modal"
-                            data-target="#createEnvironmentVariable">
+                    <button type="button" id="create_envvar" class="btn btn-secondary" @click="$refs.createEnvironmentVariable.show()">
                         <i class="fas fa-plus"></i> {{__('Environment Variable')}}
                     </button>
                 @endcan
@@ -39,102 +38,42 @@
         <variables-listing ref="listVariable" :filter="filter"
                            :permission="{{ \Auth::user()->hasPermissionsFor('environment_variables') }}"
                            @delete="deleteVariable"></variables-listing>
-    </div>
 
-    @can('create-environment_variables')
-        <div class="modal" tabindex="-1" role="dialog" id="createEnvironmentVariable">
-            <div class="modal-dialog modal-dialog-centered" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title">{{__('Create Environment Variable')}}</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close" @click="onClose">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="form-group">
-                            {!!Form::label('name', __('Name'))!!}
-                            {!!Form::text('name', null, ['class'=> 'form-control', 'v-model'=> 'name',
-                            'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.name}'])!!}
-                            <small class="form-text text-muted"
-                                   v-if="! errors.name">{{ __('The environment variable name must be distinct.') }}</small>
-                            <div class="invalid-feedback" v-for="name in errors.name">@{{name}}</div>
-                        </div>
-                        <div class="form-group">
-                            {!!Form::label('description', __('Description'))!!}
-                            {!!Form::textArea('description', null, ['class'=> 'form-control', 'v-model'=> 'description',
-                            'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.description}','rows'=>3])!!}
-                            <div class="invalid-feedback" v-for="description in errors.description">@{{description}}
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            {!!Form::label('value', __('Value'))!!}
-                            {!!Form::text('value', null, ['class'=> 'form-control', 'v-model'=> 'value',
-                            'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.value}'])!!}
-                            <div class="invalid-feedback" v-for="value in errors.value">@{{value}}</div>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal" @click="onClose">
-                            {{__('Cancel')}}
-                        </button>
-                        <button type="button" class="btn btn-secondary ml-2" @click="onSubmit" :disabled="disabled">
-                            {{__('Save')}}
-                        </button>
+        @can('create-environment_variables')
+            <b-modal hidden 
+                     ref="createEnvironmentVariable" 
+                     title="{{__('Create Environment Variable')}}" 
+                     ok-title="{{__('Save')}}"
+                     @ok="onSubmit"
+                     @hidden="onClose"
+            >
+            
+                <div class="form-group">
+                    {!!Form::label('name', __('Name'))!!}
+                    {!!Form::text('name', null, ['class'=> 'form-control', 'v-model'=> 'addEnvVariable.name',
+                    'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addEnvVariable.errors.name}'])!!}
+                    <small class="form-text text-muted"
+                            v-if="!addEnvVariable.errors.name">{{ __('The environment variable name must be distinct.') }}</small>
+                    <div class="invalid-feedback" v-for="name in addEnvVariable.errors.name">@{{name}}</div>
+                </div>
+                <div class="form-group">
+                    {!!Form::label('description', __('Description'))!!}
+                    {!!Form::textArea('description', null, ['class'=> 'form-control', 'v-model'=> 'addEnvVariable.description',
+                    'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addEnvVariable.errors.description}','rows'=>3])!!}
+                    <div class="invalid-feedback" v-for="description in addEnvVariable.errors.description">@{{description}}
                     </div>
                 </div>
-
-            </div>
-        </div>
-    @endcan
+                <div class="form-group">
+                    {!!Form::label('value', __('Value'))!!}
+                    {!!Form::text('value', null, ['class'=> 'form-control', 'v-model'=> 'addEnvVariable.value',
+                    'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addEnvVariable.errors.value}'])!!}
+                    <div class="invalid-feedback" v-for="value in addEnvVariable.errors.value">@{{value}}</div>
+                </div>
+            </b-modal>
+        @endcan
+    </div>
 @endsection
 
 @section('js')
     <script src="{{mix('js/processes/environment-variables/index.js')}}"></script>
-
-    @can('create-environment_variables')
-        <script>
-          new Vue({
-            el: '#createEnvironmentVariable',
-            data: {
-              errors: {},
-              name: '',
-              description: '',
-              value: '',
-              disabled: false,
-            },
-            methods: {
-              onClose() {
-                this.name = '';
-                this.description = '';
-                this.value = '';
-                this.errors = {};
-              },
-              onSubmit() {
-                this.errors = {};
-                //single click
-                if (this.disabled) {
-                  return
-                }
-                this.disabled = true;
-                ProcessMaker.apiClient.post('environment_variables', {
-                  name: this.name,
-                  description: this.description,
-                  value: this.value
-                })
-                  .then(response => {
-                    ProcessMaker.alert('{{__('The environment variable was created.')}}', 'success');
-                    window.location = '/designer/environment-variables';
-                  })
-                  .catch(error => {
-                    this.disabled = false;
-                    if (error.response.status === 422) {
-                      this.errors = error.response.data.errors
-                    }
-                  });
-              }
-            }
-          })
-        </script>
-    @endcan
 @endsection


### PR DESCRIPTION
Form fields were not resetting when the modal was closed. Fixed it by converting the standard bootstrap modal to a Vue bootstrap modal

closes #2565 