### PR TITLE
If the task is closed, check permission on the request instead

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -188,7 +188,10 @@ class TaskController extends Controller
         }
         $response = $this->handleOrderByRequestName($request, $query->get());
 
-        $response = $response->filter(function($processRequestToken) {
+        $response = $response->filter(function($processRequestToken) use ($request) {
+            if ($request->input('status') === 'CLOSED') {
+                return Auth::user()->can('view', $processRequestToken->processRequest);
+            }
             return Auth::user()->can('view', $processRequestToken);
         })->values();
         

--- a/resources/js/requests/components/DataSummary.vue
+++ b/resources/js/requests/components/DataSummary.vue
@@ -1,19 +1,6 @@
 <template>
     <div>
-        <table class="vuetable table table-hover border-top-0 mb-0">
-            <thead v-if="showHead">
-                <tr>
-                    <th class="border-top-0" scope="col">{{ $t('Key') }}</th>
-                    <th class="border-top-0" scope="col">{{ $t('Value') }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr v-for="(item, key) in formattedData" :key="key">
-                    <td>{{ key }}</td>
-                    <td>{{ item }}</td>
-                </tr>
-            </tbody>
-        </table>
+        <b-table :items="formattedData" :fields="fields"></b-table>
     </div>
 </template>
 
@@ -21,11 +8,20 @@
 export default {
     props: {
         summary: [Object, Array],
-        showHead: { type: Boolean, default: true }
     },
     data() {
         return {
-            formattedData: {}
+            formattedData: [],
+            fields: [
+                {
+                    key: 'key',
+                    label: this.$t('Key'),
+                },
+                {
+                    key: 'value',
+                    label: this.$t('Value'),
+                }
+            ]
         }
     },
     mounted() {
@@ -38,7 +34,10 @@ export default {
                 if (this.isObject(item)) {
                     this.formatData(prefix + key + ".", item);
                 } else {
-                    this.formattedData[prefix + key] = item
+                    this.formattedData.push({
+                        key: prefix + key,
+                        value: item,
+                    });
                 }
             }
         },

--- a/resources/js/requests/components/RequestDetail.vue
+++ b/resources/js/requests/components/RequestDetail.vue
@@ -97,7 +97,7 @@
         return !row.user_id && row.is_self_service && assignable;
       },
       isEditable(row) {
-        return String(row.user_id) === String(window.ProcessMaker.user.id) || this.canClaim(row) || row.status !== "ACTIVE";
+        return String(row.user_id) === String(window.ProcessMaker.user.id) || this.canClaim(row) || row.status === "FAILING";
       },
       onAction(action, rowData, index) {
         switch (action) {

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -13,6 +13,8 @@ use Tests\Feature\Shared\ResourceAssertionsTrait;
 use Tests\TestCase;
 use Tests\Feature\Shared\RequestHelper;
 use ProcessMaker\Facades\WorkflowManager;
+use PermissionSeeder;
+use ProcessMaker\Providers\AuthServiceProvider;
 
 /**
  * Tests routes related to tokens list and show
@@ -77,10 +79,12 @@ class TasksTest extends TestCase
         // Create some tokens
         factory(ProcessRequestToken::class, 2)->create([
             'process_request_id' => $request->id,
+            'status' => 'ACTIVE',
             'user_id' => $user_1->id
         ]);
         factory(ProcessRequestToken::class, 3)->create([
             'process_request_id' => $request->id,
+            'status' => 'ACTIVE',
             'user_id' => $user_2->id
         ]);
         //Get a page of tokens
@@ -89,6 +93,49 @@ class TasksTest extends TestCase
 
         // should only see the user's 2 tasks
         $this->assertEquals(count($response->json()['data']), 2);
+    }
+
+    /**
+     * Return all tasks if we are only requesting closed tasks and if
+     * the user can view the request.
+     */
+    public function testGetListClosedTasks()
+    {
+        //Run the permission seeder
+        (new PermissionSeeder)->run();
+
+        // Reboot our AuthServiceProvider. This is necessary so that it can
+        // pick up the new permissions and setup gates for each of them.
+        $asp = new AuthServiceProvider(app());
+        $asp->boot();
+
+        $user_1 = factory(User::class)->create();
+        $user_1->giveDirectPermission('view-all_requests');
+        // $user_1->refresh();
+        // $this->flushSession();
+
+        $this->user = $user_1;
+
+        $user_2 = factory(User::class)->create();
+
+        $request = factory(ProcessRequest::class)->create();
+        // Create some closed tasks
+        factory(ProcessRequestToken::class, 3)->create([
+            'process_request_id' => $request->id,
+            'status' => 'CLOSED',
+            'user_id' => $user_2->id
+        ]);
+        factory(ProcessRequestToken::class, 1)->create([
+            'process_request_id' => $request->id,
+            'status' => 'ACTIVE',
+            'user_id' => $user_2->id
+        ]);
+        //Get a page of tokens
+        $route = route('api.' . $this->resource . '.index', ['status' => 'CLOSED']);
+        $response = $this->apiCall('GET', $route);
+
+        // should only see the 3 closed tasks, not the active one
+        $this->assertEquals(count($response->json()['data']), 3);
     }
 
     /**


### PR DESCRIPTION
Fixes part of https://processmaker.atlassian.net/browse/FOUR-1599

Also switches to bootstrap-vue on task table to fix issue where tasks were not always shown on page load.