### PR TITLE
Improve error message when user not found in PMQL search

### DIFF
--- a/ProcessMaker/Exception/PmqlMethodException.php
+++ b/ProcessMaker/Exception/PmqlMethodException.php
@@ -1,0 +1,23 @@
+<?php
+namespace ProcessMaker\Exception;
+
+use Exception;
+
+class PmqlMethodException extends Exception
+{
+    private $field;
+    
+    /**
+     * @param string $message
+     */
+    public function __construct($field, $message)
+    {
+        $this->field = $field;
+        return parent::__construct(__($message));
+    }
+
+    public function getField()
+    {
+        return $this->field;
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Notification;
+use ProcessMaker\Exception\PmqlMethodException;
 use ProcessMaker\Exception\ReferentialIntegrityException;
 use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Http\Controllers\Controller;
@@ -144,6 +145,8 @@ class ProcessRequestController extends Controller
                 $query->pmql($pmql);
             } catch (SyntaxError $e) {
                 return response(['message' => __('Your PMQL contains invalid syntax.')], 400);
+            } catch (PmqlMethodException $e) {
+                return response(['message' => $e->getMessage(), 'field' => $e->getField()], 400);
             }
         }
 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -826,6 +826,7 @@
   "The script was duplicated.": "The script was duplicated.",
   "The script was saved.": "The script was saved.",
   "The size of the text in em": "The size of the text in em",
+  "The specified requester username does not exist.": "The specified requester username does not exist.",
   "The styles were recompiled.": "The styles were recompiled.",
   "The System": "The System",
   "The text to display": "The text to display",


### PR DESCRIPTION
## Changes
- Adds a PMQL Method Exception class to throw errors when handling PMQL alias methods
- Adds an error message when searching for invalid requester names

Closes https://processmaker.atlassian.net/browse/FOUR-1671.