### PR TITLE
Signals with payload #3449

### DIFF
--- a/ProcessMaker/BpmnEngine.php
+++ b/ProcessMaker/BpmnEngine.php
@@ -79,6 +79,11 @@ class BpmnEngine implements EngineInterface
         return $this->repository;
     }
 
+    public function getExecutionInstances()
+    {
+        return $this->executionInstances;
+    }
+
     /**
      * @param RepositoryInterface $repository
      *

--- a/ProcessMaker/Jobs/CatchSignalEventProcess.php
+++ b/ProcessMaker/Jobs/CatchSignalEventProcess.php
@@ -10,6 +10,7 @@ use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Repositories\BpmnDocument;
+use ProcessMaker\Repositories\DefinitionsRepository;
 
 class CatchSignalEventProcess implements ShouldQueue
 {
@@ -17,58 +18,49 @@ class CatchSignalEventProcess implements ShouldQueue
         InteractsWithQueue,
         Queueable;
 
-    public $eventDefinition;
     public $payload;
     public $processId;
-    public $requestId;
     public $signalRef;
-    public $throwEvent;
-    public $tokenId;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct($processId, $signalRef, $payload, $throwEvent, $eventDefinition, $tokenId, $requestId)
+    public function __construct($processId, $signalRef, $payload)
     {
-        $this->eventDefinition = $eventDefinition;
         $this->payload = $payload;
         $this->processId = $processId;
-        $this->requestId = $requestId;
         $this->signalRef = $signalRef;
-        $this->throwEvent = $throwEvent;
-        $this->tokenId = $tokenId;
     }
 
     public function handle()
     {
-        $mainRequest = ProcessRequest::find($this->requestId);
-        if ($mainRequest) {
-            $definitions = ($mainRequest->processVersion ?? $mainRequest->process)->getDefinitions(true);
-            $engine = $definitions->getEngine();
-            $throwEvent = $definitions->findElementById($this->throwEvent)->getBpmnElementInstance();
-            $instance = $engine->loadProcessRequest($mainRequest);
-            $eventDefinition = $this->getEventDefinitionBySignalRef($definitions);
-            $token = ProcessRequestToken::find($this->tokenId);
-            if ($token) {$token->setInstance($instance);}
-        }
-        else {
-            $throwEvent = null;
-            $instance = null;
-            $eventDefinition = $this->eventDefinition;
-            $token = null;
-        }
+        $repository = new DefinitionsRepository;
+        $eventDefinition = $repository->createSignalEventDefinition();
+        $signal = $repository->createSignal();
+        $signal->setId($this->signalRef);
+        $eventDefinition->setPayload($signal);
+        $eventDefinition->setProperty('signalRef', $this->signalRef);
+
         $version = Process::find($this->processId)->getLatestVersion();
         $definitions = $version->getDefinitions(true, null, false);
         $engine = $definitions->getEngine();
         $engine->loadProcessDefinitions($definitions);
         $engine->getEventDefinitionBus()->dispatchEventDefinition(
-            $throwEvent,
+            null,
             $eventDefinition,
-            $token
+            null
         );
 
+
+        if ($this->payload) {
+            foreach ($this->payload as $key => $value) {
+                $engine->getExecutionInstances()[0]->getDataStore()->putData($key, $value);
+            }
+        }
+
+        //@todo Add payload to started requests
         $engine->runToNextState();
     }
 

--- a/ProcessMaker/Jobs/CatchSignalEventProcess.php
+++ b/ProcessMaker/Jobs/CatchSignalEventProcess.php
@@ -53,14 +53,14 @@ class CatchSignalEventProcess implements ShouldQueue
             null
         );
 
-
         if ($this->payload) {
             foreach ($this->payload as $key => $value) {
-                $engine->getExecutionInstances()[0]->getDataStore()->putData($key, $value);
+                foreach ($engine->getExecutionInstances() as $instance) {
+                    $instance->getDataStore()->putData($key, $value);
+                }
             }
         }
 
-        //@todo Add payload to started requests
         $engine->runToNextState();
     }
 

--- a/ProcessMaker/Jobs/CatchSignalEventRequest.php
+++ b/ProcessMaker/Jobs/CatchSignalEventRequest.php
@@ -2,14 +2,12 @@
 
 namespace ProcessMaker\Jobs;
 
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use ProcessMaker\Models\ProcessRequest;
-use ProcessMaker\Models\ProcessRequestToken;
-use ProcessMaker\Nayra\Contracts\Bpmn\SignalEventDefinitionInterface;
-use ProcessMaker\Repositories\BpmnDocument;
+use ProcessMaker\Repositories\DefinitionsRepository;
 
 class CatchSignalEventRequest implements ShouldQueue
 {
@@ -20,62 +18,45 @@ class CatchSignalEventRequest implements ShouldQueue
     public $chunck;
     public $signalRef;
     public $payload;
-    public $throwEvent;
-    public $eventDefinition;
-    public $tokenId;
-    public $requestId;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct($chunck, $signalRef, $payload, $throwEvent, $eventDefinition, $tokenId, $requestId)
+    public function __construct($chunck, $signalRef, $payload)
     {
         $this->chunck = $chunck;
         $this->payload = $payload;
         $this->signalRef = $signalRef;
-        $this->throwEvent = $throwEvent;
-        $this->eventDefinition = $eventDefinition;
-        $this->tokenId = $tokenId;
-        $this->requestId = $requestId;
     }
 
     public function handle()
     {
-        $mainRequest = ProcessRequest::find($this->requestId);
-        $definitions = ($mainRequest->processVersion ?? $mainRequest->process)->getDefinitions(true);
-        $throwEvent = $definitions->findElementById($this->throwEvent)->getBpmnElementInstance();
-        $eventDefinition = $this->getEventDefinitionBySignalRef($definitions);
-        $token = ProcessRequestToken::find($this->tokenId);
+        $repository = new DefinitionsRepository;
+        $eventDefinition = $repository->createSignalEventDefinition();
+        $signal = $repository->createSignal();
+        $signal->setId($this->signalRef);
+        $eventDefinition->setPayload($signal);
+        $eventDefinition->setProperty('signalRef', $this->signalRef);
+
         foreach ($this->chunck as $requestId) {
             $request = ProcessRequest::find($requestId);
             $definitions = ($request->processVersion ?? $request->process)->getDefinitions(true, null, false);
             $engine = $definitions->getEngine();
-            $engine->loadProcessRequest($request);
+            $instance = $engine->loadProcessRequest($request);
             $engine->getEventDefinitionBus()->dispatchEventDefinition(
-                $throwEvent,
+                null,
                 $eventDefinition,
-                $token
+                null
             );
-            $engine->runToNextState();
-        }
-    }
 
-    /**
-     * Get event definition for the signal event
-     *
-     * @param BpmnDocument $definitions
-     *
-     * @return SignalEventDefinitionInterface
-     */
-    private function getEventDefinitionBySignalRef(BpmnDocument $definitions)
-    {
-        $eventDefinitions = $definitions->findElementById($this->throwEvent)->getElementsByTagNameNS(BpmnDocument::BPMN_MODEL, 'signalEventDefinition');
-        foreach ($eventDefinitions as $node) {
-            if ($node->getAttribute('signalRef') === $this->signalRef) {
-                return $node->getBpmnElementInstance();
+            if ($this->payload) {
+                foreach ($this->payload as $key => $value) {
+                    $instance->getDataStore()->putData($key, $value);
+                }
             }
+            $engine->runToNextState();
         }
     }
 }

--- a/ProcessMaker/Jobs/ThrowSignalEvent.php
+++ b/ProcessMaker/Jobs/ThrowSignalEvent.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+
+class ThrowSignalEvent implements ShouldQueue
+{
+    use Dispatchable,
+        InteractsWithQueue,
+        Queueable;
+
+    private const maxJobs = 10;
+
+    public $signalRef;
+    public $data;
+    public $exclude;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($signalRef, array $data = [], array $exclude = [])
+    {
+        $this->signalRef = $signalRef;
+        $this->data = $data;
+        $this->exclude = $exclude;
+    }
+
+    public function handle()
+    {
+        $processes = Process::whereNotIn('id', $this->exclude)
+            ->whereJsonContains('signal_events', $this->signalRef)
+            ->pluck('id')
+            ->toArray();
+        foreach ($processes as $process) {
+            CatchSignalEventProcess::dispatch(
+                $process,
+                $this->signalRef,
+                $this->data,
+            )->onQueue('bpmn');
+        }
+        $count = ProcessRequest::whereNotIn('id', $this->exclude)
+            ->whereJsonContains('signal_events', $this->signalRef)
+            ->count();
+        if ($count) {
+            $perJob = ceil($count / self::maxJobs);
+            $requests = ProcessRequest::select(['id'])
+                ->whereJsonContains('signal_events', $this->signalRef)
+                ->where('status', 'ACTIVE')
+                ->whereNotIn('id', $this->exclude);
+            $requests = $requests->orderBy('id')
+                ->pluck('id')
+                ->toArray();
+            $chuncks = array_chunk($requests, $perJob);
+            foreach ($chuncks as $chunck) {
+                CatchSignalEventRequest::dispatch(
+                    $chunck,
+                    $this->signalRef,
+                    $this->data,
+                )->onQueue('bpmn');
+            }
+        }
+    }
+}

--- a/ProcessMaker/Managers/WorkflowManager.php
+++ b/ProcessMaker/Managers/WorkflowManager.php
@@ -171,7 +171,7 @@ class WorkflowManager
      * @param ServiceTaskInterface $serviceTask
      * @param Token $token
      */
-    public function catchSignalEvent(ThrowEventInterface $source, EventDefinitionInterface $sourceEventDefinition, TokenInterface $token)
+    public function catchSignalEvent(ThrowEventInterface $source = null, EventDefinitionInterface $sourceEventDefinition, TokenInterface $token)
     {
         Log::info('Catch signal event: ' . $sourceEventDefinition->getName());
         CatchSignalEvent::dispatch($source, $sourceEventDefinition, $token)->onQueue('bpmn');


### PR DESCRIPTION
Resolves #3449 

Start in intermediate catch signal events can receive and handle payload data. This payload is added to the request as part of its data