### PR TITLE
Custom CSS Not Refreshing

### DIFF
--- a/ProcessMaker/Jobs/CompileSass.php
+++ b/ProcessMaker/Jobs/CompileSass.php
@@ -47,7 +47,7 @@ class CompileSass implements ShouldQueue
     public function handle()
     {
         chdir(app()->basePath());
-        $this->runCmd("docker run --rm -v $(pwd):$(pwd) -w $(pwd) jbergknoff/sass "
+        $this->runCmd("docker run --rm -v $(pwd):$(pwd) -w $(pwd) processmaker4/docker-sass-compiler "
             . $this->properties['origin'] . ' ' . $this->properties['target']);
 
         if (Str::contains($this->properties['tag'], 'app')) {


### PR DESCRIPTION
Resolves #2811 

The problem was caused because the docker image  **jbergknoff/sass** uses and old version of sass. 

To solve the problem a new docker image **processmaker4/docker-sass-compiler** has been created. 

NOTE: to test the ticket it is necessary to have the processmaker4/docker-sass-compiler published in dockerhub.

