### PR TITLE
Find items of custom menu using array_filter

### DIFF
--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -27,7 +27,10 @@
             foreach(array_merge($customNav, $defaultNav) as $item) {
                 $newItem = (array) $item;
                 $newItem['link'] = $item->url();
-                $newItem['isCustom'] = in_array($item, $customNav);
+                $itemsInCustom = array_filter($customNav, function ($el) use($item) {
+                    return $el === $item;
+                });
+                $newItem['isCustom'] = count($itemsInCustom) > 0;
                 $menuItems[] = $newItem;
             }
             // If a menu provider is installed, remove menu items from ProcessMaker but preserve any other (from packages, for example)


### PR DESCRIPTION
Resolves #3196 

The problem was caused for the use of the in_array function to search inside a multidimensional array. This function doesn't work properly with PHPs multidimensional arrays. The search now is done with a function and array_filter 
