### PR TITLE
Session timeout

### DIFF
--- a/ProcessMaker/Listeners/ActiveUserListener.php
+++ b/ProcessMaker/Listeners/ActiveUserListener.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ProcessMaker\Listeners;
+
+use Carbon\Carbon;
+use ProcessMaker\Events\SessionStarted;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class ActiveUserListener
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  SessionStarted  $event
+     * @return void
+     */
+    public function handle(SessionStarted $event)
+    {
+        $event->user->timestamps = false;
+        $event->user->active_at = Carbon::now();
+        $event->user->save();
+    }
+}

--- a/ProcessMaker/Listeners/LoginListener.php
+++ b/ProcessMaker/Listeners/LoginListener.php
@@ -17,6 +17,7 @@ class LoginListener
         // Grab our user that was logged in
         $user = $event->user;
         // Update the last_login
+        $user->timestamps = false;
         $user->loggedin_at = Carbon::now();
         $user->save();
     }

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -112,6 +112,7 @@ class User extends Authenticatable implements HasMedia
     protected $casts = [
         'is_administrator' => 'bool',
         'meta' => 'object',
+        'active_at' => 'datetime',
     ];
 
     /**

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -17,6 +17,9 @@ class EventServiceProvider extends ServiceProvider
         'Illuminate\Auth\Events\Login' => [
             'ProcessMaker\Listeners\LoginListener',
         ],
+        'ProcessMaker\Events\SessionStarted' => [
+            'ProcessMaker\Listeners\ActiveUserListener',
+        ]
     ];
 
     /**

--- a/config/session.php
+++ b/config/session.php
@@ -29,9 +29,21 @@ return [
     |
     */
 
-    'lifetime' => 120,
+    'lifetime' => env('SESSION_LIFETIME', 120),
 
     'expire_on_close' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Warning
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the number of seconds to give the user to preserve
+    | their session prior to its expiration.
+    |
+    */
+
+    'expire_warning' => env('SESSION_EXPIRE_WARNING', 180),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2020_04_06_003326_add_active_at_field_to_users_table.php
+++ b/database/migrations/2020_04_06_003326_add_active_at_field_to_users_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddActiveAtFieldToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dateTime('active_at')->nullable()->after('loggedin_at');
+            $table->index('active_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('active_at');
+        });
+    }
+}

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -16,7 +16,7 @@
     @endif
     <meta name="timeout-worker" content="{{ mix('js/timeout.js') }}">
     <meta name="timeout-length" content="{{ Session::has('rememberme') && Session::get('rememberme') ? "Number.MAX_SAFE_INTEGER" : config('session.lifetime') }}">
-    <meta name="timeout-warn-seconds" content="60">
+    <meta name="timeout-warn-seconds" content="{{ config('session.expire_warning') }}">
     @if(Session::has('_alert'))
       <meta name="alert" content="show">
       @php


### PR DESCRIPTION
## Changes
- Adds config option to specify how long a warning appears before a session ends; defaults to 3 minutes
- Adds active_at field to User model in order to better track when users were last active which will allow for better troubleshooting as well as future improvements

Closes #1524.