### PR TITLE
Remove ID column from Tasks

### DIFF
--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -20,9 +20,6 @@
         pagination-path="meta"
         ref="vuetable"
       >
-        <template slot="ids" slot-scope="props">
-          <b-link :href="onAction('edit', props.rowData, props.rowIndex)">#{{props.rowData.id}}</b-link>
-        </template>
         <template slot="name" slot-scope="props">
           <b-link
             :href="onAction('edit', props.rowData, props.rowIndex)"
@@ -136,10 +133,6 @@ export default {
         };
         
         switch (column.field) {
-          case 'id':
-            field.name = '__slot:ids';
-            field.title = '#';
-            break;
           case 'task':
             field.name = '__slot:name';
             field.field = 'element_name';
@@ -193,12 +186,6 @@ export default {
         return this.$props.columns;
       } else {
         let columns = [
-          {
-            "label": "#",
-            "field": "id",
-            "sortable": true,
-            "default": true
-          },
           {
             "label": "Task",
             "field": "task",


### PR DESCRIPTION
<h2>Changes</h2>

Remove the ID (#) column from the Tasks list under the `/tasks` route.

![Screen Shot 2020-04-23 at 2 44 41 PM](https://user-images.githubusercontent.com/52755494/80152670-f9ae4300-8570-11ea-893b-49ad8b17dc8c.png)

closes #3073 