### PR TITLE
Add explicit style import for vue-json-pretty 1.7.1

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -182,6 +182,7 @@ import CustomCSS from "@processmaker/screen-builder/src/components/custom-css";
 import "@processmaker/screen-builder/dist/vue-form-builder.css";
 import "@processmaker/vue-form-elements/dist/vue-form-elements.css";
 import VueJsonPretty from "vue-json-pretty";
+import 'vue-json-pretty/lib/styles.css';
 import MonacoEditor from "vue-monaco";
 import mockMagicVariables from "./mockMagicVariables";
 import TopMenu from "../../components/Menu";


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2377

vue-json-pretty v1.7.1 separates the styles and requires them to be imported. Does not effect standalone since its using 1.6.3.