### PR TITLE
Specify table name in Media model

### DIFF
--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -55,6 +55,8 @@ class Media extends Model
 {
     protected $connection = 'processmaker';
 
+    protected $table = 'media';
+
     /**
      * The attributes that are mass assignable.
      *


### PR DESCRIPTION
## Changes
- Directly specifies the name of the table in the Media model
- Fixes an issue where an error message appeared on every page after doing a fresh `composer install`

Closes #3115.