### PR TITLE
add scripts with status active

### DIFF
--- a/ProcessMaker/Console/Commands/RetryScriptTasks.php
+++ b/ProcessMaker/Console/Commands/RetryScriptTasks.php
@@ -65,7 +65,7 @@ class RetryScriptTasks extends Command
 
     private function retrieveTaskList()
     {
-        $tasks = ProcessRequestToken::where('status', 'FAILING')->where('element_type', 'scriptTask');
+        $tasks = ProcessRequestToken::whereIn('status', array('FAILING', 'ACTIVE'))->where('element_type', 'scriptTask');
 
         if ($this->option('process') && $this->option('request')) {
             exit($this->error('Please specify either a Process ID or a Request ID, not both.'));


### PR DESCRIPTION
Resolves #3340 

The status active to search for the stalled script tasks was added to the retry script task command.