### PR TITLE
Navbar and breadcrumb improvements

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -52,6 +52,12 @@ window.ProcessMaker.nodeTypes.get = function (id) {
   return this.find(node => node.id === id);
 };
 
+// Setup breadcrumbs as a Vue component so that we can cloak it until Vue
+// has finished loading.
+new Vue({
+  el: '#breadcrumbs'
+});
+
 // Assign our navbar component to our global ProcessMaker object
 window.ProcessMaker.navbar = new Vue({
   el: "#navbar",

--- a/resources/js/components/AvatarImage.vue
+++ b/resources/js/components/AvatarImage.vue
@@ -7,7 +7,7 @@
             :src="timestamp(value.src)"
             :width="sizeImage"
             :height="sizeImage"
-            class="image"
+            :class="image"
             :title="value.tooltip"
           >
         </template>

--- a/resources/js/components/AvatarImage.vue
+++ b/resources/js/components/AvatarImage.vue
@@ -1,7 +1,7 @@
 <template>
   <span :class="classContainer">
     <template v-for="(value, key) in options">
-      <a :href="value.id" style="margin: 0 2px;">
+      <a :href="value.id">
         <template v-if="value.src" class="align-center">
           <img
             :src="timestamp(value.src)"

--- a/resources/js/components/NavbarProfile.vue
+++ b/resources/js/components/NavbarProfile.vue
@@ -3,43 +3,44 @@
     <div id="profileMenu">    
       <avatar-image
         id="avatarMenu"
-        class-container="d-flex m-1"
+        class-container="d-flex"
         size="40"
-        class-image="m-1"
+        class-image="m-0"
         :input-data="information"
+        hide-name="true"
       ></avatar-image>
     </div>
 
-    <b-popover target="profileMenu" placement="bottomleft" triggers="click blur">
+    <b-popover target="profileMenu" placement="bottomleft" offset="3" triggers="click blur">
       <template>
         <ul class="list-group list-group-flush px-1">
           <li class="list-group-item px-2">
             <a :href="user_id">
-              <i class="fas fa-user fa-fw fa-lg"></i>
+              <i class="fas fa-user fa-fw fa-lg mr-1"></i>
               {{$t('View')}} {{username}} {{$t('Profile')}}
             </a>
           </li>
           <li class="list-group-item px-2">
             <a href="/profile/edit">
-              <i class="fas fa-user-cog fa-fw fa-lg"></i>
+              <i class="fas fa-user-cog fa-fw fa-lg mr-1"></i>
               {{$t('Edit')}} {{username}} {{$t('Profile')}}
             </a>
           </li>
           <li class="list-group-item px-2">
             <a href="https://processmaker.gitbook.io/processmaker/" target="_blank">
-              <i data-v-2eb90a9e class="fas fa-question-circle fa-fw fa-lg"></i>
+              <i data-v-2eb90a9e class="fas fa-question-circle fa-fw fa-lg mr-1"></i>
               {{$t('Documentation')}}
             </a>
           </li>
           <li class="list-group-item px-2">
             <a href="/about">
-              <i class="fas fa-info-circle fa-fw fa-lg"></i>
+              <i class="fas fa-info-circle fa-fw fa-lg mr-1"></i>
               {{$t('About')}}
             </a>
           </li>
           <li class="list-group-item px-2">
             <a href="/logout">
-              <i class="fas fa-sign-out-alt fa-fw fa-lg"></i>
+              <i class="fas fa-sign-out-alt fa-fw fa-lg mr-1"></i>
               {{$t('Log Out')}}
             </a>
           </li>
@@ -134,12 +135,5 @@ export default {
   font-size: 12px;
   padding: 5px;
   width: 160px;
-}
-
-.avatar-image {
-  width: 40px;
-  height: 40px;
-  margin-left: -16px;
-  margin-top: -7px;
 }
 </style>

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -53,6 +53,15 @@ html {
   border-bottom: 0;
 }
 
+.navbar-logo {
+  max-height: 30px;
+  max-width: 100%;
+}
+
+button:focus.navbar-toggler {
+  outline: 0;
+}
+
 .navbar-light .navbar-nav .show > .nav-link,
 .navbar-light .navbar-nav .active > .nav-link,
 .navbar-light .navbar-nav .nav-link.show,

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -64,9 +64,10 @@
   <div id="sidebar" class="d-print-none" :class="{expanded: expanded}">
       @yield('sidebar')
   </div>
-
-  <div class="d-flex flex-grow-1 flex-column" style="overflow: hidden;">
-    @include('layouts.navbar')
+  <div class="d-flex flex-grow-1 flex-column overflow-hidden">
+    <div class="flex-grow-1">
+        @include('layouts.navbar')
+    </div>
     <div class="flex-grow-1 d-flex flex-column overflow-hidden h-100" id="mainbody">
       @yield('breadcrumbs')
       <div class="main flex-grow-1 h-100 overflow-auto {{$content_margin ?? 'py-3'}}">

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -1,9 +1,9 @@
-<b-navbar id="navbar" v-cloak toggleable="md" type="light" variant="light" class="d-print-none">
-    <div class="d-flex d-none d-xs-block d-md-none w-100">
+<b-navbar id="navbar" v-cloak toggleable="lg" type="light" variant="light" class="d-print-none">
+    <div class="d-flex d-none d-xs-block d-lg-none w-100">
         @php
             $loginLogo = \ProcessMaker\Models\Setting::getLogin();
         @endphp
-        <b-navbar-brand href="#" class="d-md-none pl-2"><img class="navbar-logo" src={{$loginLogo}}></b-navbar-brand>
+        <b-navbar-brand href="#" class="d-lg-none pl-2"><img class="navbar-logo" src={{$loginLogo}}></b-navbar-brand>
         <b-navbar-toggle class="ml-auto" target="nav_collapse"></b-navbar-toggle>
     </div>
 
@@ -32,12 +32,12 @@
                 <component id="navbar-request-button" v-bind:is="'request-modal'" url="{{ route('processes.index') }}" v-bind:permission="{{ \Auth::user()->hasPermissionsFor('processes') }}"></component>
             </b-nav-item>
 
-            <b-nav-item class="d-none d-md-block">
+            <b-nav-item class="d-none d-lg-block">
                 <notifications id="navbar-notifications-button" v-bind:is="'notifications'" v-bind:messages="messages">
                 </notifications>
             </b-nav-item>
-            <li class="separator d-none d-md-block"></li>
-            <li class="d-none d-md-block">
+            <li class="separator d-none d-lg-block"></li>
+            <li class="d-none d-lg-block">
                 @php
                     $items = [];
                     foreach ($dropdown_nav->items as $item ) {

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -1,10 +1,10 @@
-<b-navbar id="navbar" v-cloak  toggleable="md" type="light" variant="light" class="d-print-none">
-    <div class="d-flex d-block d-sm-none">
+<b-navbar id="navbar" v-cloak toggleable="md" type="light" variant="light" class="d-print-none">
+    <div class="d-flex d-none d-xs-block d-md-none w-100">
         @php
             $loginLogo = \ProcessMaker\Models\Setting::getLogin();
         @endphp
-        <b-navbar-brand href="#"><img class="img-fluid" src={{$loginLogo}}></b-navbar-brand></td>
-        <b-navbar-toggle target="nav_collapse"></b-navbar-toggle></td>
+        <b-navbar-brand href="#" class="d-md-none pl-2"><img class="navbar-logo" src={{$loginLogo}}></b-navbar-brand>
+        <b-navbar-toggle class="ml-auto" target="nav_collapse"></b-navbar-toggle>
     </div>
 
     <b-collapse is-nav id="nav_collapse">
@@ -28,16 +28,16 @@
         </b-navbar-nav>
 
         <b-navbar-nav class="d-flex align-items-center ml-auto">
-            <b-nav-item class="d-none d-lg-block">
+            <b-nav-item class="d-block">
                 <component id="navbar-request-button" v-bind:is="'request-modal'" url="{{ route('processes.index') }}" v-bind:permission="{{ \Auth::user()->hasPermissionsFor('processes') }}"></component>
             </b-nav-item>
 
-            <b-nav-item class="d-none d-lg-block">
+            <b-nav-item class="d-none d-md-block">
                 <notifications id="navbar-notifications-button" v-bind:is="'notifications'" v-bind:messages="messages">
                 </notifications>
             </b-nav-item>
-            <b-nav-item class="seperator d-none d-lg-block"></b-nav-item>
-            <li class="d-none d-lg-block">
+            <li class="separator d-none d-md-block"></li>
+            <li class="d-none d-md-block">
                 @php
                     $items = [];
                     foreach ($dropdown_nav->items as $item ) {
@@ -50,15 +50,17 @@
                     $items = json_encode($items);
                     $user = Auth::user();
                 @endphp
-                <navbar-profile :info="{{$user}}"  :items="{{$items}}"></navbar-profile>
+                <navbar-profile :info="{{$user}}" :items="{{$items}}"></navbar-profile>
             </li>
         </b-navbar-nav>
     </b-collapse>
 </b-navbar>
 <style lang="scss" scoped>
-    .seperator {
+    .separator {
         border-right: 1px solid rgb(227, 231, 236);
         height: 30px;
+        margin-left: 0.5rem;
+        margin-right: 1rem;
     }
     #navbar { margin-left:-10px }
 </style>

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -1,5 +1,5 @@
 <b-navbar id="navbar" v-cloak toggleable="lg" type="light" variant="light" class="d-print-none">
-    <div class="d-flex d-none d-xs-block d-lg-none w-100">
+    <div class="d-flex d-lg-none w-100">
         @php
             $loginLogo = \ProcessMaker\Models\Setting::getLogin();
         @endphp

--- a/resources/views/shared/breadcrumbs.blade.php
+++ b/resources/views/shared/breadcrumbs.blade.php
@@ -1,42 +1,42 @@
-<div id="breadcrumbs" {{$attributes ?? ''}} class="d-print-none">
-<nav aria-label="breadcrumb" >
-    <ol class="breadcrumb border-top border-bottom">
-        <li class="breadcrumb-item"><a href="/"><i class="fas fa-home"></i></a></li>
-        @foreach($routes as $title => $link)
-            @php
-                if (is_callable($link)) {
-                    list($title, $link) = $link();
-                }
-            @endphp
+<div id="breadcrumbs" {{$attributes ?? ''}} class="d-print-none" v-cloak>
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb border-top border-bottom">
+            <li class="breadcrumb-item"><a href="/"><i class="fas fa-home"></i></a></li>
+            @foreach($routes as $title => $link)
+                @php
+                    if (is_callable($link)) {
+                        list($title, $link) = $link();
+                    }
+                @endphp
 
-            @if ($loop->last)
-                <li class="breadcrumb-item active">
-            @else
-                <li class="breadcrumb-item">
-            @endif
+                @if ($loop->last)
+                    <li class="breadcrumb-item active">
+                @else
+                    <li class="breadcrumb-item">
+                @endif
 
-            @if ($link != null)
-                <a href="{{ $link }}">
+                @if ($link != null)
+                    <a href="{{ $link }}">
+                        {{ $title }}
+                    </a>
+                @else
                     {{ $title }}
-                </a>
-            @else
-                {{ $title }}
-            @endif
+                @endif
 
-            </li>
-        @endforeach
-    </ol>
+                </li>
+            @endforeach
+        </ol>
 
-    @if (isset($showModelerSaveButton) && $showModelerSaveButton == true)
-    <button
-        type="button"
-        class="btn btn-secondary btn-sm position-absolute modeler-save-button"
-        data-test="save-process"
-        onclick="window.ProcessMaker && window.ProcessMaker.EventBus.$emit('modeler-save')"
-    >
-        <i class="fas fa-save mr-1"></i>
-        {{__('Save')}}
-    </button>
-    @endif
-</nav>
+        @if (isset($showModelerSaveButton) && $showModelerSaveButton == true)
+        <button
+            type="button"
+            class="btn btn-secondary btn-sm position-absolute modeler-save-button"
+            data-test="save-process"
+            onclick="window.ProcessMaker && window.ProcessMaker.EventBus.$emit('modeler-save')"
+        >
+            <i class="fas fa-save mr-1"></i>
+            {{__('Save')}}
+        </button>
+        @endif
+    </nav>
 </div>


### PR DESCRIPTION
## Changes
- Adds Start Request button to mobile version of navbar
- Cloaks breadcrumbs until Vue is loaded so that we no longer see them before the main navbar
- Fixes an issue where Safari was cutting off the expanded navbar on mobile
- Fixes minor issues with spacing of the navbar avatar and profile menu

## Screenshots

Before
![Screen Shot 2020-01-06 at 2 54 19 PM](https://user-images.githubusercontent.com/867714/71854937-7ede1c80-3094-11ea-9ca3-df84d2c7e80f.png)

After
![Screen Shot 2020-01-06 at 2 53 49 PM](https://user-images.githubusercontent.com/867714/71854942-83a2d080-3094-11ea-9ff3-d659ffcaf8a4.png)

Closes #2578.