### PR TITLE
Error shown in category when importing a process

### DIFF
--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -463,7 +463,7 @@ class ImportProcess implements ShouldQueue
                 $new->code = $script->code;
                 $new->created_at = $this->formatDate($script->created_at);
                 $new->save();
-                
+
                 // save categories
                 if (isset($script->categories)) {
                     foreach ($script->categories as $categoryDef) {
@@ -517,9 +517,11 @@ class ImportProcess implements ShouldQueue
                 $this->new[$type . '_categories'][] = $new;
             }
             $this->finishStatus($type . '_categories');
+            $this->finishStatus($type . '_category');
             return $new;
         } catch (\Exception $e) {
             $this->finishStatus($type . '_categories', true);
+            $this->finishStatus($type . '_category', true);
             return null;
         }
     }

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -517,11 +517,9 @@ class ImportProcess implements ShouldQueue
                 $this->new[$type . '_categories'][] = $new;
             }
             $this->finishStatus($type . '_categories');
-            $this->finishStatus($type . '_category');
             return $new;
         } catch (\Exception $e) {
             $this->finishStatus($type . '_categories', true);
-            $this->finishStatus($type . '_category', true);
             return null;
         }
     }
@@ -736,8 +734,8 @@ class ImportProcess implements ShouldQueue
     {
         $this->status = [];
 
-        $this->status['process_category'] = [
-            'label' => __('Process Category'),
+        $this->status['process_categories'] = [
+            'label' => __('Process Categories'),
             'success' => false,
             'message' => __('Starting')];
 


### PR DESCRIPTION
Resolves #2622 

The problem was caused for not setting the status for the key 'category'. Not the keys 'categories' and  'category' are updated when importing a process.
