### PR TITLE
Fix Confirm Modal test

### DIFF
--- a/tests/js/components/ConfirmModal.test.js
+++ b/tests/js/components/ConfirmModal.test.js
@@ -41,7 +41,7 @@ describe('Component Confirm Modal', () => {
       }
     });
     expect(wrapper.find('.modal-title').text()).toBe(title);
-    expect(wrapper.find('.modal-body span').text()).toBe(message);
+    expect(wrapper.find('.modal-body div').text()).toBe(message);
 
   });
 

--- a/tests/js/components/ConfirmModal.test.js
+++ b/tests/js/components/ConfirmModal.test.js
@@ -41,7 +41,7 @@ describe('Component Confirm Modal', () => {
       }
     });
     expect(wrapper.find('.modal-title').text()).toBe(title);
-    expect(wrapper.find('.modal-body div').text()).toBe(message);
+    expect(wrapper.find('.modal-body').text()).toBe(message);
 
   });
 


### PR DESCRIPTION
Span was switched to div.
<img width="723" alt="Screen Shot 2020-01-06 at 9 46 12 AM" src="https://user-images.githubusercontent.com/6653340/71825227-64427e00-3069-11ea-8863-32bd2677b618.png">
