### PR TITLE
FOUR-2841: It takes a long time to enter the screen list

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -44,6 +44,13 @@ class ScreenController extends Controller
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
      *     @OA\Parameter(ref="#/components/parameters/per_page"),
      *     @OA\Parameter(ref="#/components/parameters/include"),
+     *     @OA\Parameter(
+     *         parameter="exclude",
+     *         name="exclude",
+     *         in="query",
+     *         description="Comma separated list of fields to exclude from the response",
+     *         @OA\Schema(type="string", default=""),
+     *     ),
      *
      *     @OA\Response(
      *         response=200,
@@ -123,6 +130,13 @@ class ScreenController extends Controller
                 $request->input('order_by', 'title'),
                 $request->input('order_direction', 'ASC')
             )->paginate($request->input('per_page', 10));
+
+        $exclude = $request->input('exclude', '');
+        if ($exclude) {
+            $exclusions = explode(',', $exclude);
+            $response->makeHidden($exclusions);
+        }
+
         return new ApiCollection($response);
     }
 

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -119,7 +119,7 @@
         );
         this.loading = true;
         ProcessMaker.apiClient
-          .get('screens', {
+          .get('screens?exclude=config', {
             params: params
           })
           .then(response => {

--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -289,8 +289,9 @@ export default {
             this.orderBy +
             "&order_direction=" +
             this.orderDirection +
-            "&include=categories,category"
-        )
+            "&include=categories,category" +
+            "&exclude=config"
+    )
         .then(response => {
           this.data = this.transform(response.data);
           this.loading = false;


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2841](https://processmaker.atlassian.net/browse/FOUR-2841)

The problem occurred  for a group of screens that had a very large configurations. To avoid this a new query parameter for the endpoint that list screens has been added. The new query string parameter is named "exclude".

Swagger documentation was updated too.
