### PR TITLE
Do not load security logs if the user does not have permission

### DIFF
--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -140,11 +140,13 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="tab-pane" id="nav-logs" role="tabpanel" aria-labelledby="nav-logs-tab">
-                            <div>
-                                <security-logs-listing :user-id="@json($user->id)"></security-logs-listing>
-                            </div>
-                        </div>
+                        @can('view-security-logs')
+                          <div class="tab-pane" id="nav-logs" role="tabpanel" aria-labelledby="nav-logs-tab">
+                              <div>
+                                  <security-logs-listing :user-id="@json($user->id)"></security-logs-listing>
+                              </div>
+                          </div>
+                        @endcan
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2316

Do not load security logs list if the user does not have permission