### PR TITLE
FOUR-2725: Selected script disappears when editing script config

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
+++ b/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
@@ -39,7 +39,7 @@
                 monacoLargeOptions: {
                     automaticLayout: true,
                 },
-                code: _.get(node, this.property),
+                code: _.get(node, this.property, ''),
                 showPopup: false,
             };
         },
@@ -50,7 +50,6 @@
             code() {
                 const node = this.$root.$children[0].$refs.modeler.highlightedNode.definition;
                 _.set(node, this.property, this.code);
-                this.$emit('input', this.value);
             },
         },
         computed: {


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2725](https://processmaker.atlassian.net/browse/FOUR-2725)

When modifying the code variable (config of the script) an undefined value was always emitted. This emit has been removed.