### PR TITLE
Add padding to summary task screen

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -87,7 +87,9 @@
                              role="tabpanel" aria-labelledby="summary-tab">
                             <template v-if="showSummary">
                                 <template v-if="showScreenSummary">
-                                    <task-screen ref="screen" :screen="screenSummary.config" :data="dataSummary" :computed="screenSummary.computed" />
+                                    <div class="p-3">
+                                        <task-screen ref="screen" :screen="screenSummary.config" :data="dataSummary" :computed="screenSummary.computed" />
+                                    </div>
                                 </template>
                                 <template v-else>
                                     <template v-if="summary.length > 0">


### PR DESCRIPTION
## Changes
- Fixes padding on Task request summary screens

## Before
<img width="526" alt="Screen Shot 2020-01-16 at 12 06 20 PM" src="https://user-images.githubusercontent.com/867714/72559097-e7798600-3858-11ea-8fbd-3e05ca7accc9.png">

## After
<img width="526" alt="Screen Shot 2020-01-16 at 12 05 42 PM" src="https://user-images.githubusercontent.com/867714/72559106-eba5a380-3858-11ea-9514-e82809a2663f.png">

Closes #2748.