### PR TITLE
Fixing spacing in admin/users

### DIFF
--- a/resources/views/admin/users/deletedUsers.blade.php
+++ b/resources/views/admin/users/deletedUsers.blade.php
@@ -1,4 +1,4 @@
-<div class="px-3 page-content" id="deleted-users-listing">
+<div id="deleted-users-listing">
     <div id="search-bar" class="search mb-3" vcloak>
         <div class="d-flex flex-column flex-md-row">
             <div class="flex-grow-1">

--- a/resources/views/admin/users/list.blade.php
+++ b/resources/views/admin/users/list.blade.php
@@ -1,5 +1,5 @@
 
-<div class="px-3 page-content" id="users-listing">
+<div id="users-listing">
     <div id="search-bar" class="search mb-3" vcloak>
         <div class="d-flex flex-column flex-md-row">
             <div class="flex-grow-1">


### PR DESCRIPTION
## Changes
- Removes unneeded classes to fix spacing in the Users and Deleted Users tab

## Before
![Screen Shot 2020-03-06 at 9 15 06 AM](https://user-images.githubusercontent.com/867714/76107489-98fd8380-5f8d-11ea-8c24-c74f7f04a453.png)

## After
![Screen Shot 2020-03-06 at 9 34 12 AM](https://user-images.githubusercontent.com/867714/76107523-ac105380-5f8d-11ea-882c-84090bd1778c.png)

Closes #2933.