### PR TITLE
Add missing editor theme

### DIFF
--- a/resources/js/admin/cssOverride/edit.js
+++ b/resources/js/admin/cssOverride/edit.js
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import ColorPicker from "./components/ColorPicker";
 import Editor from '@tinymce/tinymce-vue'
+import 'tinymce/themes/silver';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/plugins/code';


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2275

Adds the editor theme globally so it doesn't try to load it via a url. Missed this because caching was enabled in my local dev environment.