### PR TITLE
Fix Watcher 'Source' selection limit

### DIFF
--- a/resources/views/processes/screen-builder/screen.blade.php
+++ b/resources/views/processes/screen-builder/screen.blade.php
@@ -30,9 +30,10 @@
         // Registrar el EP para script, datasource y execute
         if (builder.watchers) {
           if (@json(route::has('api.scripts.index'))) {
-            builder.watchers_config.api.scripts.push((data, filter) => {
+            console.log('hit in screen blade');
+            builder.watchers_config.api.scripts.push((data) => {
               ProcessMaker.apiClient
-                .get(@json(route('api.scripts.index' )) + (typeof filter === "string" ? "?filter=" + filter : ""))
+                .get(@json(route('api.scripts.index' )) + '?per_page=10000')
                 .then(response => {
                   let scripts = response.data.data.map(item => {
                     item.id = "script-" + item.id;
@@ -49,9 +50,9 @@
           }
 
           if (@json(route::has('api.data-sources.index'))) {
-            builder.watchers_config.api.scripts.push((data, filter) => {
+            builder.watchers_config.api.scripts.push((data) => {
               ProcessMaker.apiClient
-                .get('data_sources' + (typeof filter === "string" ? "?filter=" + filter : ""))
+                .get('data_sources' + '?per_page=10000')
                 .then(response => {
                   let dataSource = response.data.data.map(item => {
                     item.id = "data_source-" + item.id;


### PR DESCRIPTION
<h2>Changes</h2>

- Remove the `Filter` parameter.
- Add the `per_page` and set to a high number to display all available 'Scripts' & 'Data Connectors'


Ref [ScreenBuilder/#591](https://github.com/ProcessMaker/screen-builder/issues/591)

