### PR TITLE
Modeler: Can not un-select screen after it’s been selected.

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -59,10 +59,12 @@
         immediate: true,
         handler() {
           this.validate();
+          let selected = ''
           if (this.content) {
             this.error = '';
-            this.$emit('input', this.content.id);
+            selected = this.content.id;
           }
+          this.$emit('input', selected);
         }
       },
       value: {


### PR DESCRIPTION
Fixed [FOUR-2721](https://processmaker.atlassian.net/browse/FOUR-2721)

- allow emitting empty when a screen is deselected