### PR TITLE
Bugfix/modal resets

### DIFF
--- a/resources/views/categories/list.blade.php
+++ b/resources/views/categories/list.blade.php
@@ -41,7 +41,7 @@
 </div>
 
 @can('create-process-categories')
-    <div class="modal" tabindex="-1" role="dialog" id="createCategory">
+    <div class="modal" tabindex="-1" role="dialog" id="createCategory" data-backdrop="static">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">

--- a/resources/views/processes/environment-variables/index.blade.php
+++ b/resources/views/processes/environment-variables/index.blade.php
@@ -44,7 +44,7 @@
     </div>
 
     @can('create-environment_variables')
-        <div class="modal" tabindex="-1" role="dialog" id="createEnvironmentVariable">
+        <div class="modal" tabindex="-1" role="dialog" id="createEnvironmentVariable" data-backdrop="static">
             <div class="modal-dialog modal-dialog-centered" role="document">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -46,7 +46,7 @@
 </div>
 
 @can('create-processes')
-    <div class="modal" tabindex="-1" role="dialog" id="addProcess">
+    <div class="modal" tabindex="-1" role="dialog" id="addProcess" data-backdrop="static">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">

--- a/resources/views/processes/scripts/list.blade.php
+++ b/resources/views/processes/scripts/list.blade.php
@@ -33,7 +33,7 @@
     </div>
 
     @can('create-scripts')
-        <div class="modal" tabindex="-1" role="dialog" id="addScript">
+        <div class="modal" tabindex="-1" role="dialog" id="addScript" data-backdrop="static">
             <div class="modal-dialog modal-dialog-centered" role="document">
                 <div class="modal-content">
                     <div class="modal-header">


### PR DESCRIPTION
<h2>Issue</h2>
When clicking outside of the modal, the modal closes but does not reset form fields.

<h2>Changes</h2>
Add an attribute to prevent the modal from closing when clicking outside of the modal. The modal can now only be closed when selecting either the 'Cancel' or 'X' buttons, this also triggers the modal's form fields to reset.

<h2>Testing</h2>
<p>Navigate to a modal (Process > + Process)</p>

**Test 1**
> Try clicking outside of the modal
**Expected Behavior:** Modal does not close

**Test 2**
> Open modal and fill out some fields
> Select the 'X' button
> Open modal 
**Expected Behavior:** Modal fields have been cleared.

**Test 3**
> Open modal and fill out some fields
> Select the 'Cancel' button
> Open modal 
**Expected Behavior:** Modal fields have been cleared.

Closes #2570, #2568, #2565, #2513 