### PR TITLE
Remove task config override

### DIFF
--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -71,13 +71,6 @@ let nodeTypes = [
 ProcessMaker.nodeTypes.push(startEvent);
 ProcessMaker.nodeTypes.push(...nodeTypes);
 
-// Set default properties for task
-task.definition = function definition(moddle) {
-  return moddle.create('bpmn:Task', {
-    name: window.ProcessMaker.events.$t('New Task'),
-    assignment: 'requester'
-  });
-};
 ProcessMaker.EventBus.$on('modeler-init', registerNodes);
 
 ProcessMaker.EventBus.$on(


### PR DESCRIPTION
This change is required for the documentation feature to work correctly: https://github.com/ProcessMaker/modeler/pull/1137. The code for setting the default Task Assignment data has been moved to that PR.