### PR TITLE
mysql configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname
 homesteadYamlPath = File.expand_path("Homestead.yaml", File.dirname(__FILE__))
 homesteadJsonPath = File.expand_path("Homestead.json", File.dirname(__FILE__))
 afterScriptPath = "after.sh"
+myconfScriptPath = "script_myconf.sh"
 customizationScriptPath = "user-customizations.sh"
 aliasesPath = "aliases"
 
@@ -37,6 +38,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     if File.exist? afterScriptPath then
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
+    end
+
+    if File.exist? myconfScriptPath then
+        config.vm.provision "shell", path: myconfScriptPath, privileged: true, keep_color: true
     end
 
     if File.exist? customizationScriptPath then

--- a/script_myconf.sh
+++ b/script_myconf.sh
@@ -1,0 +1,33 @@
+# Mysql configuration
+
+sudo echo "[mysqld]" > /etc/mysql/conf.d/my.cnf
+sudo echo "back_log = 16000" >> /etc/mysql/conf.d/my.cnf
+sudo echo "connect_timeout = 31536000" >> /etc/mysql/conf.d/my.cnf
+sudo echo "explicit_defaults_for_timestamp = ON" >> /etc/mysql/conf.d/my.cnf
+sudo echo "host_cache_size = 653" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_adaptive_hash_index = OFF" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_change_buffering = none" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_checksum_algorithm = none" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_checksums = OFF" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_doublewrite = OFF" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_flush_method = O_DIRECT" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_open_files = 6000" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_page_cleaners = 2" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_purge_batch_size = 600" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_purge_threads = 1" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_stats_persistent_sample_pages = 128" >> /etc/mysql/conf.d/my.cnf
+sudo echo "innodb_use_native_aio = OFF" >> /etc/mysql/conf.d/my.cnf
+sudo echo "interactive_timeout = 31536000" >> /etc/mysql/conf.d/my.cnf
+sudo echo "max_allowed_packet = 1073741824" >> /etc/mysql/conf.d/my.cnf
+sudo echo "max_connections = 1000" >> /etc/mysql/conf.d/my.cnf
+sudo echo "max_execution_time = 18446744073709551615" >> /etc/mysql/conf.d/my.cnf
+sudo echo "myisam_recover_options = OFF" >> /etc/mysql/conf.d/my.cnf
+sudo echo "open_files_limit = 65535" >> /etc/mysql/conf.d/my.cnf
+sudo echo "performance_schema = OFF" >> /etc/mysql/conf.d/my.cnf
+sudo echo "query_cache_size = 464717824" >> /etc/mysql/conf.d/my.cnf
+sudo echo "query_cache_type = ON" >> /etc/mysql/conf.d/my.cnf
+sudo echo "skip_name_resolve = ON" >> /etc/mysql/conf.d/my.cnf
+sudo echo "table_definition_cache = 20000" >> /etc/mysql/conf.d/my.cnf
+sudo echo "table_open_cache_instances = 4" >> /etc/mysql/conf.d/my.cnf
+
+sudo service mysql restart


### PR DESCRIPTION
The following change adds the my.cnf file with the following parameters to enabled the RDS configuration in the homestead development environment as requested at KR-10254

> back_log = 16000
connect_timeout = 31536000
explicit_defaults_for_timestamp = ON
host_cache_size = 653
innodb_adaptive_hash_index = OFF
innodb_change_buffering = none
innodb_checksum_algorithm = none
innodb_checksums = OFF
innodb_doublewrite = OFF
innodb_flush_method = O_DIRECT
innodb_open_files = 6000
innodb_page_cleaners = 2
innodb_purge_batch_size = 600
innodb_purge_threads = 1
innodb_stats_persistent_sample_pages = 128
innodb_use_native_aio = OFF
interactive_timeout = 31536000
max_allowed_packet = 1073741824
max_connections = 1000
max_execution_time = 18446744073709551615
myisam_recover_options = OFF
open_files_limit = 65535
performance_schema = OFF
query_cache_size = 464717824
query_cache_type = ON
skip_name_resolve = ON
table_definition_cache = 20000
table_open_cache_instances = 4