### PR TITLE
Improvements to search indexing

### DIFF
--- a/ProcessMaker/Console/Commands/IndexedSearchEnable.php
+++ b/ProcessMaker/Console/Commands/IndexedSearchEnable.php
@@ -76,15 +76,30 @@ class IndexedSearchEnable extends Command
         }
 
         if ($confirmed) {
-            $this->line("The indexer will occasionally display its status.");
-
             foreach ($this->manager->list() as $index) {
-                $this->info("\nBeginning index of {$index->name}...");
+                $this->line("\nIndexing {$index->name}...");
                 if ($index->callback && is_callable($index->callback)) {
                     call_user_func($index->callback);
                     $this->info("All {$index->name} records have been imported.");
                 } else {
-                    $this->call("scout:import", ['model' => $index->model]);
+                    if ($index->model == 'ProcessMaker\Models\ProcessRequestToken') {
+                        $query = $index->model::whereIn('element_type', ['task', 'userTask']);
+                    } else {
+                        $query = $index->model::query();
+                    }
+
+                    $bar = $this->output->createProgressBar($query->count());
+                    $bar->start();
+
+                    $query->chunk(50, function($items) use(&$bar, &$count) {
+                        $this->addToIndex($items);
+                        foreach ($items as $item) {
+                            $bar->advance();
+                        }
+                    });
+                    
+                    $bar->finish();
+                    $this->info("\nAll {$index->name} records have been imported.");
                 }
             }
 

--- a/ProcessMaker/Console/Commands/IndexedSearchEnable.php
+++ b/ProcessMaker/Console/Commands/IndexedSearchEnable.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Console\Commands;
 
 use App;
+use Log;
 use Illuminate\Console\Command;
 use ProcessMaker\Managers\IndexManager;
 use ProcessMaker\Models\Setting;
@@ -44,6 +45,17 @@ class IndexedSearchEnable extends Command
     {
         $items = $this->manager->list()->pluck('name')->implode(', ');
         return $this->description = "{$this->description} of {$items}";
+    }
+
+    private function addToIndex($items)
+    {
+        try {
+            $items->searchable();
+        } catch (\PDOException $e) {
+            Log::error('Encountered database lock when indexing records, trying again');
+            sleep(1);
+            $this->addToIndex($items);
+        }
     }
 
     /**

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -156,6 +156,16 @@ class ProcessRequestToken extends Model implements TokenInterface
     }
 
     /**
+     * Determine whether the item should be indexed.
+     *
+     * @return boolean
+     */
+    public function shouldBeSearchable()
+    {
+        return in_array($this->element_type, ['task', 'userTask']);
+    }
+
+    /**
      * Boot application as a process instance.
      *
      * @param array $argument

--- a/config/scout.php
+++ b/config/scout.php
@@ -98,7 +98,7 @@ return [
     */
 
     'tntsearch' => [
-        'storage'  => storage_path(), //place where the index files will be stored
+        'storage'  => storage_path('search'), //place where the index files will be stored
         'fuzziness' => env('TNTSEARCH_FUZZINESS', false),
         'fuzzy' => [
             'prefix_length' => 2,

--- a/storage/search/.gitignore
+++ b/storage/search/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Changes
- Improves indexing of search records
  - Only indexes Tasks with an element_type of **task** or **humanTask**
  - Indexes records directly rather than relying upon the built-in indexer which is prone to error
  - Protects against potential table locks by catching them and trying again upon release
- Stores index files in a sub-directory for better organization