### PR TITLE
FOUR-1971: Auth Client > Search bar does not find Uppercase characters

### DIFF
--- a/resources/js/admin/auth-clients/components/AuthClientsListing.vue
+++ b/resources/js/admin/auth-clients/components/AuthClientsListing.vue
@@ -130,9 +130,9 @@ export default {
         //Manual filter
         data = data.filter((item) => {
           return (
-            item.name.toLowerCase().indexOf(this.filter) > -1 ||
-            item.redirect.toLowerCase().indexOf(this.filter) > -1 ||
-            item.secret.toLowerCase().indexOf(this.filter) > -1
+            item.name.toLowerCase().indexOf(this.filter.toLowerCase()) > -1 ||
+            item.redirect.toLowerCase().indexOf(this.filter.toLowerCase()) > -1 ||
+            item.secret.toLowerCase().indexOf(this.filter.toLowerCase()) > -1
           );
         });
       }


### PR DESCRIPTION
Resolves [FOUR-1971](https://processmaker.atlassian.net/browse/FOUR-1971)

The error happened cause the comparison to filter clients was between a lowercase and a  not modified string.  This has been fixed.