### PR TITLE
Bugfix FOUR-1836

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -458,9 +458,9 @@
       }
     },
     "@processmaker/screen-builder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@processmaker/screen-builder/-/screen-builder-1.0.3.tgz",
-      "integrity": "sha512-zEvlBV4EToT7r+G7up7vsSBXQ32wIy6ON1pqoYBWiDEAv8R57RJa29bUdqtVlJmCiwn3jyVlljnSp5IlhJo8Xg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@processmaker/screen-builder/-/screen-builder-1.1.0.tgz",
+      "integrity": "sha512-JN+3Tj+7fyBEKwlUFknaPPwxOTAQSviEY+MGT1jop8kOSGhVso3m+ro/P+YOCuIidBjSu3P8he2BtjgtKwjugA==",
       "requires": {
         "lodash": "^4.17.19",
         "moment": "^2.24.0",
@@ -471,9 +471,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "vue-loader": {
           "version": "15.9.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@panter/vue-i18next": "^0.15.2",
     "@processmaker/modeler": "^0.24.2",
     "@processmaker/processmaker-bpmn-moddle": "^0.6.0",
-    "@processmaker/screen-builder": "^1.0.3",
+    "@processmaker/screen-builder": "^1.1.0",
     "@processmaker/vue-form-elements": "^0.14.13",
     "babel-eslint": "^10.1.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -363,12 +363,18 @@
 
             window.ProcessMaker.apiClient.get(`/tasks/${id}?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition`)
               .then((response) => {
+                this.resetScreenState();
                 this.$set(this, 'task', response.data);
                 if (response.data.process_request.status === 'ERROR') {
                   this.hasErrors = true;
                 }
                 this.prepareTask();
               });
+          },
+          resetScreenState() {
+            if (this.$refs.taskScreen && this.$refs.taskScreen.$children[0]) {
+              this.$refs.taskScreen.$children[0].currentPage = 0;
+            }
           },
           claimTask() {
             ProcessMaker.apiClient


### PR DESCRIPTION
This issue was related to the interstitial feature, once the next screen is rendered, the currentPage variable should be reset to 0
This PR fix the screen currentPage when a screen is loaded after a interstitial next task.

![FixGridNextScreen](https://user-images.githubusercontent.com/8028650/90194466-6b670280-dd95-11ea-892f-6ac5bea62e03.gif)

Process to test:
[Claims management process.json.txt](https://github.com/ProcessMaker/processmaker/files/5071835/Claims.management.process.json.txt)
