### PR TITLE
Display nested data summary as a flat list

### DIFF
--- a/resources/js/requests/components/DataSummary.vue
+++ b/resources/js/requests/components/DataSummary.vue
@@ -1,0 +1,48 @@
+<template>
+    <div>
+        <table class="vuetable table table-hover border-top-0 mb-0">
+            <thead v-if="showHead">
+                <tr>
+                    <th class="border-top-0" scope="col">{{ $t('Key') }}</th>
+                    <th class="border-top-0" scope="col">{{ $t('Value') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="(item, key) in summary" :key="key">
+                    <template v-if="shouldNest(item)">
+                        <td colspan="2">
+                            <div class="d-flex">
+                                <div class="pr-2">{{ key }}</div>
+                                <div class="border border-top-0 flex-grow-1">
+                                    <data-summary :summary="item" :show-head="false"></data-summary>
+                                </div>
+                            </div>
+                        </td>
+                    </template>
+                    <template v-else>
+                        <td>{{ key }}</td>
+                        <td>{{ item }}</td>
+                    </template>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        summary: [Object, Array],
+        showHead: { type: Boolean, default: true }
+    },
+    data() {
+        return {}
+    },
+    methods: {
+        shouldNest(item) {
+            // Arrays or Objects
+            return item && typeof item === 'object';
+        },
+    }
+}
+</script>

--- a/resources/js/requests/components/DataSummary.vue
+++ b/resources/js/requests/components/DataSummary.vue
@@ -8,21 +8,9 @@
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="(item, key) in summary" :key="key">
-                    <template v-if="shouldNest(item)">
-                        <td colspan="2">
-                            <div class="d-flex">
-                                <div class="pr-2">{{ key }}</div>
-                                <div class="border border-top-0 flex-grow-1">
-                                    <data-summary :summary="item" :show-head="false"></data-summary>
-                                </div>
-                            </div>
-                        </td>
-                    </template>
-                    <template v-else>
-                        <td>{{ key }}</td>
-                        <td>{{ item }}</td>
-                    </template>
+                <tr v-for="(item, key) in formattedData" :key="key">
+                    <td>{{ key }}</td>
+                    <td>{{ item }}</td>
                 </tr>
             </tbody>
         </table>
@@ -36,10 +24,25 @@ export default {
         showHead: { type: Boolean, default: true }
     },
     data() {
-        return {}
+        return {
+            formattedData: {}
+        }
+    },
+    mounted() {
+        this.formatData("", this.summary);
     },
     methods: {
-        shouldNest(item) {
+        formatData(prefix, items) {
+            for (const key in items) {
+                const item = items[key];
+                if (this.isObject(item)) {
+                    this.formatData(prefix + key + ".", item);
+                } else {
+                    this.formattedData[prefix + key] = item
+                }
+            }
+        },
+        isObject(item) {
             // Arrays or Objects
             return item && typeof item === 'object';
         },

--- a/resources/js/requests/show.js
+++ b/resources/js/requests/show.js
@@ -1,4 +1,5 @@
 import Vue from "vue";
+import DataSummary from "./components/DataSummary";
 import RequestDetail from "./components/RequestDetail";
 import AvatarImage from "../components/AvatarImage";
 import TaskForm from '../tasks/components/TaskForm';
@@ -8,6 +9,7 @@ import debounce from 'lodash/debounce';
 import Comments from '../components/Comments'
 import RequestScreens from '../requests/components/RequestScreens';
 
+Vue.component('data-summary', DataSummary);
 Vue.component('request-detail', RequestDetail);
 Vue.component('avatar-image', AvatarImage);
 Vue.component('task-screen', TaskForm);

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -94,20 +94,7 @@
                                 <template v-else>
                                     <template v-if="summary.length > 0">
                                         <div class="card border-0">
-                                            <table class="vuetable table table-hover border-top-0 mb-0">
-                                                <thead>
-                                                <tr>
-                                                    <th class="border-top-0" scope="col">{{ __('Key') }}</th>
-                                                    <th class="border-top-0" scope="col">{{ __('Value') }}</th>
-                                                </tr>
-                                                </thead>
-                                                <tbody>
-                                                <tr v-for="item in summary">
-                                                    <td>@{{item.key}}</td>
-                                                    <td>@{{item.value}}</td>
-                                                </tr>
-                                                </tbody>
-                                            </table>
+                                            <data-summary :summary="dataSummary"></data-summary>
                                         </div>
                                     </template>
                                     <template v-else>


### PR DESCRIPTION
Fixes #2909

Displays nested data as a flat list with keys seperated with `.`

![image](https://user-images.githubusercontent.com/2546850/75701343-73f4d200-5c68-11ea-8eca-841e78f169ee.png)
