### PR TITLE
Indexed search: reduce number of records per chunk

### DIFF
--- a/ProcessMaker/Console/Commands/IndexedSearchEnable.php
+++ b/ProcessMaker/Console/Commands/IndexedSearchEnable.php
@@ -81,7 +81,7 @@ class IndexedSearchEnable extends Command
                 $bar = $this->output->createProgressBar($query->count());
                 $bar->start();
 
-                $query->chunk(25, function($items) use(&$bar, &$count) {
+                $query->chunk(5, function($items) use(&$bar, &$count) {
                     $this->addToIndex($items);
                     foreach ($items as $item) {
                         $bar->advance();


### PR DESCRIPTION
## Changes
- Fixes an issue encountered when indexing to AWS Elasticache on release-testing server where the chunk size was too large for AWS Elasticache