### PR TITLE
Notifications API fails with Apostrophy

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/Api/NotificationController.php
@@ -93,6 +93,7 @@ class NotificationController extends Controller
 
         $filter = $request->input('filter', '');
         if (!empty($filter)) {
+            $filter = addslashes($filter);
             $subsearch = '%' . $filter . '%';
             $query->where(function ($query) use ($subsearch, $filter) {
                 $query->Where('data->name', 'like', $subsearch)


### PR DESCRIPTION
closes #3161 

## Changes

- Add slashes in filter query notifications

![image](https://user-images.githubusercontent.com/1747025/83312509-87202b00-a1e0-11ea-8c03-537386fdba3c.png)
