### PR TITLE
Add correct annotation for file downloads

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -242,9 +242,14 @@ class FileController extends Controller
      *     ),
      *     @OA\Response(
      *         response=200,
-     *         description="Successfully found the file",
+     *         description="File stream",
      *         @OA\MediaType(
-     *             mediaType="application/octet-stream")
+     *             mediaType="application/octet-stream",
+     *             @OA\Schema(
+     *                 type="string",
+     *                 format="binary"
+     *             )
+     *         )
      *     ),
      * )
      */

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -874,16 +874,6 @@ class ProcessController extends Controller
      *         required=false,
      *         @OA\JsonContent(
      *                 type="object",
-     *                 @OA\Property(
-     *                     property="stringField",
-     *                     type="string",
-     *                     example="string example"
-     *                 ),
-     *                 @OA\Property(
-     *                     property="integerField",
-     *                     type="string",
-     *                     example="1"
-     *                 )
      *             )
      *     ),
      *     @OA\Response(

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -139,8 +139,14 @@ class ProcessRequestFileController extends Controller
      *     ),
      *     @OA\Response(
      *         response=200,
-     *         description="Successfully found the media file",
-     *         @OA\JsonContent(ref="#/components/schemas/mediaExported")
+     *         description="File stream",
+     *         @OA\MediaType(
+     *             mediaType="application/octet-stream",
+     *             @OA\Schema(
+     *                 type="string",
+     *                 format="binary"
+     *             )
+     *         )
      *     ),
      * )
      */

--- a/resources/views/vendor/l5-swagger/index.blade.php
+++ b/resources/views/vendor/l5-swagger/index.blade.php
@@ -95,9 +95,9 @@ window.onload = function() {
     validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
     oauth2RedirectUrl: "{{ route('l5-swagger.oauth2_callback') }}",
 
-    requestInterceptor: function() {
-      this.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
-      return this;
+    requestInterceptor: function(request) {
+      request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+      return request;
     },
 
     presets: [

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -487,9 +487,14 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successfully found the file",
+                        "description": "File stream",
                         "content": {
-                            "application/octet-stream": {}
+                            "application/octet-stream": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
                         }
                     }
                 }
@@ -1923,18 +1928,6 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "properties": {
-                                    "stringField": {
-                                        "description": "Trigger an start event within a process.",
-                                        "type": "string",
-                                        "example": "string example"
-                                    },
-                                    "integerField": {
-                                        "description": "Trigger an start event within a process.",
-                                        "type": "string",
-                                        "example": "1"
-                                    }
-                                },
                                 "type": "object"
                             }
                         }
@@ -2306,11 +2299,12 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successfully found the media file",
+                        "description": "File stream",
                         "content": {
-                            "application/json": {
+                            "application/octet-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/mediaExported"
+                                    "type": "string",
+                                    "format": "binary"
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1783

The annotation in the controller was incorrect, resulting in wrong documentation for that endpoint.

The fix was to update the annotations to correctly reflect the file stream output

![image](https://user-images.githubusercontent.com/2546850/90823859-6224eb00-e2eb-11ea-8753-3629ea254bef.png)
