### PR TITLE
Changed text for "TimerEventDefinitionInterface"

### DIFF
--- a/ProcessMaker/Listeners/BpmnSubscriber.php
+++ b/ProcessMaker/Listeners/BpmnSubscriber.php
@@ -130,7 +130,7 @@ class BpmnSubscriber
     {
         $messages = [
             MessageEventDefinitionInterface::class => 'System is waiting to receive message ":event"',
-            TimerEventDefinitionInterface::class => 'System has schedules to execute a timer ":event"'
+            TimerEventDefinitionInterface::class => 'System has scheduled timer: ":event"'
         ];
         foreach ($event->getEventDefinitions() as $eventDefinition) {
             foreach ($messages as $interface => $message) {


### PR DESCRIPTION
Updated the grammatically incorrect sentence 'System has schedules to execute a timer ":event"' to a more accurate (and concise) 'System has scheduled timer: ":event"'