### PR TITLE
Persist user data with self-service tasks and task reassignments

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -299,6 +299,7 @@ class TaskController extends Controller
                 $task->authorizeReassignment(Auth::user());
                 // Reassign user
                 $task->user_id = $userToAssign;
+                $task->persistUserData($userToAssign);
             }
             $task->save();
 

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -293,6 +293,7 @@ class TaskController extends Controller
                 // Claim task
                 $task->is_self_service = 0;
                 $task->user_id = $userToAssign;
+                $task->persistUserData($userToAssign);
             } else {
                 // Validate if user can reassign
                 $task->authorizeReassignment(Auth::user());

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -625,6 +625,20 @@ class ProcessRequestToken extends Model implements TokenInterface
             'interstitial_screen' => $interstitialScreen
         ];
     }
+    
+    public function persistUserData($user)
+    {
+        if (! is_a($user, User::class)) {
+            $user = User::find($user);
+        }
+        
+        $userData = $user->attributesToArray();
+        $data = $this->processRequest->data;
+        $data['_user'] = $userData;
+        
+        $this->processRequest->data = $data;
+        $this->processRequest->save();
+    }
 
     /**
      * Log an error when executing the token


### PR DESCRIPTION
## Changes
- Fixes an issue where the user magic variable was still null after a user self-assigned a task
- Fixes an issue where the user magic variable was still null after a task was reassigned
- Adds testing

Closes https://processmaker.atlassian.net/browse/FOUR-1994.