### PR TITLE
Fix script editor height in safari

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -151,8 +151,9 @@ class ScriptController extends Controller
         $data = json_decode($request->get('data'), true) ?: [];
         $config = json_decode($request->get('config'), true) ?: [];
         $code = $request->get('code');
+        $nonce = $request->get('nonce');
 
-        TestScript::dispatch($script, $request->user(), $code, $data, $config);
+        TestScript::dispatch($script, $request->user(), $code, $data, $config, $nonce);
         return ['status' => 'success'];
     }
 

--- a/ProcessMaker/Jobs/TestScript.php
+++ b/ProcessMaker/Jobs/TestScript.php
@@ -24,6 +24,7 @@ class TestScript implements ShouldQueue
     protected $code;
     protected $data;
     protected $configuration;
+    protected $nonce;
 
     /**
      * Create a new job instance to execute a script.
@@ -34,13 +35,14 @@ class TestScript implements ShouldQueue
      * @param array $data
      * @param array $configuration
      */
-    public function __construct(Script $script, User $current_user, $code, array $data, array $configuration)
+    public function __construct(Script $script, User $current_user, $code, array $data, array $configuration, $nonce = null)
     {
         $this->script = $script;
         $this->current_user = $current_user;
         $this->code = $code;
         $this->data = $data;
         $this->configuration = $configuration;
+        $this->nonce = $nonce;
     }
 
     /**
@@ -71,6 +73,6 @@ class TestScript implements ShouldQueue
      */
     private function sendResponse($status, array $response)
     {
-        $this->current_user->notify(new ScriptResponseNotification($status, $response));
+        $this->current_user->notify(new ScriptResponseNotification($status, $response, null, $this->nonce));
     }
 }

--- a/ProcessMaker/Notifications/ScriptResponseNotification.php
+++ b/ProcessMaker/Notifications/ScriptResponseNotification.php
@@ -17,17 +17,19 @@ class ScriptResponseNotification extends Notification
     protected $status;
     protected $response;
     protected $watcher;
+    protected $nonce;
 
     /**
      * Create a new notification instance.
      *
      * @return void
      */
-    public function __construct($status, array $response, $watcher = null)
+    public function __construct($status, array $response, $watcher = null, $nonce = null)
     {
         $this->status = $status;
         $this->response = $response;
         $this->watcher = $watcher;
+        $this->nonce = $nonce;
     }
 
     /**
@@ -58,6 +60,7 @@ class ScriptResponseNotification extends Notification
             'status' => $this->status,
             'watcher' => $this->watcher,
             'response' => $response,
+            'nonce' => $this->nonce,
         ];
     }
 
@@ -87,6 +90,14 @@ class ScriptResponseNotification extends Notification
     public function getResponse()
     {
         return $this->response;
+    }
+    
+    /**
+     * Get the value of nonce
+     */
+    public function getNonce()
+    {
+        return $this->nonce;
     }
 
     /**

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -177,6 +177,7 @@ export default {
       optionsMenu: options,
       boilerPlateTemplate: this.$t(` \r Welcome to ProcessMaker 4 Script Editor \r To access Environment Variables use {accessEnvVar} \r To access Request Data use {dataVariable} \r To access Configuration Data use {configVariable} \r To preview your script, click the Run button using the provided input and config data \r Return an array and it will be merged with the processes data \r Example API to retrieve user email by their ID {apiExample} \r API Documentation {apiDocsUrl} \r `),
       editorReference: null,
+      nonce: null,
     };
   },
   watch: {
@@ -228,6 +229,10 @@ export default {
       this.editorReference.layout();
     },
     outputResponse(response) {
+      if (response.nonce !== this.nonce) {
+        return;
+      }
+
       if (this.executionKey && this.executionKey !== response.data.watcher) {
         return;
       }
@@ -265,11 +270,13 @@ export default {
       this.preview.failure = false;
       this.preview.output = undefined;
       // Attempt to execute a script, using our temp variables
+      this.nonce = Math.random().toString(36);
       ProcessMaker.apiClient.post("scripts/" + this.script.id + "/preview", {
         code: this.code,
         data: this.preview.data,
         config: this.preview.config,
-        timeout: this.script.timeout
+        timeout: this.script.timeout,
+        nonce: this.nonce,
       }).then((response) => {
         this.executionKey = response.data.key;
       });

--- a/tests/Feature/Api/ScriptsTest.php
+++ b/tests/Feature/Api/ScriptsTest.php
@@ -385,7 +385,11 @@ class ScriptsTest extends TestCase
         $response->assertStatus(200);
 
         $url = route('api.scripts.preview', $this->getScript('php')->id);
-        $response = $this->apiCall('POST', $url, ['data' => '{}', 'code' => '<?php return ["response"=>1];']);
+        $response = $this->apiCall('POST', $url, [
+            'data' => '{}',
+            'code' => '<?php return ["response"=>1];',
+            'nonce' => '123abc',
+        ]);
         $response->assertStatus(200);
 
         // Assertion: The script output is sent to usr through broadcast channel
@@ -394,7 +398,8 @@ class ScriptsTest extends TestCase
             ScriptResponseNotification::class,
             function ($notification, $channels) {
                 $response = $notification->getResponse();
-                return $response['output'] === ['response' => 1];
+                $nonce = $notification->getNonce();
+                return $response['output'] === ['response' => 1] && $nonce === '123abc';
             }
         );
     }


### PR DESCRIPTION
Fixes #2974 
- Fixes script editor height in safari
- Prevents script preview result from showing up in another tab/window