### PR TITLE
Add self service support for users

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -363,10 +363,15 @@ class User extends Authenticatable implements HasMedia
             return false;
         }
 
-        return collect($task->self_service_groups)
-            ->intersect(
-                $this->groups()->pluck('groups.id')
-            )->count() > 0;
+        if (in_array(\Auth::user()->id, $task->self_service_groups['users'])) {
+            return true;
+        } else {
+            $groups = collect($task->self_service_groups['groups'])
+                ->intersect(
+                    $this->groups()->pluck('groups.id')
+                )->count() > 0;
+            return $groups;
+        }
     }
 
     public function updatePermissionsToRequests()

--- a/ProcessMaker/Traits/HasSelfServiceTasks.php
+++ b/ProcessMaker/Traits/HasSelfServiceTasks.php
@@ -25,7 +25,8 @@ trait HasSelfServiceTasks
             $id = $task->getAttribute('id');
             $assignment = $task->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'assignment');
             if ($assignment === 'self_service') {
-                $response[$id] = explode(',', $task->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'assignedGroups'));
+                $response[$id]['groups'] = explode(',', $task->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'assignedGroups'));
+                $response[$id]['users'] = explode(',', $task->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'assignedUsers'));
             }
         }
         return $response;


### PR DESCRIPTION
**Jira Ticket**

https://processmaker.atlassian.net/browse/FOUR-2913

<h2>Changes</h2>

This PR adds self-service support for users by including the `assignedUsers` array in the `self_service_groups` array.

<h2>To Test</h2>

- Ensure to have additional users created.
- Create a process and set the 'Assignment Rules' to 'Self Service' with a user assigned.
- Log in as the assigned user and view the 'Self Service' tasks, open the task.

**Expected Behavior**

When selecting the task the 'Claim Task' button appears with no errors.