### PR TITLE
Fix multipage printing with nested screens 4.0.16

### DIFF
--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -68,7 +68,9 @@
     },
     mounted() {
       if (this.canPrint) {
-        this.print();
+        setTimeout(() => {
+          this.print();
+        }, 750);
       }
     },
     methods: {


### PR DESCRIPTION
**Resolves Jira Ticket for 4.0.16**
https://processmaker.atlassian.net/browse/FOUR-2455



<h2>Changes</h2>

The issue was caused by the print dialog loading before Nested Screens could load on the page. This PR sets a timeout for triggering the print dialog allowing the Nested Screens to load on the page entirely before printing. 

**Video**

<a href="https://www.loom.com/share/dc15db642f484d87938bab11d5c7a81b"> <p>Edit Screen - ProcessMaker - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/dc15db642f484d87938bab11d5c7a81b-with-play.gif"> </a>
