### PR TITLE
Hard code charset and collation settings

### DIFF
--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -171,8 +171,6 @@ class Install extends Command
             $this->env['DATA_DB_DATABASE'] = $this->env['DB_DATABASE'];
             $this->env['DATA_DB_USERNAME'] = $this->env['DB_USERNAME'];
             $this->env['DATA_DB_PASSWORD'] = $this->env['DB_PASSWORD'];
-            $this->env['DATA_DB_CHARSET'] = 'utf8mb4';
-            $this->env['DATA_DB_COLLATION'] = 'utf8mb4_unicode_ci';
             $this->env['DATA_DB_ENGINE'] = 'InnoDB';
         }
         do {
@@ -413,7 +411,6 @@ class Install extends Command
         $this->env['DATA_DB_DATABASE'] = $this->anticipateOptional('data-name', __('Enter your DB database name'), ['data'], 'data');
         $this->env['DATA_DB_USERNAME'] = $this->askOptional('data-username', __('Enter your DB username'));
         $this->env['DATA_DB_PASSWORD'] = $this->secretOptional('data-password', __('Enter your DB password (input hidden)'));
-        $this->env['DATA_DB_CHARSET'] = 'utf8';
         $this->env['DATA_DB_SCHEMA'] = $this->anticipateOptional('data-schema', __('Enter your DB Schema'), ['public'], 'public');
     }
 
@@ -429,8 +426,6 @@ class Install extends Command
         $this->env['DATA_DB_DATABASE'] = $this->anticipateOptional('data-name', __('Enter your DB database name'), ['data'], 'data');
         $this->env['DATA_DB_USERNAME'] = $this->askOptional('data-username', __('Enter your DB username'));
         $this->env['DATA_DB_PASSWORD'] = $this->secretOptional('data-password', __('Enter your DB password (input hidden)'));
-        $this->env['DATA_DB_CHARSET'] = 'utf8mb4';
-        $this->env['DATA_DB_COLLATION'] = 'utf8mb4_unicode_ci';
         $this->env['DATA_DB_ENGINE'] = 'InnoDB';
     }
 
@@ -512,8 +507,6 @@ class Install extends Command
             'database' => $this->env['DATA_DB_DATABASE'],
             'username' => $this->env['DATA_DB_USERNAME'],
             'password' => $this->env['DATA_DB_PASSWORD'],
-            'charset' => isset($this->env['DATA_DB_CHARSET']) ? $this->env['DATA_DB_CHARSET'] : '',
-            'collation' => isset($this->env['DATA_DB_COLLATION']) ? $this->env['DATA_DB_COLLATION'] : '',
             'schema' => isset($this->env['DATA_DB_SCHEMA']) ? $this->env['DATA_DB_SCHEMA'] : '',
             'engine' => isset($this->env['DATA_DB_ENGINE']) ? $this->env['DATA_DB_ENGINE'] : '',
         ]]);

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,20 @@
 <?php
 
+switch(env('DATA_DB_DRIVER', 'mysql')) {
+    case 'pgsql':
+        $charset = 'utf8';
+        $collation = null;
+        break;
+    case 'sqlsrv':
+        $charset = null;
+        $collation = null;
+        break;
+    default:
+        $charset = 'utf8mb4';
+        $collation = 'utf8mb4_unicode_ci';
+        break;
+}
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -50,8 +65,8 @@ return [
             'username' => env('DATA_DB_USERNAME'),
             'password' => env('DATA_DB_PASSWORD'),
             'unix_socket' => env('DATA_DB_SOCKET'),
-            'charset' => env('DATA_DB_CHARSET'),
-            'collation' => env('DATA_DB_COLLATION'),
+            'charset' => $charset,
+            'collation' => $collation,
             'schema' => env('DATA_DB_SCHEMA'),
             'engine' => env('DATA_DB_ENGINE'),
             'date_format' => env('DATA_DB_DATE_FORMAT'),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,8 +31,6 @@ if (env('RUN_MSSQL_TESTS')) {
         'username' => env('DB_USERNAME', 'root'),
         'password' => env('DB_PASSWORD', ''),
         'unix_socket' => env('DB_SOCKET', ''),
-        'charset' => 'utf8mb4',
-        'collation' => 'utf8mb4_unicode_ci',
         'prefix' => '',
         'strict' => true,
         'engine' => null,


### PR DESCRIPTION
Fixes #2816 

Postgres - set to utf8 and default collation setting.
SqlServer - left to laravel defaults, which should be utf8-like