### PR TITLE
Add data to startEvent tasks and save timestamps

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -119,9 +119,10 @@ class TokenRepository implements TokenRepositoryInterface
         $token->process_request_id = $token->getInstance()->getKey();
         $token->user_id = empty(Auth::user()) ? null : Auth::user()->id;
 
-        $token->data = null;
+        $token->data = $token->getInstance()->getDataStore()->getData();
         $token->due_at = null;
-        $token->initiated_at = null;
+        $token->initiated_at = Carbon::now();
+        $token->completed_at = Carbon::now();
         $token->riskchanges_at = null;
         $token->saveOrFail();
         $token->setId($token->getKey());


### PR DESCRIPTION
Fixes #2854 

Add data to startEvent tasks (process_requests_tokens) and set initiated_at and completed_at timestamps