### PR TITLE
Copy files between parent and child call activities

### DIFF
--- a/ProcessMaker/Jobs/CopyRequestFiles.php
+++ b/ProcessMaker/Jobs/CopyRequestFiles.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use ProcessMaker\Models\ProcessRequest;
+
+class CopyRequestFiles implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $from, $to;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(ProcessRequest $from, ProcessRequest $to)
+    {
+        $this->from = $from;
+        $this->to = $to;
+    }
+
+    /**
+     * Copy files from one process to another, overwriting any with the same data_name
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        foreach($this->from->getMedia() as $fileToCopy) {
+            $originalCreatedBy = $fileToCopy->getCustomProperty('createdBy');
+            foreach($this->to->getMedia() as $mediaItem) {
+                if ($mediaItem->getCustomProperty('data_name') == $fileToCopy->getCustomProperty('data_name') &&
+                    $mediaItem->getCustomProperty('parent') == $fileToCopy->getCustomProperty('parent')) {
+                    
+                    $originalCreatedBy = $mediaItem->getCustomProperty('createdBy');
+                    $mediaItem->delete();
+                }
+            }
+
+            $newFile = $fileToCopy->copy($this->to);
+            $newFile->setCustomProperty('createdBy', $originalCreatedBy);
+            $newFile->save();
+        }
+    }
+}

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -12,6 +12,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\ErrorInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+use ProcessMaker\Jobs\CopyRequestFiles;
 
 /**
  * Call Activity model
@@ -79,6 +80,9 @@ class CallActivity implements CallActivityInterface
 
         $dataStore->setData($data);
         $instance = $callable->call($dataStore, $startEvent);
+
+        CopyRequestFiles::dispatch($token->getInstance(), $instance);
+
         return $instance;
     }
 
@@ -101,6 +105,9 @@ class CallActivity implements CallActivityInterface
             $dataStore->putData($key, $value);
         }
         $this->syncronizeInstances($instance, $token->getInstance());
+
+        CopyRequestFiles::dispatch($instance, $token->getInstance());
+        
         return $this;
     }
 

--- a/tests/Feature/Api/CallActivityTest.php
+++ b/tests/Feature/Api/CallActivityTest.php
@@ -9,6 +9,7 @@ use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 use ProcessMaker\Models\ProcessRequestToken;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Http\Testing\File;
 
 class CallActivityTest extends TestCase
 {
@@ -26,15 +27,20 @@ class CallActivityTest extends TestCase
 
         // Script task requires passport installed (oauth token)
         Artisan::call('passport:install',['-vvv' => true]);
-
+        
         // Create the processes
-        $parent = $this->createProcess([
-            'id' => 1,
-            'bpmn' => file_get_contents(__DIR__ . '/processes/parent.bpmn')
-        ]);
         $child = $this->createProcess([
             'id' => 2,
             'bpmn' => file_get_contents(__DIR__ . '/processes/child.bpmn')
+        ]);
+
+        $parent = $this->createProcess([
+            'id' => 1,
+            'bpmn' => str_replace(
+                ['[child_id]','[start_event_id]'],
+                [$child->id, 'node_8'],
+                file_get_contents(__DIR__ . '/processes/parent.bpmn')
+            )
         ]);
 
         // Start a process instance
@@ -50,5 +56,90 @@ class CallActivityTest extends TestCase
         $this->assertCount(0, $activeSubTokens);
         $this->assertEquals('COMPLETED', $instance->status);
         $this->assertEquals('COMPLETED', $subInstance->status);
+    }
+
+    public function testCallActivityFiles()
+    {
+        // Create the processes
+        $child = $this->createProcess([
+            'id' => 2,
+            'bpmn' => file_get_contents(__DIR__ . '/processes/child-files.bpmn')
+        ]);
+        $parent = $this->createProcess([
+            'id' => 1,
+            'bpmn' => str_replace(
+                ['[child_id]','[start_event_id]'],
+                [$child->id, 'startevent'],
+                file_get_contents(__DIR__ . '/processes/parent-files.bpmn')
+            )
+        ]);
+        $instance = $this->startProcess($parent, 'node_1');
+        $parentTask = $instance->tokens->where('status', 'ACTIVE')->first();
+
+        $route = route('api.requests.files.store', [$instance->id]);
+        $response = $this->apiCall('POST', $route, [
+            'file' => File::image('photo1.jpg'),
+            'data_name' => 'photo1',
+            'parent' => 99,
+        ]);
+        $response = $this->apiCall('POST', $route, [
+            'file' => File::image('photo-no-parent.jpg'),
+            'data_name' => 'photo1',
+        ]);
+
+        $this->completeTask($parentTask);
+
+        $this->assertCount(2, $instance->getMedia());
+        $this->assertEquals('photo1', $instance->getMedia()[0]->getCustomProperty('data_name'));
+        $this->assertEquals(99, $instance->getMedia()[0]->getCustomProperty('parent'));
+        $this->assertEquals('photo1', $instance->getMedia()[1]->getCustomProperty('data_name'));
+        $this->assertEquals(0, $instance->getMedia()[1]->getCustomProperty('parent'));
+
+        $childInstance = ProcessRequest::where('parent_request_id', $instance->id)->first();
+
+        $this->assertCount(2, $childInstance->getMedia());
+        $copiedFile1 = $childInstance->getMedia()[0];
+        $copiedFile2 = $childInstance->getMedia()[1];
+        
+        $this->assertEquals('photo1', $copiedFile1->getCustomProperty('data_name'));
+        $this->assertEquals(99, $copiedFile1->getCustomProperty('parent'));
+        $this->assertEquals('photo1', $copiedFile2->getCustomProperty('data_name'));
+        $this->assertEquals(0, $copiedFile2->getCustomProperty('parent'));
+
+        $childTask = $childInstance->tokens->where('status', 'ACTIVE')->first();
+
+        $route = route('api.requests.files.store', [$childInstance->id]);
+        $response = $this->apiCall('POST', $route, [
+            'file' => File::image('child.jpg'),
+            'data_name' => 'child_photo'
+        ]);
+
+        // This should overwrite the parent when the call activity finishes
+        $route = route('api.requests.files.store', [$childInstance->id]);
+        $response = $this->apiCall('POST', $route, [
+            'file' => File::image('overwrite.jpg'),
+            'data_name' => 'photo1',
+            'parent' => 99,
+        ]);
+        
+        $this->completeTask($childTask);
+
+        $instance->refresh();
+        $this->assertCount(3, $instance->getMedia());
+        $file1 = $instance->getMedia()[0];
+        $file2 = $instance->getMedia()[1];
+        $file3 = $instance->getMedia()[2];
+
+        $this->assertEquals('photo1', $file1->getCustomProperty('data_name'));
+        $this->assertEquals(null, $file1->getCustomProperty('parent'));
+        $this->assertEquals('photo-no-parent.jpg', $file1->file_name);
+
+        $this->assertEquals('child_photo', $file2->getCustomProperty('data_name'));
+        $this->assertEquals(null, $file2->getCustomProperty('parent'));
+        $this->assertEquals('child.jpg', $file2->file_name);
+
+        $this->assertEquals('photo1', $file3->getCustomProperty('data_name'));
+        $this->assertEquals(99, $file3->getCustomProperty('parent'));
+        $this->assertEquals('overwrite.jpg', $file3->file_name);
     }
 }

--- a/tests/Feature/Api/RequestFileUploadTest.php
+++ b/tests/Feature/Api/RequestFileUploadTest.php
@@ -10,10 +10,12 @@ use ProcessMaker\Nayra\Storage\BpmnDocument;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 use ProcessMaker\Providers\WorkflowServiceProvider;
+use Tests\Feature\Api\TestProcessExecutionTrait;
 
 class RequestFileUploadTest extends TestCase
 {
     use RequestHelper;
+    use TestProcessExecutionTrait;
 
     /**
      * @var Process $process
@@ -107,36 +109,5 @@ class RequestFileUploadTest extends TestCase
         $response->assertStatus(403);
         // Check the file was not uploaded
         $this->assertEquals(0, $request->getMedia()->count());
-    }
-
-    /**
-     * Create new task assignment type user successfully
-     */
-    private function loadTestProcess($bpmn, array $users = [])
-    {
-        // Create a new process
-        $this->process = factory(Process::class)->create([
-            'bpmn' => $bpmn,
-        ]);
-
-        $definitions = $this->process->getDefinitions();
-        foreach ($definitions->getElementsByTagNameNS(BpmnDocument::BPMN_MODEL, 'task') as $task) {
-            if ($task->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'assignment') === 'user') {
-                $userId = $task->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'assignedUsers');
-                if (isset($users[$userId])) {
-                    $task->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'assignedUsers', $users[$userId]->id);
-                } elseif (!User::find($userId)) {
-                    $users[$userId] = factory(User::class)->create([
-                        'id' => $userId,
-                        'status' => 'ACTIVE',
-                    ]);
-                    $users[$userId] =
-                    $task->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'assignedUsers', $users[$userId]->id);
-                }
-            }
-        }
-        $this->process->bpmn = $definitions->saveXml();
-        // When save the process creates the assignments
-        $this->process->save();
     }
 }

--- a/tests/Feature/Api/processes/child-files.bpmn
+++ b/tests/Feature/Api/processes/child-files.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:endEvent id="node_10" name="End Event" pm:screenRef="">
+      <bpmn:incoming>node_4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:manualTask id="node_2" name="Manual Task" pm:screenRef="3" pm:allowInterstitial="false" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_3</bpmn:incoming>
+      <bpmn:outgoing>node_4</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="node_4" name="" sourceRef="node_2" targetRef="node_10" />
+    <bpmn:startEvent id="startevent" name="Child start" pm:allowInterstitial="false" pm:config="{&#34;web_entry&#34;:{&#34;require_valid_session&#34;:false,&#34;mode&#34;:&#34;DISABLED&#34;,&#34;screen_id&#34;:null,&#34;completed_action&#34;:&#34;SCREEN&#34;,&#34;completed_screen_id&#34;:null,&#34;completed_url&#34;:null,&#34;authenticatable_type&#34;:null,&#34;authenticatable_id&#34;:null,&#34;enable_query_params&#34;:false,&#34;password&#34;:null,&#34;enable_password_protect&#34;:false,&#34;exclude_data&#34;:[]}}">
+      <bpmn:outgoing>node_3</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_3" sourceRef="startevent" targetRef="node_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+        <dc:Bounds x="340" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="140" y="70" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_4_di" bpmnElement="node_4">
+        <di:waypoint x="198" y="108" />
+        <di:waypoint x="358" y="98" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="startevent">
+        <dc:Bounds x="-120" y="70" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_3_di" bpmnElement="node_3">
+        <di:waypoint x="-102" y="88" />
+        <di:waypoint x="198" y="108" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Feature/Api/processes/parent-files.bpmn
+++ b/tests/Feature/Api/processes/parent-files.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ParentId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false" pm:assignment="user" pm:assignedUsers="1" pm:assignedGroups="" pm:config="{&#34;web_entry&#34;:{&#34;require_valid_session&#34;:false,&#34;mode&#34;:&#34;DISABLED&#34;,&#34;screen_id&#34;:null,&#34;completed_action&#34;:&#34;SCREEN&#34;,&#34;completed_screen_id&#34;:null,&#34;completed_url&#34;:null,&#34;authenticatable_type&#34;:null,&#34;authenticatable_id&#34;:null,&#34;enable_query_params&#34;:false,&#34;password&#34;:null,&#34;enable_password_protect&#34;:false,&#34;exclude_data&#34;:[]}}">
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="node_3" name="End Event" pm:screenRef="">
+      <bpmn:incoming>node_5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="node_2" name="New Call Activity" calledElement="ProcessId-[child_id]" pm:config="{&#34;calledElement&#34;:&#34;&#34;,&#34;processId&#34;:,&#34;startEvent&#34;:&#34;[start_event_id]&#34;,&#34;name&#34;:&#34;New Call Activity&#34;}">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="node_5" name="New Sequence Flow" sourceRef="node_2" targetRef="node_3" pm:startEvent="" />
+    <bpmn:manualTask id="node_7" name="Manual Task" pm:screenRef="3" pm:allowInterstitial="false" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_8</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="node_8" sourceRef="node_1" targetRef="node_7" />
+    <bpmn:sequenceFlow id="node_9" sourceRef="node_7" targetRef="node_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ParentId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="-20" y="110" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="570" y="110" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="300" y="90" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="358" y="128" />
+        <di:waypoint x="588" y="128" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_7_di" bpmnElement="node_7">
+        <dc:Bounds x="100" y="90" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="-2" y="128" />
+        <di:waypoint x="158" y="128" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="158" y="128" />
+        <di:waypoint x="358" y="128" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1820

Call activities (aka Sub Processes) are independent process so files were not shared between them. However, we do copy the data from parent to child and back to parent so it makes sense to do the same with files.

This fix creates a job to copy files between parent and child call activity process requests.