### PR TITLE
Tooltip improvements

### DIFF
--- a/resources/js/components/Sidebaricon.vue
+++ b/resources/js/components/Sidebaricon.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="filter-bar justify-content-between" id="Sidebaricon">
+    <div class="filter-bar justify-content-between" id="Sidebaricon" v-b-tooltip.hover.right="{ animation: false, disabled: expanded(), boundary: 'viewport', delay: { show: 0, hide: 0 } }" :title="item.title">
       <li class="nav-item">
-        <a :href="item.url" class="nav-link" v-b-tooltip.hover.bottomleft="item.title"  @click="toggle" :target="item.attributes.target">
+        <a :href="item.url" class="nav-link"  @click="toggle" :target="item.attributes.target">
           <i v-if="item.attributes.icon" class="fas nav-icon" :class="item.attributes.icon" ></i>
           <img v-if="item.attributes.file" :src="item.attributes.file" class="nav-icon" id="custom_icon">
           <span class="nav-text" v-if="expanded()" v-cloak >
@@ -12,10 +12,10 @@
         </a>
         <ul v-if="item.children && item.children.length" class="nav nav-list flex-column" v-show="isOpen">
             <li v-for="item in item.children" :key="item.id" class="nav-item nav-pl">
-              <a :href="item.url" class="nav-link"  v-b-tooltip.hover.bottomleft="item.title" v-show="item.attributes.icon">
+              <a :href="item.url" class="nav-link" v-show="item.attributes.icon">
                 <i class="fas nav-icon" :class="item.attributes.icon" ></i> <span class="nav-text" v-if="expanded()" v-cloak>{{item.title}}<span v-if="count !== null" class="nav-badge float-right">{{ count }}</span></span>
               </a>
-              <a :href="item.url" class="nav-link"  v-b-tooltip.hover.bottomleft="item.title" v-show="item.attributes.file">
+              <a :href="item.url" class="nav-link" v-show="item.attributes.file">
                 <img :src="item.attributes.file" class="nav-icon" id="custom_icon"><span class="nav-text" v-if="expanded()" v-cloak>{{item.title}}<span v-if="count !== null" class="nav-badge float-right">{{ count }}</span></span>
               </a>
             </li>

--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -71,8 +71,8 @@ $pagination-bg: $body-bg;
 $pagination-border-width: 0px;
 
 //tooltip
-$tooltip-bg: white;
-$tooltip-color: $secondary;
+$tooltip-bg: $secondary;
+$tooltip-color: white;
 
 //breadcrumbs
 // $breadcrumb-active-color: $primary;


### PR DESCRIPTION
## Changes
- Improves tooltip visibility by using a gray background and white text
- Improves tooltips on navigation sidebar by moving them to the right, disabling them when expanded, and removing the animation and delay

## Before
![Screen Shot 2019-12-11 at 3 11 27 PM](https://user-images.githubusercontent.com/867714/70668469-91496f80-1c28-11ea-8986-52592d29ce31.png)
![Screen Shot 2019-12-11 at 3 11 33 PM](https://user-images.githubusercontent.com/867714/70668468-91496f80-1c28-11ea-8d33-cbe5c1641d79.png)

## After
![Screen Shot 2019-12-11 at 2 59 41 PM](https://user-images.githubusercontent.com/867714/70668400-5ba48680-1c28-11ea-8b56-9ec6ff905dbc.png)
![Screen Shot 2019-12-11 at 2 59 19 PM](https://user-images.githubusercontent.com/867714/70668401-5ba48680-1c28-11ea-8b88-a12b3506dbe2.png)


Closes #2659.