### PR TITLE
Optimize updatePermissionsToRequests method

### DIFF
--- a/ProcessMaker/Models/RequestUserPermission.php
+++ b/ProcessMaker/Models/RequestUserPermission.php
@@ -15,6 +15,7 @@ class RequestUserPermission extends Model
     protected $fillable = [
         'request_id',
         'user_id',
+        'can_view',
     ];
 
     public function request()


### PR DESCRIPTION
## Changes
- Optimizes the updatePermissionsToRequests method that runs during calls to the Requests API
  - Limits **select** clause to retrieve fewer fields
  - Processes results in chunks to save memory
  - Inserts items as a batch to optimize for speed

Fixes #3245.