### PR TITLE
Add missing engine job manager to workflow service provider

### DIFF
--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -97,7 +97,9 @@ class WorkflowServiceProvider extends ServiceProvider
             //Initialize BpmnDocument repository (REQUIRES $engine $factory)
             $bpmnRepository = new BpmnDocument($params['process']);
             if ($engine) {
-                $engine->setJobManager(new TaskSchedulerManager());
+                if (!$engine->getJobManager()) {
+                    $engine->setJobManager(new TaskSchedulerManager());
+                }
                 $bpmnRepository->setEngine($engine);
             }
             $bpmnRepository->getFactory();

--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -97,6 +97,7 @@ class WorkflowServiceProvider extends ServiceProvider
             //Initialize BpmnDocument repository (REQUIRES $engine $factory)
             $bpmnRepository = new BpmnDocument($params['process']);
             if ($engine) {
+                $engine->setJobManager(new TaskSchedulerManager());
                 $bpmnRepository->setEngine($engine);
             }
             $bpmnRepository->getFactory();


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2327

- Sets the bpmn engine job manager in the singleton for BpmnDocument