### PR TITLE
Compare explicitly to check is column is sortable

### DIFF
--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -115,7 +115,7 @@ export default {
           field.field = column.field;
         }
         
-        if (column.sortable == true && !field.sortField) {
+        if (column.sortable === true && !field.sortField) {
           field.sortField = column.field;
         }
         

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -115,7 +115,7 @@ export default {
           field.field = column.field;
         }
         
-        if (column.sortable && ! field.sortField) {
+        if (column.sortable == true && !field.sortField) {
           field.sortField = column.field;
         }
         


### PR DESCRIPTION
Resolves #3236 

To solve the problem in the SavedSearch package it was necessary to explicitly check  (without implicit logical comparision) if the sortable field of the column is set to true.