### PR TITLE
Allow topnav items added by packages

### DIFF
--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -20,20 +20,31 @@
         </div>
 
         <b-navbar-nav class="d-flex align-items-center">
-            @foreach(Menu::get('topnav')->items as $item)
-                <b-nav-item href="{{ $item->url() }}" {{$item->isActive !== false ? 'active': ''}}>
-                    {!! $item->title !!}
-                </b-nav-item>
-            @endforeach
-
             @if(Menu::get('customtopnav'))
-            @foreach(Menu::get('customtopnav')->items as $item)
-                <li class="nav-item">
-                    <a  target="{{ $item->attributes['target'] }}" href="{{ $item->url() }}" class="nav-link {{ $item->isActive === true ? 'active': ''}} {{ $item->attributes['class_link'] }} " >
-                    {!! $item->title !!}
-                    </a>
-                </li>
-            @endforeach
+                @foreach(Menu::get('customtopnav')->items as $item)
+                    <li class="nav-item">
+                        <a  target="{{ $item->attributes['target'] }}" href="{{ $item->url() }}" class="nav-link {{ $item->isActive === true ? 'active': ''}} {{ $item->attributes['class_link'] }} " >
+                        {!! $item->title !!}
+                        </a>
+                    </li>
+                @endforeach
+
+                @foreach(Menu::get('topnav')->items as $item)
+                    @php
+                        $itemRoute = Route::getRoutes()->match(Request::create($item->url()))
+                    @endphp
+                    @if(!$itemRoute->isFallBack && strpos($itemRoute->action['controller'], "ProcessMaker\\Http\\") !== 0)
+                        <b-nav-item href="{{ $item->url() }}" {{$item->isActive !== false ? 'active': ''}}>
+                            {!! $item->title !!}
+                        </b-nav-item>
+                    @endif
+                @endforeach
+            @else
+                @foreach(Menu::get('topnav')->items as $item)
+                    <b-nav-item href="{{ $item->url() }}" {{$item->isActive !== false ? 'active': ''}}>
+                        {!! $item->title !!}
+                    </b-nav-item>
+                @endforeach
             @endif
 
         </b-navbar-nav>

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -19,33 +19,36 @@
             <b-alert v-for="(item, index) in alerts" :key="index" class="d-none d-lg-block alertBox" :show="item.alertShow" :variant="item.alertVariant" dismissible fade @dismissed="alertDismissed(item)" @dismiss-count-down="alertDownChanged($event, item)" style="white-space:pre-line">@{{item.alertText}}</b-alert>
         </div>
 
+        @php
+            $menuItems = [];
+            $existsMenuProvider = Menu::get('customtopnav') !== null;
+            $customNav = $existsMenuProvider ? Menu::get('customtopnav')->items->all() : [];
+            $defaultNav = Menu::get('topnav')->items->all();
+            foreach(array_merge($customNav, $defaultNav) as $item) {
+                $newItem = (array) $item;
+                $newItem['link'] = $item->url();
+                $newItem['isCustom'] = in_array($item, $customNav);
+                $menuItems[] = $newItem;
+            }
+            // If a menu provider is installed, remove menu items from ProcessMaker but preserve any other (from packages, for example)
+            if ($existsMenuProvider) {
+                $menuItems = array_filter($menuItems, function ($item) use($customNav) {
+                    $itemRoute = Route::getRoutes()->match(Request::create($item['link']));
+                    $isCoreLink =  !$itemRoute->isFallBack && isset($itemRoute->action['controller']) && strpos($itemRoute->action['controller'], "ProcessMaker\\Http\\") === 0;
+                    return !$isCoreLink || $item['isCustom'];
+                });
+            }
+        @endphp
+
         <b-navbar-nav class="d-flex align-items-center">
-            @if(Menu::get('customtopnav'))
-                @foreach(Menu::get('customtopnav')->items as $item)
-                    <b-nav-item href="{{ $item->url() }}" {{$item->isActive !== false ? 'active': ''}} target="{{ $item->attributes['target'] }}" link-classes="{{ $item->attributes['class_link'] }}">
-                        {!! $item->title !!}
-                    </b-nav-item>
-                @endforeach
-
-                @foreach(Menu::get('topnav')->items as $item)
-                    @php
-                        $itemRoute = Route::getRoutes()->match(Request::create($item->url()));
-                        $isNotCoreRoute = strpos($itemRoute->action['controller'], "ProcessMaker\\Http\\") !== 0;
-                    @endphp
-                    @if(!$itemRoute->isFallBack && $isNotCoreRoute)
-                        <b-nav-item href="{{ $item->url() }}" {{$item->isActive !== false ? 'active': ''}}>
-                            {!! $item->title !!}
-                        </b-nav-item>
-                    @endif
-                @endforeach
-            @else
-                @foreach(Menu::get('topnav')->items as $item)
-                    <b-nav-item href="{{ $item->url() }}" {{$item->isActive !== false ? 'active': ''}}>
-                        {!! $item->title !!}
-                    </b-nav-item>
-                @endforeach
-            @endif
-
+                <b-nav-item v-for="item in {{ json_encode ($menuItems) }}"
+                            :href="item.link"
+                            :link-classes="item.attributes.class_link"
+                            :target="item.attributes.target"
+                            :active="item.isActive"
+                >
+                    <span v-html="item.title"></span>
+                </b-nav-item>
         </b-navbar-nav>
 
         <b-navbar-nav class="d-flex align-items-center ml-auto">

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -22,18 +22,17 @@
         <b-navbar-nav class="d-flex align-items-center">
             @if(Menu::get('customtopnav'))
                 @foreach(Menu::get('customtopnav')->items as $item)
-                    <li class="nav-item">
-                        <a  target="{{ $item->attributes['target'] }}" href="{{ $item->url() }}" class="nav-link {{ $item->isActive === true ? 'active': ''}} {{ $item->attributes['class_link'] }} " >
+                    <b-nav-item href="{{ $item->url() }}" {{$item->isActive !== false ? 'active': ''}} target="{{ $item->attributes['target'] }}" link-classes="{{ $item->attributes['class_link'] }}">
                         {!! $item->title !!}
-                        </a>
-                    </li>
+                    </b-nav-item>
                 @endforeach
 
                 @foreach(Menu::get('topnav')->items as $item)
                     @php
-                        $itemRoute = Route::getRoutes()->match(Request::create($item->url()))
+                        $itemRoute = Route::getRoutes()->match(Request::create($item->url()));
+                        $isNotCoreRoute = strpos($itemRoute->action['controller'], "ProcessMaker\\Http\\") !== 0;
                     @endphp
-                    @if(!$itemRoute->isFallBack && strpos($itemRoute->action['controller'], "ProcessMaker\\Http\\") !== 0)
+                    @if(!$itemRoute->isFallBack && $isNotCoreRoute)
                         <b-nav-item href="{{ $item->url() }}" {{$item->isActive !== false ? 'active': ''}}>
                             {!! $item->title !!}
                         </b-nav-item>


### PR DESCRIPTION
Resolves #3181 

The layout was modified so that when a topnav provider is registerd (for example the dynami-ui package) items added by packages are rendered. All PM core menu items in the topnav are removed.