### PR TITLE
Fix missing $HOME envvar when call a script task

### DIFF
--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -62,7 +62,10 @@ abstract class Base
     {
         // Prepare the docker parameters
         $environmentVariables = $this->getEnvironmentVariables();
-    
+        if (!getenv('HOME')) {
+            putenv('HOME=' . base_path());
+        }
+
         // Create tokens for the SDK if a user is set
         $token = null;
         if ($user) {


### PR DESCRIPTION
Required by: https://github.com/ProcessMaker/package-data-sources/pull/116

This PR fix an environment variable required to execute a Script from a http request.
