### PR TITLE
Fix issue with screen import

### DIFF
--- a/ProcessMaker/Jobs/ImportScreen.php
+++ b/ProcessMaker/Jobs/ImportScreen.php
@@ -8,41 +8,15 @@ use ProcessMaker\Models\Script;
 class ImportScreen extends ImportProcess
 {
     /**
-     * Create a new Screen model for each screen object in the imported file,
-     * then save it to the database.
-     *
-     * @param Screen $screen
-     *
-     * @return void
-     */
-    private function saveScreens($screen)
-    {
-        try {
-            $this->new[Screen::class] = [];
-            $this->prepareStatus('screens', true);
-
-            $new = new Screen();
-            $new->fill((array)$screen);
-            $new->title = $this->formatName($screen->title, 'title', Screen::class);
-            $new->created_at = $this->formatDate($screen->created_at);
-            $new->watchers =  $this->watcherScriptsToSave($screen);
-
-            $new->save();
-
-            $this->finishStatus('screens');
-        } catch (Exception $e) {
-            $this->finishStatus('screens', true);
-        }
-    }
-
-    /**
      * Parse files with version 1
      *
      * @return array
      */
     private function parseFileV1()
     {
-        $this->saveScreens($this->file->screens);
+        $this->prepareStatus('screens', 1);
+        $this->saveScreen($this->file->screens);
+        $this->finishStatus('screens');
         return $this->status;
     }
 

--- a/tests/Feature/Processes/ExportImportScreenTest.php
+++ b/tests/Feature/Processes/ExportImportScreenTest.php
@@ -151,6 +151,6 @@ class ExportImportScreenTest extends TestCase
         $response->assertStatus(200);
 
         //Unable to import the screen.
-        $this->assertFalse($response->json('status')['screens']['success']);
+        $this->assertTrue($response->json('status')['screens']['success']);
     }
 }

--- a/tests/Feature/Processes/ExportImportScreenTest.php
+++ b/tests/Feature/Processes/ExportImportScreenTest.php
@@ -150,7 +150,7 @@ class ExportImportScreenTest extends TestCase
         ]);
         $response->assertStatus(200);
 
-        //Unable to import the screen.
+        //Able to import the screen.
         $this->assertTrue($response->json('status')['screens']['success']);
     }
 }


### PR DESCRIPTION
## Changes
- Fixes an issue where screens would not import if they had a category ID but no actual categories
- Relies on the parent Import class for screen import to keep code more DRY

## Testing Instructions
1. Attempt to import this screen specifically:
[Paid Sick Leave Request WE.json.zip](https://github.com/ProcessMaker/processmaker/files/4578043/Paid.Sick.Leave.Request.WE.json.zip)
2. Attempt to import other screens

Fixes #3088.