### PR TITLE
FOUR-2709: we get a generic error 500ish when having a wrong configuration for data connectors

### DIFF
--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -134,7 +134,12 @@ class CallActivity implements CallActivityInterface
         }
         if ($instance->errors && is_array($instance->errors)) {
             foreach($instance->errors as $err) {
-                $message[] = $err['message'];
+                $errorMessage = $err['message'];
+                if (array_key_exists('body', $err)) {
+                    // add the body but not the stack trace:
+                    $errorMessage = "\n" . explode('Stack trace', $err['body'])[0];
+                }
+                $message[] = $errorMessage;
             }
         }
         $token->getInstance()->logError(new Exception(implode("\n", $message)), $this);


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2709](https://processmaker.atlassian.net/browse/FOUR-2709)

Add the body part of the errors generated inside a Call Activity

Before:
![image](https://user-images.githubusercontent.com/14875032/106174154-16645080-616b-11eb-8791-3e631e268305.png)

Now:
![image](https://user-images.githubusercontent.com/14875032/106174167-195f4100-616b-11eb-97a6-3c8f386058b8.png)

With the fix the errors include more information. In this case is pointing to an array to string conversion.

All stack trace information is removed.