### PR TITLE
Removed underscore for PHP accessEnvVar

### DIFF
--- a/resources/js/processes/scripts/customFilters.js
+++ b/resources/js/processes/scripts/customFilters.js
@@ -10,7 +10,7 @@ Vue.filter('php', function(value) {
     } else if (i == value.length - 1) {
       format = line + '*/';
     } else {
-      line = line.replace('{accessEnvVar}',  `get_env("ENV_VAR_NAME")`);
+      line = line.replace('{accessEnvVar}',  `getenv("ENV_VAR_NAME")`);
       line = line.replace('{dataVariable}',  `$data`);
       line = line.replace('{configVariable}',  `$config`);
       line = line.replace('{apiExample}',  `$api->users()->getUserById(1)['email']`);


### PR DESCRIPTION
The PHP documentation inside the script editor for accessing an environmental variable is incorrect. It needs to be "getenv" and not "get_env" -- this fixes the docs.