### PR TITLE
Fix 403 error when logging in with a user who has only user permissions

### DIFF
--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -59,10 +59,12 @@
                 <component id="navbar-request-button" v-bind:is="'request-modal'" url="{{ route('processes.index') }}" v-bind:permission="{{ \Auth::user()->hasPermissionsFor('processes') }}"></component>
             </b-nav-item>
 
-            <b-nav-item class="d-none d-lg-block">
-                <notifications id="navbar-notifications-button" v-bind:is="'notifications'" v-bind:messages="messages">
-                </notifications>
-            </b-nav-item>
+            @can('view-notifications')
+                <b-nav-item class="d-none d-lg-block">
+                    <notifications id="navbar-notifications-button" v-bind:is="'notifications'" v-bind:messages="messages">
+                    </notifications>
+                </b-nav-item>
+            @endcan
             <li class="separator d-none d-lg-block"></li>
             <li class="d-none d-lg-block">
                 @php

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,7 +82,7 @@ Route::group(['middleware' => ['auth', 'sanitize', 'external.connection']], func
     Route::get('tasks', 'TaskController@index')->name('tasks.index');
     Route::get('tasks/{task}/edit', 'TaskController@edit')->name('tasks.edit');
 
-    Route::get('notifications', 'NotificationController@index')->name('notifications.index');
+    Route::get('notifications', 'NotificationController@index')->name('notifications.index')->middleware('can:view,notification');
 
     // Allows for a logged in user to see navigation on a 404 page
     Route::fallback(function () {


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2127

- Only render the notification bell and and api call if the user has permission
- Add notification permission check to web route