### PR TITLE
Fix issue with New Request modal not displaying list of processes

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -544,7 +544,7 @@ class ProcessController extends Controller
             }
         }
 
-        return new ApiCollection($processes); // TODO use existing resource class
+        return new ApiCollection($processes->values()); // TODO use existing resource class
     }
 
     /**


### PR DESCRIPTION
## Changes
- Fixes a bug where the Request modal does not display a list of processes by rekeying the list before it is sent to the API collection

Fixes #3286 