### PR TITLE
Emit an event when a new screen is imported

### DIFF
--- a/ProcessMaker/Events/ImportedScreenSaved.php
+++ b/ProcessMaker/Events/ImportedScreenSaved.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Models\Screen;
+
+class ImportedScreenSaved
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /** @var Integer */
+    public $newScreenId;
+
+    /** @var Screen */
+    public $screen;
+
+    /**
+     * @param Integer $newScreenId
+     * @param Screen $screen
+     */
+    public function __construct($newScreenId, $screen)
+    {
+        $this->newScreenId = $newScreenId;
+        $this->screen = $screen;
+    }
+}

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -7,6 +7,7 @@ use DB;
 use DOMXPath;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
+use ProcessMaker\Events\ImportedScreenSaved;
 use ProcessMaker\Models\User;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessNotificationSetting;
@@ -385,6 +386,7 @@ class ImportProcess implements ShouldQueue
             $new->type = $screen->type;
             $new->watchers =  $this->watcherScriptsToSave($screen);
             $new->save();
+            event(new ImportedScreenSaved($new->id, $screen));
 
             // save categories
             if (isset($screen->categories)) {


### PR DESCRIPTION
Emits an `ImportScreenSaved` event after a new screen is saved.

This event is handled in https://github.com/ProcessMaker/package-migration-setup/pull/16