### PR TITLE
Do not assign a process to an imported package call activity

### DIFF
--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -242,6 +242,12 @@ class ImportProcess implements ShouldQueue
         $tasks = $this->definitions->getElementsByTagName('callActivity');
         foreach ($tasks as $task) {
             $assignment = $task->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'calledElement');
+            
+            // Do not ask to assign a target if this CallActivity is a package wrapper
+            if ($this->isCallActivityFromPackage($task)) {
+                continue;
+            }
+
             if (!$assignment) {
                 $this->assignable->push((object)[
                     'type' => 'callActivity',
@@ -817,4 +823,20 @@ class ImportProcess implements ShouldQueue
         return $watcherList;
     }
 
+    /**
+     * Determine if the call activity is a wrapper around a package
+     *
+     * @param $task
+     * @return boolean
+     */
+    private function isCallActivityFromPackage($task)
+    {
+        $configString = $task->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config');
+        $config = json_decode($configString, true);
+        if (isset($config['calledElement'])) {
+            // calledElement only exists on call activities, not packages
+            return false;
+        }
+        return true;
+    }
 }

--- a/ProcessMaker/Managers/ExportManager.php
+++ b/ProcessMaker/Managers/ExportManager.php
@@ -121,7 +121,12 @@ class ExportManager
 
     public function addDependencyManager($class)
     {
-        $instance = new $class;
+        if (is_string($class)) {
+            $instance  = new $class;
+        } else {
+            $instance = $class;
+        }
+
         $this->addDependency([
             'type' => $instance->type,
             'owner' => $instance->owner,

--- a/ProcessMaker/Managers/PMConfigGenericExportManager.php
+++ b/ProcessMaker/Managers/PMConfigGenericExportManager.php
@@ -12,12 +12,16 @@ use ProcessMaker\Providers\WorkflowServiceProvider;
  */
 class PMConfigGenericExportManager
 {
-    private $tag, $class, $keys;
+    public $owner = Process::class;
+    public $type;
 
-    public function __construct(string $tag, string $class, array $keys)
+    private $tag;
+    private $keys;
+
+    public function __construct(string $tag, string $type, array $keys)
     {
         $this->tag = $tag;
-        $this->class = $class;
+        $this->type = $type;
         $this->keys = $keys;
     }
 
@@ -47,7 +51,7 @@ class PMConfigGenericExportManager
                     continue;
                 }
                 
-                $references[] = [$this->class, $config->$key];
+                $references[] = [$this->type, $config->$key];
             }
         }
 
@@ -82,7 +86,7 @@ class PMConfigGenericExportManager
                 }
 
                 $oldRef = $config->$key;
-                $newRef = $references[$this->class][$oldRef]->getKey();
+                $newRef = $references[$this->type][$oldRef]->getKey();
                 $config->$key = $newRef;
             }
             $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config', json_encode($config));

--- a/ProcessMaker/Managers/PMConfigGenericExportManager.php
+++ b/ProcessMaker/Managers/PMConfigGenericExportManager.php
@@ -1,0 +1,89 @@
+<?php
+namespace ProcessMaker\Managers;
+
+use DOMXPath;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Providers\WorkflowServiceProvider;
+
+class PMConfigGenericExportManager
+{
+    private $tag, $class, $keys;
+
+    public function __construct(string $tag, string $class, array $keys)
+    {
+        $this->tag = $tag;
+        $this->class = $class;
+        $this->keys = $keys;
+    }
+
+    /**
+     * Get screens references used in a process
+     *
+     * @param Process $process
+     * @param array $screens
+     *
+     * @return array
+     */
+    public function referencesToExport(Process $process, array $references = [])
+    {
+        $xpath = new DOMXPath($process->getDefinitions());
+        $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+
+        // Used in config
+        $nodes = $xpath->query("//{$this->tag}[@pm:config!='']");
+        foreach ($nodes as $node) {
+            $config = json_decode($node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config'));
+            foreach ($this->keys as $key) {
+                if (!isset($config->$key)) {
+                    continue;
+                }
+
+                if (!is_numeric($config->$key)) {
+                    continue;
+                }
+                
+                $references[] = [$this->class, $config->$key];
+            }
+        }
+
+        return $references;
+    }
+
+    /**
+     * Update references used in an imported process
+     *
+     * @param Process $process
+     * @param array $references
+     *
+     * @return void
+     */
+    public function updateReferences(Process $process, array $references = [])
+    {
+        $definitions = $process->getDefinitions();
+        $xpath = new DOMXPath($definitions);
+        $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+
+        // Used in config
+        $nodes = $xpath->query("//{$this->tag}[@pm:config!='']");
+        foreach ($nodes as $node) {
+            $config = json_decode($node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config'));
+            foreach ($this->keys as $key) {
+                if (!isset($config->$key)) {
+                    continue;
+                }
+
+                if (!is_numeric($config->$key)) {
+                    continue;
+                }
+
+                $oldRef = $config->$key;
+                $newRef = $references[$this->class][$oldRef]->getKey();
+                $config->$key = $newRef;
+            }
+            $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config', json_encode($config));
+        }
+
+        $process->bpmn = $definitions->saveXML();
+        $process->save();
+    }
+}

--- a/ProcessMaker/Managers/PMConfigGenericExportManager.php
+++ b/ProcessMaker/Managers/PMConfigGenericExportManager.php
@@ -5,6 +5,11 @@ use DOMXPath;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Providers\WorkflowServiceProvider;
 
+/**
+ * Used to dry up common export code in packages by specifying keys
+ * used in a pm:config attribute in a bpmn tag. See Actions By Email
+ * package service provider for example.
+ */
 class PMConfigGenericExportManager
 {
     private $tag, $class, $keys;

--- a/tests/Fixtures/pm_config_generic_export.bpmn
+++ b/tests/Fixtures/pm_config_generic_export.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:callActivity id="node_2" name="Actions By Email" calledElement="ProcessId-2" pm:config="{&#34;email&#34;:&#34;test@bla.com&#34;,&#34;subject&#34;:&#34;test abe&#34;,&#34;keyName&#34;:&#34;answer&#34;,&#34;options&#34;:[{&#34;content&#34;:&#34;yup&#34;,&#34;value&#34;:&#34;yup&#34;,&#34;buttonVariant&#34;:&#34;btn-primary&#34;},{&#34;content&#34;:&#34;nope&#34;,&#34;value&#34;:&#34;nope&#34;,&#34;buttonVariant&#34;:&#34;btn-primary&#34;}],&#34;screenRef&#34;:9991,&#34;body&#34;:&#34;foooooooooo&#34;,&#34;anotherScreenRef&#34;:9992,&#34;type&#34;:&#34;&#34;,&#34;bodyType&#34;:&#34;screen&#34;,&#34;template&#34;:&#34;welcome&#34;}">
+      <bpmn:incoming>node_4</bpmn:incoming>
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="node_3" name="End Event">
+      <bpmn:incoming>node_5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_4" name="" sourceRef="node_1" targetRef="node_2" />
+    <bpmn:sequenceFlow id="node_5" name="" sourceRef="node_2" targetRef="node_3" />
+    <bpmn:callActivity id="node_6" name="Another Actions By Email" calledElement="ProcessId-2" pm:config="{&#34;email&#34;:&#34;test@test.com&#34;,&#34;subject&#34;:&#34;testing&#34;,&#34;keyName&#34;:&#34;&#34;,&#34;options&#34;:[],&#34;screenRef&#34;:9993,&#34;body&#34;:&#34;test&#34;,&#34;anotherScreenRef&#34;:9994,&#34;type&#34;:&#34;&#34;,&#34;bodyType&#34;:&#34;screen&#34;,&#34;template&#34;:&#34;welcome&#34;}" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="180" y="130" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="140" y="240" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="180" y="370" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_4_di" bpmnElement="node_4">
+        <di:waypoint x="198" y="148" />
+        <di:waypoint x="198" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="198" y="278" />
+        <di:waypoint x="198" y="388" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+        <dc:Bounds x="290" y="240" width="116" height="76" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Managers/PMConfigGenericExportManagerTest.php
+++ b/tests/Managers/PMConfigGenericExportManagerTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace Tests\Managers;
+
+use Tests\TestCase;
+use DOMXPath;
+use ProcessMaker\Managers\PMConfigGenericExportManager;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Providers\WorkflowServiceProvider;
+
+class PMConfigGenericExportManagerTest extends TestCase {
+
+    public function test() {
+        $process = factory(Process::class)->create([
+            'bpmn' => file_get_contents(__DIR__ . '/../Fixtures/pm_config_generic_export.bpmn')
+        ]);
+
+        $manager = new PMConfigGenericExportManager(
+            'bpmn:callActivity', Screen::class, ['screenRef', 'anotherScreenRef']
+        );
+        $result = $manager->referencesToExport($process);
+        $this->assertEquals([
+            [Screen::class, 9991],
+            [Screen::class, 9992],
+            [Screen::class, 9993],
+            [Screen::class, 9994],
+        ], $result);
+
+        $abeScreen = factory(Screen::class)->create();
+        $abeAnotherScreen = factory(Screen::class)->create();
+        $anotherAbeScreen = factory(Screen::class)->create();
+        $anotherAbeAnotherScreen = factory(Screen::class)->create();
+        $references = [
+            Screen::class => [
+                9991 => $abeScreen,
+                9992 => $abeAnotherScreen,
+                9993 => $anotherAbeScreen,
+                9994 => $anotherAbeAnotherScreen,
+            ]
+        ];
+        $manager->updateReferences($process, $references);
+
+        $definitions = $process->refresh()->getDefinitions();
+        $xpath = new DOMXPath($definitions);
+        $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+
+        $nodes = $xpath->query("//bpmn:callActivity");
+        $abeConfig = json_decode(
+            $nodes[0]->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config')
+        );
+        $anotherAbeConfig = json_decode(
+            $nodes[1]->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config')
+        );
+        $this->assertEquals($abeScreen->id, $abeConfig->screenRef);
+        $this->assertEquals($abeAnotherScreen->id, $abeConfig->anotherScreenRef);
+        $this->assertEquals($anotherAbeScreen->id, $anotherAbeConfig->screenRef);
+        $this->assertEquals($anotherAbeAnotherScreen->id, $anotherAbeConfig->anotherScreenRef);
+    }
+}


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1430

Needed by https://github.com/ProcessMaker/package-actions-by-email/pull/39

Fix user being prompted to choose a call activity process when importing a process that contains a package that is a wrapper around call activities (actions by email)

Also adds a generic export manager for PM Config json objects inside bpmn tags