### PR TITLE
FOUR-2227: I cannot edit the record of a collection

### DIFF
--- a/ProcessMaker/Jobs/ThrowSignalEvent.php
+++ b/ProcessMaker/Jobs/ThrowSignalEvent.php
@@ -43,7 +43,7 @@ class ThrowSignalEvent implements ShouldQueue
             CatchSignalEventProcess::dispatch(
                 $process,
                 $this->signalRef,
-                $this->data,
+                $this->data
             )->onQueue('bpmn');
         }
         $count = ProcessRequest::whereNotIn('id', $this->exclude)
@@ -63,7 +63,7 @@ class ThrowSignalEvent implements ShouldQueue
                 CatchSignalEventRequest::dispatch(
                     $chunck,
                     $this->signalRef,
-                    $this->data,
+                    $this->data
                 )->onQueue('bpmn');
             }
         }


### PR DESCRIPTION
Resolves [https://processmaker.atlassian.net/browse/FOUR-2227](https://processmaker.atlassian.net/browse/FOUR-2227)

Trailing commas in function calls generate errors in versions lower than 7.3. Those commas were removed