### PR TITLE
Add log messages from packages on import

### DIFF
--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -668,6 +668,7 @@ class ImportProcess implements ShouldQueue
 
         $manager = app(ExportManager::class);
         $manager->updateReferences($this->new);
+        $this->status = array_merge($this->status, $manager->getLogMessages());
         $this->new['process']->save();
     }
 

--- a/ProcessMaker/Managers/ExportManager.php
+++ b/ProcessMaker/Managers/ExportManager.php
@@ -9,6 +9,8 @@ class ExportManager
 {
     private $dependencies = [];
 
+    private $logMessages = [];
+
     /**
      * Get the value of dependencies
      */
@@ -73,7 +75,7 @@ class ExportManager
         $newReferences = [];
         foreach ($this->dependencies as $dependencie) {
             if (is_a($owner, $dependencie['owner'])) {
-                $newReferences = call_user_func($dependencie['referencesToExport'], $owner, $newReferences);
+                $newReferences = call_user_func($dependencie['referencesToExport'], $owner, $newReferences, $this);
             }
         }
         $newReferences = $this->uniqueDiff($newReferences, $references);
@@ -114,7 +116,7 @@ class ExportManager
     {
         foreach ($this->dependencies as $dependencie) {
             if (is_a($model, $dependencie['owner']) && isset($dependencie['updateReferences'])) {
-                call_user_func($dependencie['updateReferences'], $model, $newReferences);
+                call_user_func($dependencie['updateReferences'], $model, $newReferences, $this);
             }
         }
     }
@@ -152,5 +154,29 @@ class ExportManager
             }
         }
         return $result;
+    }
+
+    /**
+     * Add a log message about the import process
+     *
+     * @param string $key
+     * @param string $label
+     * @param bool $success
+     * @param string $message
+     * @return void
+     */
+    public function addLogMessage($key, $label, $success, $message)
+    {
+        $this->logMessages[$key] = \compact('label', 'success', 'message');
+    }
+
+    /**
+     * Get logs of the current import process
+     *
+     * @return array
+     */
+    public function getLogMessages()
+    {
+        return $this->logMessages;
     }
 }


### PR DESCRIPTION
Required by: https://github.com/ProcessMaker/connector-send-email/pull/125
Related to: https://processmaker.atlassian.net/browse/FOUR-2528
Fixes: https://processmaker.atlassian.net/browse/FOUR-2545

- Add log methods that could be used by packages to register messages on importing process.
- Add a validation to check the scripts assigned to watchers

Since the file was generated by an old version of PM4, it does not contains the scripts assigned to watchers, causing an exception during the import process. It was validated and fixed so the process can be imported but without the missing resource.

![image](https://user-images.githubusercontent.com/8028650/102513186-46dfa780-4061-11eb-970d-da51df51c7fa.png)
