### PR TITLE
NotificationController must extend processmaker's controller

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/Api/NotificationController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
-use Laravel\Horizon\Http\Controllers\Controller;
+use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\Notifications as NotificationResource;
 use ProcessMaker\Models\Notification;


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2395

The Notification controller was extending Laravel's base controller for some reason. This was causing a 403 for any non-admin. Fix is to use ProcessMaker's base controller.