### PR TITLE
FOUR-2227: can't edit a record

### DIFF
--- a/ProcessMaker/Jobs/ThrowSignalEvent.php
+++ b/ProcessMaker/Jobs/ThrowSignalEvent.php
@@ -45,7 +45,7 @@ class ThrowSignalEvent implements ShouldQueue
             CatchSignalEventProcess::dispatch(
                 $process,
                 $this->signalRef,
-                $this->data,
+                $this->data
             )->onQueue('bpmn');
         }
         $count = ProcessRequest::whereNotIn('id', $this->excludeRequests)
@@ -66,7 +66,7 @@ class ThrowSignalEvent implements ShouldQueue
                 CatchSignalEventRequest::dispatch(
                     $chunck,
                     $this->signalRef,
-                    $this->data,
+                    $this->data
                 )->onQueue('bpmn');
             }
         }


### PR DESCRIPTION
For some reason trailing commas were reintroduced in a commit. They were removed again
