### PR TITLE
Add missing Asterisks

### DIFF
--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -22,7 +22,7 @@
                 <nav>
                     <div class="nav nav-tabs" id="nav-tab" role="tablist">
                         <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-home"
-                           role="tab" aria-controls="nav-home" aria-selected="true">{{__('Group Details')}}</a>
+                           role="tab" aria-controls="nav-home" aria-selected="true">{{__('Group Details')}} </a>
                         <a class="nav-item nav-link" id="nav-profile-tab" data-toggle="tab" href="#nav-users" role="tab"
                            aria-controls="nav-profile" aria-selected="false">{{__('Group Members')}}</a>
                         <a class="nav-item nav-link" id="nav-permissions-tab" data-toggle="tab" href="#nav-permissions"
@@ -35,7 +35,7 @@
                     <div class="card card-body border-top-0 tab-pane p-3 fade show active" id="nav-home" role="tabpanel"
                          aria-labelledby="nav-home-tab">
                         <div class="form-group">
-                            {!! Form::label('name', __('Name')) !!}
+                            {!! Form::label('name', __('Name') . '<small class="ml-1">*</small>', [], false) !!}
                             {!! Form::text('name', null, [
                             'id' => 'name',
                             'class'=> 'form-control',
@@ -122,7 +122,7 @@
                         </div>
                         <div class="modal-body">
                             <div class="form-user">
-                                {!!Form::label('users', __('Users'))!!}
+                                {!!Form::label('users', __('Users') . '<small class="ml-1">*</small>', [], false)!!}
                                 <multiselect v-model="selectedUsers"
                                              placeholder="{{__('Select user or type here to search users')}}"
                                              :options="availableUsers"

--- a/resources/views/processes/screens/edit.blade.php
+++ b/resources/views/processes/screens/edit.blade.php
@@ -28,7 +28,7 @@
                         <div class="invalid-feedback" v-if="errors.title">@{{errors.title[0]}}</div>
                     </div>
                     <div class="form-group">
-                        {!! Form::label('description', __('Description')) !!}
+                        {!! Form::label('description', __('Description') . '<small class="ml-1">*</small>', [], false) !!}
                         {!! Form::textarea('description', null, ['id' => 'description', 'rows' => 4, 'class'=> 'form-control',
                         'v-model' => 'formData.description', 'v-bind:class' => '{"form-control":true, "is-invalid":errors.description}']) !!}
                         <div class="invalid-feedback" v-if="errors.description">@{{errors.description[0]}}</div>


### PR DESCRIPTION
<h2>Changes</h2>
Adds missing Asterisks to

1. Screen config description field
2. Group Members 'Add User' modal field
3. Group Details 'Name' field

Note: 
1. queue management > monitoring > monitor tag > tag name - is part of Horizon's UI.

Closes reopened ticket #2879 