### PR TITLE
Display usernames alongside full names for adding users to a group

### DIFF
--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -156,7 +156,7 @@
 
                                     <template slot="option" slot-scope="props">
                                         <div class="option__desc d-flex align-items-center">
-                                            <span class="option__title mr-1">@{{ props.option.fullname }}</span>
+                                            <span class="option__title mr-1">@{{ props.option.fullname }} (@{{ props.option.username }})</span>
                                         </div>
                                     </template>
                                 </multiselect>


### PR DESCRIPTION
This will stop any problems that can occur if a company has two users with the same names, but different usernames.
Jira: https://processmaker.atlassian.net/browse/FOUR-956

This is something that should probably be added to the modeler for assignments as well.