### PR TITLE
Modal Close Buttons Hidden

### DIFF
--- a/resources/js/admin/script-executors/ScriptExecutors.vue
+++ b/resources/js/admin/script-executors/ScriptExecutors.vue
@@ -24,7 +24,7 @@
                     <i class="fas fa-pen-square fa-lg fa-fw"></i>
                 </b-btn>
             </template>
-            
+
             <template v-slot:cell(delete)="data">
                 <b-btn
                     variant="link"
@@ -37,7 +37,7 @@
             </template>
         </b-table>
 
-        <b-modal ref="edit" id="edit" :title="modalTitle" @hidden="reset()" @hide="doNotHideIfRunning" size="lg">
+        <b-modal ref="edit" id="edit" :title="modalTitle" @hidden="reset()" @hide="doNotHideIfRunning" size="lg" header-close-content="&times;">
 
             <b-container class="mb-2">
                 <b-row>
@@ -64,7 +64,7 @@
                     </b-col>
                 </b-row>
             </b-container>
-                
+
             <p class="mb-0">Dockerfile</i></p>
 
             <div class="d-flex flex-row mb-1">
@@ -215,7 +215,7 @@ export default {
                     });
                 }
             );
-            
+
         },
         getError(name) {
             return _.get(this.errors, name + '.0', false);

--- a/resources/js/admin/users/components/AddUserModal.vue
+++ b/resources/js/admin/users/components/AddUserModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <b-modal id="addUserModal" :title="title">
+    <b-modal id="addUserModal" :title="title" header-close-content="&times;">
         <template v-slot:default>
             <slot name="default"></slot>
         </template>
@@ -92,7 +92,7 @@ export default {
                     this.showMsgBox(messageVNode, restoreData);
                 }
             });
-    
+
         }
     },
 }

--- a/resources/js/components/requests/modal.vue
+++ b/resources/js/components/requests/modal.vue
@@ -9,6 +9,7 @@
                  class="requests-modal modal-dialog-scrollable"
                  ref="requestModalAdd"
                  :title="$t('New Request')"
+                 header-close-content="&times;"
                  hide-footer>
             <b-row no-gutters>
                 <b-col cols="8">

--- a/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
+++ b/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
@@ -9,7 +9,7 @@
                 language="json" class="editor"></monaco-editor>
         </div>
         <small class="form-text text-muted">{{$t(helper)}}</small>
-        <b-modal v-model="showPopup" size="lg" centered :title="$t('Script Config Editor')" v-cloak>
+        <b-modal v-model="showPopup" size="lg" centered :title="$t('Script Config Editor')" v-cloak header-close-content="&times;">
             <div class="editor-container">
                 <monaco-editor :options="monacoLargeOptions" v-model="code"
                     language="json" class="editor"></monaco-editor>

--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -89,7 +89,7 @@
         ref="pagination"
       ></pagination>
     </div>
-    <b-modal ref="myModalRef" :title="$t('Copy Screen')" centered>
+    <b-modal ref="myModalRef" :title="$t('Copy Screen')" centered header-close-content="&times;">
       <form>
         <div class="form-group">
           <label for="title">{{$t('Name')}}<small class="ml-1">*</small></label>

--- a/resources/js/processes/screens/components/modal/modal-screen-add.vue
+++ b/resources/js/processes/screens/components/modal/modal-screen-add.vue
@@ -1,6 +1,6 @@
 <template>
     <b-modal v-model="opened" size="md" centered @hidden="onClose" @show="onReset" @close="onClose"
-             title="Create New Screen" v-cloak>
+             title="Create New Screen" v-cloak header-close-content="&times;">
         <create-screen ref="fieldsScreen" v-on:save="afterSave"></create-screen>
 
         <div slot="modal-footer">

--- a/resources/js/processes/scripts/components/ScriptListing.vue
+++ b/resources/js/processes/scripts/components/ScriptListing.vue
@@ -80,7 +80,7 @@
         ref="pagination"
       ></pagination>
     </div>
-    <b-modal ref="myModalRef" :title="$t('Copy Script')" centered>
+    <b-modal ref="myModalRef" :title="$t('Copy Script')" centered  header-close-content="&times;" >
       <form>
         <div class="form-group">
           <label for="title">{{ $t('Name') }}<small class="ml-1">*</small></label>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -155,6 +155,7 @@
                                 </button>
                               <b-modal v-model="showReassignment" size="md" centered title="{{__('Reassign to')}}"
                                       @hide="cancelReassign"
+                                      header-close-content="&times;"
                                       v-cloak>
                                 <div class="form-group">
                                     {!!Form::label('user', __('User'))!!}


### PR DESCRIPTION
Resolves #2991  

The property header-close-content="&times;" was added to interactive <b-modal>s used in the UI.

This is the PR that resolves the same problem in the ScreenBuilder project:

https://github.com/ProcessMaker/screen-builder/pull/670