### PR TITLE
Fix permissions can overwrite super user status

### DIFF
--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -411,6 +411,9 @@
             })
               .then(response => {
                 ProcessMaker.alert('{{__('User Permissions Updated Successfully ')}}', 'success');
+                if (this.userId === this.currentUserId) {
+                  ProcessMaker.alert('{{__('Please logout and login again to reflect permission changes')}}', 'warning');
+                }
               })
           },
           hasPermission() {


### PR DESCRIPTION
<h2>Changes</h2>

This PR adds an alert message notifying the user to logout and back in when the user changes their permissions.

![Screen Shot 2020-07-29 at 11 44 49 AM 1](https://user-images.githubusercontent.com/52755494/88840504-7284f280-d191-11ea-9d9b-b4c8cf4e9fff.png)


**Reference Jira Ticket**
https://processmaker.atlassian.net/browse/FOUR-1659