### PR TITLE
Category select: default to Uncategorized

### DIFF
--- a/resources/js/processes/categories/components/CategorySelect.vue
+++ b/resources/js/processes/categories/components/CategorySelect.vue
@@ -42,7 +42,6 @@
       return {
         content: [],
         loading: false,
-        firstSelect: true,
         options: [],
         error: ''
       };
@@ -106,18 +105,24 @@
           });
       },
       load(filter) {
+        if (!this.value) {
+          this.loadUncategorized();
+        }
         ProcessMaker.apiClient
           .get(this.apiList + "?order_direction=asc&status=active" + (typeof filter === 'string' ? '&filter=' + filter : ''))
           .then(response => {
             this.loading = false;
-            if (this.firstSelect && _.size(response.data.data) === 1) {
-              this.firstSelect = false;
-              this.content = response.data.data;
-            }
             this.options = response.data.data;
           })
           .catch(err => {
             this.loading = false;
+          });
+      },
+      loadUncategorized() {
+        ProcessMaker.apiClient
+          .get(this.apiList + "?filter=Uncategorized&per_page=1&order_by=id&order_direction=ASC")
+          .then(response => {
+            this.content = response.data.data;
           });
       }
     }


### PR DESCRIPTION
## Changes
- Fixes a bug where the Category Select component did not always default to **Uncategorized** when no other value was selected

Closes https://processmaker.atlassian.net/browse/FOUR-2500.