### PR TITLE
Calculate time remaining based of the current timestamp

### DIFF
--- a/resources/js/timeout.js
+++ b/resources/js/timeout.js
@@ -12,18 +12,22 @@ self.addEventListener('message', function (e) {
 });
 
 self.start = function (data) {
-  self.time = data.timeout * 60;
+  var timestampAtStart = Math.floor(Date.now() / 1000);
+  var timeoutAt = timestampAtStart + (data.timeout * 60);
+  
   clearInterval(self.interval);
   self.interval = setInterval(function () {
-    self.time--;
-    
-    if (self.time < data.warnSeconds && self.time > 0) {
-      self.postMessage({ method: 'countdown', data: { time: self.time } });
+
+    var currentTimestamp = Math.floor(Date.now() / 1000);
+    var timeRemaining = timeoutAt - currentTimestamp;
+
+    if (timeRemaining < data.warnSeconds && timeRemaining > 0) {
+      self.postMessage({ method: 'countdown', data: { time: timeRemaining } });
     }
 
-    if (self.time < 1) {
+    if (timeRemaining < 1) {
       clearInterval(self.interval);
-      self.postMessage({ method: 'timedOut', data: { time: self.time } });
+      self.postMessage({ method: 'timedOut', data: { time: timeRemaining } });
     }
   }, 1000);
 }


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2278

The code that keeps track of how much time is left in a session was decrementing a seconds counter. The problem is if the system sleeps, or in some cases, when the tab is not focused, browser code execution can be paused, causing the counter to be inaccurate.

The solution was to base the timeout on the current timestamp and the timestamp when the session started.