### PR TITLE
Fix Environment Variable Text Limit

### DIFF
--- a/database/migrations/2020_03_03_181316_update_env_var_value_column.php
+++ b/database/migrations/2020_03_03_181316_update_env_var_value_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateEnvVarValueColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('environment_variables', function (Blueprint $table) {
+            $table->longText('value')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('environment_variables', function (Blueprint $table) {
+            $table->text('value')->change();
+        });
+    }
+}

--- a/resources/views/processes/environment-variables/index.blade.php
+++ b/resources/views/processes/environment-variables/index.blade.php
@@ -71,7 +71,7 @@
                         </div>
                         <div class="form-group">
                             {!!Form::label('value', __('Value'))!!}
-                            {!!Form::text('value', null, ['class'=> 'form-control', 'v-model'=> 'value',
+                            {!!Form::textArea('value', null, ['class'=> 'form-control', 'v-model'=> 'value',
                             'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.value}'])!!}
                             <div class="invalid-feedback" v-for="value in errors.value">@{{value}}</div>
                         </div>


### PR DESCRIPTION
<h2>Changes</h2>

- Change the env variable value Input to a Textarea, allowing for displaying longer data. 

- Convert the env variable value column type from 'TEXT' to 'LONGTEXT' in the database allowing storing of data larger than 64kb. 



https://www.loom.com/share/2697f4c87e9b4545a52e333ff90d46d7

<h2>To Test</h2>

- Create an Env Variable with a value longer than 64kb and save

**Expected Result**
Env variable is successfully created.

closes #2875 