### PR TITLE
Do not emit empty id when there is no screen yet

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -61,8 +61,6 @@
           if (this.content) {
             this.error = '';
             this.$emit('input', this.content.id);
-          } else  {
-            this.$emit('input', '');
           }
         }
       },


### PR DESCRIPTION
Fixes #2941 

Fixes task screen select loosing its value in inspector