### PR TITLE
Wide tables scroll horizontally

### DIFF
--- a/resources/js/components/common/Pagination.vue
+++ b/resources/js/components/common/Pagination.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="row my-2 px-2" v-if="tablePagination && tablePagination.last_page > 0">
-    <div class="col-md-6 col-sm-12 pt-1 d-flex">
+  <div class="w-100 d-flex my-2 px-2" v-if="tablePagination && tablePagination.last_page > 0">
+    <div class="pt-1 mr-auto">
       <div
         v-if="tablePagination"
         class="pagination"
@@ -10,7 +10,7 @@
         v-if="tablePagination && tablePagination.last_page < 1"
       >{{tablePagination.total}} {{title}}</div>
     </div>
-    <div class="col-md-6 col-sm-12 d-flex justify-content-end button-pagination">
+    <div class="justify-content-end button-pagination">
       <div v-show="tablePagination" :class="css.wrapperClass">
         <div
           @click="loadPage(1)"

--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -106,7 +106,7 @@ export default {
             // Cancel token which should be stored from axios if you want to cancel the current in progress request
             cancelToken: null,
             css: {
-                tableClass: "table table-hover table-responsive text-break mb-0",
+                tableClass: "table table-hover table-responsive-lg text-break mb-0",
                 loadingClass: "loading",
                 detailRowClass: "vuetable-detail-row",
                 handleIcon: "grey sidebar icon",

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -29,6 +29,7 @@ html {
 }
 
 .table-card {
+  overflow-x: scroll;
   padding: 0;
 }
 


### PR DESCRIPTION
## Changes
- Fixes issues where Vuetables overflowed their boundaries and did not properly scroll horizontally

## Screenshots

Before
<img width="814" alt="horizontal-scroll" src="https://user-images.githubusercontent.com/867714/104759523-e2be0b00-5714-11eb-82e8-9c42871e0d84.png">

After
<img width="609" alt="Screen Shot 2021-01-15 at 9 35 01 AM" src="https://user-images.githubusercontent.com/867714/104759584-f8cbcb80-5714-11eb-8a28-64bfbe1beb5e.png">

## Related
- Requires https://github.com/ProcessMaker/package-collections/pull/240
- Requires https://github.com/ProcessMaker/package-savedsearch/pull/223

## Tickets
- Closes https://processmaker.atlassian.net/browse/FOUR-2677