### PR TITLE
Replace prefix when setting the assigned group

### DIFF
--- a/resources/js/processes/modeler/components/inspector/AssignExpression.vue
+++ b/resources/js/processes/modeler/components/inspector/AssignExpression.vue
@@ -231,7 +231,7 @@ export default {
           field = {
             "type" : "group",
             "name": this.assignedExpression.groups[0].name,
-            "id": this.assignedExpression.groups[0].id,
+            "id": this.assignedExpression.groups[0].id.replace('group-', ''),
           };
         }
         let byExpression = {


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2772

- Was setting with a prefix "group-". This removes that when setting in the BPMN
- NOTE: user will need to unselect and reselect group to set it to the fixed value