### PR TITLE
Add ability to save process with unset start signal references

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1097,20 +1097,20 @@ class Process extends Model implements HasMedia, ProcessModelInterface
     }
 
     /**
-     * Get the start events with signal events
+     * Get the unique Signal References for the Signal Start Events.
      *
      * @return array
      */
-    public function getUpdatedStartEventsSignalEvents()
+    public function getUpdatedStartEventsSignalEvents(): array
     {
-        $response = [];
-        foreach($this->start_events as $event) {
-            foreach($event['eventDefinitions'] as $eventDefinition) {
-                if ($eventDefinition['$type'] === 'signalEventDefinition') {
-                    $response[] = $eventDefinition['signalRef'];
-                }
-            }
-        }
-        return $response;
+        $eventDefinitions = collect($this->start_events)->pluck('eventDefinitions')->flatten(1);
+
+        $signalEventDefinitions = $eventDefinitions->filter(function ($eventDefinition) {
+            return $eventDefinition['$type'] === 'signalEventDefinition';
+        });
+
+        $signalReferences = $signalEventDefinitions->pluck('signalRef')->unique();
+
+        return $signalReferences->toArray();
     }
 }


### PR DESCRIPTION
This allows an incomplete process that contains unconfigured Signal Start Events to be saved.

The `Process` model iterates over the `startEventDefinitions` and returns all `signalRef`s in `getUpdatedStartEventsSignalEvents`.

Originally, this would cause an exception to be thrown if the `signalRef` was not set up:
`Undefined index: signalRef at /home/vagrant/processmaker/ProcessMaker/Models/Process.php:1110`

This PR refactors `getUpdatedStartEventsSignalEvents` to use a more permissive pipeline approach. It will now return an empty array if no `signalRefs` are set, allowing us to save a process that is not fully finished.

**IMPORTANT BEHAVIOUR CHANGE**
The original returned all signal references, i.e. including duplicates. Having to processes start on the same signal would return:
```
array (
  0 => 'signal_ref',
  1 => 'signal_ref',
)
```

This version does run `unique()` on the references, so it would return:
```
array (
  0 => 'signal_ref',
)
```
in the same circumstances.

@caleeli I especially need your input on whether returning a unique set is the correct behaviour :) It's easily changed should it be incorrect.

Fixes #3058 