### PR TITLE
Register the bpmn namespace when searching for items to export

### DIFF
--- a/ProcessMaker/Managers/PMConfigGenericExportManager.php
+++ b/ProcessMaker/Managers/PMConfigGenericExportManager.php
@@ -37,6 +37,7 @@ class PMConfigGenericExportManager
     {
         $xpath = new DOMXPath($process->getDefinitions());
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', 'http://www.omg.org/spec/BPMN/20100524/MODEL');
 
         // Used in config
         $nodes = $xpath->query("//{$this->tag}[@pm:config!='']");


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2203

The xml was using a prefix other than 'bpmn' so we needed to register its URI so the rest of the script can continue to reference it as 'bpmn'