### PR TITLE
Fix Files Package Errors

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -273,23 +273,6 @@ class ProcessRequestFileController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @param Media $file
-     *
-     * @return \Illuminate\Http\Response
-     *
-     */
-    public function update(Request $laravel_request, ProcessRequest $request)
-    {
-        $request->getMedia()[0]->delete();
-        $newFile = $laravel_request->file;
-        $request->addMedia($newFile)->toMediaCollection();
-        return new JsonResponse(['message' => 'file successfully updated'], 200);
-    }
-
-    /**
      * Remove the specified resource from storage.
      *
      * @param Media $file

--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Models;
 
 use ProcessMaker\Models\ProcessRequest;
 use Spatie\MediaLibrary\Models\Media as Model;
+use Illuminate\Validation\ValidationException;
 
 /**
  * Represents media files stored in the database
@@ -128,6 +129,9 @@ class Media extends Model
             $media->setCustomProperty('updatedBy', $user ? $user->id : null);
         });
         self::saving(function($media) {
+            if (empty($media->getCustomProperty('data_name'))) {
+                throw ValidationException::withMessages(['data_name' => 'data_name is required']);
+            }
             $media->setCustomProperty('updatedBy', pmUser() ? pmUser()->id : null);
         });
     }

--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -129,8 +129,10 @@ class Media extends Model
             $media->setCustomProperty('updatedBy', $user ? $user->id : null);
         });
         self::saving(function($media) {
-            if (empty($media->getCustomProperty('data_name'))) {
-                throw ValidationException::withMessages(['data_name' => 'data_name is required']);
+            if ($media->model instanceof ProcessRequest) {
+                if (empty($media->getCustomProperty('data_name'))) {
+                    throw ValidationException::withMessages(['data_name' => 'data_name is required']);
+                }
             }
             $media->setCustomProperty('updatedBy', pmUser() ? pmUser()->id : null);
         });

--- a/resources/js/processes/screen-builder/components/file-upload-control.js
+++ b/resources/js/processes/screen-builder/components/file-upload-control.js
@@ -36,7 +36,9 @@ export default {
         field: "name",
         config: {
           label: "Name",
-          helper: "The name of the upload"
+          name: 'Name',
+          helper: "The name of the upload",
+          validation: 'required'
         }
       },
       {

--- a/routes/api.php
+++ b/routes/api.php
@@ -124,7 +124,6 @@ Route::group(
     Route::get('requests/{request}/files', 'ProcessRequestFileController@index')->name('requests.files.index')->middleware('can:participate,request');
     Route::get('requests/{request}/files/{file}', 'ProcessRequestFileController@show')->name('requests.files.show')->middleware('can:participate,request');
     Route::post('requests/{request}/files', 'ProcessRequestFileController@store')->name('requests.files.store')->middleware('can:participate,request');
-    Route::put('requests/{request}/files/{file}', 'ProcessRequestFileController@update')->name('requests.files.update')->middleware('can:participate,request');
     Route::delete('requests/{request}/files/{file}', 'ProcessRequestFileController@destroy')->name('requests.filesrequests.files.destroy')->middleware('can:participate,request');
 
     // Files

--- a/tests/Feature/Api/ManualTaskTest.php
+++ b/tests/Feature/Api/ManualTaskTest.php
@@ -44,7 +44,8 @@ class ManualTaskTest extends TestCase
         $route = route('api.requests.files.store', [$request->id, 'event' => 'node_1']);
         $response = $this->actingAs($uploadTask->user, 'api')
                          ->json('POST', $route, [
-                             'file' => File::image('photo.jpg')
+                             'file' => File::image('photo.jpg'),
+                             'data_name' => 'photo'
                          ]);
         // Check the user has access to upload a file
         $response->assertStatus(200);

--- a/tests/Feature/Api/ProcessRequestFileTest.php
+++ b/tests/Feature/Api/ProcessRequestFileTest.php
@@ -29,7 +29,10 @@ class ProcessRequestFileTest extends TestCase
         $fileUpload = File::image('photo.jpg');
 
         //save the file with media lib
-        $process_request->addMedia($fileUpload)->toMediaCollection();
+        $process_request
+            ->addMedia($fileUpload)
+            ->withCustomProperties(['data_name' => 'test'])
+            ->toMediaCollection();
 
         $response = $this->apiCall('GET', '/requests/' . $process_request->id . '/files');
         $response->assertStatus(200);
@@ -49,36 +52,12 @@ class ProcessRequestFileTest extends TestCase
 
         //post photo id with the request
         $response = $this->apiCall('POST', '/requests/' . $process_request->id . '/files', [
-            'file' => File::image('photo.jpg')
+            'file' => File::image('photo.jpg'),
+            'data_name' => 'photo'
         ]);
         $response->assertStatus(200);
         $this->assertEquals($process_request->getMedia()[0]->file_name, 'photo.jpg');
 
-    }
-
-    /**
-     * test update of an existing file
-     */
-    public function testFileUpdate()
-    {
-        //create a request
-        $process_request = factory(ProcessRequest::class)->create();
-        // upload file
-        $fileUpload = File::image('photo.jpg');
-
-        $fileUploadUpdate= File::image('updatedFile.jpg');
-        //save the file with media lib
-        $process_request->addMedia($fileUpload)->toMediaCollection();
-        //update
-        $file = $process_request->getMedia()[0]->id;
-
-        $response = $this->apiCall('PUT', '/requests/' . $process_request->id . '/files/' . $file, [
-            'file' => $fileUploadUpdate
-        ]);
-        $process_request->refresh();
-        $response->assertStatus(200);
-
-        $this->assertEquals($process_request->getMedia()[0]->file_name, 'updatedFile.jpg');
     }
 
     /**
@@ -90,7 +69,10 @@ class ProcessRequestFileTest extends TestCase
         $process_request = factory(ProcessRequest::class)->create();
         // upload file
         $fileUpload = File::image('HEEEEy.jpg');
-        $process_request->addMedia($fileUpload)->toMediaCollection();
+        $process_request
+            ->addMedia($fileUpload)
+            ->withCustomProperties(['data_name' => 'test'])
+            ->toMediaCollection();
         //delete the file
         $process_request->refresh();
         $process_request->getMedia()[0]->delete();
@@ -112,8 +94,14 @@ class ProcessRequestFileTest extends TestCase
         $fileUpload2 = File::image('photo2.jpg');
 
         //save the file with media lib
-        $file1 = $process_request->addMedia($fileUpload1)->toMediaCollection();
-        $file2 = $process_request->addMedia($fileUpload2)->toMediaCollection();
+        $file1 = $process_request
+            ->addMedia($fileUpload1)
+            ->withCustomProperties(['data_name' => 'test'])
+            ->toMediaCollection();
+        $file2 = $process_request
+            ->addMedia($fileUpload2)
+            ->withCustomProperties(['data_name' => 'test'])
+            ->toMediaCollection();
 
         $response = $this->apiCall('GET', '/requests/' . $process_request->id . '/files/' . $file2->id);
         $response->assertStatus(200);

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -492,8 +492,10 @@ class ProcessRequestsTest extends TestCase
         ]);
 
         // Add the file to the request
-        $addedMedia = $request->addMedia($fileUpload)->toMediaCollection('local');
-
+        $addedMedia = $request
+            ->addMedia($fileUpload)
+            ->withCustomProperties(['data_name' => 'test'])
+            ->toMediaCollection('local');
 
         $route = self::API_TEST_URL . '/'. $request->id . '/files/' . $addedMedia->id;
         $response = $this->apiCall('GET', $route);

--- a/tests/Feature/Api/RequestFileUploadTest.php
+++ b/tests/Feature/Api/RequestFileUploadTest.php
@@ -58,7 +58,8 @@ class RequestFileUploadTest extends TestCase
         $route = route('api.requests.files.store', [$request->id, 'event' => 'node_1']);
         $response = $this->actingAs($uploadTask->user, 'api')
             ->json('POST', $route, [
-                'file' => File::image('photo.jpg')
+                'file' => File::image('photo.jpg'),
+                'data_name' => 'photo'
             ]);
         // Check the user has access to upload a file
         $response->assertStatus(200);


### PR DESCRIPTION
<h2>Changes</h2>

- `data_name` is now always required when saving media. 
-  File Upload component in SB now displays a 'required' validation for the 'name' input.