### PR TITLE
Remove toobar from error pages

### DIFF
--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,18 +1,10 @@
-@extends('layouts.layout')
+@extends('errors.base')
 
 @section('title')
   {{__('Unauthorized - ProcessMaker')}}
 @endsection
 
-@section('sidebar')
-@include('layouts.sidebar', ['sidebar'=> Menu::get('sidebar_designer')])
+@section('message')
+  <h1>{{__('Not Authorized')}}</h1>
+  <p>{{__('Contact your administrator for more information')}}</p>
 @endsection
-
-@section('content')
- <div class="container mr-5 mt-5">
-     <img class="ml-5" src="/img/robot.png"/>
-    <h1>{{__('Not Authorized')}}</h1>
-    <p>{{__('Contact your administrator for more information')}}</p>
-</div>
-@endsection
-

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,43 +1,10 @@
-@extends('layouts.layout')
+@extends('errors.base')
 
 @section('title')
   {{__('Page not found - ProcessMaker')}}
 @endsection
 
-@section('sidebar')
-@include('layouts.sidebar', ['sidebar'=> Menu::get('sidebar_designer')])
-@endsection
-
-@section('content')
-<div class="error-404">
-    <div class="error-404-icon">
-      <img src="/img/robot.png"/>
-    </div>
-    <div class="error-content">
-      <h1>{{__('Oops!')}}</h1>
-      <p>{{__('The page you are looking for could not be found')}}</p>
-    </div>
-</div>
-@endsection
-
-@section('css')
-
-<style lang="scss" scoped>
-    .error-404 {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      margin-top: 150px;
-    }
-    .error-404-icon {
-      margin: auto;
-    }
-    img {
-      margin-left: -33px;
-    }
-    .error-content {
-      margin-top: 0px;
-    }
-
-</style>
+@section('message')
+  <h1>{{__('Oops!')}}</h1>
+  <p>{{__('The page you are looking for could not be found')}}</p>
 @endsection

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,18 +1,11 @@
-@extends('layouts.layout')
+@extends('errors.base')
 
 @section('title')
   {{__('Server Error - ProcessMaker')}}
 @endsection
 
-@section('sidebar')
-@include('layouts.sidebar', ['sidebar'=> Menu::get('sidebar_designer')])
-@endsection
-
-@section('content')
- <div class="container mr-5 mt-5">
-     <img class="ml-5" src="/img/robot.png"/>
-    <h1>{{__('Server Error')}}</h1>
-    <p>{{__('Contact your administrator for more information')}}</p>
-</div>
+@section('message')
+  <h1>{{__('Server Error')}}</h1>
+  <p>{{__('Contact your administrator for more information')}}</p>
 @endsection
 

--- a/resources/views/errors/base.blade.php
+++ b/resources/views/errors/base.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.minimal')
+
+@section('title')
+  {{__('Unauthorized - ProcessMaker')}}
+@endsection
+
+@section('content')
+<div class="error-container">
+    <div class="error-404-icon">
+      <img src="/img/robot.png"/>
+    </div>
+    <div class="error-content">
+      @yield('message')
+    </div>
+    <div class="buttons">
+        <div class="row">
+            <div class="col">
+                <a class="btn btn-primary btn-block" href="javascript:history.back()" role="button"><i class="fas fa-backward"></i></a>
+            </div>
+            <div class="col">
+                <a class="btn btn-primary btn-block" href="/" role="button"><i class="fas fa-home"></i></a>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@section('css')
+
+<style>
+    .container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-top: 10%;
+    }
+    .error-content {
+        margin-top: auto;
+    }
+    .error-404-icon {
+        text-align: center;
+    }
+
+</style>
+@endsection

--- a/resources/views/errors/unavailable.blade.php
+++ b/resources/views/errors/unavailable.blade.php
@@ -1,18 +1,11 @@
-@extends('layouts.layout')
+@extends('errors.base')
 
 @section('title')
   {{__('Server Error - ProcessMaker')}}
 @endsection
 
-@section('sidebar')
-@include('layouts.sidebar', ['sidebar'=> Menu::get('sidebar_designer')])
-@endsection
-
-@section('content')
- <div class="container mr-5 mt-5">
-     <img class="ml-5" src="/img/robot.png"/>
+@section('message')
     <h1>{{__('Server Error')}}</h1>
     <p>{{__('One of the data sources in unavailable. Contact with your system administrator.')}}</p>
-</div>
 @endsection
 


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1721?focusedCommentId=191728

Remove the toolbar and add some navigation buttons to the error pages to prevent notifications from trying to load.

![image](https://user-images.githubusercontent.com/2546850/91479696-b59cb900-e856-11ea-92c7-6dffbb5d32b5.png)
