### PR TITLE
Fix issue with fallback routing in packages

### DIFF
--- a/ProcessMaker/Exception/Handler.php
+++ b/ProcessMaker/Exception/Handler.php
@@ -85,7 +85,7 @@ class Handler extends ExceptionHandler
         $prefixes = [];
         $prefixes[] = explode('.', $route->getName())[0];
         if (isset($route->computedMiddleware) && count($route->computedMiddleware)) {
-            if (in_array('api', $route->computedMiddleware) || in_array('aduth:api', $route->computedMiddleware)) {
+            if (in_array('api', $route->computedMiddleware) || in_array('auth:api', $route->computedMiddleware)) {
                 $prefixes[] = 'api';
             }
         }

--- a/ProcessMaker/Exception/Handler.php
+++ b/ProcessMaker/Exception/Handler.php
@@ -9,7 +9,8 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use Illuminate\Routing\Route;
 
 /**
  * Our general exception handler
@@ -59,19 +60,43 @@ class Handler extends ExceptionHandler
     {
         $prefix = '';
         $route = $request->route();
-        // Make sure we are using the correct fallback, web or api
-        if ($route && substr($route->getName(), 0, 4) === 'api.') {
-            $prefix = 'api.';
+        
+        if ($route) {
+            if ($exception instanceof NotFoundHttpException) {
+                return RouteFacade::respondWithRoute($this->getFallbackRoute($route));
+            }
+    
+            if ($exception instanceof ModelNotFoundException) {
+                return RouteFacade::respondWithRoute($this->getFallbackRoute($route));
+            }   
         }
-
-        if ($exception instanceof NotFoundHttpException) {
-            return Route::respondWithRoute($prefix . 'fallback');
-        }
-
-        if ($exception instanceof ModelNotFoundException) {
-            return Route::respondWithRoute($prefix . 'fallback');
-        }
+        
         return parent::render($request, $exception);
+    }
+    
+    /**
+     * Determine which fallback route should be used.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return string
+     */    
+    private function getFallbackRoute(Route $route)
+    {
+        $prefixes = [];
+        $prefixes[] = explode('.', $route->getName())[0];
+        if (isset($route->computedMiddleware) && count($route->computedMiddleware)) {
+            if (in_array('api', $route->computedMiddleware) || in_array('aduth:api', $route->computedMiddleware)) {
+                $prefixes[] = 'api';
+            }
+        }
+        
+        foreach ($prefixes as $prefix) {
+            if (RouteFacade::has("$prefix.fallback")) {
+                return "$prefix.fallback";
+            }
+        }
+        
+        return "fallback";
     }
 
     /**


### PR DESCRIPTION
## Changes
- Fixes an issue where a 500 error was returned instead of a 404 error in certain package API routes (for example: Collections and Saved Search)
  - Refactors the way a fallback route is determined when a model is not found in a bound route
    - Many packages do not namespace API route names with the `api.` prefix but rather with the name of the package
    - This caused the fallback routing to return the web fallback route when a model could not be found, which in turn generated a 500 error because web middleware was being used on an API route
    - Now we determine whether a fallback route exists under the package namespace
      - If so, we return it
      - If not, we check to see whether API middleware is in use and fallback to our API fallback route if so

Closes https://processmaker.atlassian.net/browse/FOUR-2882