### PR TITLE
Fix duplicate screens created in seeder

### DIFF
--- a/database/seeds/ScreenSystemSeeder.php
+++ b/database/seeds/ScreenSystemSeeder.php
@@ -24,7 +24,9 @@ class ScreenSystemSeeder extends Seeder
                     $screen->categories()->sync([]);
                     $screen->save();
                 }
-            } else {
+            }
+            
+            if (!$screen) {
                 $screen = new Screen();
                 $screen->fill([
                     'title' => $json[0]->name,


### PR DESCRIPTION
Addendum to https://processmaker.atlassian.net/browse/FOUR-2773

Multiple screens were being created when the seeder ran multiple times. This fixes that