### PR TITLE
Remove Birthdate from Validation Rules

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -134,8 +134,7 @@ class User extends Authenticatable implements HasMedia
             'lastname' => ['required', 'max:50'],
             'email' => ['required', 'email', $unique, $checkUserIsDeleted],
             'status' => ['required', 'in:ACTIVE,INACTIVE'],
-            'password' => 'required|sometimes|min:6',
-            'birthdate' => 'date'
+            'password' => 'required|sometimes|min:6'
         ];
     }
 


### PR DESCRIPTION
<h2>Issue</h2>
The birthdate is not present in the edit page, but the validator is requesting some value for this field of the table.
Closes #2632 

<h2>Changes</h2>
Remove 'birthdate' from the validation rules.

<h2>Testing</h2>

- Create a user
- Edit user, changing some field.

**Expected behavior:** User is successfully updated. 

