### PR TITLE
Notifications Not Clearing by Broadcast

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -38,8 +38,8 @@ class TaskController extends Controller
     {
         $this->authorize('update', $task);
         //Mark as unread any not read notification for the task
-        Notification::where('data->url', Request::path())
-            ->whereNotNull('read_at')
+        Notification::where('data->url', '/' . Request::path())
+            ->whereNull('read_at')
             ->update(['read_at' => Carbon::now()]);
 
         $manager = new ScreenBuilderManager();

--- a/tests/Feature/NotificationControlsTest.php
+++ b/tests/Feature/NotificationControlsTest.php
@@ -2,19 +2,19 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Support\Facades\Request;
-use ProcessMaker\Models\Notification;
-use ProcessMaker\Models\ProcessRequestToken;
-use Tests\TestCase;
 use Illuminate\Database\Seeder;
-use ProcessMaker\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Request;
+use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Models\Notification;
+use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessNotificationSetting;
-use ProcessMaker\Models\Permission;
-use ProcessMaker\Facades\WorkflowManager;
-use Illuminate\Support\Facades\Artisan;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
-use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
 
 class NotificationControlsTest extends TestCase
 {

--- a/tests/Feature/NotificationControlsTest.php
+++ b/tests/Feature/NotificationControlsTest.php
@@ -120,7 +120,6 @@ class NotificationControlsTest extends TestCase
         // Create a request token to simulate that a new task is created for the user
         $token = factory(ProcessRequestToken::class)->create();
 
-
         //url to edit the task
         $taskUrl = route('tasks.edit', ['taks' => $token->id], false);
 


### PR DESCRIPTION
Resolves #2978 

- The query used to identify the unread notifications has been fixed
- A new test to verify this notification behavior has been added.
