### PR TITLE
Update user password rule to require it for a new user

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -145,7 +145,7 @@ class User extends Authenticatable implements HasMedia
             'lastname' => ['required', 'max:50'],
             'email' => ['required', 'email', $unique, $checkUserIsDeleted],
             'status' => ['required', 'in:ACTIVE,INACTIVE'],
-            'password' => 'required|sometimes|min:6',
+            'password' => $existing ? 'required|sometimes|min:6' : 'required|min:6',
             'birthdate' => 'date|nullable'
         ];
     }

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -566,5 +566,10 @@ class UsersTest extends TestCase
         $payload['password'] = 'abc123';
         $response = $this->apiCall('PUT', route('api.users.update', $userId), $payload);
         $response->assertStatus(204);
+        
+        // It's OK to update a user without the password
+        unset($payload['password']);
+        $response = $this->apiCall('PUT', route('api.users.update', $userId), $payload);
+        $response->assertStatus(204);
     }
 }

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -528,6 +528,43 @@ class UsersTest extends TestCase
         $response = $this->apiCall('GET', self::API_TEST_URL);
         $response->assertJsonFragment(['id' => $id]);
     }
-    
 
+    public function testCreateWithoutPassword()
+    {
+        $payload = [
+            "firstname" => "foo",
+            "lastname" => "bar",
+            "email" => "foobar@test.com",
+            "username" => "foobar",
+            "status" => "ACTIVE"
+        ];
+        $response = $this->apiCall('POST', self::API_TEST_URL, $payload);
+        $response->assertStatus(422);
+        $json = $response->json();
+        $this->assertEquals('The password field is required.', $json['errors']['password'][0]);
+
+        $payload['password'] = 'abc';
+        $response = $this->apiCall('POST', self::API_TEST_URL, $payload);
+        $response->assertStatus(422);
+        $json = $response->json();
+        $this->assertEquals('The password must be at least 6 characters.', $json['errors']['password'][0]);
+        
+        $payload['password'] = 'abc123';
+        $response = $this->apiCall('POST', self::API_TEST_URL, $payload);
+        $response->assertStatus(201);
+        $json = $response->json();
+        $userId = $json['id'];
+
+        // Test updating the users's password
+
+        $payload['password'] = 'abc';
+        $response = $this->apiCall('PUT', route('api.users.update', $userId), $payload);
+        $response->assertStatus(422);
+        $json = $response->json();
+        $this->assertEquals('The password must be at least 6 characters.', $json['errors']['password'][0]);
+        
+        $payload['password'] = 'abc123';
+        $response = $this->apiCall('PUT', route('api.users.update', $userId), $payload);
+        $response->assertStatus(204);
+    }
 }


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1831

The validation rule for users didn't require a password. It did, however, require it at the database level, meaning that if you try to create a user without a password you got a SQL error instead of a standard validation error.

This fix updates the model validation to make it required there.

```
{
    "message": "The given data was invalid.",
    "errors": {
        "password": [
            "The password field is required."
        ]
    }
}
```
