### PR TITLE
Fix duplicate value for the anonymous assignment rule on sub process

### DIFF
--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div class="form-group"> 
+        <div class="form-group">
             <label>{{ $t( label ) }}</label>
             <select
                 ref="assignmentsDropDownList"
@@ -18,9 +18,9 @@
             v-if="showAssignments"
             :label="$t('Assigned Users/Groups')"
             v-model="assignments"
-            :hide-users="hideUsers" 
+            :hide-users="hideUsers"
             :multiple="true" />
-          
+
           <user-by-id
               v-if="showAssignUserById"
               :label="$t('Variable Name')"
@@ -28,15 +28,15 @@
               :helper="$t('Variable containing the numeric User ID')"
           ></user-by-id>
 
-          <self-service-select v-if="showAssignSelfService" 
+          <self-service-select v-if="showAssignSelfService"
             v-model="assignments"
           ></self-service-select>
 
-          <assign-expression 
+          <assign-expression
             v-if="showAssignRuleExpression"
-            v-model="specialAssignments" 
+            v-model="specialAssignments"
           />
-            
+
           <form-checkbox
               v-if="configurables.includes('LOCK_TASK_ASSIGNMENT')"
               :label="$t('Lock Task Assignment to User')"
@@ -178,7 +178,7 @@
         get () {
           const value = this.specialAssignmentsListGetter;
           return value;
-        }, 
+        },
         set(value) {
           this.assignmentRulesSetter(value);
         }
@@ -201,7 +201,7 @@
       },
       assignment: {
         get () {
-          const value = _.get(this.node, "assignment");
+          const value = _.get(this.node, "assignment", "");
           return value;
         },
         set (value) {

--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -126,7 +126,7 @@ ProcessMaker.EventBus.$on(
         params: {
           type: 'FORM',
           interactive: true
-        }        
+        }
       }
     });
 
@@ -347,10 +347,6 @@ ProcessMaker.EventBus.$on(
             name: 'taskAssignment',
             configurables: [],
             assignmentTypes: [
-              {
-                value: '',
-                label: ''
-              },
               {
                 value: '',
                 label: 'Anonymous'


### PR DESCRIPTION
Fixes #3584.

<img width="403" alt="Screen Shot 2020-12-22 at 2 02 26 PM" src="https://user-images.githubusercontent.com/68430564/102923768-55153580-445e-11eb-9ed3-516805ff76ce.png">

This fix assumes that anonymous assignment is the default. E.g: The following two sub process BPMN elements are both assumed to have the default "anonymous" assignment:

```xml
<bpmn:callActivity pm:assignment="" pm:assignedUsers="" pm:assignedGroups="" />
<bpmn:callActivity />
```