### PR TITLE
Changes on /file api spoil all file related routines

### DIFF
--- a/resources/js/processes/screen-builder/components/form/file-upload.vue
+++ b/resources/js/processes/screen-builder/components/form/file-upload.vue
@@ -219,8 +219,12 @@ export default {
     },
     fileUploaded(rootFile, file, message) {
       if (this.fileType == 'request') {
-        message = JSON.parse(message);
-        this.$emit("input", message.fileUploadId);
+        let id = '';
+        if (message) {
+          message = JSON.parse(message);
+          id = message.fileUploadId;
+        }
+        this.$emit("input", id);
       }
 
       if (this.fileType == 'collection') {

--- a/resources/js/processes/screen-builder/components/form/file-upload.vue
+++ b/resources/js/processes/screen-builder/components/form/file-upload.vue
@@ -218,12 +218,13 @@ export default {
       }
     },
     fileUploaded(rootFile, file, message) {
-      message = JSON.parse(message);
       if (this.fileType == 'request') {
+        message = JSON.parse(message);
         this.$emit("input", message.fileUploadId);
       }
 
       if (this.fileType == 'collection') {
+        message = JSON.parse(message);
         this.$emit("input", {
           id: message.id,
           name: message.file_name

--- a/resources/js/processes/screen-builder/components/form/file-upload.vue
+++ b/resources/js/processes/screen-builder/components/form/file-upload.vue
@@ -140,7 +140,6 @@ export default {
           chunk: true,
           data_name: this.name,
           parent: null,
-          marco: 'test',
         },
         testChunks: false,
         // Setup our headers to deal with API calls
@@ -219,12 +218,12 @@ export default {
       }
     },
     fileUploaded(rootFile, file, message) {
+      message = JSON.parse(message);
       if (this.fileType == 'request') {
-        this.$emit("input", file.name);
+        this.$emit("input", message.fileUploadId);
       }
 
       if (this.fileType == 'collection') {
-        message = JSON.parse(message);
         this.$emit("input", {
           id: message.id,
           name: message.file_name


### PR DESCRIPTION
Fixed https://processmaker.atlassian.net/browse/FOUR-1931

Change filename by id in return information

NOTE: as file id is returned, script tasks that expect file names will need to be modified accordingly.