### PR TITLE
Update policy for running scripts in tasks

### DIFF
--- a/ProcessMaker/Policies/ScriptPolicy.php
+++ b/ProcessMaker/Policies/ScriptPolicy.php
@@ -19,6 +19,6 @@ class ScriptPolicy
             return $policyExtension->authorize('execute', $user, $script);
         }
         
-        return $user->can('view-scripts');
+        return !$user->isAnonymous;
     }
 }

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -211,6 +211,7 @@
     window.PM4ConfigOverrides = {
       requestFiles: @json($files),
       getScreenEndpoint: 'tasks/{{ $task->id }}/screens',
+      postScriptEndpoint: '/scripts/execute/{id}?task_id={{ $task->id }}',
     };
 
     const task = @json($task);

--- a/routes/api.php
+++ b/routes/api.php
@@ -73,8 +73,8 @@ Route::group(
     Route::put('scripts/{script}/duplicate', 'ScriptController@duplicate')->name('scripts.duplicate')->middleware('can:create-scripts');
     Route::delete('scripts/{script}', 'ScriptController@destroy')->name('scripts.destroy')->middleware('can:delete-scripts');
     Route::post('scripts/{script}/preview', 'ScriptController@preview')->name('scripts.preview')->middleware('can:view-scripts');
-    Route::post('scripts/execute/{script_id}/{script_key?}', 'ScriptController@execute')->name('scripts.execute')->middleware('can:view-scripts');
-    Route::get('scripts/execution/{key}', 'ScriptController@execution')->name('scripts.execution')->middleware('can:view-scripts');
+    Route::post('scripts/execute/{script_id}/{script_key?}', 'ScriptController@execute')->name('scripts.execute');
+    Route::get('scripts/execution/{key}', 'ScriptController@execution')->name('scripts.execution');
 
     // Script Categories
     Route::get('script_categories', 'ScriptCategoryController@index')->name('script_categories.index')->middleware('can:view-script-categories');


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2691

- Removes permission checks on routes
- Updates policy for core to allow all scripts if the user is not anonymous
- Adds task_id query to script URL override so anonymous users (web entry) can still run scripts in a secure way (without executing other scripts)