### PR TITLE
Fix failing dusk test

### DIFF
--- a/tests/Browser/Pages/RequestsPage.php
+++ b/tests/Browser/Pages/RequestsPage.php
@@ -41,6 +41,7 @@ class RequestsPage extends Page
             '@vuetable' => '.data-table',
             '@pmql' => '#search-manual input',
             '@search-button' => '#search-actions button:first-of-type',
+            '@advanced-search-button' => '#search-actions button:last-of-type',
         ];
     }
 }

--- a/tests/Browser/RequestsSearchTest.php
+++ b/tests/Browser/RequestsSearchTest.php
@@ -27,7 +27,7 @@ class RequestsSearchTest extends DuskTestCase
         $this->browse(function (Browser $browser) use ($user) {
             $browser->loginAs($user)
                 ->visit(new RequestsPage)
-                ->click("button[data-original-title='Advanced Search']")
+                ->click("@advanced-search-button") 
                 ->waitFor('@pmql')
 
                 ->value('@pmql', '')->type('@pmql', 'foo = "bar"')


### PR DESCRIPTION
<h2>Issue</h2>
A dusk test was failing when looking for an attribute on a button that no longer existed.

<h2>Changes</h2>
Modified test to look for the last button.

