### PR TITLE
Add --rm flag when running docker containers

### DIFF
--- a/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
@@ -63,7 +63,7 @@ trait ScriptDockerBindingFilesTrait
         }
 
         $cmd .= config('app.processmaker_scripts_docker') . sprintf(
-            ' run %s %s %s %s 2>&1',
+            ' run --rm %s %s %s %s 2>&1',
             $parameters,
             $bindings,
             $image,

--- a/laravel-echo-server.json
+++ b/laravel-echo-server.json
@@ -8,6 +8,7 @@
 	],
 	"database": "redis",
 	"databaseConfig": {
+		"redis": {},
 		"sqlite": {
 			"databasePath": "/database/laravel-echo-server.sqlite"
 		}


### PR DESCRIPTION
Fixes #2715 

Remove containers after they run. Note this only applies to the runner function that binds files (normal docker execution). The function that copies files (test environment) already removes the container.

To test, check the total number of containers
`docker ps -a | wc -l`
Preview a script and check again. The number should not change.