### PR TITLE
Fix importing large processes

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -721,6 +721,15 @@ class ProcessController extends Controller
                 422
             );
         }
+        $queue = $request->input('queue');
+        if ($queue) {
+            $path = $request->file('file')->store('imports');
+            $code = uniqid('import', true);
+            ImportProcess::dispatch(null, $code, $path, Auth::id());
+            return [
+                'code' => $code,
+            ];
+        }
         $import = ImportProcess::dispatchNow($content);
         return response([
             'status' => $import->status,

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -748,6 +748,15 @@ class ProcessController extends Controller
      *     summary="Check if the import is ready",
      *     tags={"Processes"},
      *
+     *     @OA\Parameter(
+     *         description="Import code",
+     *         in="path",
+     *         name="code",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="check is import is ready",

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -739,6 +739,48 @@ class ProcessController extends Controller
     }
 
     /**
+     * Check if the import is ready
+     *
+     * @param Request $request
+     *
+     * @OA\Head(
+     *     path="/processes/import/{code}/is_ready",
+     *     summary="Check if the import is ready",
+     *     tags={"Processes"},
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="check is import is ready",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(
+     *                 property="ready",
+     *                 type="boolean",
+     *             ),
+     *         ),
+     *     ),
+     * )
+     */
+    public function import_ready($code)
+    {
+        $user = Auth::user();
+        $notifications = $user
+            ->notifications()
+            ->where('type', 'ProcessMaker\Notifications\ImportReady')
+            ->get();
+        foreach ($notifications as $notification) {
+            if ($notification->data['code'] === $code) {
+                $data = $notification->data['data'];
+                $data['ready'] = true;
+                return $data;
+            }
+        }
+        return [
+            'ready' => false,
+        ];
+    }
+
+    /**
      * Import Assignments of process.
      *
      * @param Process $process

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -183,11 +183,9 @@ class ProcessController extends Controller
         return view('processes.export', compact('process'));
     }
 
-    public function import(Process $process, Request $request)
+    public function import(Process $process)
     {
-        $importingCode = $request->input('code', false);
-        $submitted = !!$importingCode;
-        return view('processes.import', compact('importingCode', 'submitted'));
+        return view('processes.import');
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -183,9 +183,11 @@ class ProcessController extends Controller
         return view('processes.export', compact('process'));
     }
 
-    public function import(Process $process)
+    public function import(Process $process, Request $request)
     {
-        return view('processes.import');
+        $importingCode = $request->input('code', false);
+        $submitted = !!$importingCode;
+        return view('processes.import', compact('importingCode', 'submitted'));
     }
 
     /**

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -877,8 +877,6 @@ class ImportProcess implements ShouldQueue
 
     private function broadcastResponse($response)
     {
-        \Log::debug('Import User: ' . $this->user);
-        \Log::debug(json_encode($response));
         if ($this->user) {
             User::find($this->user)->notify(new ImportReady(
                 $this->code,

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -21,6 +21,8 @@ use ProcessMaker\Managers\ExportManager;
 use ProcessMaker\Providers\WorkflowServiceProvider;
 use ProcessMaker\Traits\PluginServiceProviderTrait;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use ProcessMaker\Notifications\ImportReady;
 
 class ImportProcess implements ShouldQueue
 {
@@ -32,6 +34,20 @@ class ImportProcess implements ShouldQueue
      * @var string
      */
     private $fileContents;
+
+    /**
+     * Importing code.
+     *
+     * @var string
+     */
+    private $code;
+
+    /**
+     * The path of the imported file.
+     *
+     * @var string
+     */
+    private $path;
 
     /**
      * The decoded object obtained from the file.
@@ -71,6 +87,13 @@ class ImportProcess implements ShouldQueue
     protected $status = [];
 
     /**
+     * User that requests the import
+     *
+     * @var int
+     */
+    protected $user;
+
+    /**
      * In order to handle backwards compatibility with previous packages, an
      * array with a previous package name as the key, and the updated
      * package name as the value.
@@ -86,9 +109,12 @@ class ImportProcess implements ShouldQueue
      *
      * @return void
      */
-    public function __construct($fileContents)
+    public function __construct($fileContents, $code = false, $path = null, $user = null)
     {
         $this->fileContents = $fileContents;
+        $this->code = $code;
+        $this->path = $path;
+        $this->user = $user;
     }
 
     /**
@@ -593,6 +619,7 @@ class ImportProcess implements ShouldQueue
             $this->new['process'] = $new;
             $this->finishStatus('process');
         } catch (\Exception $e) {
+            throw $e;
             $this->finishStatus('process', true);
         }
     }
@@ -731,6 +758,9 @@ class ImportProcess implements ShouldQueue
      */
     public function handle()
     {
+        if ($this->path && !$this->fileContents) {
+            $this->fileContents = Storage::get($this->path);
+        }
         //First, decode the file
         $this->decodeFile();
 
@@ -738,7 +768,9 @@ class ImportProcess implements ShouldQueue
         if ($this->file->type == 'process_package') {
             if ($method = $this->getParser()) {
                 $this->resetStatus();
-                return $this->{$method}();
+                $response = $this->{$method}();
+                $this->broadcastResponse($response);
+                return $response;
             }
         }
 
@@ -841,5 +873,17 @@ class ImportProcess implements ShouldQueue
             return false;
         }
         return true;
+    }
+
+    private function broadcastResponse($response)
+    {
+        \Log::debug('Import User: ' . $this->user);
+        \Log::debug(json_encode($response));
+        if ($this->user) {
+            User::find($this->user)->notify(new ImportReady(
+                $this->code,
+                json_decode(json_encode($response), true)
+            ));
+        }
     }
 }

--- a/ProcessMaker/Notifications/ImportReady.php
+++ b/ProcessMaker/Notifications/ImportReady.php
@@ -57,6 +57,8 @@ class ImportReady extends Notification
         return [
             'code' => $this->code,
             'data' => $this->data,
+            'name' => __('Process imported'),
+            'processName' => $this->data['process']['name'],
         ];
     }
 

--- a/ProcessMaker/Notifications/ImportReady.php
+++ b/ProcessMaker/Notifications/ImportReady.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace ProcessMaker\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Notification;
+
+class ImportReady extends Notification
+{
+    use Queueable;
+
+    /**
+     * Importing code
+     *
+     * @var string
+     */
+    private $code;
+
+    /**
+     * Response of the import
+     *
+     * @var array
+     */
+    private $data = [];
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($code, array $data = [])
+    {
+        $this->code = $code;
+        $this->data = $data;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['broadcast', 'database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            'code' => $this->code,
+            'data' => $this->data,
+        ];
+    }
+
+    /**
+     * To broadcast.
+     *
+     * @param mixed $notifiable
+     *
+     * @return \Illuminate\Notifications\Messages\BroadcastMessage
+     */
+    public function toBroadcast($notifiable)
+    {
+        return new BroadcastMessage($this->toArray($notifiable));
+    }
+
+    /**
+     * Get the type of the notification being broadcast.
+     *
+     * @return string
+     */
+    public function broadcastType()
+    {
+        return str_replace('\\', '.', static::class);
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -46,6 +46,10 @@ return [
             'driver' => 'local',
             'root' => storage_path('app'),
         ],
+        'imports' => [
+            'driver' => 'local',
+            'root' => storage_path('app/imports'),
+        ],
         'keys' => [
             'driver' => 'local',
             'root' => env('KEYS_PATH') ? base_path(env('KEYS_PATH')) : storage_path('keys')

--- a/routes/api.php
+++ b/routes/api.php
@@ -88,6 +88,7 @@ Route::group(
     Route::get('processes/{process}', 'ProcessController@show')->name('processes.show')->middleware('can:view-processes');
     Route::post('processes/{process}/export', 'ProcessController@export')->name('processes.export')->middleware('can:export-processes');
     Route::post('processes/import', 'ProcessController@import')->name('processes.import')->middleware('can:import-processes');
+    Route::get('processes/import/{code}/is_ready', 'ProcessController@import_ready')->name('processes.import_is_ready')->middleware('can:import-processes');
     Route::post('processes/{process}/import/assignments', 'ProcessController@importAssignments')->name('processes.import.assignments')->middleware('can:import-processes');
     Route::post('processes', 'ProcessController@store')->name('processes.store')->middleware('can:create-processes');
     Route::put('processes/{process}', 'ProcessController@update')->name('processes.update')->middleware('can:edit-processes');


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-2545

Importing large processes could take time (more than 5 seconds), this PR adds a query property (queue) the import endpoint to execute the import in background, when it is ready a notification in send to the user so it could continue with the import in the user interface.
