### PR TITLE
Remove unneeded sections from Request detail screen

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -256,11 +256,13 @@
                               @endforeach
                             </li>
                             @endif
+                            @if ($request->participants->count())
                             <li class="list-group-item">
                                 <h5>{{__('Participants')}}</h5>
                                 <avatar-image size="32" class="d-inline-flex pull-left align-items-center"
                                               :input-data="participants" hide-name="true"></avatar-image>
                             </li>
+                            @endif
                             <li class="list-group-item">
                                 <h5>@{{statusLabel}}</h5>
                                 <i class="far fa-calendar-alt"></i>

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -210,6 +210,7 @@
                             <h4 style="margin:0; padding:0; line-height:1">@{{ __(statusLabel) }}</h4>
                         </div>
                         <ul class="list-group list-group-flush w-100">
+                            @if($request->user_id)
                             <li class="list-group-item">
                                 <h5>{{__('Requested By')}}</h5>
                                 <avatar-image v-if="userRequested" size="32"
@@ -217,7 +218,7 @@
                                               :input-data="requestBy" display-name="true"></avatar-image>
                                 <span v-if="!userRequested">{{__('Web Entry')}}</span>
                             </li>
-
+                            @endif
                             @if($canCancel == true && $request->status === 'ACTIVE')
                                 <template>
                                     <li class="list-group-item">


### PR DESCRIPTION
## Changes
- Removes the **Participants** section from a Request detail screen if a Request has no participants
- Removes the **Requested By** section from a Request detail screen if a Request has no requester

## Testing
- Create a process that will have no participants (i.e. a process with a Start Timer Event connected directly to an End Event)
- Wait for the process to run, then view its Request detail screen
- There should be no Requested By or Participants section

## Screenshot
![Screen Shot 2019-11-21 at 8 26 20 AM](https://user-images.githubusercontent.com/867714/69356638-a4c07680-0c38-11ea-8bb4-d6418250aebe.png)

Closes #2535.