### PR TITLE
Fix RecordList File Upload

### DIFF
--- a/resources/js/processes/screen-builder/components/form/file-upload.vue
+++ b/resources/js/processes/screen-builder/components/form/file-upload.vue
@@ -60,16 +60,8 @@ export default {
   },
   mounted() {
     this.removeDefaultClasses();
-
-    // If we're in a record list, this will fire to give us the prefix
-    this.$root.$on('set-upload-data-name', (recordList, index) => {
-      if (index === null) {
-        // Adding new record
-        index = recordList.value ? recordList.value.length : 0;
-      }
-      const prefix = recordList.name + "." + index.toString() + ".";
-      this.setFileUploadNameForChildren(recordList.$children, prefix);
-    })
+    
+    this.checkIfInRecordList();
 
     this.setPrefix();
     if (this.$refs['uploader']) {
@@ -273,6 +265,14 @@ export default {
             '&collection=' +
             'collection'
           : null;
+      }
+    },
+    checkIfInRecordList() {
+      const parent =  this.$parent.$parent.$parent;
+      if (parent.$options._componentTag == 'FormRecordList') {
+        const recordList = parent;
+        const prefix = recordList.name + '.';
+        this.setFileUploadNameForChildren(recordList.$children, prefix);
       }
     }
   }


### PR DESCRIPTION
<h2>Changes</h2>

1. Removes the index stored in the `data_name` prefixes when saving the uploaded file. Allowing correct referencing when using the file download component. 

2. Update the `data_name` prefix for upload files with visibility rules, by checking if the parent of the control is within a record list.

https://www.loom.com/share/75dbb9298ddb4b7e901840308e18b56c

<h2>To Test</h2>

1. Import attached process
[Test Record List.json.txt](https://github.com/ProcessMaker/processmaker/files/4718787/Test.Record.List.json.txt)


**Expected Results**
All uploaded files are able to download in the 2nd task. 

closes https://github.com/ProcessMaker/screen-builder/issues/752
