### PR TITLE
Show process in all caregories it belongs to when starting new request

### DIFF
--- a/resources/js/components/requests/modal.vue
+++ b/resources/js/components/requests/modal.vue
@@ -128,7 +128,7 @@
             this.filter +
             "&order_by=category.name,name" +
             "&order_direction=asc,asc" +
-            "&include=events,category"
+            "&include=events,categories"
           )
           .then(response => {
             let data = response.data;
@@ -153,16 +153,15 @@
         // We need to pull out the category name, and if it's available in our processes, append it there
         // if not, create the category in our processes array and then append it
         for (let process of data) {
-          let category = process.category
-            ? process.category.name
-            : "Uncategorized";
-          // Now determine if we have it defined in our processes list
-          if (typeof this.processes[category] == "undefined") {
-            // Create it
-            this.processes[category] = [];
+          for (let category of process.categories) {
+            // Now determine if we have it defined in our processes list
+            if (typeof this.processes[category.name] == "undefined") {
+              // Create it
+              this.processes[category.name] = [];
+            }
+            // Now append
+            this.processes[category.name].push(process);
           }
-          // Now append
-          this.processes[category].push(process);
         }
       }
     }


### PR DESCRIPTION
Fixes #2521 

Test by creating a process that exists in 2 categories (must have a start event). Click the +request button and verify the same process is under both categories.