### PR TITLE
Make API timeout configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ DATE_FORMAT="m/d/Y H:i"
 MAIN_LOGO_PATH="/img/processmaker_logo.png"
 ICON_PATH_PATH="/img/processmaker_icon.png"
 LOGIN_LOGO_PATH="img/processmaker_login.png"
+API_TIMEOUT=5000
 DB_HOSTNAME=localhost
 DB_PORT=3306
 DB_DATABASE=processmaker

--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -37,6 +37,7 @@ class Install extends Command
             {--first-name=                      : The default admin user's first name}
             {--last-name=                       : The default admin user's last name}
             {--telescope                        : Enable Telescope debugging}
+            {--api-timeout=                     : The length of the API timeout in milliseconds (0 for no timeout)}
             {--db-host=                         : The primary database host}
             {--db-port=                         : The primary database port}
             {--db-name=                         : The primary database name}
@@ -124,6 +125,7 @@ class Install extends Command
             'REDIS_CLIENT' => $this->option('redis-client'),
             'REDIS_PREFIX' => $this->option('redis-prefix'),
             'HORIZON_PREFIX' => $this->option('horizon-prefix'),
+            'API_TIMEOUT' => $this->option('api-timeout') ? $this->option('api-timeout') : 5000,
         ];
 
         if ($this->option('redis-host')) {

--- a/config/app.php
+++ b/config/app.php
@@ -40,6 +40,9 @@ return [
     // The fallback locale
     'fallback_locale' => 'en',
 
+    // The timeout length for API calls, in milliseconds (0 for no timeout)
+    'api_timeout' => env('API_TIMEOUT', 5000),
+
     'disable_php_upload_execution' => env('DISABLE_PHP_UPLOAD_EXECUTION', 0),
 
     //Option Fractal, Serializer

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -182,8 +182,13 @@ if (token) {
 }
 
 window.ProcessMaker.apiClient.defaults.baseURL = "/api/1.0/";
-// Default to a 5 second timeout, which is an eternity in web app terms
-window.ProcessMaker.apiClient.defaults.timeout = 25000;
+
+// Set the default API timeout
+let apiTimeout = 5000;
+if (window.Processmaker && window.Processmaker.apiTimeout !== undefined) {
+    apiTimeout = window.Processmaker.apiTimeout;
+}
+window.ProcessMaker.apiClient.defaults.timeout = apiTimeout;
 
 // Default alert functionality
 window.ProcessMaker.alert = function (text, variant) {

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -38,6 +38,7 @@
         csrfToken: "{{csrf_token()}}",
         userId: "{{\Auth::user()->id}}",
         messages: @json(\Auth::user()->activeNotifications()),
+        apiTimeout: {{config('app.api_timeout')}}
       };
       @if(config('broadcasting.default') == 'redis')
         window.Processmaker.broadcasting = {


### PR DESCRIPTION
## Changes
- Adds a configuration option for API timeout length in milliseconds (0 is no timeout)
- Adds this configuration option to the installer and to the example ENV file

Closes #3259.