### PR TITLE
Fixing missing status translations for groups, users & categories.

### DIFF
--- a/resources/js/admin/groups/components/GroupsListing.vue
+++ b/resources/js/admin/groups/components/GroupsListing.vue
@@ -129,9 +129,9 @@ export default {
       return (
         '<i class="fas fa-circle ' +
         bubbleColor[status] +
-        ' small"></i> ' +
-        status.charAt(0).toUpperCase() +
-        status.slice(1)
+        ' small"></i><span class="text-capitalize"> ' +
+        this.$t(status.charAt(0).toUpperCase() + status.slice(1)) +
+        '</span>'
       );
     },
     onEdit(data, index) {

--- a/resources/js/admin/groups/components/UsersInGroupListing.vue
+++ b/resources/js/admin/groups/components/UsersInGroupListing.vue
@@ -93,8 +93,9 @@
         return (
           '<i class="fas fa-circle ' +
           bubbleColor[status] +
-          ' small"></i> ' +
-          this.$t(status.charAt(0).toUpperCase() + status.slice(1))
+          ' small"></i><span class="text-capitalize"> ' +
+          this.$t(status.charAt(0).toUpperCase() + status.slice(1)) +
+          '</span>'
         );
       },
       onEdit(data, index) {

--- a/resources/js/admin/users/components/UsersListing.vue
+++ b/resources/js/admin/users/components/UsersListing.vue
@@ -141,8 +141,8 @@ export default {
         '<i class="fas fa-circle ' +
         bubbleColor[status] +
         ' small"></i><span class="text-capitalize"> ' +
-        this.$t(status) +
-        "</span>"
+        this.$t(status.charAt(0).toUpperCase() + status.slice(1)) +
+        '</span>'
       );
     },
     goToEdit(data) {

--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -179,10 +179,21 @@
             break;
         }
       },
-      formatStatus (value) {
-        let response =
-          "<i class=\"fas fa-circle " + value.toLowerCase() + "\"></i> ";
-        return response + _.capitalize(value);
+      formatStatus(status) {
+        status = status.toLowerCase();
+        let bubbleColor = {
+          active: "text-success",
+          inactive: "text-danger",
+          draft: "text-warning",
+          archived: "text-info"
+        };
+        return (
+          '<i class="fas fa-circle ' +
+          bubbleColor[status] +
+          ' small"></i><span class="text-capitalize"> ' +
+          this.$t(status.charAt(0).toUpperCase() + status.slice(1)) +
+          '</span>'
+        );
       }
     }
   };

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -57,7 +57,7 @@
                         </div>
                         <div class="form-group mt-3">
                             {!! Form::label('status', __('Status')) !!}
-                            {!! Form::select('status', ['ACTIVE' => __('active'), 'INACTIVE' => __('inactive')], null, [
+                            {!! Form::select('status', ['ACTIVE' => __('active'), 'INACTIVE' => __('Inactive')], null, [
                             'id' => 'status',
                             'class' => 'form-control',
                             'v-model' => 'formData.status',

--- a/resources/views/categories/list.blade.php
+++ b/resources/views/categories/list.blade.php
@@ -59,7 +59,7 @@
                         </div>
                         <div class="form-group">
                             {!! Form::label('status', __('Status')) !!}
-                            {!! Form::select('status', ['ACTIVE' => __('active'), 'INACTIVE' => __('inactive')], null, ['id' => 'status',
+                            {!! Form::select('status', ['ACTIVE' => __('active'), 'INACTIVE' => __('Inactive')], null, ['id' => 'status',
                             'class' => 'form-control', 'v-model' => 'status', 'v-bind:class' => '{"form-control":true, "is-invalid":errors.status}']) !!}
                             <div class="invalid-feedback" v-for="status in errors.status">@{{status}}</div>
                         </div>


### PR DESCRIPTION
For the edit.blade and list.blade files, I think this is more of a bandaid than an actual fix. My theory is something is sending the "inactive" status improperly, so PM4 is interpreting it everywhere as "inactive" as opposed to "Inactive", and that capital "I" is required for the translation to work correctly.

JIRA: https://processmaker.atlassian.net/browse/FOUR-276