### PR TITLE
Don't reset preview data when changing from preview to builder

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -472,8 +472,9 @@ export default {
         this.$refs.menuScreen.sectionRight = false;
       }
       this.mode = mode;
-      this.previewData = this.previewInputValid ? JSON.parse(this.previewInput) : {};
       if (mode == 'preview') {
+        this.previewData = this.previewInputValid ? JSON.parse(this.previewInput) : {};
+
         this.rendererKey++;
         this.preview.config = cloneDeep(this.config);
         this.preview.computed = cloneDeep(this.computed);


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2269

In screen builder, when switching back from preview mode, the defaults that were correctly setup by the renderer, were being erased. This makes it so the preview data is only reset when switching from builder to preview.