### PR TITLE
Fix screen select validation update

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -2,6 +2,7 @@
     <div class="form-group">
         <label>{{ $t(label) }}</label>
         <multiselect v-model="content"
+                     ref="screen-select"
                      track-by="id"
                      label="title"
                      :class="{'is-invalid':error}"
@@ -61,6 +62,7 @@
           if (this.content) {
             this.error = '';
             this.$emit('input', this.content.id);
+            this.$refs['screen-select'].$el.focus();
           }
         }
       },


### PR DESCRIPTION
Fixes https://github.com/ProcessMaker/modeler/issues/1216.

Video of fix: https://drive.google.com/file/d/1r9CciDnkL3fzJL1d0rOVFpctPsc0xufF/view?usp=sharing.

To keep the undo/redo history sane (i.e. to prevent every keystroke from adding a history item), we only update state on focusout. However, after selecting an item in the multiselect dropdown, focus does not return to the input and therefor no state update is triggered after making a selection. This PR fixes that issue for this dropdown component.