### PR TITLE
Add ability to activate and deactivate users.

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/UserController.php
+++ b/ProcessMaker/Http/Controllers/Admin/UserController.php
@@ -52,6 +52,7 @@ class UserController extends Controller
         $currentUser = $user;
         $states = JsonData::states();
         $countries = JsonData::countries();
+        $status = [__('ACTIVE'), __('INACTIVE')];
 
         $timezones = array_reduce(JsonData::timezones(),
             function ($result, $item) {
@@ -77,7 +78,8 @@ class UserController extends Controller
             'timezones',
             'countries',
             'datetimeFormats',
-            'availableLangs'
+            'availableLangs',
+            'status'
         ));
     }
 

--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -2,8 +2,9 @@
 namespace ProcessMaker\Http\Controllers\Auth;
 
 use Illuminate\Http\Request;
-use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use ProcessMaker\Models\User;
 use ProcessMaker\Http\Controllers\Controller;
+use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
 class LoginController extends Controller
 {
@@ -52,6 +53,13 @@ class LoginController extends Controller
             // Getting intended deletes it, so put in back
             $request->session()->put('url.intended', $intended);
         }
+        
+        // Check the status of the user
+        $user = User::where('username', $request->input('username'))->firstOrFail();
+        if ($user->status === 'INACTIVE') {
+            return redirect()->back();
+        }
+        
         return $this->login($request);
     }
 

--- a/ProcessMaker/Http/Controllers/ProfileController.php
+++ b/ProcessMaker/Http/Controllers/ProfileController.php
@@ -20,6 +20,7 @@ class ProfileController extends Controller
         $currentUser = \Auth::user();
         $states = JsonData::states();
         $countries = JsonData::countries();
+        $status = [__('ACTIVE'), __('INACTIVE')];
 
         $langs = ['en'];
         if (app()->getProvider(\ProcessMaker\Package\Translations\PackageServiceProvider::class)) {
@@ -43,7 +44,7 @@ class ProfileController extends Controller
                             );
 
         return view('profile.edit',
-            compact('currentUser', 'states', 'timezones', 'countries', 'datetimeFormats', 'availableLangs'));
+            compact('currentUser', 'states', 'timezones', 'countries', 'datetimeFormats', 'availableLangs', 'status'));
     }
 
     /**

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -269,6 +269,7 @@
             states: @json($states),
             userId: @json($user->id),
             image: '',
+            status: @json($status),
             errors: {
               username: null,
               firstname: null,

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -85,6 +85,7 @@
                 datetimeFormats: @json($datetimeFormats),
                 countries: @json($countries),
                 states: @json($states),
+                status: @json($status),
                 errors: {
                     username: null,
                     firstname: null,

--- a/resources/views/shared/users/sidebar.blade.php
+++ b/resources/views/shared/users/sidebar.blade.php
@@ -77,5 +77,14 @@
                     @{{errors.language}}
                 </div>
             </div>
+
+            <div class="form-group">
+                {!! Form::label('status', __('Status')) !!}
+                <b-form-select id="status" v-model="formData.status" class="form-control" :options="status">
+                </b-form-select>
+                <div class="invalid-feedback" v-if="errors.status">
+                    @{{errors.status}}
+                </div>
+            </div>
     </div>
 </div>

--- a/tests/Browser/LoginTest.php
+++ b/tests/Browser/LoginTest.php
@@ -38,4 +38,21 @@ class LoginTest extends DuskTestCase
                 ->logout();
         });
     }
+
+    public function test_inactive_user_login_fails() {
+        $user = factory(User::class)->create([
+            'username' => 'testuser',
+            'password' => Hash::make('secret'),
+            'status' => 'INACTIVE'
+        ]);
+
+        $this->browse(function (Browser $browser) use ($user) {
+            $browser->visit(new LoginPage)
+                ->type('username', $user->username)
+                ->type('password', 'secret')
+                ->assertInputValue('password', 'secret')
+                ->press('@login')
+                ->assertRouteIs('login');
+        });
+    }
 }


### PR DESCRIPTION
<h2>Changes</h2>

- Add Status dropdown to user profiles.
- Prevent users from logging in that have an 'Inactive' status.
- Add Dusk test to ensure if users are 'Inactive' they can not log in.

![Screen Shot 2020-01-15 at 1 50 52 PM](https://user-images.githubusercontent.com/52755494/72474656-1c74d280-379e-11ea-950c-94bf4c2ca8f0.png)

<h2>To Test</h2>

1. Admin > Users > Select user to edit.
2. Under 'Settings' change the 'Status' to 'Inactive'
3. Logout and try to login as the edited user.

**Expected Behavior:**
Login fails and you are redirected back to the login page.

1. Admin > Users > Select user to edit.
2. Under 'Settings' change the 'Status' to 'Active'
3. Logout and try to login as the edited user.

**Expected Behavior:**
Login is successful and you are redirected to the 'requests' page.

closes #2737 
