### PR TITLE
Export with All Caps

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScreenController.php
@@ -95,7 +95,7 @@ class ScreenController extends Controller
      */
     public function download(Screen $screen, $key)
     {
-        $fileName = snake_case($screen->title) . '.json';
+        $fileName = trim($screen->title) . '.json';
         $fileContents = Cache::get($key);
 
         if (! $fileContents) {

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -191,7 +191,7 @@ class ProcessController extends Controller
      */
     public function download(Process $process, $key)
     {
-        $fileName = snake_case($process->name) . '.json';
+        $fileName = trim($process->name) . '.json';
         $fileContents = Cache::get($key);
 
         if (!$fileContents) {

--- a/tests/Feature/Processes/ExportImportScreenTest.php
+++ b/tests/Feature/Processes/ExportImportScreenTest.php
@@ -107,7 +107,7 @@ class ExportImportScreenTest extends TestCase
         // Download a type file: processmaker.
         $response = $this->webCall('GET', $response->json('url'));
         $response->assertStatus(200);
-        $response->assertHeader('content-disposition', 'attachment; filename=leave_absence_request.json');
+        $response->assertHeader('content-disposition', 'attachment; filename="Leave Absence Request.json"');
 
         // Get our file contents (we have to do it this way because of
         // Symfony's weird response API)

--- a/tests/Feature/Processes/ExportImportScreenTest.php
+++ b/tests/Feature/Processes/ExportImportScreenTest.php
@@ -61,7 +61,7 @@ class ExportImportScreenTest extends TestCase
         // Test to ensure we can download the exported file
         $response = $this->webCall('GET', $response->json('url'));
         $response->assertStatus(200);
-        $response->assertHeader('content-disposition', 'attachment; filename=approve.json');
+        $response->assertHeader('content-disposition', 'attachment; filename=Approve.json');
 
         // Get our file contents (we have to do it this way because of
         // Symfony's weird response API)


### PR DESCRIPTION
Resolves #2543 

The problem was caused for the use of the deprecated function snake_case. It was removed and now the exported file respects the original casing and formatting the process and screen names