### PR TITLE
FOUR-1117 Request Aborted" error banner seen in Firefox after completing task

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -371,7 +371,10 @@
                   this.hasErrors = true;
                 }
                 this.prepareTask();
-              });
+              })
+              .catch(error => {
+                  this.hasErrors = true;
+              })
           },
           resetScreenState() {
             if (this.$refs.taskScreen && this.$refs.taskScreen.$children[0]) {


### PR DESCRIPTION
Resolves [FOUR-1117](https://processmaker.atlassian.net/browse/FOUR-1117)

When an API error is generated, now it is cached and the task view status updated accordingly.
