### PR TITLE
Process Screens Not Importing

### DIFF
--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -379,9 +379,16 @@ class ImportProcess implements ShouldQueue
             $this->prepareStatus('screens', count($screens) > 0);
             foreach ($screens as $screen) {
                 $new = new Screen;
-                $new->fill((array)$screen);
-                $new->title = $this->formatName($screen->title, 'title', Screen::class);
+                $new->computed = $screen->computed;
+                $new->config = $screen->config;
                 $new->created_at = $this->formatDate($screen->created_at);
+                $new->custom_css = $screen->custom_css;
+                $new->description = $screen->description;
+                $new->title = $this->formatName($screen->title, 'title', Screen::class);
+                $new->type = $screen->type;
+                if (property_exists($screen, 'watchers')) {
+                    $new->watchers = $screen->watchers;
+                }
                 $new->save();
 
                 // save categories


### PR DESCRIPTION
Resolves #2678 

The problem was casued by the line  $model->fill((array)...) of the Jobs/ImportProcess.php file. The problem is caused for the presence of JSON columns in the screens table.

The issue was introducing when resolving the issue:
 https://github.com/ProcessMaker/processmaker/issues/2640

### For testing:

- Create a process with screens that have watchers.
- Export the process and verify that the process' screens are correctly imported including the watchers.