### PR TITLE
Fix About Page fails without node_modules

### DIFF
--- a/ProcessMaker/Http/Controllers/AboutController.php
+++ b/ProcessMaker/Http/Controllers/AboutController.php
@@ -14,11 +14,12 @@ class AboutController extends Controller
      */
     public function index()
     {
+        $root = base_path('');
         $vendor_path = base_path('vendor/processmaker');
-        $node_path = base_path('node_modules/@processmaker');
-        
+        $package_json_path = json_decode(file_get_contents($root . '/package.json'));
+        $dependencies = $package_json_path->dependencies;
         $vendor_directories = \File::directories($vendor_path);
-        $node_directories = \File::directories($node_path);
+        $string = '@processmaker';
         
         $packages = array();
 
@@ -26,10 +27,17 @@ class AboutController extends Controller
             $content = json_decode(file_get_contents($vendor_path . '/' . basename($directory) . '/composer.json'));
             array_push($packages, $content);
         }
-        foreach($node_directories as $directory) {
-            $content = json_decode(file_get_contents($node_path . '/' . basename($directory) . '/package.json'));
-            array_push($packages, $content);
+
+        foreach($dependencies as $key => $value) {
+            if (strpos($key, $string) !== false) {
+                $value = str_replace('^', '', $value);
+                $content = new \stdClass();
+                $content->name = $key;
+                $content->version = $value;
+                array_push($packages, $content);
+            }
         }
+        
         return view('about.index', compact('packages'));
     }
 }


### PR DESCRIPTION
<h2>Changes</h2>

Parses the installed packages from the `package.json`file instead of the `node_modules` directory.

**Note:**
The packages will no longer have a description field since there is no description within the `packages.json` file.

<h4>Before</h4>

![Screen Shot 2020-03-24 at 10 38 35 AM](https://user-images.githubusercontent.com/52755494/77463151-68f21500-6dc2-11ea-9081-fc8d02d7cdc2.png)

<h4>After</h4>

![Screen Shot 2020-03-24 at 11 22 37 AM](https://user-images.githubusercontent.com/52755494/77463174-714a5000-6dc2-11ea-9643-1a06be702563.png)

<h2>To Test</h2>

 - Navigate to the `About` page in the UI.

- Remove your `node_modules` directory

- Refresh the `About` page.

**Expected Results**
The about page does not break and all of the installed packages are listed. 

closes #2977 
