### PR TITLE
Fix PMQL: 500 ISE "Trying to get property 'id' of non-object"

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -18,6 +18,7 @@ use ProcessMaker\Traits\SqlsrvSupportTrait;
 use Spatie\MediaLibrary\HasMedia\HasMedia;
 use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
 use Throwable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
  * Represents an Eloquent model of a Request which is an instance of a Process.
@@ -569,7 +570,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
      */
     private function valueAliasParticipant($value, $expression)
     {
-        $user = User::where('username', $value)->get()->first();
+        $user = User::where('username', $value)->firstOrFail();
         $tokens = ProcessRequestToken::where('user_id', $expression->operator, $user->id)->get();
 
         return function ($query) use ($tokens) {

--- a/resources/js/components/common/DataLoading.vue
+++ b/resources/js/components/common/DataLoading.vue
@@ -71,8 +71,12 @@
                 }
             })
             ProcessMaker.EventBus.$on('api-client-error', (error) => {
-                this.noResults = false
-                this.error = true
+                if (error && error.response.data.error == 'Not Found') {
+                    this.noResults = true;
+                } else {
+                    this.noResults = false
+                    this.error = true
+                }
             })
         },
         methods: {

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -270,8 +270,10 @@ export default {
                 this.data = this.transform(response.data);
               }).catch(error => {
                 if (_.has(error, 'response.data.message')) {
-                  ProcessMaker.alert(error.response.data.message, 'danger');
-                } else {
+                  ProcessMaker.alert(error.response.data.message, 'danger');  
+                } else if(_.has(error, 'response.data.error')) {
+                  return;
+                }  else {
                   throw error;
                 }
               });


### PR DESCRIPTION
<h2>Changes</h2>

- Replace the 'Api failed to load` message with the 'No Data Available' message
- Removes the 404 alert error banner

![Screen Shot 2020-06-24 at 1 31 32 PM](https://user-images.githubusercontent.com/52755494/85627927-255ab180-b624-11ea-995b-58f6657c4d81.png)

<h2>To Test</h2>

- From inside /requests, run a PMQL search:
participant = "invalidusername"

**Expected Result**

The 'No Data Available' message appears in the main results.

closes #3214 

