### PR TITLE
Publish new process result in ProcessImport model

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -109,8 +109,9 @@ use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
  *     allOf={
  *      @OA\Schema(ref="#/components/schemas/ProcessEditable"),
  *      @OA\Schema(
- *         @OA\Property( property="status", type="object"),
- *         @OA\Property( property="assignable", type="array", @OA\Items(type="string") )
+ *         @OA\Property(property="status", type="object"),
+ *         @OA\Property(property="assignable", type="array", @OA\Items(type="object")),
+ *         @OA\Property(property="process", type="object")
  *      )
  *    }
  * ),

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -4428,8 +4428,12 @@
                                 "description": "Represents a business process definition.",
                                 "type": "array",
                                 "items": {
-                                    "type": "string"
+                                    "type": "object"
                                 }
+                            },
+                            "process": {
+                                "description": "Represents a business process definition.",
+                                "type": "object"
                             }
                         },
                         "type": "object"


### PR DESCRIPTION
The **ImportProcess** job returns the following object:
`return (object)[
            'status' => collect($this->status),
            'assignable' => $this->assignable,
            'process' => $this->new['process']
        ];`
This includes the newly imported process data, the problem is when being consumed by **sdk-node**, this is not parsed in the response since the item '**process**' is not taken into account and we need this to know the new **id** created for the new one process.