### PR TITLE
Fix CallActivity-EventBasedGateway v4.0.15

### DIFF
--- a/ProcessMaker/BpmnEngine.php
+++ b/ProcessMaker/BpmnEngine.php
@@ -115,6 +115,7 @@ class BpmnEngine implements EngineInterface
         $key = $processVersion->getKey();
         if (!isset($this->definitions[$key])) {
             $this->definitions[$key] = $processVersion->getDefinitions(false, $this);
+            $this->loadProcessDefinitions($this->definitions[$key]);
         }
         return $this->definitions[$key];
     }

--- a/ProcessMaker/BpmnEngine.php
+++ b/ProcessMaker/BpmnEngine.php
@@ -157,4 +157,9 @@ class BpmnEngine implements EngineInterface
         }
         $this->getJobManager()->disableRegisterStartEvents();
     }
+
+    public function getExecutionInstances()
+    {
+        return $this->executionInstances;
+    }
 }

--- a/ProcessMaker/Facades/WorkflowManager.php
+++ b/ProcessMaker/Facades/WorkflowManager.php
@@ -7,12 +7,13 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @see \ProcessMaker\Managers\WorkflowManager
  * 
- * @methodStatic mixed callProcess($filename, $processId)
- * @methodStatic mixed triggerStartEvent($definitions, $event, array $data)
- * @methodStatic mixed runScripTask(\ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface $scriptTask, Token $token)
- * @methodStatic mixed runServiceTask(\ProcessMaker\Nayra\Contracts\Bpmn\ServiceTaskInterface $serviceTask, Token $token)
- * @methodStatic void onDataValidation(callable $callback)
- * @methodStatic void validateData(array $data, $definitions, $element)
+ * @method static mixed callProcess($filename, $processId)
+ * @method static mixed triggerStartEvent($definitions, $event, array $data)
+ * @method static mixed runScripTask(\ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface $scriptTask, Token $token)
+ * @method static mixed runServiceTask(\ProcessMaker\Nayra\Contracts\Bpmn\ServiceTaskInterface $serviceTask, Token $token)
+ * @method static void throwSignalEventDefinition(\ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface $sourceEventDefinition, \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface $token)
+ * @method static void onDataValidation(callable $callback)
+ * @method static void validateData(array $data, $definitions, $element)
  */
 class WorkflowManager extends Facade
 {

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -909,7 +909,8 @@ class ProcessController extends Controller
         // Trigger the start event
         try {
             $processRequest = WorkflowManager::triggerStartEvent($process, $event, $data);
-        } catch (Throwable $exection) {
+        } catch (Throwable $exception) {
+            throw $exception;
             return response()->json([
                 'message' => __('Unable to start process'),
             ], 422);

--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -77,12 +77,12 @@ abstract class BpmnAction implements ShouldQueue
             $instance = $this->lockInstance($this->instanceId);
             $processModel = $instance->process;
             $definitions = ($instance->processVersion ?? $instance->process)->getDefinitions(true);
-            $engine = $definitions->getEngine();
+            $engine = app(BpmnEngine::class, ['definitions' => $definitions]);
             $instance = $engine->loadProcessRequest($instance);
         } else {
             $processModel = Definitions::find($this->definitionsId);
             $definitions = $processModel->getDefinitions();
-            $engine = $definitions->getEngine(true);
+            $engine = app(BpmnEngine::class, ['definitions' => $definitions]);
             $instance = null;
         }
 

--- a/ProcessMaker/Jobs/CatchSignalEvent.php
+++ b/ProcessMaker/Jobs/CatchSignalEvent.php
@@ -43,6 +43,7 @@ class CatchSignalEvent implements ShouldQueue
         $event = $sourceEventDefinition->getPayload();
         $this->signalRef = $event ? $event->getId() : $sourceEventDefinition->getProperty('signalRef') ;
         $this->throwEvent = $throwEvent->getId();
+        $token->saveToken();
         $this->tokenId = $token->getId();
         $this->processId = $token->getInstance()->process_id;
     }

--- a/ProcessMaker/Jobs/CatchSignalEvent.php
+++ b/ProcessMaker/Jobs/CatchSignalEvent.php
@@ -12,6 +12,9 @@ use ProcessMaker\Nayra\Bpmn\Models\SignalEventDefinition;
 use ProcessMaker\Nayra\Contracts\Bpmn\ThrowEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 
+/**
+ * @deprecated 4.0.15 Use ThrowSignalEvent
+ */
 class CatchSignalEvent implements ShouldQueue
 {
     use Dispatchable,

--- a/ProcessMaker/Jobs/CatchSignalEventRequest.php
+++ b/ProcessMaker/Jobs/CatchSignalEventRequest.php
@@ -50,7 +50,6 @@ class CatchSignalEventRequest implements ShouldQueue
                 $eventDefinition,
                 null
             );
-
             if ($this->payload) {
                 foreach ($this->payload as $key => $value) {
                     $instance->getDataStore()->putData($key, $value);

--- a/ProcessMaker/Jobs/CatchSignalEventRequest.php
+++ b/ProcessMaker/Jobs/CatchSignalEventRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use ProcessMaker\BpmnEngine;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Repositories\DefinitionsRepository;
 
@@ -42,8 +43,8 @@ class CatchSignalEventRequest implements ShouldQueue
 
         foreach ($this->chunck as $requestId) {
             $request = ProcessRequest::find($requestId);
-            $definitions = ($request->processVersion ?? $request->process)->getDefinitions(true, null, false);
-            $engine = $definitions->getEngine();
+            $definitions = ($request->processVersion ?? $request->process)->getDefinitions(true, null);
+            $engine = app(BpmnEngine::class, ['definitions' => $definitions, 'globalEvents' => false]);
             $instance = $engine->loadProcessRequest($request);
             $engine->getEventDefinitionBus()->dispatchEventDefinition(
                 null,

--- a/ProcessMaker/Jobs/ThrowSignalEvent.php
+++ b/ProcessMaker/Jobs/ThrowSignalEvent.php
@@ -19,23 +19,25 @@ class ThrowSignalEvent implements ShouldQueue
 
     public $signalRef;
     public $data;
-    public $exclude;
+    public $excludeProcess;
+    public $excludeRequests;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct($signalRef, array $data = [], array $exclude = [])
+    public function __construct($signalRef, array $data = [], array $excludeProcess = [], array $excludeRequests = [])
     {
         $this->signalRef = $signalRef;
         $this->data = $data;
-        $this->exclude = $exclude;
+        $this->excludeProcess = $excludeProcess;
+        $this->excludeRequests = $excludeRequests;
     }
 
     public function handle()
     {
-        $processes = Process::whereNotIn('id', $this->exclude)
+        $processes = Process::whereNotIn('id', $this->excludeProcess)
             ->whereJsonContains('signal_events', $this->signalRef)
             ->pluck('id')
             ->toArray();
@@ -46,7 +48,8 @@ class ThrowSignalEvent implements ShouldQueue
                 $this->data,
             )->onQueue('bpmn');
         }
-        $count = ProcessRequest::whereNotIn('id', $this->exclude)
+        $count = ProcessRequest::whereNotIn('id', $this->excludeRequests)
+            ->where('status', 'ACTIVE')
             ->whereJsonContains('signal_events', $this->signalRef)
             ->count();
         if ($count) {
@@ -54,7 +57,7 @@ class ThrowSignalEvent implements ShouldQueue
             $requests = ProcessRequest::select(['id'])
                 ->whereJsonContains('signal_events', $this->signalRef)
                 ->where('status', 'ACTIVE')
-                ->whereNotIn('id', $this->exclude);
+                ->whereNotIn('id', $this->excludeRequests);
             $requests = $requests->orderBy('id')
                 ->pluck('id')
                 ->toArray();

--- a/ProcessMaker/Jobs/ThrowSignalEvent.php
+++ b/ProcessMaker/Jobs/ThrowSignalEvent.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+
+class ThrowSignalEvent implements ShouldQueue
+{
+    use Dispatchable,
+        InteractsWithQueue,
+        Queueable;
+
+    private const maxJobs = 10;
+
+    public $signalRef;
+    public $data;
+    public $exclude;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($signalRef, array $data = [], array $exclude = [])
+    {
+        $this->signalRef = $signalRef;
+        $this->data = $data;
+        $this->exclude = $exclude;
+    }
+
+    public function handle()
+    {
+        $processes = Process::whereNotIn('id', $this->exclude)
+            ->whereJsonContains('signal_events', $this->signalRef)
+            ->pluck('id')
+            ->toArray();
+        foreach ($processes as $process) {
+            CatchSignalEventProcess::dispatch(
+                $process,
+                $this->signalRef,
+                $this->data,
+            )->onQueue('bpmn');
+        }
+        $count = ProcessRequest::whereNotIn('id', $this->exclude)
+            ->whereJsonContains('signal_events', $this->signalRef)
+            ->count();
+        if ($count) {
+            $perJob = ceil($count / self::maxJobs);
+            $requests = ProcessRequest::select(['id'])
+                ->whereJsonContains('signal_events', $this->signalRef)
+                ->where('status', 'ACTIVE')
+                ->whereNotIn('id', $this->exclude);
+            $requests = $requests->orderBy('id')
+                ->pluck('id')
+                ->toArray();
+            $chuncks = array_chunk($requests, $perJob);
+            foreach ($chuncks as $chunck) {
+                CatchSignalEventRequest::dispatch(
+                    $chunck,
+                    $this->signalRef,
+                    $this->data,
+                )->onQueue('bpmn');
+            }
+        }
+    }
+}

--- a/ProcessMaker/Managers/WorkflowManager.php
+++ b/ProcessMaker/Managers/WorkflowManager.php
@@ -170,8 +170,20 @@ class WorkflowManager
      *
      * @param ServiceTaskInterface $serviceTask
      * @param Token $token
+     * @deprecated 4.0.15 Use WorkflowManager::throwSignalEventDefinition()
      */
     public function catchSignalEvent(ThrowEventInterface $source = null, EventDefinitionInterface $sourceEventDefinition, TokenInterface $token)
+    {
+        $this->throwSignalEventDefinition($sourceEventDefinition, $token);
+    }
+
+    /**
+     * Catch a signal event.
+     *
+     * @param EventDefinitionInterface $sourceEventDefinition
+     * @param Token $token
+     */
+    public function throwSignalEventDefinition(EventDefinitionInterface $sourceEventDefinition, TokenInterface $token)
     {
         Log::info('Catch signal event: ' . $sourceEventDefinition->getName());
         $signalRef = $sourceEventDefinition->getProperty('signalRef');
@@ -186,9 +198,7 @@ class WorkflowManager
             $exclude[] = $token->getInstance()->getKey();
         }
         ThrowSignalEvent::dispatch($signalRef, $data, $exclude);
-        //$source, $sourceEventDefinition, $token)->onQueue('bpmn');
     }
-
     /**
      * Attach validation event
      *

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
 use Mustache_Engine;
 use ProcessMaker\AssignmentRules\PreviousTaskAssignee;
+use ProcessMaker\BpmnEngine;
 use ProcessMaker\Contracts\ProcessModelInterface;
 use ProcessMaker\Exception\InvalidUserAssignmentException;
 use ProcessMaker\Exception\TaskDoesNotHaveRequesterException;
@@ -1145,12 +1146,13 @@ class Process extends Model implements HasMedia, ProcessModelInterface
     {
         try {
             $definitions = $this->getDefinitions();
-            $engine = $definitions->getEngine();
+            $engine = app(BpmnEngine::class, ['definitions' => $definitions]);
             $processes = $definitions->getElementsByTagNameNS(BpmnDocument::BPMN_MODEL, 'process');
             foreach ($processes as $process) {
                 $process->getBpmnElementInstance()->getTransitions($engine->getRepository());
             }
         } catch (Throwable $exception) {
+            throw $exception;
             $warning = [
                 'title' => __('Process invalid for execution'),
                 'text' => __('Process invalid for execution'),

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -664,4 +664,18 @@ class ProcessRequestToken extends Model implements TokenInterface
             ARRAY_FILTER_USE_KEY
         );
     }
+
+    public function saveToken()
+    {
+        $activity = $this->getOwnerElement();
+        $token = $this;
+        $token->status = $token->getStatus();
+        $token->element_id = $activity->getId();
+        $token->element_type = $activity->getBpmnElement()->localName;
+        $token->element_name = $activity->getName();
+        $token->process_id = $token->getInstance()->process->getKey();
+        $token->process_request_id = $token->getInstance()->getKey();
+        $token->saveOrFail();
+        $token->setId($token->getKey());        
+    }
 }

--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -90,28 +90,6 @@ class WorkflowServiceProvider extends ServiceProvider
         $this->app->bind(BpmnDocumentInterface::class, function ($app, $params) {
             $repository = new DefinitionsRepository();
             $engine = $params['engine'] ?? new BpmnEngine($repository, app('events'));
-            //if (!empty($params['engine'])) {
-            //    $eventBus = app('events');
-//
-            //    //Initialize the BpmnEngine
-            //    $engine = empty($params['engine']) ? new BpmnEngine($repository, $eventBus) : $params['engine'];
-            //    $eventDefinitionBus = new EventDefinitionBus;
-            //    $engine->setEventDefinitionBus($eventDefinitionBus);
-    //
-            //    // Catch the signal events
-            //    if ($params['globalEvents']) {
-            //        $eventDefinitionBus->attachEvent(
-            //            SignalEventDefinition::class,
-            //            function (ThrowEventInterface $source, EventDefinitionInterface $sourceEventDefinition, TokenInterface $token) {
-            //                WorkflowManagerFacade::catchSignalEvent($source, $sourceEventDefinition, $token);
-            //            }
-            //        );
-            //    }
-    //
-            //    $engine->setJobManager(new TaskSchedulerManager());
-            //} else {
-            //    $engine = null;
-            //}
 
             //Initialize BpmnDocument repository (REQUIRES $engine $factory)
             $bpmnRepository = new BpmnDocument($params['process']);

--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -62,7 +62,7 @@ class WorkflowServiceProvider extends ServiceProvider
 
         $this->app->bind(BpmnEngine::class, function ($app, $params) {
             $definitions = $params['definitions'];
-            $globalEvents = true;
+            $globalEvents = $params['globalEvents'] ?? true;
             $repository = $definitions->getFactory();
             $eventBus = app('events');
             //Initialize the BpmnEngine

--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -74,7 +74,7 @@ class WorkflowServiceProvider extends ServiceProvider
                 $eventDefinitionBus->attachEvent(
                     SignalEventDefinition::class,
                     function (ThrowEventInterface $source, EventDefinitionInterface $sourceEventDefinition, TokenInterface $token) {
-                        WorkflowManagerFacade::catchSignalEvent($source, $sourceEventDefinition, $token);
+                        WorkflowManagerFacade::throwSignalEventDefinition($sourceEventDefinition, $token);
                     }
                 );
             }

--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -118,7 +118,7 @@ abstract class Base
         \Log::debug("Docker returned: " . substr(json_encode($response), 0, 500));
         if ($returnCode || $stdOutput) {
             // Has an error code
-            throw new RuntimeException(implode("\n", $stdOutput));
+            throw new RuntimeException("(Code: {$returnCode})" . implode("\n", $stdOutput));
         } else {
             // Success
             $response = json_decode($output, true);

--- a/ProcessMaker/Traits/ProcessTrait.php
+++ b/ProcessMaker/Traits/ProcessTrait.php
@@ -32,7 +32,7 @@ trait ProcessTrait
             $this->bpmnDefinitions = app(BpmnDocumentInterface::class, $options);
             if ($this->bpmn) {
                 $this->bpmnDefinitions->loadXML($this->bpmn);
-                try {
+                /*try {
                     $this->bpmnDefinitions->getEngine()->loadProcessDefinitions($this->bpmnDefinitions);
                 } catch (ElementNotFoundException $e) {
                     $warnings = is_array($this->warnings) ? $this->warnings : [];
@@ -41,7 +41,7 @@ trait ProcessTrait
                         'text' => $e->getMessage()
                     ];
                     $this->warnings = $warnings;
-                }
+                }*/
             }
         }
         return $this->bpmnDefinitions;

--- a/ProcessMaker/Traits/ProcessTrait.php
+++ b/ProcessMaker/Traits/ProcessTrait.php
@@ -4,7 +4,6 @@ namespace ProcessMaker\Traits;
 
 use ProcessMaker\Models\ProcessVersion;
 use ProcessMaker\Nayra\Contracts\Storage\BpmnDocumentInterface;
-use ProcessMaker\Nayra\Exceptions\ElementNotFoundException;
 use ProcessMaker\Repositories\BpmnDocument;
 
 trait ProcessTrait
@@ -23,25 +22,14 @@ trait ProcessTrait
      *
      * @return BpmnDocument
      */
-    public function getDefinitions($forceParse = false, $engine = null, $globalEvents = true)
+    public function getDefinitions($forceParse = false, $engine = null)
     {
         if ($forceParse || empty($this->bpmnDefinitions)) {
             $options = ['process' => $this instanceof ProcessVersion ? $this->process : $this];
             !$engine ?: $options['engine'] = $engine;
-            $options['globalEvents'] = $globalEvents;
             $this->bpmnDefinitions = app(BpmnDocumentInterface::class, $options);
             if ($this->bpmn) {
                 $this->bpmnDefinitions->loadXML($this->bpmn);
-                /*try {
-                    $this->bpmnDefinitions->getEngine()->loadProcessDefinitions($this->bpmnDefinitions);
-                } catch (ElementNotFoundException $e) {
-                    $warnings = is_array($this->warnings) ? $this->warnings : [];
-                    $warnings[] = [
-                        'title' => __('Element Not Found'),
-                        'text' => $e->getMessage()
-                    ];
-                    $this->warnings = $warnings;
-                }*/
             }
         }
         return $this->bpmnDefinitions;

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "processmaker/docker-executor-node": "^1.0",
     "processmaker/docker-executor-php": "^1.0",
     "processmaker/laravel-i18next": "dev-master",
-    "processmaker/nayra": "1.1.1",
+    "processmaker/nayra": "1.1.2",
     "processmaker/pmql": "1.1.3",
     "pusher/pusher-php-server": "^4.0",
     "ralouphie/getallheaders": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fc02d337ba04e17d321fcb06b983c3e",
+    "content-hash": "cc5e48042ddf17180ba2f79f337d43e0",
     "packages": [
         {
             "name": "babenkoivan/elastic-adapter",
@@ -3937,16 +3937,16 @@
         },
         {
             "name": "processmaker/nayra",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ProcessMaker/nayra.git",
-                "reference": "86983f2fdbba03a9deb2f5e1ef73579b35a9ca9f"
+                "reference": "738862afaa923f1ecd0acf111a40eb6cf832f1f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ProcessMaker/nayra/zipball/86983f2fdbba03a9deb2f5e1ef73579b35a9ca9f",
-                "reference": "86983f2fdbba03a9deb2f5e1ef73579b35a9ca9f",
+                "url": "https://api.github.com/repos/ProcessMaker/nayra/zipball/738862afaa923f1ecd0acf111a40eb6cf832f1f1",
+                "reference": "738862afaa923f1ecd0acf111a40eb6cf832f1f1",
                 "shasum": ""
             },
             "require-dev": {
@@ -3963,7 +3963,7 @@
                 "Apache-2.0"
             ],
             "description": "BPMN compliant engine",
-            "time": "2020-10-02T23:27:29+00:00"
+            "time": "2020-10-14T16:28:51+00:00"
         },
         {
             "name": "processmaker/pmql",
@@ -9485,5 +9485,6 @@
     "platform": {
         "php": ">=7.2.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/resources/js/components/requests/card.vue
+++ b/resources/js/components/requests/card.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="mt-3">
-      <div class="card" v-for="event in process.startEvents" :key="event.id">
+      <div class="card" v-for="event in emptyStartEvents" :key="event.id">
         <div class="card-body">
           <div class="row">
             <div class="col-10">
@@ -69,6 +69,9 @@ export default {
     }
   },
   computed: {
+    emptyStartEvents () {
+      return this.process.startEvents.filter(event => !event.eventDefinitions || event.eventDefinitions.length === 0);
+    },
     transformedName() {
       return this.process.name.replace(new RegExp(this.filter, "gi"), match => {
         return match;

--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -3,6 +3,7 @@
 import {
   association,
   endEvent,
+  terminateEndEvent,
   exclusiveGateway,
   inclusiveGateway,
   parallelGateway,
@@ -202,6 +203,16 @@ ProcessMaker.EventBus.$on(
       }
     });
     registerInspectorExtension(endEvent, {
+      component: 'ModelerScreenSelect',
+      config: {
+        label: 'Summary Screen',
+        helper:
+          'Select Display-type Screen to show the summary of this Request when it completes',
+        name: 'screenRef',
+        params: { type: 'DISPLAY' }
+      }
+    });
+    registerInspectorExtension(terminateEndEvent, {
       component: 'ModelerScreenSelect',
       config: {
         label: 'Summary Screen',

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -208,6 +208,7 @@ export default {
     window.Echo.private(
       `ProcessMaker.Models.User.${userID.content}`
     ).notification(response => {
+      console.log(response);
       this.outputResponse(response);
     });
     this.loadBoilerplateTemplate();
@@ -259,7 +260,7 @@ export default {
     },
     stopResizing: _.debounce(function() {
       this.resizing = false;
-      this.resizeEditor();
+      //this.resizeEditor();
     }, 50),
     handleResize() {
       this.resizing = true;

--- a/routes/console.php
+++ b/routes/console.php
@@ -28,3 +28,15 @@ Artisan::command('notifications:resend {username}', function ($username) {
         $user->notify($notification);
     }
 })->describe('Resend to user the notifications of his/her active tasks');
+
+Artisan::command('check {path}', function ($path) {
+    $dom = new DOMDocument;
+    $dom->load($path);
+    $query = new DOMXPath($dom);
+    $nodes = $query->evaluate("//*[@bpmnElement]");
+    foreach($nodes as $node) {
+        $id = $node->getAttribute('bpmnElement');
+        $elem = $query->evaluate("//*[@id='$id']")->item(0);
+        dump($elem);
+    }
+})->describe('Display an inspiring quote');

--- a/tests/Feature/Api/GlobalSignalsTest.php
+++ b/tests/Feature/Api/GlobalSignalsTest.php
@@ -61,6 +61,7 @@ class GlobalSignalsTest extends TestCase
         // Assertion: Active Task = Task 4a (process one)
         $instance->refresh();
         $activeTask = $instance->tokens()->where('status', 'ACTIVE')->first();
+        dd($instance->tokens()->where('status', 'ACTIVE')->get()->toArray());
         $this->assertEquals('Task 4a', $activeTask->element_name);
         // Complete Parent Task
         $this->completeTask($activeTask, []);

--- a/tests/Feature/Api/GlobalSignalsTest.php
+++ b/tests/Feature/Api/GlobalSignalsTest.php
@@ -61,7 +61,6 @@ class GlobalSignalsTest extends TestCase
         // Assertion: Active Task = Task 4a (process one)
         $instance->refresh();
         $activeTask = $instance->tokens()->where('status', 'ACTIVE')->first();
-        dd($instance->tokens()->where('status', 'ACTIVE')->get()->toArray());
         $this->assertEquals('Task 4a', $activeTask->element_name);
         // Complete Parent Task
         $this->completeTask($activeTask, []);


### PR DESCRIPTION
Fix CallActivity-EventBasedGateway

This PR includes:

- Fix Message Event throwing/catching Jobs
- Fix Signal Event throwing/catching Jobs
- Update tests

Use case:
The following processes runs 3 requests:

- Request 1: Calls Requests 2, then waits for a signal (`signal1` or `signal2`)
- Request 2: Runs an script, Start Request 3 and finish
- Request 3: Runs an script and then trigger randomly `signal1` or `signa2`

![CallActivityEBG](https://user-images.githubusercontent.com/8028650/97466851-f3cb5d00-1919-11eb-9971-204b99c9e61a.gif)

![image](https://user-images.githubusercontent.com/8028650/97464911-e1502400-1917-11eb-8d8c-024694ce31b4.png)
![image](https://user-images.githubusercontent.com/8028650/97465187-2a07dd00-1918-11eb-8d67-10e4b2fa123e.png)


[Call Activity - Event Based Gateway.json.txt](https://github.com/ProcessMaker/processmaker/files/5453363/Call.Activity.-.Event.Based.Gateway.json.txt)
[Signals.json.txt](https://github.com/ProcessMaker/processmaker/files/5453364/Signals.json.txt)
