### PR TITLE
Add missing elements to nodes list

### DIFF
--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -66,6 +66,8 @@ let nodeTypes = [
   messageFlow,
   serviceTask,
   textAnnotation,
+  intermediateMessageCatchEvent,
+  eventBasedGateway,
 ];
 
 ProcessMaker.nodeTypes.push(startEvent);


### PR DESCRIPTION
This PR fixes an issue with the vocabularies component in modeler. Two elements were accidentally removed from the `nodeTypes` list and this PR re-adds them.

<img width="544" alt="Screen Shot 2020-03-17 at 2 14 06 PM" src="https://user-images.githubusercontent.com/7561061/76889256-a8b57b80-685b-11ea-96d5-edb1591ec1e7.png">
