### PR TITLE
Truncate docker output log and display more info

### DIFF
--- a/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
@@ -86,7 +86,11 @@ trait ScriptDockerBindingFilesTrait
                 );
             }
             Log::error('Script threw return code ' . $returnCode . 'Message: ' . implode("\n", $output));
-            throw new ScriptException(implode("\n", $output));
+            
+            $message = implode("\n", $output);
+            $message .= "\n\nProcessMaker Stack:\n";
+            $message .= (new \Exception)->getTraceAsString();
+            throw new ScriptException($message);
         }
         $outputs = $this->getOutputFilesContent();
         $this->removeTemporalFiles();

--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -115,7 +115,7 @@ abstract class Base
         $returnCode = $response['returnCode'];
         $stdOutput = $response['output'];
         $output = $response['outputs']['response'];
-        \Log::debug("Docker returned: " . json_encode($response));
+        \Log::debug("Docker returned: " . substr(json_encode($response), 0, 500));
         if ($returnCode || $stdOutput) {
             // Has an error code
             throw new RuntimeException(implode("\n", $stdOutput));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -94,10 +94,10 @@ if (env('POPULATE_DATABASE')) {
     Artisan::call('migrate:fresh', []);
 }
 
-if (count(ScriptExecutor::listOfExecutorImages('php')) === 0) {
+if (ScriptExecutor::where('language', 'php')->count() === 0) {
     Artisan::call('docker-executor-php:install');
 }
 
-if (count(ScriptExecutor::listOfExecutorImages('lua')) === 0) {
+if (ScriptExecutor::where('language', 'lua')->count() === 0) {
     Artisan::call('docker-executor-lua:install');
 }


### PR DESCRIPTION
Fixes #3167 
Requires https://github.com/ProcessMaker/docker-executor-php/pull/8

- Truncates docker log output to 500 characters
- Provides more info when a script task fails

Obscuring sensitive data is not necessary since docker output is only in the system log, not shown to any users.