### PR TITLE
Display icon when a file is already uploaded in file upload control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18394,9 +18394,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-uploader.js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/simple-uploader.js/-/simple-uploader.js-0.4.2.tgz",
-      "integrity": "sha512-pbEjt8UgLqbo8DF2PNvlVFc/df8o71YqP03RkRaEI9yJbGsHuQnYwep4gboLnj284wLastFRt01P2xpJqZUcag=="
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/simple-uploader.js/-/simple-uploader.js-0.5.4.tgz",
+      "integrity": "sha512-Dmysgp0wyKqGdnZ9qnxS7QTg/Hfr25GxKM2XlrEnmzSPFmKroFqzW4Qaq/AbJDBvXv4YPGqS3S5YfVI3UxAU0A=="
     },
     "slash": {
       "version": "1.0.0",
@@ -20149,11 +20149,11 @@
       "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
     },
     "vue-simple-uploader": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/vue-simple-uploader/-/vue-simple-uploader-0.5.6.tgz",
-      "integrity": "sha512-nEn2626Sn9zxI5nUTIJ4KTy38GesQjDwRNwYWfMqLwyZql4rdGXxZ9XlhLKzGbsc+HEOtjWqlqraAMyyAXjhzQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/vue-simple-uploader/-/vue-simple-uploader-0.7.4.tgz",
+      "integrity": "sha512-33uv07lkVj7m9gI7IIrQHAUcZkvl70g55lxnfnO/MZ8icwqiemW9Ah4ZexGWNrEfL1p6fV54PlOGICU17aBPFQ==",
       "requires": {
-        "simple-uploader.js": "^0.4.2"
+        "simple-uploader.js": "^0.5.4"
       }
     },
     "vue-style-loader": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "vue-password": "^1.2.0",
     "vue-resource": "^1.5.1",
     "vue-router": "^3.1.3",
-    "vue-simple-uploader": "^0.5.6",
+    "vue-simple-uploader": "^0.7.4",
     "vue-template-compiler": "^2.6.11",
     "vuetable-2": "^1.7.5",
     "webpack": "^3.11.0",

--- a/resources/js/processes/screen-builder/components/form/file-upload.vue
+++ b/resources/js/processes/screen-builder/components/form/file-upload.vue
@@ -6,8 +6,9 @@
     </b-card>
     <uploader
       v-else
-      :key="reRenderKey"
+      :key="renderKey"
       :options="options"
+      :attrs="attrs"
       ref="uploader"
       @complete="complete"
       @upload-start="start"
@@ -22,7 +23,18 @@
         <uploader-btn id="submitFile" class="btn btn-secondary text-white">{{ $t('select file') }}</uploader-btn>
       </uploader-drop>
 
-      <uploader-list></uploader-list>
+      <uploader-list>
+        <template slot-scope="{ fileList }">
+          <ul>
+            <li v-if="fileList.length === 0 && value">
+              <i class="fas fa-paperclip"></i> {{ value }}
+            </li>
+            <li v-for="file in fileList" :key="file.id">
+              <uploader-file :file="file" :list="true"></uploader-file>
+            </li>
+          </ul>
+        </template>
+      </uploader-list>
     </uploader>
 
     <div class="invalid-feedback" v-if="error">{{error}}</div>
@@ -52,20 +64,18 @@ export default {
 
     // If we're in a record list, this will fire to give us the prefix
     this.$root.$on('set-upload-data-name', (recordList, index) => {
-      if (!index) {
+      if (index === null) {
         // Adding new record
         index = recordList.value ? recordList.value.length : 0;
       }
-      const prefix = recordList.name + "." + index.toString() + ".";
-      this.options.query.data_name = prefix + this.name;
-
-      // Trigger re-render
-      this.reRenderKey++;
-      this.$nextTick(() => this.removeDefaultClasses());
+      this.prefix = recordList.name + "." + index.toString() + ".";
+      this.options.query.data_name = this.prefix + this.name;
     })
-
   },
   computed: {
+    renderKey() {
+      return this.prefix + this.name;
+    },
     mode() {
       return this.$root.$children[0].mode;
     },
@@ -91,6 +101,11 @@ export default {
       return accept;
     }
   },
+  watch: {
+    name() {
+      this.options.query.data_name = this.name;
+    },
+  },
   data() {
     return {
       content: "",
@@ -99,6 +114,7 @@ export default {
         errorCount: 0,
         errors: [],
       },
+      prefix: '',
       options: {
         target: this.getTargetUrl,
         // We cannot increase this until laravel chunk uploader handles this gracefully
@@ -118,7 +134,6 @@ export default {
       attrs: {
         accept: this.accept
       },
-      reRenderKey: 0,
     };
   },
   methods: {
@@ -130,8 +145,8 @@ export default {
         }
         if (file.ignored) {
           ProcessMaker.alert(this.$t("File not allowed."), "danger");
+          return false
         }
-        return false
       }
       file.ignored = false;
       return true;


### PR DESCRIPTION
Fixes #2723 

Due to the nature of the uploader package, we can not get the uploaded file display info back once the compoent has been removed (switching pages).

This change displays an icon under the upload button if a file has already been uploaded to that control. This is what will show when loading a task page or switching back to a page with an uploaded file. Needs style update but at least it will show it for now.

![image](https://user-images.githubusercontent.com/2546850/72378936-3abbcf00-36c7-11ea-9bae-170fb1a893c8.png)
