### PR TITLE
redirect to the first page when process is archived

### DIFF
--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -248,9 +248,9 @@
                       .then(response => {
                         ProcessMaker.alert(
                             this.$t("The process was archived."),
-                            "warning"
+                            "success"
                         );
-                        this.$emit("reload");
+                        this.$refs.pagination.loadPage(1);
                       });
                 }
             );


### PR DESCRIPTION
<h2>Issue</h2>
When a process is archived, did not redirect to the processes list the first page, displayed no data. Also displayed the yellow warning alert instead of the green success alert.

<h2>Changes</h2>

- Changed the yellow warning alert to the green success alert
- Reload the first page when the process has been successfully archived.

<h2>How to Test</h2>

> 
- Create multiple processes that will paginate the process list by at least 2 pages. 
- On the second page archive a process
**Expected Results:**
A green success alert will appear. 
Redirected to the process list on the first page with displaying data. 
> 

closes #2557 