### PR TITLE
Fix screen search not returning accurate results

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -89,8 +89,6 @@ class ScreenController extends Controller
                 $query->where(function ($query) use ($filter) {
                     $query->where('title', 'like', $filter)
                         ->orWhere('description', 'like', $filter)
-                        ->orWhere('type', 'like', $filter)
-                        ->orWhere('config', 'like', $filter)
                         ->orWhere('category.name', 'like', $filter);
                 });
             } else {


### PR DESCRIPTION
<h2>Changes</h2>

Screens were being filtered by the screen type & the screen configs. This PR removed those filters allowing it to only filter by the screen name, description & category.

**video**

<a href="https://www.loom.com/share/de5a2ca782404082aba05f13d5d215e6"> <p>Screens - ProcessMaker - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/de5a2ca782404082aba05f13d5d215e6-with-play.gif"> </a>

**Reference Jira Ticket**
https://processmaker.atlassian.net/browse/FOUR-1309