### PR TITLE
Allow spaces and slashes in variable name for File Upload control

### DIFF
--- a/resources/js/processes/screen-builder/components/file-upload-control.js
+++ b/resources/js/processes/screen-builder/components/file-upload-control.js
@@ -38,7 +38,7 @@ export default {
           label: "Name",
           name: 'Name',
           helper: "The name of the upload",
-          validation: 'required'
+          validation: 'regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_. \/a-z])*$/|required'
         }
       },
       {


### PR DESCRIPTION
## Changes
- Fixes an issue where spaces and slashes were not allowed in the variable name for file uploads

Fixes https://processmaker.atlassian.net/browse/FOUR-1927.