### PR TITLE
RestApi > When a user doesn't have permissions appear an error exception

### DIFF
--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -55,7 +55,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
+        'auth' => \ProcessMaker\Http\Middleware\ProcessMakerAuthenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,

--- a/ProcessMaker/Http/Middleware/ProcessMakerAuthenticate.php
+++ b/ProcessMaker/Http/Middleware/ProcessMakerAuthenticate.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace ProcessMaker\Http\Middleware;
+
+
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Support\Str;
+
+class ProcessMakerAuthenticate extends Authenticate
+{
+
+    protected function authenticate($request, array $guards)
+    {
+        $this->addAcceptJsonHeaderIfApiCall($request, $guards);
+
+        return parent::authenticate($request, $guards);
+    }
+
+    /**
+     * @param array $guards
+     * @param \Illuminate\Http\Request $request
+     */
+    private function addAcceptJsonHeaderIfApiCall(\Illuminate\Http\Request $request, array $guards): void
+    {
+        if (in_array('api', $guards) && !$this->requestHasAcceptJsonHeader($request)) {
+            $request->headers->set('accept', 'application/json,' . $request->header('accept'));
+        }
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return bool
+     */
+
+    private function requestHasAcceptJsonHeader(\Illuminate\Http\Request $request): bool
+    {
+        return Str::contains($request->header('accept'), ['/json', '+json']);
+    }
+
+}

--- a/tests/Feature/Api/CssOverrideTest.php
+++ b/tests/Feature/Api/CssOverrideTest.php
@@ -29,8 +29,7 @@ class CssOverrideTest extends TestCase
     {
         $response = $this->actingAs($this->user, 'api')->call('POST', '/api/1.0/customize-ui', []);
 
-        //Validate that the error does a redirection
-        $response->assertStatus(302);
+        $response->assertStatus(422);
     }
 
     /**
@@ -40,8 +39,7 @@ class CssOverrideTest extends TestCase
     {
         $response = $this->actingAs($this->user, 'api')->call('POST', '/api/1.0/customize-ui', ['wrongkey' => 'key']);
 
-        //Validate that the error does a redirection
-        $response->assertStatus(302);
+        $response->assertStatus(422);
     }
 
     private function cssValues($testColor)

--- a/tests/Feature/Api/FilesTest.php
+++ b/tests/Feature/Api/FilesTest.php
@@ -191,4 +191,19 @@ class FilesTest extends TestCase
       // Validate that the media file has been removed from the user
       $this->assertEquals(0, $model->getMedia()->count());
   }
+
+  public function testUserWithoutPermission() {
+      // We create a fake file to upload
+      Storage::fake('public');
+      $fileUpload = UploadedFile::fake()->create('my_test_file123.txt', 1);
+
+      // We create a model (in this case a user) and associate to him the file
+      $model = factory(User::class)->create();
+      $model->addMedia($fileUpload)->toMediaCollection('local');
+
+      //The call is done without an authenticated user so it should return 401
+      $response = $this->actingAs(factory(User::class)->create())
+                    ->json('GET', '/api/1.0' . self::API_TEST_URL, ['']);
+      $response->assertStatus(401);
+  }
 }

--- a/tests/Feature/Api/ScreenTest.php
+++ b/tests/Feature/Api/ScreenTest.php
@@ -468,4 +468,21 @@ class ScreenTest extends TestCase
         $response = $this->apiCall('PUT', $url, $params);
         $response->assertStatus(204);
     }
+
+
+    public function testWithUserWithoutAuthorization() {
+        $screen = factory(Screen::class)->create();
+        $url = route('api.screens.update', $screen);
+        $params = [
+            'title' => 'Title Screen',
+            'type' => 'FORM',
+            'description' => 'Description.',
+            'screen_category_id' => factory(ScreenCategory::class)->create()->getKey() . ',' . factory(ScreenCategory::class)->create()->getKey()
+        ];
+
+        //The call is done without an authenticated user so it should return 401
+        $response = $this->actingAs(factory(User::class)->create())
+            ->json('PUT', $url, $params);
+        $response->assertStatus(401);
+    }
 }

--- a/tests/Feature/Api/ServiceTaskExecutionTest.php
+++ b/tests/Feature/Api/ServiceTaskExecutionTest.php
@@ -7,6 +7,7 @@ use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\Script;
 use ProcessMaker\Models\ScriptExecutor;
+use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
@@ -98,5 +99,21 @@ class ServiceTaskExecutionTest extends TestCase
 
         //Assertion: If the service task is executed it will return a pong
         $this->assertEquals($request->data['pong'], $ping);
+    }
+
+    public function testWithUserWithoutAuthorization()
+    {
+        // We'll test executing a process with someone that is not authenticated
+        $url = route('api.process_events.trigger',
+            [$this->process->id, 'event' => self::START_EVENT_ID]);
+        $ping = '1';
+        $data = [
+            'ping' => $ping,
+        ];
+
+        //The call is done without an authenticated user so it should return 401
+        $response = $this->actingAs(factory(User::class)->create())
+            ->json('GET', $url, []);
+        $response->assertStatus(401);
     }
 }

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -382,4 +382,21 @@ class TasksTest extends TestCase
         $response = $this->apiCall('PUT', '/tasks/' . $token->id, $params);
         $this->assertStatus(200, $response);
     }
+
+    public function testWithUserWithoutAuthorization()
+    {
+        // We'll test viewing a new task with someone that is not authenticated
+        $request = factory(ProcessRequest::class)->create();
+
+        //Create a new process without category
+        $token = factory(ProcessRequestToken::class)->create([
+            'process_request_id' => $request->id
+        ]);
+        $url = route('api.' . $this->resource . '.show', [$token->id, 'include' => 'user,definition']);
+
+        //The call is done without an authenticated user so it should return 401
+        $response = $this->actingAs(factory(User::class)->create())
+            ->json('GET', $url, []);
+        $response->assertStatus(401);
+    }
 }


### PR DESCRIPTION
Resolves [FOUR-1782](https://processmaker.atlassian.net/browse/FOUR-1782)

A new Authentication provider has been added. If the API call doesn't have the Accept header, this header is added as Accept:application.json. In this way the call goes through Laravel's API route and the corresponding 401 error is returned instead of redirecting to the login page.
Note that the correct error to return is 401 and not 403 as requested in the ticket FOUR-1782