### PR TITLE
Add missing close button for modals

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -661,3 +661,7 @@ h1.page-title {
     max-width: 350px;
   }  
 }
+
+button.close:empty::before {
+  content: "×";
+}


### PR DESCRIPTION
This PR add the missing content for close buttons.

![image](https://user-images.githubusercontent.com/8028650/79273091-72761680-7e70-11ea-9ec5-23ffc1d0ae96.png)
