### PR TITLE
FOUR-1863: Users assigned permissions to view all requests through group permissions cannot view request files

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -121,8 +121,8 @@ Route::group(
     Route::post('requests/{request}/events/{event}', 'ProcessRequestController@activateIntermediateEvent')->name('requests.update,request');
 
     // Request Files
-    Route::get('requests/{request}/files', 'ProcessRequestFileController@index')->name('requests.files.index')->middleware('can:participate,request');
-    Route::get('requests/{request}/files/{file}', 'ProcessRequestFileController@show')->name('requests.files.show')->middleware('can:participate,request');
+    Route::get('requests/{request}/files', 'ProcessRequestFileController@index')->name('requests.files.index')->middleware('can:view,request');
+    Route::get('requests/{request}/files/{file}', 'ProcessRequestFileController@show')->name('requests.files.show')->middleware('can:view,request');
     Route::post('requests/{request}/files', 'ProcessRequestFileController@store')->name('requests.files.store')->middleware('can:participate,request');
     Route::delete('requests/{request}/files/{file}', 'ProcessRequestFileController@destroy')->name('requests.filesrequests.files.destroy')->middleware('can:participate,request');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -73,7 +73,7 @@ Route::group(['middleware' => ['auth', 'sanitize', 'external.connection']], func
     Route::get('requests/{type}', 'RequestController@index')
         ->where('type', 'all|in_progress|completed')
         ->name('requests_by_type');
-    Route::get('request/{request}/files/{media}', 'RequestController@downloadFiles')->middleware('can:participate,request');
+    Route::get('request/{request}/files/{media}', 'RequestController@downloadFiles')->middleware('can:view,request');
     Route::get('requests', 'RequestController@index')->name('requests.index');
     Route::get('requests/{request}', 'RequestController@show')->name('requests.show');
     Route::get('requests/{request}/screen/{screen}', 'RequestController@screenPreview')->name('requests.screen-preview');


### PR DESCRIPTION
Resolves [FOUR-1863](https://processmaker.atlassian.net/browse/FOUR-1863)

Processmaker had a restriction to access files from a request. The user needed to have participated in the request. This has been changed. Now to get files from a request, the user just needs to have view access to the request. 