### PR TITLE
Pages must be numeric strings or null

### DIFF
--- a/ProcessMaker/ScreenConsolidator.php
+++ b/ProcessMaker/ScreenConsolidator.php
@@ -119,8 +119,8 @@ class ScreenConsolidator {
     private function setRecordList($item, &$new, $index0 = 0)
     {
         $pageId = $item['config']['form'];
-        if ($pageId)  {
-            $item['config']['form'] = $pageId + $index0;
+        if ($pageId) {
+            $item['config']['form'] = (string) (intval($pageId) + $index0);
         }
         $new[] = $item;
     }


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2647

The screen consolidator reindexer was casting string keys as integers. Page keys must be numeric strings or null.