### PR TITLE
Add documentation view button for package-process-documenter

### DIFF
--- a/ProcessMaker/PackageHelper.php
+++ b/ProcessMaker/PackageHelper.php
@@ -2,9 +2,7 @@
 
 namespace ProcessMaker;
 
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use Symfony\Component\ErrorHandler\Error\UndefinedFunctionError;
 
 /**
  * A way to check if a package is installed by seeing if its service provider
@@ -22,10 +20,16 @@ use Symfony\Component\ErrorHandler\Error\UndefinedFunctionError;
  *  - passing your own service provider class string:
  *      e.g. PackageHelper::isPackageInstalled('ProcessMaker\Package\WebEntry\WebEntryServiceProvider')
  *
- * We don't use the ::class way to get the classname string, since that would fail if the class is not
- * installed.
+ * We don't use the ::class way to get the service provider's classname string, since
+ * that would fail if the class is not installed.
  *
  * @package ProcessMaker
+ *
+ * @method static bool isPmDockerExecutorLuaInstalled()
+ * @method static bool isPmDockerExecutorNodeInstalled()
+ * @method static bool isPmDockerExecutorPhpInstalled()
+ * @method static bool isPmPackageProcessDocumenterInstalled()
+ * @method static bool isPmPackageWebentryInstalled()
  */
 class PackageHelper
 {
@@ -52,38 +56,28 @@ class PackageHelper
      * @return bool
      * @throws \Exception
      */
-    public static function __callStatic($methodName, $parameters): bool
+    public static function __callStatic(string $methodName, array $parameters): bool
     {
         $matches = [];
         $matchesMagicMethodSignature = preg_match('/^is(.+)Installed$/', $methodName, $matches);
         if ($matchesMagicMethodSignature) {
             $constantName = self::magicNameToConstantName($matches[1]);
-            if (! self::isConstantDefined($constantName)) {
+            if (! defined('self::' . $constantName)) {
                 throw new \Exception(
                     sprintf('%s: No constant named \'%s\' defined.', self::class, $constantName)
                 );
             }
-            return self::getInstalledStatusForConstant($constantName);
+            return self::isPackageInstalled(constant('self::' . $constantName));
         }
 
         throw new \Exception(sprintf('%s: No function named \'%s\' defined.', self::class, $methodName));
-    }
-
-    private static function getInstalledStatusForConstant(string $constantName)
-    {
-        return self::isPackageInstalled(constant('self::' . $constantName));
-    }
-
-    private static function isConstantDefined($constantName)
-    {
-        return defined('self::' . $constantName);
     }
 
     /**
      * Turns the inside of a magic method invocation into its
      * symbolic constant form (i.e. ALL_UPPER_SNAKE).
      */
-    private static function magicNameToConstantName($magicName): string
+    private static function magicNameToConstantName(string $magicName): string
     {
         return strtoupper(Str::snake($magicName));
     }

--- a/ProcessMaker/PackageHelper.php
+++ b/ProcessMaker/PackageHelper.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace ProcessMaker;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\ErrorHandler\Error\UndefinedFunctionError;
+
+/**
+ * A way to check if a package is installed by seeing if its service provider
+ * class exists. This should be computationally cheaper than the method used in the
+ * about page (but doesn't provide the extra data that the about page has).
+ *
+ * The constants below are added as a convenience, and are not a complete list of package
+ * service providers. They do drive the "magic" method way of using this helper, though.
+ *
+ * You can use this helper by:
+ *  - using the magic methods:
+ *      e.g. PackageHelper::isPmPackageProcessDocumenterInstalled()
+ *  - passing the constants directly:
+ *      e.g. PackageHelper::isPackageInstalled(PackageHelper::PM_DOCKER_EXECUTOR_LUA)
+ *  - passing your own service provider class string:
+ *      e.g. PackageHelper::isPackageInstalled('ProcessMaker\Package\WebEntry\WebEntryServiceProvider')
+ *
+ * We don't use the ::class way to get the classname string, since that would fail if the class is not
+ * installed.
+ *
+ * @package ProcessMaker
+ */
+class PackageHelper
+{
+    const PM_DOCKER_EXECUTOR_LUA = 'ProcessMaker\Package\DockerExecutorLua\DockerExecutorLuaServiceProvider';
+    const PM_DOCKER_EXECUTOR_NODE = 'ProcessMaker\Package\DockerExecutorNode\DockerExecutorNodeServiceProvider';
+    const PM_DOCKER_EXECUTOR_PHP = 'ProcessMaker\Package\DockerExecutorPhp\DockerExecutorPhpServiceProvider';
+    const PM_PACKAGE_PROCESS_DOCUMENTER = 'ProcessMaker\Package\PackageProcessDocumenter\PackageServiceProvider';
+    const PM_PACKAGE_WEBENTRY = 'ProcessMaker\Package\WebEntry\WebEntryServiceProvider';
+
+    public static function isPackageInstalled(string $serviceProviderClass): bool
+    {
+        if (! $serviceProviderClass) {
+            return false;
+        }
+
+        return class_exists($serviceProviderClass);
+    }
+
+    /**
+     * Handle "magic" invocation.
+     *
+     * @param $methodName
+     * @param $parameters
+     * @return bool
+     * @throws \Exception
+     */
+    public static function __callStatic($methodName, $parameters): bool
+    {
+        $matches = [];
+        $matchesMagicMethodSignature = preg_match('/^is(.+)Installed$/', $methodName, $matches);
+        if ($matchesMagicMethodSignature) {
+            $constantName = self::magicNameToConstantName($matches[1]);
+            if (! self::isConstantDefined($constantName)) {
+                throw new \Exception(
+                    sprintf('%s: No constant named \'%s\' defined.', self::class, $constantName)
+                );
+            }
+            return self::getInstalledStatusForConstant($constantName);
+        }
+
+        throw new \Exception(sprintf('%s: No function named \'%s\' defined.', self::class, $methodName));
+    }
+
+    private static function getInstalledStatusForConstant(string $constantName)
+    {
+        return self::isPackageInstalled(constant('self::' . $constantName));
+    }
+
+    private static function isConstantDefined($constantName)
+    {
+        return defined('self::' . $constantName);
+    }
+
+    /**
+     * Turns the inside of a magic method invocation into its
+     * symbolic constant form (i.e. ALL_UPPER_SNAKE).
+     */
+    private static function magicNameToConstantName($magicName): string
+    {
+        return strtoupper(Str::snake($magicName));
+    }
+}

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -72,7 +72,7 @@
               </b-btn>
               <b-btn
                       variant="link"
-                      @click="onAction('action-todo', props.rowData, props.rowIndex)"
+                      @click="onAction('view-documentation', props.rowData, props.rowIndex)"
                       v-b-tooltip.hover
                       :title="$t('Documentation')"
                       v-if="permission.includes('view-processes') && isDocumenterInstalled"
@@ -189,6 +189,9 @@
       goToEdit(data) {
         window.location = "/processes/" + data + "/edit";
       },
+      goToDocumentation(processId) {
+        window.location = `/modeler/${processId}/print`;
+      },
       goToDesigner(data) {
         window.location = "/modeler/" + data;
       },
@@ -233,6 +236,9 @@
             break;
           case "edit-item":
             this.goToEdit(data.id);
+            break;
+          case "view-documentation":
+            this.goToDocumentation(data.id);
             break;
           case "export-item":
             this.goToExport(data.id);

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -74,7 +74,7 @@
                       variant="link"
                       @click="onAction('view-documentation', props.rowData, props.rowIndex)"
                       v-b-tooltip.hover
-                      :title="$t('Documentation')"
+                      :title="$t('View Documentation')"
                       v-if="permission.includes('view-processes') && isDocumenterInstalled"
               >
                 <i class="fas fa-map-signs fa-lg fa-fw"></i>

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -72,6 +72,15 @@
               </b-btn>
               <b-btn
                       variant="link"
+                      @click="onAction('action-todo', props.rowData, props.rowIndex)"
+                      v-b-tooltip.hover
+                      :title="$t('Documentation')"
+                      v-if="permission.includes('view-processes') && isDocumenterInstalled"
+              >
+                <i class="fas fa-map-signs fa-lg fa-fw"></i>
+              </b-btn>
+              <b-btn
+                      variant="link"
                       @click="onAction('export-item', props.rowData, props.rowIndex)"
                       v-b-tooltip.hover
                       :title="$t('Export')"

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -120,7 +120,7 @@
 
   export default {
     mixins: [datatableMixin, dataLoadingMixin],
-    props: ["filter", "id", "status", "permission"],
+    props: ["filter", "id", "status", "permission", "isDocumenterInstalled"],
     data() {
       return {
         orderBy: "name",

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -41,7 +41,7 @@
             v-on:edit="edit"
             v-on:reload="reload"
             :permission="{{ \Auth::user()->hasPermissionsFor('processes') }}"
-            :is-documenter-installed="{{\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()}}"
+            is-documenter-installed="{{\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()}}"
         ></processes-listing>
     </div>
 </div>

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -41,6 +41,7 @@
             v-on:edit="edit"
             v-on:reload="reload"
             :permission="{{ \Auth::user()->hasPermissionsFor('processes') }}"
+            :is-documenter-installed="{{\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()}}"
         ></processes-listing>
     </div>
 </div>


### PR DESCRIPTION
This adds a documentation link in the processes list.

The documentation button shows conditionally if the user has `view-processes` privileges and the `package-process-documenter` is installed.

## Determining if a package is installed

This PR adds a new helper file, `ProcessMaker/PackageHelper.php` that allows us to easily determine whether a package is installed (e.g. by calling `\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()`).

## Screenshots
### Without package-process-documenter
![image](https://user-images.githubusercontent.com/28595383/80248418-643dac80-865f-11ea-9753-ef39f5f0c3c2.png)


### With package-process-documenter installed
![image](https://user-images.githubusercontent.com/28595383/80248482-80d9e480-865f-11ea-8b67-59c2572fe73f.png)


Fixes: https://github.com/ProcessMaker/package-process-documenter/issues/12