### PR TITLE
Fix broken unit tests

### DIFF
--- a/ProcessMaker/Listeners/SecurityLogger.php
+++ b/ProcessMaker/Listeners/SecurityLogger.php
@@ -22,35 +22,37 @@ class SecurityLogger
      */
     public function handle($event)
     {
-        $class = get_class($event);
-        
-        if (array_key_exists($class, $this->eventTypes)) {
-            $eventType = $this->eventTypes[$class];
+        if (config('auth.log_auth_events')) {
+            $class = get_class($event);
             
-            if (isset($event->user)) {
-                $userId = $event->user->id;
-            } else {
-                $userId = null;
-            }
-            
-            $userAgent = $this->userAgent();
-            
-            SecurityLog::create([
-               'event' => $eventType,
-               'ip' => request()->ip(),
-               'meta' => [
-                   'user_agent' => $userAgent->string,
-                   'browser' => [
-                       'name' => $userAgent->browser->name,
-                       'version' => $userAgent->browser->version,
+            if (array_key_exists($class, $this->eventTypes)) {
+                $eventType = $this->eventTypes[$class];
+                
+                if (isset($event->user)) {
+                    $userId = $event->user->id;
+                } else {
+                    $userId = null;
+                }
+                
+                $userAgent = $this->userAgent();
+                
+                SecurityLog::create([
+                   'event' => $eventType,
+                   'ip' => request()->ip(),
+                   'meta' => [
+                       'user_agent' => $userAgent->string,
+                       'browser' => [
+                           'name' => $userAgent->browser->name,
+                           'version' => $userAgent->browser->version,
+                       ],
+                       'os' => [
+                           'name' => $userAgent->os->name,
+                           'version' => $userAgent->os->version,
+                       ]
                    ],
-                   'os' => [
-                       'name' => $userAgent->os->name,
-                       'version' => $userAgent->os->version,
-                   ]
-               ],
-               'user_id' => $userId,
-            ]);
+                   'user_id' => $userId,
+                ]);
+            }
         }
     }
     

--- a/config/auth.php
+++ b/config/auth.php
@@ -84,4 +84,15 @@ return [
             'expire' => 60,
         ],
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Security Logging
+    |--------------------------------------------------------------------------
+    |
+    | This controls the logging of authentication events such as login, logout,
+    | and attempts to a database table. If disabled, such events will not be
+    | logged. If enabled, the events will be displayed within user admin.
+    |
+    */
+    'log_auth_events' => env('LOG_AUTH_EVENTS', true),
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -56,6 +56,7 @@ return [
             'prefix' => '',
             'strict' => true,
             'engine' => 'InnoDB',
+            'timezone'  => env('DB_TIMEZONE'),
         ],
         'data' => [
             'driver' => env('DATA_DB_DRIVER', 'mysql'),
@@ -70,6 +71,7 @@ return [
             'schema' => env('DATA_DB_SCHEMA'),
             'engine' => env('DATA_DB_ENGINE'),
             'date_format' => env('DATA_DB_DATE_FORMAT'),
+            'timezone'  => env('DATA_DB_TIMEZONE'),
         ]
     ],
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -41,6 +41,8 @@
       <env name="DB_ADAPTER" value="mysql" />
       <env name="DB_DATABASE" value="test" />
       <env name="DATA_DB_DATABASE" value="test" />
+      <env name="DB_TIMEZONE" value="+00:00" />
+      <env name="DATA_DB_TIMEZONE" value="+00:00" />
 
       <!-- Log config -->
       <env name="LOG_CHANNEL" value="test" />

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,7 @@
       <env name="TESTING_VERBOSE" value="false" />
       <env name="POPULATE_DATABASE" value="true" />
       <env name="TELESCOPE_ENABLED" value="false" />
+      <env name="LOG_AUTH_EVENTS" value="false" />
       <env name="BROADCAST_DRIVER" value="log"/>
 
       <!-- Caching config -->

--- a/tests/Feature/Api/TaskAssignmentExecutionTest.php
+++ b/tests/Feature/Api/TaskAssignmentExecutionTest.php
@@ -171,12 +171,11 @@ class TaskAssignmentExecutionTest extends TestCase
         $processRequest = WorkflowManager::triggerStartEvent($process, $event, []);
         $task = $processRequest->refresh()->tokens()->where('status', 'ACTIVE')->first();
 
-        $listTasksUrl = route('api.tasks.index');
-        // $listTasksUrl = route('api.tasks.index', ['pmql' => '(status = "Self Service")']);
         $updateTaskUrl = route('api.tasks.update', [$task->id]);
 
         // Assert someone not in the group can not take the task
         $this->user = $userWithNoGroup;
+        $listTasksUrl = route('api.tasks.index', ['pmql' => "user_id = {$userWithNoGroup->id}"]);
         $response = $this->apiCall('GET', $listTasksUrl)->json();
         $this->assertCount(0, $response['data']);
         $response = $this->apiCall('put', $updateTaskUrl, [
@@ -187,6 +186,7 @@ class TaskAssignmentExecutionTest extends TestCase
         
         // Assert a group member can claim the task
         $this->user = $users[1];
+        $listTasksUrl = route('api.tasks.index');
         $response = $this->apiCall('GET', $listTasksUrl)->json();
 
         $this->assertCount(1, $response['data']);

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -48,12 +48,4 @@ class AuthTest extends TestCase
         ]));
         $this->assertEquals($user->id, Auth::id());
     }
-
-    /**
-     * Do not use transactions for this test
-     */
-    protected function connectionsToTransact()
-    {
-        return [];
-    }
 }

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -31,12 +31,4 @@ class RedirectTest extends TestCase
         //302 because we want to make sure they are being redirected
         $response->assertStatus(302);
     }
-    
-    /**
-     * Do not use transactions for this test
-     */
-    protected function connectionsToTransact()
-    {
-        return [];
-    }
 }

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -31,4 +31,12 @@ class RedirectTest extends TestCase
         //302 because we want to make sure they are being redirected
         $response->assertStatus(302);
     }
+    
+    /**
+     * Do not use transactions for this test
+     */
+    protected function connectionsToTransact()
+    {
+        return [];
+    }
 }

--- a/tests/Feature/SecurityLoggerTest.php
+++ b/tests/Feature/SecurityLoggerTest.php
@@ -18,6 +18,9 @@ class SecurityLoggerTest extends TestCase
      */
     public function testLogSecurityEvents()
     {
+        // Set the config to log security events
+        config(['auth.log_auth_events' => true]);
+        
         // Build a user with a specified password
         $user = factory(User::class)->create([
             'username' =>'newuser',
@@ -42,6 +45,9 @@ class SecurityLoggerTest extends TestCase
         // Attempt to logout
         Auth::logout();
         $this->assertDatabaseHas('security_logs', ['event' => 'logout', 'user_id' => $user->id]);
+        
+        // Disable security logging
+        config(['auth.log_auth_events' => false]);
     }
     
     /**


### PR DESCRIPTION
## Changes
- Fixes the following tests:
  - [x] testSelfServeAssignment
  - [x] test401RedirectsToLogin
  - [x] testRoutesSpeed
- Adds environment variables to control the MySQL timezone (`DB_TIMEZONE` and `DATA_DB_TIMEZONE`), the lack of which was causing failing tests
- Adds an environment variable (`LOG_AUTH_EVENTS`) to control the logging of security events (login, logout, attempt), the lack of which was causing tests to fail

## Notes
See commit messages for further information on why tests were failing and how they were fixed