### PR TITLE
Fix copy script error

### DIFF
--- a/resources/js/processes/scripts/components/ScriptListing.vue
+++ b/resources/js/processes/scripts/components/ScriptListing.vue
@@ -94,6 +94,15 @@
           <div class="invalid-feedback" v-if="errors.title">{{errors.title[0]}}</div>
         </div>
         <div class="form-group">
+          <category-select
+          :label="$t('Category')"
+          api-get="script_categories"
+          api-list="script_categories"
+          v-model="dupScript.script_category_id"
+          :errors="errors.script_category_id">
+          </category-select>
+        </div>
+        <div class="form-group">
           <label for="description">{{ $t('Description') }}</label>
           <textarea class="form-control" id="description" rows="3" v-model="dupScript.description"></textarea>
         </div>
@@ -118,8 +127,9 @@ export default {
       dupScript: {
         title: "",
         type: "",
-        category: "",
-        description: ""
+        category: {},
+        description: "",
+        script_category_id: "",
       },
       errors: [],
       orderBy: "title",
@@ -216,6 +226,7 @@ export default {
           this.dupScript.code = data.code;
           this.dupScript.description = data.description;
           this.dupScript.category = data.category;
+          this.dupScript.script_category_id = data.script_category_id;
           this.dupScript.id = data.id;
           this.dupScript.run_as_user_id = data.run_as_user_id;
           this.showModal();


### PR DESCRIPTION
<h2>Issue</h2>
Duplicating a script would fail during the CategoryRule validation because the screen_category_id was not being set.

<h2>Changes</h2>

- Adds a category select within the 'Copy Script' modal 

- Pass the screen_category_id in the script body.

https://www.dropbox.com/s/xb42iwlg0aonlti/Scripts%20-%20ProcessMaker%20%281%29.mp4?dl=0

<h2>To Test</h2>

- Create a script

- Duplicate script

**Expected Behavior**
The script successfully duplicates.

closes #2786 
