### PR TITLE
Request History Missing

### DIFF
--- a/resources/js/components/Timeline.vue
+++ b/resources/js/components/Timeline.vue
@@ -13,7 +13,7 @@
         @refresh="load"
       />
     </template>
-    <template v-if="isDefined('comment-editor')">
+    <template v-if="isDefined('comment-editor') && adding">
     <comment-editor
       v-model="newComment"
       class="mt-2"
@@ -31,7 +31,15 @@ const SubjectIcons = {
   'Gateway': 'far fa-square fa-rotate-45',
 };
 export default {
-  props: ["commentable_id", "commentable_type", "type", "hidden", "reactions", "voting", "edit", "remove"],
+  props: ["commentable_id", 
+            "commentable_type", 
+            "type", 
+            "hidden", 
+            "reactions", 
+            "voting", 
+            "edit", 
+            "remove",
+            "adding"],
   data() {
     return {
       newComment: '',

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -223,15 +223,14 @@
                         @endisset
                     </div>
                 </div>
-                <div v-if="configurationComments.comments">
                     <timeline commentable_id="{{ $request->getKey() }}"
                               commentable_type="{{ get_class($request) }}"
                               :reactions="configurationComments.reactions"
                               :voting="configurationComments.voting"
                               :edit="configurationComments.edit"
                               :remove="configurationComments.remove"
+                              :adding="configurationComments.comments"
                               />
-                </div>
             </div>
             <div class="ml-md-3 mt-3 mt-md-0">
                 <template v-if="statusLabel">

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -110,13 +110,14 @@
                                 </div>
                               </div>
                             </template>
-                            <div v-if="taskHasComments && taskHasComments.comments">
+                            <div v-if="taskHasComments">
                                 <timeline :commentable_id="task.id"
                                           commentable_type="ProcessMaker\Models\ProcessRequestToken"
                                           :reactions="taskHasComments.reactions"
                                           :voting="taskHasComments.voting"
                                           :edit="taskHasComments.edit_comments"
                                           :remove="taskHasComments.remove_comments"
+                                          :adding="taskHasComments.comments"
                                           />
                             </div>
                         </div>


### PR DESCRIPTION
Resolves #3223 

By mistake to show the timeline it was needed that the comments option for the process was set to active. Changes were made in the requests and task edit screens.
