### PR TITLE
Add additional debug info to script executor build output

### DIFF
--- a/ProcessMaker/Console/Commands/BuildScriptExecutors.php
+++ b/ProcessMaker/Console/Commands/BuildScriptExecutors.php
@@ -4,7 +4,6 @@ namespace ProcessMaker\Console\Commands;
 
 use Illuminate\Console\Command;
 use ProcessMaker\Events\BuildScriptExecutor;
-use ProcessMaker\BuildSdk;
 use ProcessMaker\Models\ScriptExecutor;
 use \Exception;
 
@@ -130,7 +129,11 @@ class BuildScriptExecutors extends Command
             }
 
             $this->info("Building the SDK");
-            $this->artisan("processmaker:sdk $sdkLanguage $sdkDir --clean");
+            $cmd = "processmaker:sdk $sdkLanguage $sdkDir --clean";
+            if ($this->userId) {
+                $cmd .= ' --user-id=' . $this->userId;
+            }
+            $this->artisan($cmd);;
             $this->info("SDK is at ${sdkDir}");
         }
 

--- a/ProcessMaker/Console/Commands/GenerateSdk.php
+++ b/ProcessMaker/Console/Commands/GenerateSdk.php
@@ -14,7 +14,7 @@ class GenerateSdk extends Command
      *
      * @var string
      */
-    protected $signature = 'processmaker:sdk {language=none} {output=storage/api} {--list-options} {--clean}';
+    protected $signature = 'processmaker:sdk {language=none} {output=storage/api} {--list-options} {--clean} {--user-id=}';
 
     /**
      * The console command description.
@@ -41,7 +41,13 @@ class GenerateSdk extends Command
     public function handle()
     {
         $jsonPath = base_path('storage/api-docs/api-docs.json');
-        $builder = new BuildSdk($jsonPath, $this->argument('output'), false);
+        $builder = new BuildSdk($jsonPath, $this->argument('output'));
+        
+        $userId = $this->options()['user-id'];
+        if ($userId) {
+            $builder->setUserId($userId);
+        }
+
         if ($this->argument('language') === 'none') {
             $this->info(
                 "No language specified. Choose one of these: \n" . 


### PR DESCRIPTION
Fixes #3215 

I tried both staging and release-testing today and it didn't have the problem. My guess is it was waiting for some large docker image to download. This PR adds additional debugging info to the command. If it stalls at that step again we should be able to see what it's doing.

![image](https://user-images.githubusercontent.com/2546850/86047748-3f213d80-ba04-11ea-9ca4-5eb45f3e6bd9.png)
