### PR TITLE
Improve permissions for Advanced Search Bar and Saved Search sharing

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -185,7 +185,7 @@ class User extends Authenticatable implements HasMedia
         ]);
     }
 
-    public function hasPermissionsFor($resource)
+    public function hasPermissionsFor(...$resources)
     {
         if ($this->is_administrator) {
             $perms = Permission::all(['name'])->pluck('name');
@@ -193,12 +193,12 @@ class User extends Authenticatable implements HasMedia
             $perms = collect(session('permissions'));
         }
 
-        $filtered = $perms->filter(function ($value) use ($resource) {
-            $match = preg_match("/(.+)-{$resource}/", $value);
-            if ($match === 1) {
-                return true;
-            } else {
-                return false;
+        $filtered = $perms->filter(function ($value) use ($resources) {
+            foreach ($resources as $resource) {
+                $match = preg_match("/(.+)-{$resource}/", $value);
+                if ($match === 1) {
+                    return true;
+                }
             }
         });
 

--- a/ProcessMaker/Traits/SearchAutocompleteTrait.php
+++ b/ProcessMaker/Traits/SearchAutocompleteTrait.php
@@ -68,14 +68,16 @@ trait SearchAutocompleteTrait
         $results = collect([]);
         $results->push(Auth::user());
 
-        if (empty($query)) {
-            $results = $results->merge(User::limit(49)->where('id', '!=', Auth::user()->id)->get());
-        } else {
-            $results = $results->merge(User::pmql('username = "' . $query . '" OR firstname = "' . $query . '"  OR lastname = "' . $query . '"', function($expression) {
-                return function($query) use($expression) {
-                    $query->where($expression->field->field(), 'LIKE',  '%' . $expression->value->value() . '%');
-                };
-            })->where('id', '!=', Auth::user()->id)->limit(49)->get());
+        if (Auth::user()->can('view-users')) {
+            if (empty($query)) {
+                $results = $results->merge(User::limit(49)->where('id', '!=', Auth::user()->id)->get());
+            } else {
+                $results = $results->merge(User::pmql('username = "' . $query . '" OR firstname = "' . $query . '"  OR lastname = "' . $query . '"', function($expression) {
+                    return function($query) use($expression) {
+                        $query->where($expression->field->field(), 'LIKE',  '%' . $expression->value->value() . '%');
+                    };
+                })->where('id', '!=', Auth::user()->id)->limit(49)->get());
+            }
         }
 
         return $results->map(function ($user) {
@@ -88,14 +90,16 @@ trait SearchAutocompleteTrait
         $results = collect([]);
         $results->push(Auth::user());
 
-        if (empty($query)) {
-            $results = $results->merge(User::limit(49)->where('id', '!=', Auth::user()->id)->get());
-        } else {
-            $results = $results->merge(User::pmql('username = "' . $query . '" OR firstname = "' . $query . '"  OR lastname = "' . $query . '"', function($expression) {
-                return function($query) use($expression) {
-                    $query->where($expression->field->field(), 'LIKE',  '%' . $expression->value->value() . '%');
-                };
-            })->where('id', '!=', Auth::user()->id)->limit(49)->get());
+        if (Auth::user()->can('view-users')) {
+            if (empty($query)) {
+                $results = $results->merge(User::limit(49)->where('id', '!=', Auth::user()->id)->get());
+            } else {
+                $results = $results->merge(User::pmql('username = "' . $query . '" OR firstname = "' . $query . '"  OR lastname = "' . $query . '"', function($expression) {
+                    return function($query) use($expression) {
+                        $query->where($expression->field->field(), 'LIKE',  '%' . $expression->value->value() . '%');
+                    };
+                })->where('id', '!=', Auth::user()->id)->limit(49)->get());
+            }
         }
 
         return $results->map(function ($user) {

--- a/resources/js/components/AdvancedSearch.vue
+++ b/resources/js/components/AdvancedSearch.vue
@@ -167,7 +167,11 @@
                     <div class="search-bar-actions d-flex flex-shrink mt-3 mt-md-0">
                         <b-btn class="btn-search-toggle mr-2 mr-md-0" variant="secondary" @click="toggleAdvanced" v-b-tooltip.hover :title="$t('Advanced Mode')"><i class="fas fa-ellipsis-h"></i></b-btn>
                         <b-btn class="btn-search-run flex-grow-1" variant="primary" @click="runSearch()" v-b-tooltip.hover :title="$t('Search')"><i class="fas fa-search"></i><span class="d-md-none"> Search</span></b-btn>
-                        <div class="search-bar-additions"></div>
+                        <div class="search-bar-additions">
+                          <div v-for="addition in additions">
+                            <component :is="addition" :permission="permission"></component>
+                          </div>
+                        </div>
                     </div>
                 </div>
                 <div class="search-bar-advanced d-flex w-100" v-if="advanced">
@@ -177,7 +181,11 @@
                     <div class="search-bar-actions d-flex flex-shrink btn-search-advanced">
                         <b-btn class="btn-search-toggle" variant="success" @click="toggleAdvanced" v-b-tooltip.hover :title="$t('Basic Mode')"><i class="fas fa-ellipsis-h"></i></b-btn>
                         <b-btn class="btn-search-run" variant="primary" @click="runSearch(true)" v-b-tooltip.hover :title="$t('Search')"><i class="fas fa-search"></i></b-btn>
-                        <div class="search-bar-additions"></div>
+                        <div class="search-bar-additions">
+                          <div v-for="addition in additions">
+                            <component :is="addition" :permission="permission"></component>
+                          </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -188,7 +196,7 @@
 
 <script>
 export default {
-  props: ["type", "paramProcess", "paramStatus", "paramRequester", "paramParticipants", "paramRequest", "paramName"],
+  props: ["type", "paramProcess", "paramStatus", "paramRequester", "paramParticipants", "paramRequest", "paramName", "permission"],
   data() {
     return {
         process: [],
@@ -203,6 +211,7 @@ export default {
         participantsOptions: [],
         requestOptions: [],
         nameOptions: [],
+        additions: [],
         advanced: false,
         pmql: '',
         isLoading: {
@@ -219,6 +228,11 @@ export default {
     pmql(query) {
         this.$emit('change', query);
     },
+  },
+  mounted() {
+    ProcessMaker.EventBus.$on('advanced-search-addition', (component) => {
+      this.additions.push(component);
+    });
   },
   methods: {
       toggleAdvanced() {

--- a/resources/views/requests/index.blade.php
+++ b/resources/views/requests/index.blade.php
@@ -59,7 +59,7 @@
                     @endcan
 
                 </div>
-                <advanced-search ref="advancedSearch" type="requests" :param-status="status" :param-requester="requester" @change="onChange" @submit="onSearch"></advanced-search>
+                <advanced-search ref="advancedSearch" type="requests" :permission="{{ Auth::user()->hasPermissionsFor('users', 'groups') }}" :param-status="status" :param-requester="requester" @change="onChange" @submit="onSearch"></advanced-search>
             </template>
             <requests-listing ref="requestList" :filter="filter" :pmql="pmql"></requests-listing>
         </div>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -24,7 +24,7 @@
                 </b-alert>
             </div>
         </div>
-        <advanced-search ref="advancedSearch" type="tasks" :param-status="status" @change="onChange" @submit="onSearch"></advanced-search>
+        <advanced-search ref="advancedSearch" type="tasks" :permission="{{ Auth::user()->hasPermissionsFor('users', 'groups') }}" :param-status="status" @change="onChange" @submit="onSearch"></advanced-search>
         <div class="container-fluid">
             <tasks-list ref="taskList" :filter="filter" :pmql="pmql" @in-overdue="setInOverdueMessage"></tasks-list>
         </div>


### PR DESCRIPTION
## Changes
- Updates the Advanced Search Bar on request and task listing screens to only display current user if a user does not have "view user" permissions
- Updates the Create Saved Search modal to only display lists of shareable users and groups if a user has appropriate permissions

## Requirements
- https://github.com/ProcessMaker/package-savedsearch/pull/200
- https://github.com/ProcessMaker/package-collections/pull/207

Closes https://processmaker.atlassian.net/browse/FOUR-1524.