### PR TITLE
Fix Reload is not a function error

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -315,7 +315,7 @@
                 is_self_service: 0,
               })
               .then(response => {
-                this.reload();
+                window.location.reload();
               });
           },
           // Data editor


### PR DESCRIPTION
**Jira Ticket**
https://processmaker.atlassian.net/browse/FOUR-2426#icft=FOUR-2426

<h2>Changes</h2>

Replaces the nonexisting `this.reload()` method so that the task is properly reloaded when claiming a task.