### PR TITLE
Add support for Redis and Horizon prefixing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,6 @@ DATA_DB_USERNAME=homestead
 DATA_DB_PASSWORD=secret
 APP_URL=https://processmaker.local.processmaker.com
 TELESCOPE_ENABLED=false
+REDIS_CLIENT=predis
+REDIS_PREFIX=
+HORIZON_PREFIX=horizon:

--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -76,7 +76,10 @@ class Install extends Command
             'DATE_FORMAT' => '"m/d/Y H:i"',
             'MAIN_LOGO_PATH' => '"/img/processmaker_logo.png"',
             'ICON_PATH_PATH' => '"/img/processmaker_icon.png"',
-            'LOGIN_LOGO_PATH' => '"img/processmaker_login.png"'
+            'LOGIN_LOGO_PATH' => '"img/processmaker_login.png"',
+            'REDIS_CLIENT' => 'predis',
+            'REDIS_PREFIX' => null,
+            'HORIZON_PREFIX' => 'horizon:',
         ];
 
         // Configure the filesystem to be local

--- a/config/database.php
+++ b/config/database.php
@@ -80,7 +80,7 @@ return [
     |
     */
     'redis' => [
-        'client' => 'predis',
+        'client' => env('REDIS_CLIENT', 'predis'),
         'default' => [
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),

--- a/config/database.php
+++ b/config/database.php
@@ -86,6 +86,7 @@ return [
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', '6379'),
             'database' => 0,
+            'prefix' => env('REDIS_PREFIX', null),
         ],
     ],
 ];


### PR DESCRIPTION
## Changes
- Adds variables that can be changed via the .env file
  - REDIS_CLIENT will allow the user to choose phpredis, which supports prefixing
  - REDIS_PREFIX will allow the user to set a Redis prefix
  - HORIZON_PREFIX will allow the user to set a Horizon-specific prefix

## Testing Instructions
- Follow all of the instructions laid out in the [Prefixing Redis and Horizon with PHPRedis](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/595001836/Prefixing+Redis+and+Horizon+with+PHPRedis) document. The **Verifying Your Changes** section includes instructions on verifying that your configuration changes are working.

Closes #2489.