### PR TITLE
"Screen for input" menu always expands when clicking a form task

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -62,7 +62,8 @@
           if (this.content) {
             this.error = '';
             this.$emit('input', this.content.id);
-            this.$refs['screen-select'].$el.focus();
+            this.$refs['screen-select'].activate();
+            this.$refs['screen-select'].deactivate();
           }
         }
       },


### PR DESCRIPTION
Resolves #3113 

Multiselect opens the options list when focus is set. This behavior will be resolved in the version 3 of the this component but it still in beta. [Look at this thread](https://github.com/shentao/vue-multiselect/issues/740).

For the problem mentioned above, we added the deactivation of the component so that the  option list is closed after the focus is set. 

In the attached video it can be seen that the process validator is updated when selecting a screen and that the list of screens is opened (for the focus) and closed immediately  when selecting a task.

![Peek 2020-05-08 17-05](https://user-images.githubusercontent.com/14875032/81449497-5f442700-914e-11ea-86a3-4d9467e3e4d7.gif)


**Note:** In pull request 3080 the change to set the  focus was added because there was a  problem with the process validator. It was not updated after a screen selection. For reference, these are the issue and the related PR:

https://github.com/ProcessMaker/modeler/issues/1216
https://github.com/ProcessMaker/processmaker/pull/3080