### PR TITLE
Fix users populating the 'Reassign to' dropdown

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -69,22 +69,11 @@ class Task extends ApiResource
         }
         if (in_array('assignableUsers', $include)) {
             $definition = $this->getDefinition();
-            $assignment = isset($definition['assignment']) ? $definition['assignment'] : 'requester';
-            switch ($assignment) {
-                case 'self_service':
-                case 'cyclical':
-                case 'group':
-                case 'user_group':
-                    $ids = $this->process->getAssignableUsers($this->element_id);
-                    $users = User::where('status', 'ACTIVE')->whereIn('id', $ids)->get();
-                    break;
-                case 'user':
-                case 'requester':
-                    $users = User::where('status', 'ACTIVE')->get();
-                    break;
-                default:
-                    $users = [];
-            }
+            $currentUser = \Auth::user();
+            $users = User::where('status', 'ACTIVE')
+                ->where('id', '!=', $currentUser->id)
+                ->where('is_system', 'false')
+                ->get();
             $array['assignable_users'] = $users;
         }
         return $array;

--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -68,7 +68,6 @@ class Task extends ApiResource
             $array['interstitial_screen'] = $interstitial['interstitial_screen'];
         }
         if (in_array('assignableUsers', $include)) {
-            $definition = $this->getDefinition();
             $currentUser = \Auth::user();
             $users = User::where('status', 'ACTIVE')
                 ->where('id', '!=', $currentUser->id)

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -17,6 +17,7 @@ use ProcessMaker\Exception\InvalidUserAssignmentException;
 use ProcessMaker\Exception\TaskDoesNotHaveRequesterException;
 use ProcessMaker\Exception\TaskDoesNotHaveUsersException;
 use ProcessMaker\Exception\UserOrGroupAssignmentEmptyException;
+use ProcessMaker\Nayra\Bpmn\Models\Activity;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ServiceTaskInterface;
@@ -512,7 +513,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
                 $user = $this->getNextUserFromVariable($activity, $token);
                 break;
             case 'requester':
-                $user = $this->getRequester($token);
+                $user = $this->getRequester($activity, $token);
                 break;
             case 'previous_task_assignee':
                 $rule = new PreviousTaskAssignee();
@@ -684,7 +685,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
                             $user = $item->assignee;
                             break;
                         case 'requester':
-                            $user = $this->getRequester($token);
+                            $user = $this->getRequester($activity, $token);
                             break;
                         case 'manual':
                         case 'self_service':
@@ -917,16 +918,19 @@ class Process extends Model implements HasMedia, ProcessModelInterface
     /**
      * Get the requester of the current token
      *
-     * @param string $processTaskUuid
+     * @param $token
+     * @param $activity
      *
-     * @return Integer $user_id
+     * @return Integer|null $user_id
      * @throws TaskDoesNotHaveRequesterException
      */
-    private function getRequester($token)
+    private function getRequester($activity, $token)
     {
         $processRequest = $token->getInstance();
 
-        if (!$processRequest->user_id) {
+        $validateUserId = $activity instanceof Activity;
+
+        if ($validateUserId  && !$processRequest->user_id) {
             throw new TaskDoesNotHaveRequesterException();
         }
 
@@ -1150,7 +1154,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
                 $this->warnings = $warnings;
             }
             return false;
-        } 
+        }
         return true;
     }
 }


### PR DESCRIPTION
**Jira Ticket**

https://processmaker.atlassian.net/browse/FOUR-2692



<h2>Changes</h2>

The issue was caused by returning only users assigned to a Group when the `Assignment Type` was set to `User/Group`. This PR returns all `ACTIVE` users, except the current logged in user & system users in the Reassign to dropdown regardless of the 'Assignment Type' configured.

<h2>To Test</h2>

 - Ensure you have multiple users created within your environment. 
 - Configure a task with any `Assignment Type`
 - Enable `Allow Reassignment` 
 - Run the process and select `Reassign` within the Task details page.

**Expected Behavior**

- The dropdown list populates with all `ACTIVE` users. 
- Selecting a User and clicking the `Reassign` button reassigns the task to the selected user.


**Video**

https://www.loom.com/share/f1360df397db45eeb95e8bf29e2087a3