### PR TITLE
FOUR-2716: Data Connector after a Signal Start Event generates an error

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -17,6 +17,7 @@ use ProcessMaker\Exception\InvalidUserAssignmentException;
 use ProcessMaker\Exception\TaskDoesNotHaveRequesterException;
 use ProcessMaker\Exception\TaskDoesNotHaveUsersException;
 use ProcessMaker\Exception\UserOrGroupAssignmentEmptyException;
+use ProcessMaker\Nayra\Bpmn\Models\Activity;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ServiceTaskInterface;
@@ -512,7 +513,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
                 $user = $this->getNextUserFromVariable($activity, $token);
                 break;
             case 'requester':
-                $user = $this->getRequester($token);
+                $user = $this->getRequester($activity, $token);
                 break;
             case 'previous_task_assignee':
                 $rule = new PreviousTaskAssignee();
@@ -684,7 +685,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
                             $user = $item->assignee;
                             break;
                         case 'requester':
-                            $user = $this->getRequester($token);
+                            $user = $this->getRequester($activity, $token);
                             break;
                         case 'manual':
                         case 'self_service':
@@ -917,16 +918,19 @@ class Process extends Model implements HasMedia, ProcessModelInterface
     /**
      * Get the requester of the current token
      *
-     * @param string $processTaskUuid
+     * @param $token
+     * @param $activity
      *
-     * @return Integer $user_id
+     * @return Integer|null $user_id
      * @throws TaskDoesNotHaveRequesterException
      */
-    private function getRequester($token)
+    private function getRequester($activity, $token)
     {
         $processRequest = $token->getInstance();
 
-        if (!$processRequest->user_id) {
+        $validateUserId = $activity instanceof Activity;
+
+        if ($validateUserId  && !$processRequest->user_id) {
             throw new TaskDoesNotHaveRequesterException();
         }
 
@@ -1150,7 +1154,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
                 $this->warnings = $warnings;
             }
             return false;
-        } 
+        }
         return true;
     }
 }

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -271,8 +271,9 @@ trait MakeHttpRequests
 
         $merged = array_merge($data, $content, $headers);
         foreach ($config['dataMapping'] as $map) {
-            $apiVar = (str_contains( $map['value'], '{{')) ? $map['value'] : '{{' . $map['value'] . '}}';
-            $evaluatedApiVar = $this->getMustache()->render($apiVar, $merged);
+            $evaluatedApiVar = (str_contains( $map['value'], '{{'))
+                ? $this->getMustache()->render($map['value'], $merged)
+                : Arr::get($merged, $map['value']);
             $processVar = $this->getMustache()->render($map['key'], $merged);
             $mapped[$processVar] = $evaluatedApiVar;
         }
@@ -315,7 +316,7 @@ trait MakeHttpRequests
     private function addQueryStringsParamsToUrl($endpoint, array $config,  array $data)
     {
         // Note that item['key'] corresponds to an endpoint property (in the header, querystring, etc.)
-        //           item['value'] corresponds to a PM request variable or mustache expression 
+        //           item['value'] corresponds to a PM request variable or mustache expression
         //           item['type'] location of the property defined in 'key'. It can be BODY, PARAM (in the query string), HEADER
 
         $url = $endpoint['url'];


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2716](https://processmaker.atlassian.net/browse/FOUR-2716)

Fixes a problem that occurred when a Call Activiy was after a Signal Start Event. As the request instance doens't have a user, the user assignment failed to the activity failed. The new version of data connectors uses a call activity, and for that reason the problem arose.


