### PR TITLE
Disallow dashes in Environment Variable Names

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/EnvironmentVariablesController.php
+++ b/ProcessMaker/Http/Controllers/Api/EnvironmentVariablesController.php
@@ -106,7 +106,7 @@ class EnvironmentVariablesController extends Controller
    */
   public function store(Request $request)
   {
-      $request->validate(EnvironmentVariable::rules());
+      $request->validate(EnvironmentVariable::rules(), EnvironmentVariable::messages());
       $environment_variable = EnvironmentVariable::create($request->all());
 
       return new EnvironmentVariableResource($environment_variable);

--- a/ProcessMaker/Models/EnvironmentVariable.php
+++ b/ProcessMaker/Models/EnvironmentVariable.php
@@ -62,11 +62,12 @@ class EnvironmentVariable extends Model
     public static function rules($existing = null)
     {
         $unique = Rule::unique('environment_variables')->ignore($existing);
+        $validVariableName = '/^[a-zA-Z][a-zA-Z_$0-9]*$/';
 
         return [
             'description' => 'required',
             'value' => 'nullable',
-            'name' => ['required', 'alpha_dash', $unique]
+            'name' => ['required', "regex:${validVariableName}", $unique],
         ];
     }
 

--- a/ProcessMaker/Models/EnvironmentVariable.php
+++ b/ProcessMaker/Models/EnvironmentVariable.php
@@ -25,7 +25,6 @@ use Illuminate\Validation\Rule;
  * )
  *
  *
-
  *
  *
  */
@@ -71,4 +70,10 @@ class EnvironmentVariable extends Model
         ];
     }
 
+    public static function messages()
+    {
+        return [
+            'name.regex' => trans('environmentVariables.validation.name.invalid_variable_name'),
+        ];
+    }
 }

--- a/resources/lang/en/environmentVariables.php
+++ b/resources/lang/en/environmentVariables.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    "validation" => [
+        "name" => [
+            "invalid_variable_name" => "Name has to start with a letter and can contain only letters, numbers, and underscores (_).",
+        ],
+    ],
+];


### PR DESCRIPTION
This adds validation that ensures that an environment variable has a valid name. This allows `getenv()` to access the variable correctly. 

This addresses [2908](https://github.com/ProcessMaker/processmaker/issues/2908).

The validation checks that:
 - the variable name starts with a letter.
 - the variable name only contains alphanumeric characters or underscores.

This also adds a custom validation feedback message should the aforementioned validation not pass. This is defined in the newly added translation file (`resources/lang/en/environmentVariables.php`).

Feedback looks as follows:
<img src="https://user-images.githubusercontent.com/28595383/75801204-a7bc1e80-5d72-11ea-9ddc-99b782c8e4b3.png" width="450" />
