### PR TITLE
Allow inclusion of SVG in serialized Process

### DIFF
--- a/ProcessMaker/Http/Resources/Process.php
+++ b/ProcessMaker/Http/Resources/Process.php
@@ -23,6 +23,9 @@ class Process extends ApiResource
         if (in_array('events', $include)) {
             $array['events'] = $this->getStartEvents(true);
         }
+        if (in_array('svg', $include)) {
+            $array['svg'] = $this->svg;
+        }
         return $array;
     }
 }


### PR DESCRIPTION
This PR allows the inclusion of the svg property on the serialized process when retrieving a process from the /processes/{id} endpoint. 

This is used by [this PR on modeler](https://github.com/ProcessMaker/modeler/pull/1295) to show the svg in a modal when the user clicks [+] on a subprocess.