### PR TITLE
Fix Assign by Expression User ID

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -681,6 +681,11 @@ class Process extends Model implements HasMedia
                         case 'self_service':
                             $user = null;
                             break;
+                        case 'user_by_id':
+                            $mustache = new Mustache_Engine();
+                            $assigneeId = $mustache->render($item->assignee, $instanceData);
+                            $user = $assigneeId;
+                            break;
                         case 'script':
                         default:
                             $user = null;

--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -166,6 +166,7 @@
         error: "",
         hideUsers: false,
         hideUsersAssignmentExpression: false,
+        specialAssignedUserID: null,
       };
     },
     mounted () {
@@ -235,20 +236,6 @@
           if (this.assignment === "user_by_id" && value) {
             this.assignedUserSetter(value);
             this.assignedGroupSetter("");
-          }
-        }
-      },
-      specialAssignedUserID: {
-        get () {
-          let value = "";
-          if (this.typeAssignmentExpression === "user_by_id") {
-            value = this.specialAssignedUserIdGetter();
-          }
-          return value;
-        },
-        set (value) {
-          if (this.typeAssignmentExpression === "user_by_id" && value) {
-            this.specialAssignedUserIdSetter(value);
           }
         }
       },
@@ -357,7 +344,7 @@
           this.assignmentExpression = "";
           this.typeAssignmentExpression = "";
           this.assignedExpression = null;
-          this.specialAssignedUserIdSetter(null);
+          this.specialAssignedUserID = null;
         }
       },
 
@@ -389,7 +376,7 @@
           this.assignmentExpression = "";
           this.typeAssignmentExpression = "";
           this.assignedExpression = null;
-          this.specialAssignedUserIdSetter(null);
+          this.specialAssignedUserID = null;
         }
 
         this.addingSpecialAssignment = false;
@@ -486,13 +473,6 @@
           }
         })
       },
-      specialAssignedUserIdSetter (id) {        
-        this.$set(this.node, "specialAssignedUserId", id);
-      },
-      specialAssignedUserIdGetter () {
-        let value = _.get(this.node, "specialAssignedUserId");
-        return value;
-      }
     },
     watch: {
       assigned: {

--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -296,13 +296,13 @@
         this.$set(node, "assignedGroups", id);
       },
       formatIfById (val) {
-        if (this.assignment === "user_by_id" || this.typeAssignmentExpression === "user_by_id") {
+        if (this.assignment === "user_by_id") {
           return `{{ ${val} }}`;
         }
         return val;
       },
       unformatIfById (val) {
-        if (this.assignment === "user_by_id" || this.typeAssignmentExpression === "user_by_id") {
+        if (this.assignment === "user_by_id") {
           try {
             return val.match(/^{{ (.*) }}$/)[1];
           } catch (e) {


### PR DESCRIPTION
<h2>Changes</h2>

- Display input when assigning a user by User ID.

- Enable the input field to run mustache syntax. 

<a href="https://www.loom.com/share/c5c5b6c6b1494a28a44bdfad11712ed5"> <p>5 March, 2020 - Loom Recording - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/c5c5b6c6b1494a28a44bdfad11712ed5-with-play.gif"> </a>

<h2>To Test</h2>

1. Before testing ensure you have an additional user account you are able to login to. 
2. Login as an Admin and create a screen.
3. Add an input field with a variable name `foo`.
4. Add another field that will allow selecting/inputting the above user account id with a variable name `user_id`
5. Create a process and attach the above screen to a task. 
6. Add another task to the process and set the assignment rules by expression to `User ID`
7. In the expression field input `foo=="bar"`
8. In the Name of 'Variable Name of User ID' field input `{{user_id}}` or optionally you can set the input to a specific User ID `2` for example.
9. Save and run the process.
10. In the `foo` field input `bar`. Select/input the correct user ID in step 1 into the `user_id` field and submit.
11. Login as the user in Step 1. Filter the task by request name. 

<b>Expected Result</b>
A task should display for that user. 







 
