### PR TITLE
Fix file download editor-control

### DIFF
--- a/resources/js/processes/screen-builder/components/file-download-control.js
+++ b/resources/js/processes/screen-builder/components/file-download-control.js
@@ -11,7 +11,7 @@ export default {
         label: "File Download",
         component: "FileDownload",
         "editor-component": "FormText",
-        "editor-config": "FormText",
+        "editor-control": "FileDownload",
         config: {
             label: "New File Download",
             icon: "fas fa-file-download"


### PR DESCRIPTION
<h2>Changes</h2>

The issue occurs when adding a RecordList control, saving the screen, and refreshing. The File Download Control was overwriting the RecordList inspector configurations after refreshing because they shared the same `editor-control`. This PR prevents the RecordList inspector configurations from being overwritten by updating the File Download `editor-control` key value to `FileDownload`. 

<h2>Before</h2>

<a href="https://www.loom.com/share/41ba1258050d4ecd87448d548a6c4c4c"> <p>11 March, 2020 - Loom Recording - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/41ba1258050d4ecd87448d548a6c4c4c-with-play.gif"> </a>

<h2>After</h2>

https://www.loom.com/share/0d544be5732a4f82b45b7f2ecb6a637b


<h2>To Test</h2>

Drag a RecordList control onto the screen
Check the Inspector configurations
Save & refresh the page
Select the RecordList control and check the inspector configurations

**Expected Result**
The inspector configurations are the same as when the control was first added onto the screen.


Dependency: [ScreenBuilder/#629 ](https://github.com/ProcessMaker/screen-builder/pull/629)

Ref [ScreenBuilder/#628](https://github.com/ProcessMaker/screen-builder/issues/628)