### PR TITLE
Fix Screen/Script Select

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -82,15 +82,22 @@ class ScreenController extends Controller
 
 
         $filter = $request->input('filter', '');
+        $isSelectList = $request->input('selectList', '');
         if (!empty($filter)) {
             $filter = '%' . $filter . '%';
-            $query->where(function ($query) use ($filter) {
-                $query->where('title', 'like', $filter)
-                    ->orWhere('description', 'like', $filter)
-                    ->orWhere('type', 'like', $filter)
-                    ->orWhere('config', 'like', $filter)
-                    ->orWhere('category.name', 'like', $filter);
-            });
+            if (!$isSelectList) {
+                $query->where(function ($query) use ($filter) {
+                    $query->where('title', 'like', $filter)
+                        ->orWhere('description', 'like', $filter)
+                        ->orWhere('type', 'like', $filter)
+                        ->orWhere('config', 'like', $filter)
+                        ->orWhere('category.name', 'like', $filter);
+                });
+            } else {
+                $query->where(function ($query) use ($filter) {
+                    $query->where('title', 'like', $filter);
+                });
+            }
         }
         if ($request->input('type')) {
             $types = explode(',', $request->input('type'));

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -87,14 +87,21 @@ class ScriptController extends Controller
         }
 
         $filter = $request->input('filter', '');
+        $isSelectList = $request->input('selectList', '');
         if (!empty($filter)) {
             $filter = '%' . $filter . '%';
-            $query->where(function ($query) use ($filter) {
-                $query->Where('title', 'like', $filter)
-                    ->orWhere('description', 'like', $filter)
-                    ->orWhere('language', 'like', $filter)
-                    ->orWhere('category.name', 'like', $filter);
-            });
+            if (!$isSelectList) {
+                $query->where(function ($query) use ($filter) {
+                    $query->Where('title', 'like', $filter)
+                        ->orWhere('description', 'like', $filter)
+                        ->orWhere('language', 'like', $filter)
+                        ->orWhere('category.name', 'like', $filter);
+                });    
+            } else  {
+                $query->where(function ($query) use ($filter) {
+                    $query->Where('title', 'like', $filter);
+                });
+            }
         }
 
 

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -103,6 +103,7 @@
             type: this.type(),
             order_direction: 'asc',
             status: 'active',
+            selectList: true,
             filter: (typeof filter === 'string' ? filter : '')
           },
           this.params

--- a/resources/js/processes/modeler/components/inspector/ScriptSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScriptSelect.vue
@@ -104,9 +104,16 @@
     },
     methods: {
       load(filter) {
+        let params = Object.assign({
+          order_direction: 'asc',
+          selectList: true,
+          filter:(typeof filter === 'string' ? filter : '')
+        });
         this.loading = true;
         ProcessMaker.apiClient
-          .get("scripts?order_direction=asc" + (typeof filter === 'string' ? '&filter=' + filter : ''))
+          .get('scripts', {
+            params: params
+          })
           .then(response => {
             this.loading = false;
             this.scripts = response.data.data;


### PR DESCRIPTION
<h2>Changes</h2>

- Add `isSelectList` param when using a screen/script select list
- Query only by `name` when using a screen/script select list


![Screen Shot 2020-06-23 at 11 11 21 AM](https://user-images.githubusercontent.com/52755494/85439851-4e0a7a80-b542-11ea-9fc4-eb69fe0431af.png)

![Screen Shot 2020-06-23 at 11 11 08 AM](https://user-images.githubusercontent.com/52755494/85439848-4d71e400-b542-11ea-8679-61a4e2084cf9.png)

![Screen Shot 2020-06-23 at 11 12 54 AM](https://user-images.githubusercontent.com/52755494/85440066-81e5a000-b542-11ea-9adf-a1fb1db11641.png)

<h2>To Test</h2>

- Ensure you have multiple screens/scripts
- In Modeler select a form/script task
- Select the screen/script dropdown. 
- Search for a screen/script

**Expected Result**

Only relevant screens/scripts are returned based on the search query. 

closes #3218 