### PR TITLE
Add preview message cards for file upload and download

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -54,9 +54,17 @@ window.ProcessMaker.nodeTypes.get = function (id) {
 
 // Setup breadcrumbs as a Vue component so that we can cloak it until Vue
 // has finished loading.
-new Vue({
-  el: '#breadcrumbs'
-});
+
+if (document.getElementById("breadcrumbs")) {
+  window.ProcessMaker.breadcrumbs = new Vue({
+    el: '#breadcrumbs',
+    data() {
+      return {
+        taskTitle: '',
+      }
+    }
+  });
+}
 
 // Assign our navbar component to our global ProcessMaker object
 window.ProcessMaker.navbar = new Vue({

--- a/resources/js/processes/screen-builder/components/file-download.vue
+++ b/resources/js/processes/screen-builder/components/file-download.vue
@@ -1,20 +1,25 @@
 <template>
   <div>
-    <div v-if="loading">
-      <i class="fas fa-cog fa-spin text-muted"></i>
-      {{$t('Loading...')}}
-    </div>
+    <b-card v-if="mode === 'preview'" class="mb-2">
+      {{ messageForPreview }}
+    </b-card>
     <div v-else>
-      <template v-if="! loading && files.data && files.data.length !== 0">
-        <div v-for="file in files.data">
-          <b-btn v-show="!isReadOnly" class="mb-2 d-print-none" variant="primary" @click="onClick(file)">
-            <i class="fas fa-file-download"></i> {{$t('Download')}}
-          </b-btn>
-          {{file.file_name}}
-        </div>
-      </template>
+      <div v-if="loading">
+        <i class="fas fa-cog fa-spin text-muted"></i>
+        {{$t('Loading...')}}
+      </div>
       <div v-else>
-        {{$t('No files available for download')}}
+        <template v-if="! loading && files.data && files.data.length !== 0">
+          <div v-for="file in files.data">
+            <b-btn v-show="!isReadOnly" class="mb-2 d-print-none" variant="primary" @click="onClick(file)">
+              <i class="fas fa-file-download"></i> {{$t('Download')}}
+            </b-btn>
+            {{file.file_name}}
+          </div>
+        </template>
+        <div v-else>
+          {{$t('No files available for download')}}
+        </div>
       </div>
     </div>
   </div>
@@ -56,6 +61,15 @@
       }
     },
     computed: {
+      messageForPreview() {
+        return this.$t(
+          'Download button for {{fileName}} will appear here.',
+          { fileName: this.name }
+        );
+      },
+      mode() {
+        return this.$root.$children[0].mode;
+      },
       isReadOnly() {
         return this.$attrs.readonly ? this.$attrs.readonly : false
       },

--- a/resources/js/processes/screen-builder/components/form/file-upload.vue
+++ b/resources/js/processes/screen-builder/components/form/file-upload.vue
@@ -1,8 +1,11 @@
 <template>
   <div>
     <label v-uni-for="name">{{ label }}</label>
-
+    <b-card v-if="mode === 'preview'" class="mb-2">
+      {{ $t('File uploads are unavailable in preview mode.') }}
+    </b-card>
     <uploader
+      v-else
       :key="reRenderKey"
       :options="options"
       ref="uploader"
@@ -41,6 +44,9 @@ export default {
   beforeMount() {
     this.getFileType();
   },
+  updated() {
+    this.removeDefaultClasses();
+  },
   mounted() {
     this.removeDefaultClasses();
 
@@ -60,6 +66,9 @@ export default {
 
   },
   computed: {
+    mode() {
+      return this.$root.$children[0].mode;
+    },
     classList() {
       return {
         "is-invalid": (this.validator && this.validator.errorCount) || this.error,
@@ -70,6 +79,10 @@ export default {
       return this.$refs.uploader.fileList.some(file => file._prevProgress < 1);
     },
     filesAccept() {
+      if (!this.accept) {
+        return null;
+      }
+
       let accept = [];
 
       (this.accept.split(',')).forEach(item => {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1032,5 +1032,7 @@
   "Requests In Progress": "Requests In Progress",
   "The variable, :variable, which equals \":value\", is not a valid User ID in the system": "The variable, :variable, which equals \":value\", is not a valid User ID in the system",
   "Variable Name of User ID Value": "Variable Name of User ID Value",
-  "By User ID": "By User ID"
+  "By User ID": "By User ID",
+  "File uploads are unavailable in preview mode.": "File uploads are unavailable in preview mode.",
+  "Download button for {{fileName}} will appear here.": "Download button for {{fileName}} will appear here."
 }

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -273,7 +273,7 @@
           task: {
             deep: true,
             handler(task) {
-              breadcrumbs.taskTitle = task.element_name;
+              window.ProcessMaker.breadcrumbs.taskTitle = task.element_name;
             }
           },
           showReassignment (show) {
@@ -480,14 +480,7 @@
           this.prepareTask(true);
         }
       });
-      const breadcrumbs = new Vue({
-        el: "#breadcrumbs",
-        data() {
-          return {
-            taskTitle: @json($task->element_name),
-          };
-        }
-      });
+      window.ProcessMaker.breadcrumbs.taskTitle = @json($task->element_name)
     </script>
 @endsection
 


### PR DESCRIPTION
Fixes #2720 
Fixes https://github.com/ProcessMaker/screen-builder/issues/494

Disable functionality and show messages for file uploads and downloads when previewing in screen builder.

![image](https://user-images.githubusercontent.com/2546850/72027438-dd8dcc80-3233-11ea-855c-734f5f7bff60.png)

![image](https://user-images.githubusercontent.com/2546850/72027451-ea122500-3233-11ea-90b1-6be91731ec97.png)
