### PR TITLE
Updates needed for Python executor runner and SDK

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -55,7 +55,6 @@ use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
  *   @OA\Property(property="pause_timer_start", type="integer"),
  *   @OA\Property(property="cancel_screen_id", type="integer"),
  *   @OA\Property(property="has_timer_start_events", type="boolean"),
- *   @OA\Property(property="start_events", type="string", format="json"),
  * ),
  * @OA\Schema(
  *   schema="Process",

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -164,7 +164,7 @@ export default {
         failure: false
       },
       outputOpen: true,
-      boilerPlateTemplate: this.$t(` \r Welcome to ProcessMaker 4 Script Editor \r To access Environment Variables use get_env("ENV_VAR_NAME") \r To access Request Data use {dataVariable} \r To access Configuration Data use {configVariable} \r To preview your script, click the Run button using the provided input and config data \r Return an array and it will be merged with the processes data \r Example API to retrieve user email by their ID {apiExample} \r `),
+      boilerPlateTemplate: this.$t(` \r Welcome to ProcessMaker 4 Script Editor \r To access Environment Variables use {accessEnvVar} \r To access Request Data use {dataVariable} \r To access Configuration Data use {configVariable} \r To preview your script, click the Run button using the provided input and config data \r Return an array and it will be merged with the processes data \r Example API to retrieve user email by their ID {apiExample} \r `),
     };
   },
   watch: {
@@ -274,6 +274,9 @@ export default {
           break;
         case 'java':
           this.code = Vue.filter('java')(this.boilerPlateTemplate);
+          break;
+        case 'python':
+          this.code = Vue.filter('python')(this.boilerPlateTemplate);
           break;
         }
 

--- a/resources/js/processes/scripts/customFilters.js
+++ b/resources/js/processes/scripts/customFilters.js
@@ -10,6 +10,7 @@ Vue.filter('php', function(value) {
     } else if (i == value.length - 1) {
       format = line + '*/';
     } else {
+      line = line.replace('{accessEnvVar}',  `get_env("ENV_VAR_NAME")`);
       line = line.replace('{dataVariable}',  `$data`);
       line = line.replace('{configVariable}',  `$config`);
       line = line.replace('{apiExample}',  `$api->users()->getUserById(1)['email']`);
@@ -33,6 +34,7 @@ Vue.filter('javascript', function(value) {
     } else if (i == value.length - 1) {
       format = line + '*/';
     } else {
+      line = line.replace('{accessEnvVar}',  `process.env.ENV_VAR_NAME`);
       line = line.replace('{dataVariable}',  `$data`);
       line = line.replace('{configVariable}',  `$config`);
       line = line.replace('{apiExample}',  `getUserById(id, (error, data, response) => {})`);
@@ -56,6 +58,7 @@ Vue.filter('lua', function(value) {
     } else if (i == value.length - 1) {
       format = line + ' --]]';
     } else {
+      line = line.replace('{accessEnvVar}',  `os.getenv("ENV_VAR_NAME")`);
       line = line.replace('{dataVariable}',  `data`);
       line = line.replace('{configVariable}',  `config`);
       line = line.replace('{apiExample}',  `users_api:get_users(filter, order_by, order_direction, per_page, include)`);
@@ -79,6 +82,7 @@ Vue.filter('csharp', function(value) {
     } else if (i == value.length - 1) {
       format = line + ' */';
     } else {
+      line = line.replace('{accessEnvVar}',  `System.Environment.GetEnvironmentVariable('ENV_VAR_NAME')`);
       line = line.replace('{dataVariable}',  `data`);
       line = line.replace('{configVariable}',  `config`);
       line = line.replace('{apiExample}',  `apiInstance.GetUserById(id)`);
@@ -102,6 +106,7 @@ Vue.filter('java', function(value) {
     } else if (i == value.length - 1) {
       format = line + '*/';
     } else {
+      line = line.replace('{accessEnvVar}',  `System.getenv("ENV_VAR_NAME")`);
       line = line.replace('{dataVariable}',  `data`);
       line = line.replace('{configVariable}',  `config`);
       line = line.replace('{apiExample}',  `apiInstance.getUserByID(id);`);
@@ -111,4 +116,26 @@ Vue.filter('java', function(value) {
   });
 
   return content.join("\n") + `\n\n\ return {};`;
+});
+
+// Python
+Vue.filter('python', function(value) {
+  value = value.split("\r");
+  let format = '';
+  let content = [];
+
+  value.shift();
+  value.forEach((line, i) => {
+    line = line.replace('{accessEnvVar}',  `os.environ['ENV_VAR_NAME']`);
+    line = line.replace('{dataVariable}',  `the data variable`);
+    line = line.replace('{configVariable}',  `the config variable`);
+    line = line.replace('{apiExample}',  ':');
+    format = '# ' + line;
+    content.push(format);
+  });
+  content.push(`#  users_api_instance = pmsdk.UsersApi(pmsdk.ApiClient(configuration))`);
+  content.push(`#  user = users_api_instance.get_user_by_id(1)`);
+  content.push(`#  output = {"name": user.fullname}`);
+
+  return content.join("\n") + `\n\noutput={};`;
 });

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -4745,11 +4745,6 @@
                     "has_timer_start_events": {
                         "description": "Represents a business process definition.",
                         "type": "boolean"
-                    },
-                    "start_events": {
-                        "description": "Represents a business process definition.",
-                        "type": "string",
-                        "format": "json"
                     }
                 },
                 "type": "object"


### PR DESCRIPTION
Fixes #2840 
- Escape slash interpreted as unicode for python SDK - bug in OpenAPI Generator
- Remove duplicate property in process schema - causing the Python sdk builder to fail

Executor Package: https://github.com/ProcessMaker/docker-executor-python
SDK: https://github.com/ProcessMaker/sdk-python