### PR TITLE
Fix created_at on versions for Processes, Screens, and Scripts

### DIFF
--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -32,11 +32,6 @@ class ProcessVersion extends Model
     protected $connection = 'processmaker';
 
     /**
-     * Do not automatically set created_at
-     */
-    const CREATED_AT = null;
-
-    /**
      * Attributes that are not mass assignable.
      *
      * @var array $fillable

--- a/ProcessMaker/Models/ScreenVersion.php
+++ b/ProcessMaker/Models/ScreenVersion.php
@@ -14,11 +14,6 @@ class ScreenVersion extends Model
     protected $connection = 'processmaker';
 
     /**
-     * Do not automatically set created_at
-     */
-    const CREATED_AT = null;
-
-    /**
      * Attributes that are not mass assignable.
      *
      * @var array $fillable

--- a/ProcessMaker/Models/ScriptVersion.php
+++ b/ProcessMaker/Models/ScriptVersion.php
@@ -5,7 +5,6 @@ namespace ProcessMaker\Models;
 use Illuminate\Database\Eloquent\Model;
 use ProcessMaker\Traits\HasCategories;
 
-
 class ScriptVersion extends Model
 {
     use HasCategories;
@@ -13,11 +12,6 @@ class ScriptVersion extends Model
     const categoryClass = ScriptCategory::class;
 
     protected $connection = 'processmaker';
-
-    /**
-     * Do not automatically set created_at
-     */
-    const CREATED_AT = null;
 
     /**
      * Attributes that are not mass assignable.


### PR DESCRIPTION
## Changes
- Fixes issue where created_at was `NULL` on Process, Screen, and Script versions

## Related
- https://github.com/ProcessMaker/package-vocabularies/pull/17 fixes the same issue for Vocabularies

Closes #2853.