### PR TITLE
Save script and screen categories with export

### DIFF
--- a/ProcessMaker/Jobs/ExportProcess.php
+++ b/ProcessMaker/Jobs/ExportProcess.php
@@ -112,7 +112,7 @@ class ExportProcess implements ShouldQueue
      */
     private function packageProcessCategory()
     {
-        $this->package['process_category'] = $this->process->category->toArray();
+        $this->package['process_categories'] = $this->process->categories->toArray();
     }
 
     /**
@@ -123,6 +123,7 @@ class ExportProcess implements ShouldQueue
     private function packageScreens()
     {
         $this->package['screens'] = [];
+        $this->package['screen_categories'] = [];
 
         $screenIds = [];
 
@@ -144,7 +145,9 @@ class ExportProcess implements ShouldQueue
             $screens = Screen::whereIn('id', $screenIds)->get();
 
             $screens->each(function ($screen) {
-                $this->package['screens'][] = $screen->toArray();
+                $screenArray = $screen->toArray();
+                $screenArray['categories'] = $screen->categories->toArray();
+                $this->package['screens'][] = $screenArray;
             });
         }
     }
@@ -169,8 +172,10 @@ class ExportProcess implements ShouldQueue
         if (count($scriptIds)) {
             $scripts = Script::whereIn('id', $scriptIds)->get();
 
-            $scripts->each(function ($scripts) {
-                $this->package['scripts'][] = $scripts->toArray();
+            $scripts->each(function ($script) {
+                $scriptArray = $script->toArray();
+                $scriptArray['categories'] = $script->categories->toArray();
+                $this->package['scripts'][] = $scriptArray;
             });
         }
     }

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -9,7 +9,6 @@ use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use ProcessMaker\Models\User;
 use ProcessMaker\Models\Process;
-use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessNotificationSetting;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\Script;
@@ -389,6 +388,14 @@ class ImportProcess implements ShouldQueue
                 $new->created_at = $this->formatDate($screen->created_at);
                 $new->save();
 
+                // save categories
+                if (isset($screen->categories)) {
+                    foreach ($screen->categories as $categoryDef) {
+                        $category = $this->saveCategory('screen', $categoryDef);
+                        $new->categories()->save($category);
+                    }
+                }
+
                 $this->updateScreenRefs($screen->id, $new->id, $process);
 
                 $this->new['screens'][] = $new;
@@ -456,6 +463,14 @@ class ImportProcess implements ShouldQueue
                 $new->code = $script->code;
                 $new->created_at = $this->formatDate($script->created_at);
                 $new->save();
+                
+                // save categories
+                if (isset($script->categories)) {
+                    foreach ($script->categories as $categoryDef) {
+                        $category = $this->saveCategory('script', $categoryDef);
+                        $new->categories()->save($category);
+                    }
+                }
 
                 $this->updateScriptRefs($script->id, $new->id);
 
@@ -477,25 +492,35 @@ class ImportProcess implements ShouldQueue
      *
      * @return void
      */
-    private function saveProcessCategory($processCategory)
+    private function saveCategory($type, $category)
     {
+        if (!array_key_exists($type . '_categories', $this->new)) {
+            $this->new[$type . '_categories'] = [];
+        };
+
+        // use ProcessMaker\Models\ProcessCategory;
+        $class = '\\ProcessMaker\\Models\\' . ucfirst($type) . 'Category';
+
         try {
-            $existing = ProcessCategory::where('name', $processCategory->name)->first();
-            $this->prepareStatus('process_category', true);
+            $existing = $class::where('name', $category->name)->first();
+            $this->prepareStatus($type . '_categories', true);
             if ($existing) {
-                $this->new['process_category'] = $existing;
+                $this->new[$type . '_categories'][] = $existing;
+                $new = $existing;
             } else {
-                $new = new ProcessCategory;
-                $new->name = $processCategory->name;
-                $new->status = $processCategory->status;
-                $new->created_at = $this->formatDate($processCategory->created_at);
+                $new = new $class;
+                $new->name = $category->name;
+                $new->status = $category->status;
+                $new->created_at = $this->formatDate($category->created_at);
                 $new->save();
 
-                $this->new['process_category'] = $new;
+                $this->new[$type . '_categories'][] = $new;
             }
-            $this->finishStatus('process_category');
+            $this->finishStatus($type . '_categories');
+            return $new;
         } catch (\Exception $e) {
-            $this->finishStatus('process_category', true);
+            $this->finishStatus($type . '_categories', true);
+            return null;
         }
     }
 
@@ -512,7 +537,7 @@ class ImportProcess implements ShouldQueue
         try {
             $this->prepareStatus('process', true);
             $new = new Process;
-            $new->process_category_id = $this->new['process_category']->id;
+            $new->process_category_id = array_shift($this->new['process_categories'])->id;
             $new->user_id = $this->currentUser()->id;
             $new->bpmn = $process->bpmn;
             $new->description = $process->description;
@@ -521,6 +546,8 @@ class ImportProcess implements ShouldQueue
             $new->created_at = $this->formatDate($process->created_at);
             $new->deleted_at = $this->formatDate($process->deleted_at);
             $new->save();
+
+            $new->categories()->saveMany($this->new['process_categories']);
 
             if (property_exists($process, 'notifications')) {
                 foreach ($process->notifications as $notifiable => $notificationTypes) {
@@ -641,7 +668,15 @@ class ImportProcess implements ShouldQueue
             ];
         }
 
-        $this->saveProcessCategory($this->file->process_category);
+        if (isset($this->file->process_category)) {
+            $this->saveCategory('process', $this->file->process_category);
+        }
+        if (isset($this->file->process_categories)) {
+            foreach($this->file->process_categories as $category) {
+                $this->saveCategory('process', $category);
+            }
+        }
+
         $this->saveProcess($this->file->process);
         $this->saveScripts($this->file->scripts);
         $this->saveScreens($this->file->screens, $this->file->process);

--- a/tests/Feature/Processes/ExportImportTest.php
+++ b/tests/Feature/Processes/ExportImportTest.php
@@ -13,6 +13,9 @@ use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 use ProcessMaker\Providers\WorkflowServiceProvider;
+use ProcessMaker\Models\ProcessCategory;
+use ProcessMaker\Models\ScriptCategory;
+use ProcessMaker\Models\ScreenCategory;
 
 class ExportImportTest extends TestCase
 {
@@ -151,6 +154,19 @@ class ExportImportTest extends TestCase
         // Get the process we'll be testing on
         $process = Process::where('name', 'Leave Absence Request')->first();
 
+
+        // Add additional categories
+        $secondProcessCategory = factory(ProcessCategory::class)->create(['name' => 'Second Category']);
+        $process->categories()->save($secondProcessCategory);
+
+        $script = Script::where('title', 'Get available days Script')->firstOrFail();
+        $secondScriptCategory = ScriptCategory::create(['name' => 'Other Script Category']);
+        $script->categories()->save($secondScriptCategory);
+        
+        $screen = Screen::where('title', 'Request Time Off')->firstOrFail();
+        $secondScreenCategory = ScreenCategory::create(['name' => 'Other Screen Category']);
+        $screen->categories()->save($secondScreenCategory);
+
         // Test to ensure our standard user cannot export a process
         $this->user = $standardUser;
         $response = $this->apiCall('POST', "/processes/{$process->id}/export");
@@ -191,11 +207,22 @@ class ExportImportTest extends TestCase
         $response = $this->apiCall('POST', "/processes/import", [
             'file' => $file,
         ]);
+        // dd($response->json());
         $response->assertJsonStructure(['status' => [], 'assignable' => []]);
         $response->assertStatus(200);
         $this->assertDatabaseHas('processes', ['name' => 'Leave Absence Request 2']);
         $this->assertDatabaseHas('screens', ['title' => 'Request Time Off 2']);
         $this->assertDatabaseHas('scripts', ['title' => 'Get available days Script 2']);
+
+        // Assert items were added to both categories
+        $this->assertCount(2, $process->category->refresh()->processes);
+        $this->assertCount(2, $secondProcessCategory->refresh()->processes);
+        
+        $this->assertCount(2, $script->category->refresh()->scripts);
+        $this->assertCount(2, $secondScriptCategory->refresh()->scripts);
+
+        $this->assertCount(2, $screen->category->refresh()->screens);
+        $this->assertCount(2, $secondScreenCategory->refresh()->screens);
     }
 
     /**


### PR DESCRIPTION
Fixes #2596 

To test:
- Create a screen that belongs to multiple categories
- Create a script that belongs to multiple categories
- Create a process that belongs to multiple categories
- Use the screen and script somewhere in the process
- Export the process
- Clear the db (optional)
- Import the process
- Verify the imported process, script, and screen are assigned to correct categories