### PR TITLE
Fix issue with Pusher payload size

### DIFF
--- a/ProcessMaker/Events/ActivityAssigned.php
+++ b/ProcessMaker/Events/ActivityAssigned.php
@@ -13,10 +13,8 @@ class ActivityAssigned implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    /**
-     * @var ProcessRequestToken $token
-     */
-    public $token;
+    public $payload;
+    public $processRequestKey;
 
     /**
      * Create a new event instance.
@@ -25,7 +23,11 @@ class ActivityAssigned implements ShouldBroadcastNow
      */
     public function __construct(ProcessRequestToken $token)
     {
-        $this->token = $token;
+        $this->payload = [
+            'type' => 'process_request_token',
+            'id' => $token->id,
+        ];
+        $this->processRequestKey = $token->processRequest->getKey();
     }
 
     /**
@@ -45,6 +47,6 @@ class ActivityAssigned implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->token->processRequest->getKey());
+        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->processRequestKey);
     }
 }

--- a/ProcessMaker/Events/ActivityAssigned.php
+++ b/ProcessMaker/Events/ActivityAssigned.php
@@ -13,8 +13,9 @@ class ActivityAssigned implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $payload;
-    public $processRequestKey;
+    public $payloadUrl;
+    
+    private $processRequest;
 
     /**
      * Create a new event instance.
@@ -23,11 +24,8 @@ class ActivityAssigned implements ShouldBroadcastNow
      */
     public function __construct(ProcessRequestToken $token)
     {
-        $this->payload = [
-            'type' => 'process_request_token',
-            'id' => $token->id,
-        ];
-        $this->processRequestKey = $token->processRequest->getKey();
+        $this->payloadUrl = route('api.tasks.show', ['task' => $token->id]);
+        $this->processRequest = $token->processRequest;
     }
 
     /**
@@ -47,6 +45,6 @@ class ActivityAssigned implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->processRequestKey);
+        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->processRequest->getKey());
     }
 }

--- a/ProcessMaker/Events/ActivityCompleted.php
+++ b/ProcessMaker/Events/ActivityCompleted.php
@@ -13,7 +13,7 @@ class ActivityCompleted implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $processRequestToken;
+    public $payload;
 
     /**
      * Create a new event instance.
@@ -22,7 +22,10 @@ class ActivityCompleted implements ShouldBroadcastNow
      */
     public function __construct(ProcessRequestToken $processRequestToken)
     {
-        $this->processRequestToken = $processRequestToken;
+        $this->payload = [
+            'type' => 'process_request_token',
+            'id' => $processRequestToken->getKey(),
+        ];
     }
 
     /**
@@ -42,6 +45,6 @@ class ActivityCompleted implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('ProcessMaker.Models.ProcessRequestToken.' . $this->processRequestToken->getKey());
+        return new PrivateChannel('ProcessMaker.Models.ProcessRequestToken.' . $this->payload['id']);
     }
 }

--- a/ProcessMaker/Events/ActivityCompleted.php
+++ b/ProcessMaker/Events/ActivityCompleted.php
@@ -13,7 +13,9 @@ class ActivityCompleted implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $payload;
+    public $payloadUrl;
+    
+    private $processRequestToken;
 
     /**
      * Create a new event instance.
@@ -22,10 +24,8 @@ class ActivityCompleted implements ShouldBroadcastNow
      */
     public function __construct(ProcessRequestToken $processRequestToken)
     {
-        $this->payload = [
-            'type' => 'process_request_token',
-            'id' => $processRequestToken->getKey(),
-        ];
+        $this->payloadUrl = route('api.tasks.show', ['task' => $processRequestToken->id]);
+        $this->processRequestToken = $processRequestToken;
     }
 
     /**
@@ -45,6 +45,6 @@ class ActivityCompleted implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('ProcessMaker.Models.ProcessRequestToken.' . $this->payload['id']);
+        return new PrivateChannel('ProcessMaker.Models.ProcessRequestToken.' . $this->processRequestToken->getKey());
     }
 }

--- a/ProcessMaker/Events/ProcessCompleted.php
+++ b/ProcessMaker/Events/ProcessCompleted.php
@@ -13,7 +13,7 @@ class ProcessCompleted implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $processRequest;
+    public $payload;
 
     /**
      * Create a new event instance.
@@ -22,7 +22,10 @@ class ProcessCompleted implements ShouldBroadcastNow
      */
     public function __construct(ProcessRequest $processRequest)
     {
-        $this->processRequest = $processRequest;
+        $this->payload = [
+            'type' => 'process_request',
+            'id' => $processRequest->getKey(),
+        ];
     }
 
     /**
@@ -42,6 +45,6 @@ class ProcessCompleted implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->processRequest->getKey());
+        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->payload['id']);
     }
 }

--- a/ProcessMaker/Events/ProcessCompleted.php
+++ b/ProcessMaker/Events/ProcessCompleted.php
@@ -13,7 +13,9 @@ class ProcessCompleted implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $payload;
+    public $payloadUrl;
+    
+    private $processRequest;
 
     /**
      * Create a new event instance.
@@ -22,10 +24,8 @@ class ProcessCompleted implements ShouldBroadcastNow
      */
     public function __construct(ProcessRequest $processRequest)
     {
-        $this->payload = [
-            'type' => 'process_request',
-            'id' => $processRequest->getKey(),
-        ];
+        $this->payloadUrl = route('api.requests.show', ['request' => $processRequest->getKey()]);
+        $this->processRequest = $processRequest;
     }
 
     /**
@@ -45,6 +45,6 @@ class ProcessCompleted implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->payload['id']);
+        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->processRequest->getKey());
     }
 }

--- a/ProcessMaker/Events/ProcessUpdated.php
+++ b/ProcessMaker/Events/ProcessUpdated.php
@@ -13,7 +13,7 @@ class ProcessUpdated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $processRequest;
+    public $payload;
     public $event;
 
     /**
@@ -23,7 +23,10 @@ class ProcessUpdated implements ShouldBroadcastNow
      */
     public function __construct(ProcessRequest $processRequest, $event)
     {
-        $this->processRequest = $processRequest;
+        $this->payload = [
+            'type' => 'process_request',
+            'id' => $processRequest->getKey(),
+        ];
         $this->event = $event;
     }
 
@@ -44,6 +47,6 @@ class ProcessUpdated implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->processRequest->getKey());
+        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->payload['id']);
     }
 }

--- a/ProcessMaker/Events/ProcessUpdated.php
+++ b/ProcessMaker/Events/ProcessUpdated.php
@@ -13,8 +13,10 @@ class ProcessUpdated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $payload;
+    public $payloadUrl;
     public $event;
+    
+    private $processRequest;
 
     /**
      * Create a new event instance.
@@ -23,11 +25,10 @@ class ProcessUpdated implements ShouldBroadcastNow
      */
     public function __construct(ProcessRequest $processRequest, $event)
     {
-        $this->payload = [
-            'type' => 'process_request',
-            'id' => $processRequest->getKey(),
-        ];
+        $this->payloadUrl = route('api.requests.show', ['request' => $processRequest->getKey()]);
         $this->event = $event;
+        
+        $this->processRequest = $processRequest;
     }
 
     /**
@@ -47,6 +48,6 @@ class ProcessUpdated implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->payload['id']);
+        return new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->processRequest->getKey());
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,7 @@
       <env name="TESTING_VERBOSE" value="false" />
       <env name="POPULATE_DATABASE" value="true" />
       <env name="TELESCOPE_ENABLED" value="false" />
+      <env name="BROADCAST_DRIVER" value="log"/>
 
       <!-- Caching config -->
       <env name="CACHE_DRIVER" value="array" />

--- a/resources/js/tasks/components/ProcessRequestChannel.js
+++ b/resources/js/tasks/components/ProcessRequestChannel.js
@@ -6,24 +6,24 @@ export default {
   },
   mounted () {
     this.addSocketListener(`ProcessMaker.Models.ProcessRequest.${this.instanceId}`, ".ActivityAssigned", (data) => {
-      if (data.payload) {
-        this.obtainPayload(data.payload.type, data.payload.id)
+      if (data.payloadUrl) {
+        this.obtainPayload(data.payloadUrl)
           .then(response => {
-            this.$emit("activity-assigned", response)
+            this.$emit("activity-assigned", response);
           });        
       }
     });
     this.addSocketListener(`ProcessMaker.Models.ProcessRequest.${this.instanceId}`, ".ProcessCompleted", (data) => {
-      if (data.payload) {
-        this.obtainPayload(data.payload.type, data.payload.id)
+      if (data.payloadUrl) {
+        this.obtainPayload(data.payloadUrl)
           .then(response => {
             this.$emit("process-completed", response);
           });
       }
     });
     this.addSocketListener(`ProcessMaker.Models.ProcessRequest.${this.instanceId}`, ".ProcessUpdated", (data) => {
-      if (data.payload) {
-        this.obtainPayload(data.payload.type, data.payload.id)
+      if (data.payloadUrl) {
+        this.obtainPayload(data.payloadUrl)
           .then(response => {
             if (data.event) {
               response.event = data.event;
@@ -44,16 +44,7 @@ export default {
         callback
       );
     },
-    obtainPayload(type, id) {
-      let url;
-      switch (type) {
-        case 'process_request':
-          url = `/requests/${id}`;
-          break;
-        case 'process_request_token':
-          url = `/tasks/${id}`;
-          break;
-      }
+    obtainPayload(url) {
       return new Promise((resolve, reject) => {
         ProcessMaker.apiClient
           .get(url)

--- a/tests/Feature/BroadcastTest.php
+++ b/tests/Feature/BroadcastTest.php
@@ -25,6 +25,7 @@ class BroadcastTest extends TestCase
         event(new ActivityAssigned($task));
         $this->assertLogContainsText('ActivityAssigned');
         $this->assertLogContainsText(addcslashes(route('api.tasks.show', ['task' => $task->id]), '/'));
+        $this->assertBroadcastEventSizeLessThan('ActivityAssigned', 10000);
     }
 
      /**
@@ -38,6 +39,7 @@ class BroadcastTest extends TestCase
         event(new ActivityCompleted($task));
         $this->assertLogContainsText('ActivityCompleted');
         $this->assertLogContainsText(addcslashes(route('api.tasks.show', ['task' => $task->id]), '/'));
+        $this->assertBroadcastEventSizeLessThan('ActivityCompleted', 10000);
     }
 
      /**
@@ -51,6 +53,7 @@ class BroadcastTest extends TestCase
         event(new ProcessCompleted($request));
         $this->assertLogContainsText('ProcessCompleted');
         $this->assertLogContainsText(addcslashes(route('api.requests.show', ['task' => $request->id]), '/'));
+        $this->assertBroadcastEventSizeLessThan('ProcessCompleted', 10000);
     }
 
     /**
@@ -64,5 +67,6 @@ class BroadcastTest extends TestCase
         event(new ProcessUpdated($request, 'ACTIVITY_COMPLETED'));
         $this->assertLogContainsText('ProcessUpdated');
         $this->assertLogContainsText(addcslashes(route('api.requests.show', ['task' => $request->id]), '/'));
+        $this->assertBroadcastEventSizeLessThan('ProcessUpdated', 10000);
     }
 }

--- a/tests/Feature/BroadcastTest.php
+++ b/tests/Feature/BroadcastTest.php
@@ -1,15 +1,24 @@
 <?php
 namespace Tests\Feature;
 
+use Auth;
 use Tests\TestCase;
 use Tests\Feature\Shared\LoggingHelper;
 use ProcessMaker\Events\ActivityAssigned;
 use ProcessMaker\Events\ActivityCompleted;
 use ProcessMaker\Events\ProcessCompleted;
 use ProcessMaker\Events\ProcessUpdated;
+use ProcessMaker\Events\ScreenBuilderStarting;
+use ProcessMaker\Events\ModelerStarting;
+use ProcessMaker\Events\SessionStarted as SessionStartedEvent;
+use ProcessMaker\Models\User;
 use ProcessMaker\Models\ProcessRequestToken as Task;
 use ProcessMaker\Models\ProcessRequest as Request;
+use ProcessMaker\Managers\ScreenBuilderManager as ScreenBuilder;
+use ProcessMaker\Managers\ModelerManager as Modeler;
 use Illuminate\Foundation\Testing\WithFaker;
+
+
 
 class BroadcastTest extends TestCase
 {
@@ -100,5 +109,44 @@ class BroadcastTest extends TestCase
         $this->assertLogContainsText('ProcessUpdated');
         $this->assertLogContainsText(addcslashes(route('api.requests.show', ['task' => $request->id]), '/'));
         $this->assertBroadcastEventSizeLessThan('ProcessUpdated', 10000);
+    }
+
+
+    /**
+     * Asserts that the ScreenBuilderStarting broadcast event works.
+     *
+     * @return void
+     */
+    public function testScreenBuilderStartingBroadcast()
+    {
+        $this->markTestSkipped('Will implement later');
+        $manager = new ScreenBuilder();
+        event(new ScreenBuilderStarting($manager, 'DISPLAY'));
+    }
+
+     /**
+     * Asserts that the ScreenBuilderStarting broadcast event works.
+     *
+     * @return void
+     */
+    public function testModelerStartingBroadcast()
+    {
+        $this->markTestSkipped('Will implement later');
+        $manager = new Modeler();
+        event(new ModelerStarting($manager));
+    }
+
+     /**
+     * Asserts that the SessionStart broadcast event works.
+     *
+     * @return void
+     */
+    public function testSessionStartedBroadcast()
+    {
+        $user = factory(User::class)->create();
+        event(new SessionStartedEvent($user));
+        
+        $this->assertLogContainsText('SessionStarted');
+        $this->assertBroadcastEventSizeLessThan('SessionStarted', 10000);
     }
 }

--- a/tests/Feature/BroadcastTest.php
+++ b/tests/Feature/BroadcastTest.php
@@ -6,6 +6,7 @@ use Tests\Feature\Shared\LoggingHelper;
 use ProcessMaker\Events\ActivityAssigned;
 use ProcessMaker\Events\ActivityCompleted;
 use ProcessMaker\Events\ProcessCompleted;
+use ProcessMaker\Events\ProcessUpdated;
 use ProcessMaker\Models\ProcessRequestToken as Task;
 use ProcessMaker\Models\ProcessRequest as Request;
 
@@ -60,8 +61,8 @@ class BroadcastTest extends TestCase
     public function testProcessUpdatedBroadcast()
     {
         $request = factory(Request::class)->create();
-        event(new ProcessCompleted($request));
-        $this->assertLogContainsText('ProcessCompleted');
+        event(new ProcessUpdated($request, 'ACTIVITY_COMPLETED'));
+        $this->assertLogContainsText('ProcessUpdated');
         $this->assertLogContainsText(addcslashes(route('api.requests.show', ['task' => $request->id]), '/'));
     }
 }

--- a/tests/Feature/BroadcastTest.php
+++ b/tests/Feature/BroadcastTest.php
@@ -4,7 +4,10 @@ namespace Tests\Feature;
 use Tests\TestCase;
 use Tests\Feature\Shared\LoggingHelper;
 use ProcessMaker\Events\ActivityAssigned;
+use ProcessMaker\Events\ActivityCompleted;
+use ProcessMaker\Events\ProcessCompleted;
 use ProcessMaker\Models\ProcessRequestToken as Task;
+use ProcessMaker\Models\ProcessRequest as Request;
 
 class BroadcastTest extends TestCase
 {
@@ -21,5 +24,44 @@ class BroadcastTest extends TestCase
         event(new ActivityAssigned($task));
         $this->assertLogContainsText('ActivityAssigned');
         $this->assertLogContainsText(addcslashes(route('api.tasks.show', ['task' => $task->id]), '/'));
+    }
+
+     /**
+     * Asserts that the ActivityCompleted broadcast event works.
+     *
+     * @return void
+     */
+    public function testActivityCompletedBroadcast()
+    {
+        $task = factory(Task::class)->create();
+        event(new ActivityCompleted($task));
+        $this->assertLogContainsText('ActivityCompleted');
+        $this->assertLogContainsText(addcslashes(route('api.tasks.show', ['task' => $task->id]), '/'));
+    }
+
+     /**
+     * Asserts that the ProcessCompleted broadcast event works.
+     *
+     * @return void
+     */
+    public function testProcessCompletedBroadcast()
+    {
+        $request = factory(Request::class)->create();
+        event(new ProcessCompleted($request));
+        $this->assertLogContainsText('ProcessCompleted');
+        $this->assertLogContainsText(addcslashes(route('api.requests.show', ['task' => $request->id]), '/'));
+    }
+
+    /**
+     * Asserts that the ProcessUpdated broadcast event works.
+     *
+     * @return void
+     */
+    public function testProcessUpdatedBroadcast()
+    {
+        $request = factory(Request::class)->create();
+        event(new ProcessCompleted($request));
+        $this->assertLogContainsText('ProcessCompleted');
+        $this->assertLogContainsText(addcslashes(route('api.requests.show', ['task' => $request->id]), '/'));
     }
 }

--- a/tests/Feature/BroadcastTest.php
+++ b/tests/Feature/BroadcastTest.php
@@ -14,6 +14,20 @@ class BroadcastTest extends TestCase
 {
     use LoggingHelper;
 
+    public function testBroadcastEventsHaveTesting()
+    {
+        $path = app_path('Events');
+        $files = scandir($path);
+        foreach ($files as $file) {
+            $doesMatch = preg_match('/(?<name>.+).php/', $file, $matches);
+            if ($doesMatch) {
+                $name = $matches['name'];
+                $methodName = "test{$name}Broadcast";
+                $this->assertTrue(method_exists($this, $methodName), "Failed asserting that broadcast event $name has a test.");
+            }
+        }
+    }
+
     /**
      * Asserts that the ActivityAssigned broadcast event works.
      *

--- a/tests/Feature/BroadcastTest.php
+++ b/tests/Feature/BroadcastTest.php
@@ -9,10 +9,11 @@ use ProcessMaker\Events\ProcessCompleted;
 use ProcessMaker\Events\ProcessUpdated;
 use ProcessMaker\Models\ProcessRequestToken as Task;
 use ProcessMaker\Models\ProcessRequest as Request;
+use Illuminate\Foundation\Testing\WithFaker;
 
 class BroadcastTest extends TestCase
 {
-    use LoggingHelper;
+    use LoggingHelper, WithFaker;
 
     public function testBroadcastEventsHaveTesting()
     {
@@ -35,7 +36,12 @@ class BroadcastTest extends TestCase
      */
     public function testActivityAssignedBroadcast()
     {
-        $task = factory(Task::class)->create();
+        $task = factory(Task::class)->create([
+            'data' => [
+                'test' => $this->faker->text(20000),
+            ]
+        ]);
+        
         event(new ActivityAssigned($task));
         $this->assertLogContainsText('ActivityAssigned');
         $this->assertLogContainsText(addcslashes(route('api.tasks.show', ['task' => $task->id]), '/'));
@@ -49,7 +55,11 @@ class BroadcastTest extends TestCase
      */
     public function testActivityCompletedBroadcast()
     {
-        $task = factory(Task::class)->create();
+        $task = factory(Task::class)->create([
+            'data' => [
+                'test' => $this->faker->text(20000),
+            ]
+        ]);
         event(new ActivityCompleted($task));
         $this->assertLogContainsText('ActivityCompleted');
         $this->assertLogContainsText(addcslashes(route('api.tasks.show', ['task' => $task->id]), '/'));
@@ -63,7 +73,11 @@ class BroadcastTest extends TestCase
      */
     public function testProcessCompletedBroadcast()
     {
-        $request = factory(Request::class)->create();
+        $request = factory(Request::class)->create([
+            'data' => [
+                'test' => $this->faker->text(20000),
+            ]
+        ]);
         event(new ProcessCompleted($request));
         $this->assertLogContainsText('ProcessCompleted');
         $this->assertLogContainsText(addcslashes(route('api.requests.show', ['task' => $request->id]), '/'));
@@ -77,7 +91,11 @@ class BroadcastTest extends TestCase
      */
     public function testProcessUpdatedBroadcast()
     {
-        $request = factory(Request::class)->create();
+        $request = factory(Request::class)->create([
+            'data' => [
+                'test' => $this->faker->text(20000),
+            ]
+        ]);
         event(new ProcessUpdated($request, 'ACTIVITY_COMPLETED'));
         $this->assertLogContainsText('ProcessUpdated');
         $this->assertLogContainsText(addcslashes(route('api.requests.show', ['task' => $request->id]), '/'));

--- a/tests/Feature/BroadcastTest.php
+++ b/tests/Feature/BroadcastTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Tests\Feature\Shared\LoggingHelper;
+use ProcessMaker\Events\ActivityAssigned;
+use ProcessMaker\Models\ProcessRequestToken as Task;
+
+class BroadcastTest extends TestCase
+{
+    use LoggingHelper;
+
+    /**
+     * Asserts that the ActivityAssigned broadcast event works.
+     *
+     * @return void
+     */
+    public function testActivityAssignedBroadcast()
+    {
+        $task = factory(Task::class)->create();
+        event(new ActivityAssigned($task));
+        $this->assertLogContainsText('ActivityAssigned');
+        $this->assertLogContainsText(addcslashes(route('api.tasks.show', ['task' => $task->id]), '/'));
+    }
+}

--- a/tests/Feature/Shared/LoggingHelper.php
+++ b/tests/Feature/Shared/LoggingHelper.php
@@ -37,6 +37,37 @@ trait LoggingHelper
         
         return $this->assertEquals($count, $matches, 'Failed asserting that a log entry exists.');
     }
+    
+    /**
+     * Assert that a log entry 
+     *
+     * @param array $data
+     *
+     * @return mixed
+     */        
+    public function assertLogContainsText($data)
+    {
+        $records = app('log')->getHandlers()[0]->getRecords();
+        $count = 1;
+        $matches = 0;
+
+        foreach ($records as $record) {
+            $matches = 0;
+            
+            if (array_key_exists('message', $record)) {
+                $message = $record['message'];
+                if (strpos($message, $data) !== false) {
+                    $matches = 1;
+                }
+            }
+            
+            if ($matches === $count) {
+                break;
+            }
+        }
+        
+        return $this->assertEquals($count, $matches, 'Failed asserting that the log contains text.');
+    }
 
     /**
      * Assert that a log message exists. This exclusively tests only the actual

--- a/tests/Feature/Shared/LoggingHelper.php
+++ b/tests/Feature/Shared/LoggingHelper.php
@@ -42,7 +42,8 @@ trait LoggingHelper
      * Assert that an event broadcast to the log has a payload smaller than the
      * specified size in bytes.
      *
-     * @param array $data
+     * @param string $name
+     * @param integer $size
      *
      * @return mixed
      */

--- a/tests/Feature/Shared/LoggingHelper.php
+++ b/tests/Feature/Shared/LoggingHelper.php
@@ -38,6 +38,26 @@ trait LoggingHelper
         return $this->assertEquals($count, $matches, 'Failed asserting that a log entry exists.');
     }
     
+    public function assertBroadcastEventSizeLessThan($name, $size)
+    {
+        $length = 0;
+        $records = app('log')->getHandlers()[0]->getRecords();
+        
+        foreach ($records as $record) {
+            if (array_key_exists('message', $record)) {
+                $doesMatch = preg_match('/Broadcasting \[(?<name>.+)\].+ with payload:(?<payload>.+)/s', $record['message'], $matches);
+                if ($doesMatch) {
+                    if ($matches['name'] == $name) {
+                        $length = strlen($matches['payload']);
+                        break;
+                    }
+                }
+            }
+        }
+        
+        $this->assertLessThan($size, $length);
+    }
+    
     /**
      * Assert that a log entry exists that contains specific text
      *

--- a/tests/Feature/Shared/LoggingHelper.php
+++ b/tests/Feature/Shared/LoggingHelper.php
@@ -37,7 +37,15 @@ trait LoggingHelper
         
         return $this->assertEquals($count, $matches, 'Failed asserting that a log entry exists.');
     }
-    
+
+    /**
+     * Assert that an event broadcast to the log has a payload smaller than the
+     * specified size in bytes.
+     *
+     * @param array $data
+     *
+     * @return mixed
+     */
     public function assertBroadcastEventSizeLessThan($name, $size)
     {
         $length = 0;
@@ -55,7 +63,7 @@ trait LoggingHelper
             }
         }
         
-        $this->assertLessThan($size, $length);
+        return $this->assertLessThan($size, $length);
     }
     
     /**


### PR DESCRIPTION
## Changes
- Reduces payload size of the following broadcast events by referring to API URLs instead of sending entire object:
  - ActivityAssigned
  - ActivityCompleted
  - ProcessCompleted
  - ProcessUpdated
- Updates ProcessRequestChannel component to obtain these objects via API call rather than via the broadcast event
- Adds testing around broadcast events
  - To ensure that all broadcast events have a corresponding test
  - To ensure that all broadcast event payloads are less than 10KB

Fixes #2857.