### PR TITLE
Add computed data to task form for summary screen

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -87,7 +87,7 @@
                              role="tabpanel" aria-labelledby="summary-tab">
                             <template v-if="showSummary">
                                 <template v-if="showScreenSummary">
-                                    <task-screen ref="screen" :screen="screenSummary" :data="dataSummary"/>
+                                    <task-screen ref="screen" :screen="screenSummary.config" :data="dataSummary" :computed="screenSummary.computed" />
                                 </template>
                                 <template v-else>
                                     <template v-if="summary.length > 0">
@@ -375,7 +375,7 @@
            * Get Screen summary
            * */
           screenSummary() {
-            return this.request.summary_screen.config;
+            return this.request.summary_screen;
           },
           /**
            * prepare data screen


### PR DESCRIPTION
Needs https://github.com/ProcessMaker/screen-builder/pull/445

Fixes #2547 

Test:
- Import process attached to the issue. Verify Final Amount and Interest Earned are showing on the summary screen after the process has finished.
- Put the same fields and calculations somewhere in a screen form task in between and verify they display correctly on the task edit page when the process is in progress