### PR TITLE
Fix export of service call activity elements

### DIFF
--- a/ProcessMaker/Jobs/ExportProcess.php
+++ b/ProcessMaker/Jobs/ExportProcess.php
@@ -92,9 +92,14 @@ class ExportProcess implements ShouldQueue
         }
 
         //remove assignments to call Activity
-        $callActivity = $this->definitions->getElementsByTagName('callActivity');
-        foreach ($callActivity as $task) {
-            $task->removeAttribute('calledElement');
+        $callActivities = $this->definitions->getElementsByTagName('callActivity');
+        foreach ($callActivities as $task) {
+            $callActivity = $task->getBPMNElementInstance();
+            $external = $callActivity->isFromExternalDefinition();
+            $service = $callActivity->isServiceSubProcess();
+            if ($external && !$service) {
+                $task->removeAttribute('calledElement');
+            }
         }
 
         $this->process->bpmn = $this->definitions->saveXML();

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -220,4 +220,26 @@ class CallActivity implements CallActivityInterface
             $currentInstance->getProcess()->getEngine()->runToNextState();
         }
     }
+
+    /**
+     * Returns true if callable element is external to the owner definition
+     *
+     * @return boolean
+     */
+    public function isFromExternalDefinition()
+    {
+        $ref = explode('-', $this->getProperty(CallActivityInterface::BPMN_PROPERTY_CALLED_ELEMENT));
+        return count($ref) === 2 && is_numeric($ref[1]);
+    }
+
+    /**
+     * Returns true if callable element is a service sub process (like data-connector)
+     *
+     * @return boolean
+     */
+    public function isServiceSubProcess()
+    {
+        $ref = explode('-', $this->getProperty(CallActivityInterface::BPMN_PROPERTY_CALLED_ELEMENT));
+        return count($ref) === 2 && !is_numeric($ref[1]);
+    }
 }


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-2569 for v4.1

This PR fixes:

- Export of processes with Call Activities used as Service like (data-connectors)

![image](https://user-images.githubusercontent.com/8028650/102663394-2c87f580-4157-11eb-839c-a0b2f996ac74.png)
