### PR TITLE
Auth Client Modal Submitting without Validation

### DIFF
--- a/resources/js/components/common/DataLoading.vue
+++ b/resources/js/components/common/DataLoading.vue
@@ -56,7 +56,7 @@
 
         mounted() {
             ProcessMaker.EventBus.$on('api-client-loading', (request) => {
-                if (this.for && this.for.test(request.url)) {
+                if (this.for && this.for.test(request.url) && request.method.toLowerCase() === 'get') {
                     this.dataLoading = true
                     this.error = false
                     this.noResults = false


### PR DESCRIPTION
Resolves #3121 

The problem was caused by the testing condition used to shoe the DataLoading component. It tests if the current request has some specific string but it is not differentiating between get/put/post calls. 

It was added the condition to restrict the DataLoading display just whit GET calls.

