### PR TITLE
Fix to error logging call

### DIFF
--- a/ProcessMaker/Listeners/BpmnSubscriber.php
+++ b/ProcessMaker/Listeners/BpmnSubscriber.php
@@ -187,7 +187,7 @@ class BpmnSubscriber
             $instance->getDataStore()->setData($instance->data);
             $instance->saveOrFail();
         } catch (\Exception $e) {
-            Log::error('The expression used in the flow generated and error: ', $e->getMessage());
+            Log::error('The expression used in the flow generated and error: ', [$e->getMessage()]);
             $instance->logError($e, $transition->getOwner());
         }
     }


### PR DESCRIPTION
Resolves #3276 

There was a mistaken in the log parameter. If the evaluated expression has some error it is logged to the process and to PM logs. 