### PR TITLE
Do not include buttons in nested screens

### DIFF
--- a/ProcessMaker/ScreenConsolidator.php
+++ b/ProcessMaker/ScreenConsolidator.php
@@ -41,10 +41,13 @@ class ScreenConsolidator {
         ];
     }
 
-    public function replace($items)
+    public function replace($items, $removeButtons = false)
     {
         $new = [];
         foreach ($items as $item) {
+            if ($removeButtons && $this->is('FormButton', $item)) {
+                continue;
+            }
             if ($this->is('FormMultiColumn', $item)) {
                 $new[] = $this->getMultiColumn($item, $new);
 
@@ -75,7 +78,7 @@ class ScreenConsolidator {
         $this->appendCustomCss($screen);
 
         // Only use the first page
-        foreach ($this->replace($screen->config[0]['items']) as $screenItem) {
+        foreach ($this->replace($screen->config[0]['items'], true) as $screenItem) {
             $new[] = $screenItem;
         }
         $this->recursion = 0;


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2451
Also needs https://github.com/ProcessMaker/screen-builder/pull/855

Removes buttons from nested screens when outputting the compiled screen.