### PR TITLE
 Vue Tables Clearing Incorrectly 

### DIFF
--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="data-table">
     <data-loading
-            :for="/\/processes\?page|\/processes\?status/"
+            :for="/\/processes\?page/"
             v-show="shouldShowLoader"
             :empty="$t('No Data Available')"
             :empty-desc="$t('')"


### PR DESCRIPTION
The problem happened when the Process List in the Archived Process tab finished. As there aren't archived processes the event 'api-data-no-results' was sent. 

The component ProcessesListing.vue, listen to this event do determine to show or hide  the process list or the data nod found message. 

The fix consists in listening to the call of active processes only.