### PR TITLE
Added a missing period

### DIFF
--- a/resources/js/processes/screen-builder/components/file-upload-control.js
+++ b/resources/js/processes/screen-builder/components/file-upload-control.js
@@ -21,7 +21,7 @@ export default {
         config: {
           label: "Variable Name",
           name: 'Name',
-          helper: "A variable name is a symbolic name to reference information",
+          helper: "A variable name is a symbolic name to reference information.",
           validation: 'regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_. \/a-z])*$/|required'
         }
       },


### PR DESCRIPTION
To maintain UI consistency with Variable Name helper labels, a period was needed.