### PR TITLE
Allow users to edit the default interstitial

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -68,7 +68,6 @@ class ScreenController extends Controller
     {
         $query = Screen::nonSystem()
                     ->select('screens.*')
-                    ->where('key', null)
                     ->leftJoin('screen_categories as category', 'screens.screen_category_id', '=', 'category.id');
         $include = $request->input('include', '');
 
@@ -109,10 +108,6 @@ class ScreenController extends Controller
         if (!$interactive  && $request->input('type')) {
             $types = explode(',', $request->input('type'));
             $query->whereIn('type', $types);
-        }
-
-        if($request->input('interstitial', false)) {
-            $query->orWhere('key', 'interstitial');
         }
 
         $pmql = $request->input('pmql', '');

--- a/database/seeds/ScreenSystemSeeder.php
+++ b/database/seeds/ScreenSystemSeeder.php
@@ -16,17 +16,27 @@ class ScreenSystemSeeder extends Seeder
         $path = database_path('processes/screens/interstitial.json');
         if (file_exists($path)) {
             $json = json_decode(file_get_contents($path));
-            return factory(Screen::class)->create([
-                'title' => $json[0]->name,
-                'description' => 'Screen for the interstitial',
-                'type' => 'DISPLAY',
-                'config' => $json,
-                'key' => 'interstitial',
-                'screen_category_id' => factory(ScreenCategory::class)->create([
-                    'name' => 'System',
-                    'is_system' => true
-                ])->getKey()
-            ]);
+            $screen = Screen::where('title', $json[0]->name)->first();
+            $systemCategory = ScreenCategory::where('is_system', true)->first();
+            if ($screen && $systemCategory) {
+                if ($screen->screen_category_id === $systemCategory->id) {
+                    $screen->screen_category_id = null;
+                    $screen->categories()->sync([]);
+                    $screen->save();
+                }
+            } else {
+                $screen = new Screen();
+                $screen->fill([
+                    'title' => $json[0]->name,
+                    'description' => 'Screen for the interstitial',
+                    'type' => 'DISPLAY',
+                    'config' => $json,
+                    'key' => 'interstitial',
+                    'screen_category_id' => null 
+                ]);
+                $screen->save();
+            }
+            return $screen;
         }
 
 

--- a/resources/js/processes/modeler/components/inspector/Interstitial.vue
+++ b/resources/js/processes/modeler/components/inspector/Interstitial.vue
@@ -35,7 +35,6 @@
         error: '',
         parameters: {
           type: 'DISPLAY',
-          interstitial: true
         }
       };
     },

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -103,18 +103,11 @@
         }
         return false;
       },
-      interstitial() {
-        if (this.params && this.params.interstitial) {
-          return this.params.interstitial
-        }
-        return false
-      },
       load(filter) {
         let params = Object.assign(
           {
             type: this.type(),
             interactive: this.interactive(),
-            interstitial: this.interstitial(),
             order_direction: 'asc',
             status: 'active',
             selectList: true,


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2779

NOTE: requires devops to run `php artisan db:seed --class=ScreenSystemSeeder` after code is updated

- Allows users to edit the default screen interstitial that gets seeded with the app