### PR TITLE
Assignment by Rules Broken

### DIFF
--- a/ProcessMaker/Exception/UserOrGroupAssignmentEmptyException.php
+++ b/ProcessMaker/Exception/UserOrGroupAssignmentEmptyException.php
@@ -1,0 +1,20 @@
+<?php
+namespace ProcessMaker\Exception;
+
+use Exception;
+
+/**
+ * The task does not have users to assign
+ *
+ */
+class UserOrGroupAssignmentEmptyException extends Exception
+{
+
+    /**
+     * @param string $task
+     */
+    public function __construct($task)
+    {
+        parent::__construct(__('The task ":task" has an incomplete assignment. The group was not found or it does not have users.', ['task' => $task]));
+    }
+}

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -15,6 +15,7 @@ use ProcessMaker\Contracts\ProcessModelInterface;
 use ProcessMaker\Exception\InvalidUserAssignmentException;
 use ProcessMaker\Exception\TaskDoesNotHaveRequesterException;
 use ProcessMaker\Exception\TaskDoesNotHaveUsersException;
+use ProcessMaker\Exception\UserOrGroupAssignmentEmptyException;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ProcessInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
@@ -567,7 +568,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
             $users = $this->getAssignableUsers($processTaskUuid);
         }
         if (empty($users)) {
-            throw new TaskDoesNotHaveUsersException($processTaskUuid);
+            throw new UserOrGroupAssignmentEmptyException($processTaskUuid);
         }
         sort($users);
         if ($last) {
@@ -644,6 +645,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
         $assignmentRules = $activity->getProperty('assignmentRules', null);
 
         $instanceData = $token->getInstance()->getDataStore()->getData();
+
         if ($assignmentRules && $instanceData) {
             $list = json_decode($assignmentRules);
             $list = ($list === null) ? [] : $list;


### PR DESCRIPTION
Resolves #3090 

The issue happened because the selected group (by the rule) is empty - it doesn't have users. 
A new and more specific exception has been added. The exception now is:

![image](https://user-images.githubusercontent.com/14875032/81116815-08dbac00-8ef4-11ea-91e9-aa2780eea07a.png)
