### PR TITLE
Fix issue with pagination of Requests

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -141,6 +141,7 @@ class ProcessRequestController extends Controller
                 str_ireplace('.', '->', $request->input('order_by', 'name')),
                 $request->input('order_direction', 'ASC')
             )->paginate($request->input('per_page', 10));
+            $total = $response->total();
         } catch(QueryException $e) {
             throw $e;
             $rawMessage = $e->getMessage();

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -140,8 +140,7 @@ class ProcessRequestController extends Controller
             $response = $query->orderBy(
                 str_ireplace('.', '->', $request->input('order_by', 'name')),
                 $request->input('order_direction', 'ASC')
-            )->get();//->paginate($request->input('per_page', 10));
-
+            )->paginate($request->input('per_page', 10));
         } catch(QueryException $e) {
             throw $e;
             $rawMessage = $e->getMessage();

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -161,7 +161,8 @@ class ProcessRequestController extends Controller
         } else {
             $response = collect([]);
         }
-        return new ProcessRequestsCollection($response);
+
+        return new ProcessRequestsCollection($response, $total);
     }
 
     /**

--- a/ProcessMaker/Http/Resources/ApiCollection.php
+++ b/ProcessMaker/Http/Resources/ApiCollection.php
@@ -33,7 +33,7 @@ class ApiCollection extends ResourceCollection
     
     protected $appended;
 
-    protected $total;
+    protected $totalCount;
     
     /**
      * Create a new resource instance.
@@ -45,8 +45,8 @@ class ApiCollection extends ResourceCollection
     {
         parent::__construct($resource);
 
-        if ($this->total !== null) {
-            $this->total = (int) $total;
+        if ($total !== null) {
+            $this->totalCount = (int) $total;
         }
         
         $this->appended = (object) [];
@@ -112,10 +112,10 @@ class ApiCollection extends ResourceCollection
      */
     public function collectionToPaginator(Collection $collection, Request $request)
     {
-        if ($this->total === null) {
+        if ($this->totalCount === null) {
             $count = $collection->count();
         } else {
-            $count = $this->total;
+            $count = $this->totalCount;
         }
 
         $page = (int) $request->input('page', 1);

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -181,9 +181,16 @@ class ProcessTest extends TestCase
         $response = $this->apiCall('GET', route('api.processes.start', ['order_by' => 'category.name,name']));
         $this->assertStatus(200, $response);
 
+        $responseData = $response->getData()->data;
+        if (is_array($responseData)) {
+            $responseItem = $responseData[0];
+        } elseif (is_object($responseData)) {
+           $responseItem = $responseData->{'0'};
+        }
+
         // The returned list should be ordered category and then by process name, alphabetically
-        $this->assertEquals($cat2->id, $response->getData()->data[0]->process_category_id);
-        $this->assertEquals('BProcess', $response->getData()->data[0]->name);
+        $this->assertEquals($cat2->id, $responseItem->process_category_id);
+        $this->assertEquals('BProcess', $responseItem->name);
     }
 
 


### PR DESCRIPTION
## Changes
- Paginates the database request for Process Requests so as to avoid memory limit errors on large datasets
- Adds support for manually passing total number of rows to ApiCollection so that pagination metadata is properly generated
- Manually retrieves the total number of rows from the database request and passes it to ApiCollection

Fixes #3245.