### PR TITLE
Add autoincrement to request_user_permissions

### DIFF
--- a/ProcessMaker/Models/RequestUserPermission.php
+++ b/ProcessMaker/Models/RequestUserPermission.php
@@ -10,10 +10,6 @@ class RequestUserPermission extends Model
 {
     protected $table = "request_user_permissions";
 
-    protected $primaryKey = ['request_id', 'user_id'];
-
-    public $incrementing = false;
-
     protected $connection = 'data';
 
     protected $fillable = [

--- a/database/migrations/2020_03_16_124924_add_id_request_user_permissions_table.php
+++ b/database/migrations/2020_03_16_124924_add_id_request_user_permissions_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIdRequestUserPermissionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('request_user_permissions', function (Blueprint $table) {
+            $table->dropPrimary( ['request_id', 'user_id'] );
+        });
+        Schema::table('request_user_permissions', function (Blueprint $table) {
+            $table->increments('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('request_user_permissions', function (Blueprint $table) {
+            $table->dropColumn(['id']);
+            $table->primary(['request_id', 'user_id']);
+        });
+    }
+}


### PR DESCRIPTION
Resolves #2961 

This PR fixes and issue when the model is registered by Telescope. To do that following changes were made:

- Remove the primary key (`request_id`, `user_id`) of request_user_permissions
- Add an auto-incremental primary key `id`
- Update the Model

