### PR TITLE
Swagger is asking for data_name when testing /requests/.../files/ endpoint

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -95,14 +95,14 @@ class FileController extends Controller
      *         name="model_id",
      *         in="query",
      *         description="ID of the model to which the file will be associated",
-     *         required=false,
+     *         required=true,
      *         @OA\Schema(type="integer"),
      *     ),
      *      @OA\Parameter(
      *         name="model",
      *         in="query",
      *         description="Name of the class of the model",
-     *         required=false,
+     *         required=true,
      *         @OA\Schema(type="string"),
      *     ),
      *      @OA\Parameter(

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -194,7 +194,7 @@ class ProcessRequestFileController extends Controller
      *         name="data_name",
      *         in="query",
      *         description="Variable name in the request data to use for the file name",
-     *         required=true,
+     *         required=false,
      *         @OA\Schema(type="string"),
      *     ),
      *      @OA\Parameter(
@@ -255,7 +255,7 @@ class ProcessRequestFileController extends Controller
         $user = pmUser();
         $originalCreatedBy = $user ? $user->id : null;
 
-        $data_name = $laravelRequest->input('data_name');
+        $data_name = $laravelRequest->input('data_name', $file->getClientOriginalName());
         $parent = (int)$laravelRequest->input('parent', null);
 
         foreach($processRequest->getMedia() as $mediaItem) {

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -339,7 +339,7 @@
                         "name": "model_id",
                         "in": "query",
                         "description": "ID of the model to which the file will be associated",
-                        "required": false,
+                        "required": true,
                         "schema": {
                             "type": "integer"
                         }
@@ -348,7 +348,7 @@
                         "name": "model",
                         "in": "query",
                         "description": "Name of the class of the model",
-                        "required": false,
+                        "required": true,
                         "schema": {
                             "type": "string"
                         }
@@ -2221,7 +2221,7 @@
                         "name": "data_name",
                         "in": "query",
                         "description": "Variable name in the request data to use for the file name",
-                        "required": true,
+                        "required": false,
                         "schema": {
                             "type": "string"
                         }


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1873

Change the data_name field to not required and the file name is used as the default