### PR TITLE
Saved Search Only Return Columns Needed

### DIFF
--- a/ProcessMaker/Factories/SearchRequestFactory.php
+++ b/ProcessMaker/Factories/SearchRequestFactory.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace ProcessMaker\Factories;
+
+use ElasticScoutDriver\Factories\SearchRequestFactoryInterface;
+use ElasticAdapter\Search\SearchRequest;
+use Laravel\Scout\Builder;
+use stdClass;
+
+final class SearchRequestFactory implements SearchRequestFactoryInterface
+{
+    public function makeFromBuilder(Builder $builder, array $options = []): SearchRequest
+    {
+        $searchRequest = new SearchRequest($this->makeQuery($builder));
+
+        if ($sort = $this->makeSort($builder)) {
+            $searchRequest->setSort($sort);
+        }
+
+        if ($from = $this->makeFrom($options)) {
+            $searchRequest->setFrom($from);
+        }
+
+        if ($size = $this->makeSize($builder, $options)) {
+            $searchRequest->setSize($size);
+        }
+        
+        $searchRequest->setSource('id');
+
+        return $searchRequest;
+    }
+
+    protected function makeQuery(Builder $builder): array
+    {
+        $query = [
+            'bool' => [],
+        ];
+
+        if (strlen($builder->query) > 0) {
+            $query['bool']['must'] = [
+                'query_string' => [
+                    'query' => $builder->query,
+                ],
+            ];
+        } else {
+            $query['bool']['must'] = [
+                'match_all' => new stdClass(),
+            ];
+        }
+
+        if ($filter = $this->makeFilter($builder)) {
+            $query['bool']['filter'] = $filter;
+        }
+
+        return $query;
+    }
+
+    protected function makeFilter(Builder $builder): ?array
+    {
+        $filter = collect($builder->wheres)->map(static function ($value, string $field) {
+            return [
+                'term' => [$field => $value],
+            ];
+        })->values();
+
+        return $filter->isEmpty() ? null : $filter->all();
+    }
+
+    protected function makeSort(Builder $builder): ?array
+    {
+        $sort = collect($builder->orders)->map(static function (array $order) {
+            return [
+                $order['column'] => $order['direction'],
+            ];
+        });
+
+        return $sort->isEmpty() ? null : $sort->all();
+    }
+
+    protected function makeFrom(array $options): ?int
+    {
+        if (isset($options['page']) && isset($options['perPage'])) {
+            return ($options['page'] - 1) * $options['perPage'];
+        }
+
+        return null;
+    }
+
+    protected function makeSize(Builder $builder, array $options): ?int
+    {
+        return $options['perPage'] ?? $builder->limit;
+    }
+}

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -161,10 +161,13 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
      */
     public function toSearchableArray()
     {
+        $dataToInclude = $this->data;
+        unset($dataToInclude['_request']);
+        unset($dataToInclude['_user']);
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'data' => json_encode($this->data),
+            'data' => json_encode($dataToInclude),
         ];
     }
 

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -149,11 +149,14 @@ class ProcessRequestToken extends Model implements TokenInterface
      */
     public function toSearchableArray()
     {
+        $dataToInclude = $this->data;
+        unset($dataToInclude['_request']);
+        unset($dataToInclude['_user']);
         return [
             'id' => $this->id,
             'element_name' => $this->element_name,
             'request' => isset($this->processRequest->name) ? $this->processRequest->name : "",
-            'data' => json_encode($this->data),
+            'data' => json_encode($dataToInclude),
         ];
     }
 

--- a/config/app.php
+++ b/config/app.php
@@ -163,6 +163,11 @@ return [
          */
         'Theme' => Igaster\LaravelTheme\Facades\Theme::class,
         'Menu'      => Lavary\Menu\Facade::class,
+        
+        /**
+         * Overwrite package classes
+         */        
+        'ElasticScoutDriver\Factories\SearchRequestFactory' => ProcessMaker\Factories\SearchRequestFactory::class,
 
 
     ],

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="data-table">
     <data-loading
-            :for=/requests\?page/
+            :for=/requests\?page|results\?page/
             v-show="shouldShowLoader"
             :empty="$t('No Data Available')"
             :empty-desc="$t('')"
@@ -71,7 +71,14 @@ Vue.component("avatar-image", AvatarImage);
 
 export default {
   mixins: [datatableMixin, dataLoadingMixin],
-  props: ["filter", "columns", "pmql"],
+  props: {
+    filter: {},
+    columns: {},
+    pmql: {},
+    savedSearch: {
+      default: false
+    }
+  },
   data() {
     return {
       orderBy: "id",
@@ -87,6 +94,15 @@ export default {
       fields: [],
       previousFilter: ""
     };
+  },
+  computed: {
+    endpoint() {
+      if (this.savedSearch !== false) {
+        return `saved-searches/${this.savedSearch}/results`;
+      }
+      
+      return 'requests';
+    },
   },
   mounted() {
     this.setupColumns();
@@ -253,7 +269,7 @@ export default {
             // Load from our api client
             ProcessMaker.apiClient
               .get(
-                "requests?page=" +
+                `${this.endpoint}?page=` +
                   this.page +
                   "&per_page=" +
                   this.perPage +

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="data-table">
     <data-loading
-      :for=/tasks\?page/
+      :for=/tasks\?page|results\?page/
       v-show="shouldShowLoader"
       :empty="$t('Congratulations')"
       :empty-desc="$t('You don\'t currently have any tasks assigned to you')"
@@ -99,7 +99,14 @@ Vue.component("avatar-image", AvatarImage);
 
 export default {
   mixins: [datatableMixin, dataLoadingMixin],
-  props: ["filter", "columns", "pmql"],
+  props: {
+    filter: {},
+    columns: {},
+    pmql: {},
+    savedSearch: {
+      default: false
+    }
+  },
   data() {
     return {
       orderBy: "ID",
@@ -115,6 +122,15 @@ export default {
       fields: [],
       previousFilter: ""
     };
+  },
+  computed: {
+    endpoint() {
+      if (this.savedSearch !== false) {
+        return `saved-searches/${this.savedSearch}/results`;
+      }
+      
+      return 'tasks';
+    },
   },
   mounted: function mounted() {
     this.setupColumns();
@@ -328,7 +344,7 @@ export default {
             // Load from our api client
             ProcessMaker.apiClient
               .get(
-                "tasks?page=" +
+                `${this.endpoint}?page=` +
                   this.page +
                   "&include=process,processRequest,processRequest.user,user,data" +
                   "&pmql=" +


### PR DESCRIPTION
## Changes
- Updates request and task list components to utilize a Saved Search endpoint if viewing a Saved Search, an endpoint which removes unneeded columns to reduce payload size and improve security
- Removes unneeded data from the search index
- Overrides the Elasticsearch Scout driver to only return the ID from the Elasticsearch server rather than all data

## Requires
- https://github.com/ProcessMaker/package-savedsearch/pull/211
- https://github.com/ProcessMaker/package-collections/pull/226

Closes https://processmaker.atlassian.net/browse/FOUR-2449.