### PR TITLE
Check if container items are arrays and convert if not

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -306,6 +306,10 @@ import formTypes from "./formTypes";
       },
       getValidationErrorsForItems(items, page) {
         const validationErrors = [];
+            
+        if (!Array.isArray(items)) {
+          items = [items];
+        }
 
         items.forEach(item => {
           if (item.container) {
@@ -350,6 +354,9 @@ import formTypes from "./formTypes";
         return item.component === 'FormButton' && item.config.event === 'submit';
       },
       itemsContainSubmitButton(items) {
+        if (!Array.isArray(items)) {
+          items = [items];
+        }
         return items.some(item => {
           return item.container
             ? item.items.some(this.itemsContainSubmitButton)


### PR DESCRIPTION
Fixes #2812 

Required for ProcessMaker/screen-builder#527

Container items are expected to be nested arrays of items (for Multi Column containers, each column contains an array of items). This is no longer the case with Loop containers. A Loop container is a single array of items. There are a number of validation checks here in core that rely on this nested array structure (I don't know why these checks are not in screen-builder)

The simple solution is to check and see if 'items' is an array, and if it is not, wrap it in a single-item array.