### PR TITLE
FOUR-2462

### DIFF
--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -104,7 +104,9 @@
       loadPages() {
         this.$nextTick(() => {
           this.$refs.print.forEach((page, index) => {
-            page.setCurrentPage(this.printablePages[index]);
+            if (page.setCurrentPage) {
+              page.setCurrentPage(this.printablePages[index]);
+            }
           });
         });
       },


### PR DESCRIPTION
Console error removed, the detail screen checks if the setCurrentPage method is present on Advanced Forms.