### PR TITLE
Fix Signal Event - QA observations

### DIFF
--- a/resources/js/processes/modeler/components/inspector/SignalSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/SignalSelect.vue
@@ -122,7 +122,7 @@ export default {
       const usage = this.signalUsage(this.deleteSignal.id);
       const labels = [];
       usage.forEach(element => labels.push(element.name || element.id));
-      return labels.length ? (this.$t('Can not delete this signal, it is used by') + ': ' + labels.join(', ')) : '';
+      return labels.length ? (this.$t('This signal cannot be removed, it is used by') + ': ' + labels.join(', ')) : '';
     },
     localSignals() {
       const signals = [];
@@ -313,11 +313,8 @@ export default {
           name: signal.name,
         };
       } else {
-        window.ProcessMaker.apiClient
-          .get(`${this.api}/${value}`)
-          .then((response) => {
-            this.selectedOption = response.data;
-          });
+        this.$emit('input', '');
+        this.fixUnrefreshedVueFormRender();
       }
     },
   },

--- a/resources/js/processes/modeler/components/inspector/SignalSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/SignalSelect.vue
@@ -58,8 +58,8 @@
       </div>
     </div>
     <div v-else-if="showConfirmDelete" class="card mb-3 bg-danger text-white">
-      <div v-if="deleteSignalUsage" class="card-body p-2">
-        {{ deleteSignalUsage }}
+      <div v-if="deleteSignalUsage(deleteSignal.id)" class="card-body p-2">
+        {{ deleteSignalUsage(deleteSignal.id) }}
       </div>
       <div v-else class="card-body p-2">
         {{ $t('Are you sure you want to delete this item?') }}
@@ -69,7 +69,7 @@
         <button type="button" class="btn btn-sm btn-light mr-2 p-1 font-xs" @click="showConfirmDelete=false">
           Cancel
         </button>
-        <button v-if="!deleteSignalUsage" type="button" class="btn btn-sm btn-danger p-1 font-xs" @click="confirmDeleteSignal">
+        <button v-if="!deleteSignalUsage(deleteSignal.id)" type="button" class="btn btn-sm btn-danger p-1 font-xs" @click="confirmDeleteSignal">
           Delete
         </button>
       </div>
@@ -118,12 +118,6 @@ export default {
     },
   },
   computed: {
-    deleteSignalUsage() {
-      const usage = this.signalUsage(this.deleteSignal.id);
-      const labels = [];
-      usage.forEach(element => labels.push(element.name || element.id));
-      return labels.length ? (this.$t('This signal cannot be removed, it is used by') + ': ' + labels.join(', ')) : '';
-    },
     localSignals() {
       const signals = [];
       ProcessMaker.$modeler.definitions.rootElements.forEach((element) => {
@@ -158,6 +152,12 @@ export default {
     };
   },
   methods: {
+    deleteSignalUsage(id) {
+      const usage = this.signalUsage(id);
+      const labels = [];
+      usage.forEach(element => labels.push(element.name || element.id));
+      return labels.length ? (this.$t('This signal cannot be removed, it is used by') + ': ' + labels.join(', ')) : '';
+    },
     signalUsage(signalId) {
       const definitions = ProcessMaker.$modeler.definitions;
       const usage = [];

--- a/resources/js/processes/modeler/components/inspector/SignalSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/SignalSelect.vue
@@ -24,11 +24,8 @@
         </template>
       </multiselect>
       <div class="btn-group ml-1" role="group">
-        <button type="button" class="btn btn-secondary btn-sm" @click="showAddSignal">
-          <i class="fa fa-plus"></i>
-        </button>
-        <button v-if="value" type="button" class="btn btn-secondary btn-sm" @click="editSignal">
-          <i class="fa fa-pen"></i>
+        <button type="button" class="btn btn-secondary btn-sm" @click="toggleConfigSignal">
+          <i class="fa fa-ellipsis-h"></i>
         </button>
       </div>
     </div>
@@ -60,6 +57,31 @@
         </button>
       </div>
     </div>
+    <template v-if="showListSignals && !showNewSignal && !showEditSignal">
+      <table class="table table-sm table-striped" width="100%">
+        <thead>
+          <tr>
+            <td colspan="2" align="right">
+              <button type="button" class="btn btn-secondary btn-sm p-1 font-xs" @click="showAddSignal">
+                <i class="fa fa-plus"></i> Signal
+              </button>
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="signal in localSignals" :key="`signal-${signal.id}`">
+            <td>
+              <b-badge variant="secondary">{{ signal.id }}</b-badge>
+              {{ signal.name }}
+            </td>
+            <td align="right">
+              <a href="javascript:void(0)" @click="editSignal(signal)"><i class="fa fa-pen ml-1"></i></a>
+              <a href="javascript:void(0)" @click="removeSignal(signal)"><i class="fa fa-trash ml-1"></i></a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
   </div>
 </template>
 
@@ -79,6 +101,18 @@ export default {
     },
   },
   computed: {
+    localSignals() {
+      const signals = [];
+      ProcessMaker.$modeler.definitions.rootElements.forEach((element) => {
+        if (element.$type === 'bpmn:Signal') {
+          signals.push({
+            id: element.id,
+            name: element.name
+          });
+        }
+      });
+      return signals;
+    },
     valid() {
       return String(this.signalId) !== '' && String(this.signalName) !== '';
     },
@@ -86,6 +120,7 @@ export default {
   data() {
     return {
       pmql: 'id!=' + ProcessMaker.modeler.process.id,
+      showListSignals: false,
       showNewSignal: false,
       showEditSignal: false,
       globalSignals: [],
@@ -94,8 +129,16 @@ export default {
     };
   },
   methods: {
-    editSignal() {
-      const signal = this.getSignalById(this.value);
+    removeSignal(signal) {
+      const index = ProcessMaker.$modeler.definitions.rootElements.findIndex(element => element.id === signal.id);
+      if (index) {
+        ProcessMaker.$modeler.definitions.rootElements.splice(index, 1);
+      }
+    },
+    toggleConfigSignal() {
+      this.showListSignals = !this.showListSignals;
+    },
+    editSignal(signal) {
       this.signalId = signal.id;
       this.signalName = signal.name;
       this.showEditSignal = true;
@@ -174,3 +217,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+  .font-xs {
+    font-size: 0.75rem;
+  }
+</style>

--- a/resources/js/processes/modeler/components/inspector/SignalSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/SignalSelect.vue
@@ -57,7 +57,21 @@
         </button>
       </div>
     </div>
-    <template v-if="showListSignals && !showNewSignal && !showEditSignal">
+    <div v-else-if="showConfirmDelete" class="card mb-3 bg-danger text-white">
+      <div class="card-body p-2">
+        {{ $t('Are you sure you want to delete this item?') }}
+        ({{ deleteSignal.id }}) {{ deleteSignal.name }}
+      </div>
+      <div class="card-footer text-right p-2">
+        <button type="button" class="btn btn-sm btn-light mr-2 p-1 font-xs" @click="showConfirmDelete=false">
+          Cancel
+        </button>
+        <button type="button" class="btn btn-sm btn-danger p-1 font-xs" @click="confirmDeleteSignal">
+          Delete
+        </button>
+      </div>
+    </div>
+    <template v-else-if="showListSignals && !showNewSignal && !showEditSignal">
       <table class="table table-sm table-striped" width="100%">
         <thead>
           <tr>
@@ -123,17 +137,24 @@ export default {
       showListSignals: false,
       showNewSignal: false,
       showEditSignal: false,
+      showConfirmDelete: false,
+      deleteSignal: null,
       globalSignals: [],
       signalId: '',
       signalName: '',
     };
   },
   methods: {
-    removeSignal(signal) {
-      const index = ProcessMaker.$modeler.definitions.rootElements.findIndex(element => element.id === signal.id);
+    confirmDeleteSignal() {
+      this.showConfirmDelete = false;
+      const index = ProcessMaker.$modeler.definitions.rootElements.findIndex(element => element.id === this.deleteSignal.id);
       if (index) {
         ProcessMaker.$modeler.definitions.rootElements.splice(index, 1);
       }
+    },
+    removeSignal(signal) {
+      this.showConfirmDelete = true;
+      this.deleteSignal = signal;
     },
     toggleConfigSignal() {
       this.showListSignals = !this.showListSignals;

--- a/resources/js/processes/modeler/components/inspector/SignalSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/SignalSelect.vue
@@ -234,6 +234,11 @@ export default {
       return ProcessMaker.$modeler.definitions.rootElements.find(element => element.id === id);
     },
     change (value) {
+      if (!value) {
+        this.$emit('input', '');
+        this.fixUnrefreshedVueFormRender();
+        return;
+      }
       let signal = this.getSignalById(value.id);
       if (!signal) {
         signal = ProcessMaker.$modeler.moddle.create('bpmn:Signal', {
@@ -243,6 +248,18 @@ export default {
         ProcessMaker.$modeler.definitions.rootElements.push(signal);
       }
       this.$emit('input', this.storeId ? get(value, this.trackBy) : value);
+      this.fixUnrefreshedVueFormRender();
+    },
+    fixUnrefreshedVueFormRender() {
+      this.$nextTick(() => {
+        let form = this;
+        while (form && form.$options._componentTag !== 'vue-form-renderer') {
+          form = form.$parent;
+        }
+        if (form) {
+          form.$emit('update', form.transientData);
+        }
+      });
     },
     showAddSignal() {
       this.showNewSignal = true;


### PR DESCRIPTION
Fixes #2990 
Requires: https://github.com/ProcessMaker/modeler/pull/1176

This PR includes the following fixes and improvements:

- Add validation for `id` and `name` properties
- Do not delete unused signals when a signal reference is changed
- Fix create new signal
- Clear signal reference if pointing to a non-existent signal
- Add a list of signals to edit and remove signal definitions
- Validate if a signal is used before remove it

