### PR TITLE
Wrap task scheduler manager in schedule call method

### DIFF
--- a/ProcessMaker/Console/Kernel.php
+++ b/ProcessMaker/Console/Kernel.php
@@ -27,13 +27,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        /**
-         * Currently no scheduled tasks exists, however once scheduled cron tasks are required, they should
-         * be placed here.
-         */
 
-        $scheduleManager = new TaskSchedulerManager();
-        $scheduleManager->scheduleTasks($schedule);
+        $schedule->call(function() {
+            $scheduleManager = new TaskSchedulerManager();
+            $scheduleManager->scheduleTasks();
+        })->everyMinute();
     }
 
     /**

--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -120,9 +120,8 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
     /**
      * Checks the schedule_tasks table to execute jobs
      *
-     * @param Schedule $schedule
      */
-    public function scheduleTasks(Schedule $schedule)
+    public function scheduleTasks()
     {
         $today = $this->today();
         try {

--- a/tests/Feature/Api/IntermediateTimerEventTest.php
+++ b/tests/Feature/Api/IntermediateTimerEventTest.php
@@ -189,9 +189,8 @@ class IntermediateTimerEventTest extends TestCase
         Carbon::setTestNow(Carbon::now()->addMinute(5));
 
         // Re-schedule events for artisan call
-        $schedule = app()->make(\Illuminate\Console\Scheduling\Schedule::class);
         $scheduleManager = new TaskSchedulerManager();
-        $scheduleManager->scheduleTasks($schedule);
+        $scheduleManager->scheduleTasks();
         \Artisan::call('schedule:run');
 
         $iteToken = $request->tokens()->where('element_id', '_5')->firstOrFail();
@@ -201,7 +200,7 @@ class IntermediateTimerEventTest extends TestCase
         Carbon::setTestNow(Carbon::now()->addMinute(5));
 
         // Re-schedule events for artisan call
-        $scheduleManager->scheduleTasks($schedule);
+        $scheduleManager->scheduleTasks();
         \Artisan::call('schedule:run');
 
         $iteToken->refresh();

--- a/tests/Feature/Shared/ProcessTestingTrait.php
+++ b/tests/Feature/Shared/ProcessTestingTrait.php
@@ -131,6 +131,7 @@ trait ProcessTestingTrait
      */
     private function runScheduledTasks()
     {
+        $schedule = app()->make(Schedule::class);
         $scheduleManager = new TaskSchedulerManager();
         $scheduleManager->scheduleTasks();
         ///

--- a/tests/Feature/Shared/ProcessTestingTrait.php
+++ b/tests/Feature/Shared/ProcessTestingTrait.php
@@ -131,9 +131,8 @@ trait ProcessTestingTrait
      */
     private function runScheduledTasks()
     {
-        $schedule = app()->make(Schedule::class);
         $scheduleManager = new TaskSchedulerManager();
-        $scheduleManager->scheduleTasks($schedule);
+        $scheduleManager->scheduleTasks();
         ///
         $events = collect($schedule->events());
         $events->each(function (Event $event) {


### PR DESCRIPTION
Fixes #2882 
- Wrap the task manager in schedule->call so it has access to the full bootstrapped app environment
- Remove unused $schedule argument for scheduleTasks method