### PR TITLE
Add permission to view other user's profiles

### DIFF
--- a/ProcessMaker/Http/Controllers/ProfileController.php
+++ b/ProcessMaker/Http/Controllers/ProfileController.php
@@ -57,8 +57,15 @@ class ProfileController extends Controller
      *
      * @return \Illuminate\View\View|\Illuminate\Contracts\View
      */
-    public function show($id)
+    public function show(Request $request, $id)
     {
+        if (
+            $request->user()->id !== intval($id) &&
+            !$request->user()->can('view-other-users-profiles')
+        ){
+            abort(404);
+        }
+
         $user = User::findOrFail($id);
         return view('profile.show', compact('user'));
     }

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -66,6 +66,7 @@ class PermissionSeeder extends Seeder
             'delete-users',
             'edit-users',
             'view-users',
+            'view-other-users-profiles',
         ],
         'Requests' => [
             'view-all_requests',

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -100,16 +100,14 @@ class PermissionSeeder extends Seeder
 
     public function run($seedUser = null)
     {
-        if (Permission::count() === 0) {
-            foreach ($this->permissionGroups as $groupName => $permissions) {
-                foreach ($permissions as $permissionString) {
-                    $permission = factory(Permission::class)->create([
-                        'title' => ucwords(preg_replace('/(\-|_)/', ' ',
-                                $permissionString)),
-                        'name' => $permissionString,
-                        'group' => $groupName,
-                    ]);
-                }
+        foreach ($this->permissionGroups as $groupName => $permissions) {
+            foreach ($permissions as $permissionString) {
+                Permission::updateOrCreate([
+                    'name' => $permissionString,
+                ],[
+                    'title' => ucwords(preg_replace('/(\-|_)/', ' ', $permissionString)),
+                    'group' => $groupName,
+                ]);
             }
         }
 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1211,5 +1211,6 @@
   "Key name in the selected object to display to the user in the select list. Leave blank to show the entire selected value.": "Key name in the selected object to display to the user in the select list. Leave blank to show the entire selected value.",
   "Variable Data Property": "Variable Data Property",
   "Enter the property name from the Request data variable that will be passed as the value when selected.": "Enter the property name from the Request data variable that will be passed as the value when selected.",
-  "Endpoint to populate select": "Endpoint to populate select"
+  "Endpoint to populate select": "Endpoint to populate select",
+  "View Other Users Profiles": "View Other Users Profiles"
 }


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1721

Adds a new view-other-users-profiles permission.

I also had to refactor the permissions seeder so that it can add new permissions that don't exist.

IMPORTANT: after this is deployed, devops will need to run `php artisan db:seed --class=PermissionSeeder` to add the new permission

![image](https://user-images.githubusercontent.com/2546850/90833434-d9af4600-e2fc-11ea-9967-9f1371977893.png)
