### PR TITLE
Validate if signal is defined

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -627,7 +627,10 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
             if ($element instanceof IntermediateCatchEventInterface) {
                 foreach ($element->getEventDefinitions() as $eventDefinition) {
                     if ($eventDefinition instanceof SignalEventDefinitionInterface) {
-                        $signalEvents[]= $eventDefinition->getProperty('signal')->getId();
+                        $signal = $eventDefinition->getProperty('signal');
+                        if ($signal) {
+                            $signalEvents[]= $signal->getId();
+                        }
                     }
                 }
             }

--- a/tests/Feature/Api/GlobalSignalsTest.php
+++ b/tests/Feature/Api/GlobalSignalsTest.php
@@ -153,70 +153,24 @@ class GlobalSignalsTest extends TestCase
      *
      * @group process_tests
      */
-    public function testGlobalSignalIntermediateWithoutCollaboration()
+    public function testProcessWithGlobalThrowWithoutSignal()
     {
         // Create the processes
         $parent = $this->createProcess([
             'id' => 1,
-            'bpmn' => file_get_contents(__DIR__ . '/processes/GlobalSignalSource.bpmn')
-        ]);
-        $target = $this->createProcess([
-            'id' => 2,
-            'bpmn' => file_get_contents(__DIR__ . '/processes/GlobalSignalIntermediate.bpmn')
+            'bpmn' => file_get_contents(__DIR__ . '/processes/GlobalSignalSourceMissing.bpmn')
         ]);
 
         // Start a parent process instance
-        $instance = $this->startProcess($parent, 'node_1');
+        $instance = $this->startProcess($parent, 'node_10');
 
-        // Assertion: Active Task = Task 1
-        $activeTask = $instance->tokens()->where('status', 'ACTIVE')->first();
-        $this->assertEquals('Task 1', $activeTask->element_name);
-        // Complete Parent Task
-        $this->completeTask($activeTask, []);
+        // Assertion: The process can be started without errors
+        $this->assertEquals('ACTIVE', $instance->status);
 
-        // Start the second process
-        $childRequest = $this->startProcess($target, 'node_1');
+        // Try update catch events
+        $instance->updateCatchEvents();
 
-        // Assertion: There are 2 Requests started
-        $this->assertEquals(2, ProcessRequest::count());
-
-        // Assertion: Active Task = Task 2 (in process two)
-        $activeTask = $childRequest->tokens()->where('status', 'ACTIVE')->first();
-        $this->assertEquals('Task 2', $activeTask->element_name);
-        // Complete Child Task
-        $this->completeTask($activeTask, []);
-
-        // Assertion: Active Task = Task 3 (process one)
-        $instance->refresh();
-        $activeTask = $instance->tokens()->where('status', 'ACTIVE')->first();
-        $this->assertEquals('Task 3', $activeTask->element_name);
-        // Complete Parent Task
-        $this->completeTask($activeTask, []);
-
-        // Assertion: Active Task = Task 4b (process two)
-        $childRequest->refresh();
-        $activeTask = $childRequest->tokens()->where('status', 'ACTIVE')->first();
-        $this->assertEquals('Task 4b', $activeTask->element_name);
-        // Complete Parent Task
-        $this->completeTask($activeTask, []);
-
-        // Assertion: Active Task = Task 4a (process one)
-        $instance->refresh();
-        $activeTask = $instance->tokens()->where('status', 'ACTIVE')->first();
-        $this->assertEquals('Task 4a', $activeTask->element_name);
-        // Complete Parent Task
-        $this->completeTask($activeTask, []);
-
-        // Get active tokens
-        $instance->refresh();
-        $childRequest->refresh();
-        $activeTokensParent = $instance->tokens()->where('status', 'ACTIVE')->get();
-        $activeTokensChild = $childRequest->tokens()->where('status', 'ACTIVE')->get();
-
-        // Assertion: All the request were completed
-        $this->assertCount(0, $activeTokensParent);
-        $this->assertCount(0, $activeTokensChild);
-        $this->assertEquals('COMPLETED', $instance->status);
-        $this->assertEquals('COMPLETED', $childRequest->status);
+        // Assertion: No signal events are registered
+        $this->assertCount(0, $instance->signal_events);
     }
 }

--- a/tests/Feature/Api/GlobalSignalsTest.php
+++ b/tests/Feature/Api/GlobalSignalsTest.php
@@ -149,11 +149,11 @@ class GlobalSignalsTest extends TestCase
     }
 
     /**
-     * Test send signals from two diffetent processes
+     * Test process with undefined signals
      *
      * @group process_tests
      */
-    public function testProcessWithGlobalThrowWithoutSignal()
+    public function testProcessWithUndefinedSignals()
     {
         // Create the processes
         $parent = $this->createProcess([

--- a/tests/Feature/Api/processes/GlobalSignalSourceMissing.bpmn
+++ b/tests/Feature/Api/processes/GlobalSignalSourceMissing.bpmn
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:intermediateThrowEvent id="node_4" name="Intermediate Signal Throw Event">
+      <bpmn:incoming>node_11</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="node_6" name="Intermediate Signal Catch Event">
+      <bpmn:incoming>node_8</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="node_7" name="End Event">
+      <bpmn:incoming>node_9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_8" sourceRef="node_4" targetRef="node_6" />
+    <bpmn:sequenceFlow id="node_9" sourceRef="node_6" targetRef="node_7" />
+    <bpmn:startEvent id="node_10" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_11</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_11" sourceRef="node_10" targetRef="node_4" />
+  </bpmn:process>
+  <bpmn:signal id="signal" name="signal" />
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="390" y="140" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+        <dc:Bounds x="640" y="140" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_7_di" bpmnElement="node_7">
+        <dc:Bounds x="820" y="140" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="408" y="158" />
+        <di:waypoint x="658" y="158" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="658" y="158" />
+        <di:waypoint x="838" y="158" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+        <dc:Bounds x="170" y="140" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+        <di:waypoint x="188" y="158" />
+        <di:waypoint x="408" y="158" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Resolves #3216 

This PR includes:

- A validation to check if a signal event is defined.
- Add a test to validate a process with empty signals did not crash.
