### PR TITLE
Convert Task & Request listing buttons to actual links

### DIFF
--- a/resources/js/requests/components/RequestDetail.vue
+++ b/resources/js/requests/components/RequestDetail.vue
@@ -13,14 +13,14 @@
             >
                 <template slot="ids" slot-scope="props">
                     <b-link v-if="isEditable(props.rowData)"
-                            @click="onAction('edit', props.rowData, props.rowIndex)">
+                            :href="onAction('edit', props.rowData, props.rowIndex)">
                         #{{props.rowData.id}}
                     </b-link>
                     <span v-else>#{{props.rowData.id}}</span>
                 </template>
                 <template slot="name" slot-scope="props">
                     <b-link v-if="isEditable(props.rowData)"
-                            @click="onAction('edit', props.rowData, props.rowIndex)">
+                            :href="onAction('edit', props.rowData, props.rowIndex)">
                         {{props.rowData.element_name}}
                     </b-link>
                     <span v-else>{{props.rowData.element_name}}</span>
@@ -102,7 +102,7 @@
       onAction(action, rowData, index) {
         switch (action) {
           case "edit":
-            window.location = "/tasks/" + rowData.id + "/edit";
+            return "/tasks/" + rowData.id + "/edit";
             break;
         }
       },

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -21,7 +21,7 @@
         ref="vuetable"
       >
         <template slot="ids" slot-scope="props">
-          <b-link @click="openRequest(props.rowData, props.rowIndex)">#{{props.rowData.id}}</b-link>
+          <b-link :href="openRequest(props.rowData, props.rowIndex)">#{{props.rowData.id}}</b-link>
         </template>
         <template slot="participants" slot-scope="props">
           <avatar-image
@@ -38,7 +38,7 @@
             <div class="popout">
               <b-btn
                 variant="link"
-                @click="onAction('edit-designer', props.rowData, props.rowIndex)"
+                :href="openRequest(props.rowData, props.rowIndex)"
                 v-b-tooltip.hover
                 :title="$t('Open Request')"
               >
@@ -176,15 +176,8 @@ export default {
         ];
       }
     },
-    onAction(action, data, index) {
-      switch (action) {
-        case "edit-designer":
-          this.openRequest(data, index);
-          break;
-      }
-    },
     openRequest(data, index) {
-      window.location.href = "/requests/" + data.id;
+      return "/requests/" + data.id;
     },
     formatStatus(status) {
       let color = "success",

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -21,17 +21,17 @@
         ref="vuetable"
       >
         <template slot="ids" slot-scope="props">
-          <b-link @click="onAction('edit', props.rowData, props.rowIndex)">#{{props.rowData.id}}</b-link>
+          <b-link :href="onAction('edit', props.rowData, props.rowIndex)">#{{props.rowData.id}}</b-link>
         </template>
         <template slot="name" slot-scope="props">
           <b-link
-            @click="onAction('edit', props.rowData, props.rowIndex)"
+            :href="onAction('edit', props.rowData, props.rowIndex)"
           >{{props.rowData.element_name}}</b-link>
         </template>
 
         <template slot="requestName" slot-scope="props">
           <b-link
-            @click="onAction('showRequestSummary', props.rowData, props.rowIndex)"
+            :href="onAction('showRequestSummary', props.rowData, props.rowIndex)"
           >#{{props.rowData.process_request.id}} {{props.rowData.process.name}}</b-link>
         </template>
 
@@ -61,7 +61,7 @@
             <div class="popout">
               <b-btn
                 variant="link"
-                @click="onAction('edit', props.rowData, props.rowIndex)"
+                :href="onAction('edit', props.rowData, props.rowIndex)"
                 v-b-tooltip.hover
                 :title="$t('Open Task')"
               >
@@ -69,7 +69,7 @@
               </b-btn>
               <b-btn
                 variant="link"
-                @click="onAction('showRequestSummary', props.rowData, props.rowIndex)"
+                :href="onAction('showRequestSummary', props.rowData, props.rowIndex)"
                 v-b-tooltip.hover
                 :title="$t('Open Request')"
               >
@@ -247,12 +247,12 @@ export default {
     onAction(action, rowData, index) {
       if (action === "edit") {
         let link = "/tasks/" + rowData.id + "/edit";
-        window.location = link;
+        return link;
       }
 
       if (action === "showRequestSummary") {
         let link = "/requests/" + rowData.process_request.id;
-        window.location = link;
+        return link;
       }
     },
     statusColor(props) {

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -441,6 +441,7 @@ h1.page-title {
   font-weight: 400;
 }
 
+.popout a,
 .popout button {
   padding: 0 10px;
 }


### PR DESCRIPTION
## Changes
- In the Task and Request listing components, converts buttons which were previously using JS events to actual links with href tags

## Requirements
- Requires https://github.com/ProcessMaker/package-savedsearch/pull/114 to bring these changes into Saved Searches

Closes #2851.