### PR TITLE
FOUR-2921: Unable to filter the list in a Saved Search chart

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -390,8 +390,13 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
             $filter = '%' . mb_strtolower($filter) . '%';
             $query->where(function ($query) use ($filter) {
                 $query->where(DB::raw('LOWER(name)'), 'like', $filter)
-                    ->orWhere(DB::raw('LOWER(data)'), 'like', $filter);
-            });            
+                    ->orWhere(DB::raw('LOWER(data)'), 'like', $filter)
+                    ->orWhere(DB::raw('id'), 'like', $filter)
+                    ->orWhere(DB::raw('LOWER(status)'), 'like', $filter)
+                    ->orWhere('initiated_at', 'like', $filter)
+                    ->orWhere('created_at', 'like', $filter)
+                    ->orWhere('updated_at', 'like', $filter);
+            });
         }
         
         return $query;

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -443,8 +443,13 @@ class ProcessRequestToken extends Model implements TokenInterface
             $filter = '%' . mb_strtolower($filter) . '%';
             $query->where(function ($query) use ($filter) {
                 $query->where(DB::raw('LOWER(element_name)'), 'like', $filter)
-                    ->orWhere(DB::raw('LOWER(data)'), 'like', $filter);
-            });            
+                    ->orWhere(DB::raw('LOWER(data)'), 'like', $filter)
+                    ->orWhere(DB::raw('LOWER(status)'), 'like', $filter)
+                    ->orWhere('id', 'like', $filter)
+                    ->orWhere('created_at', 'like', $filter)
+                    ->orWhere('due_at', 'like', $filter)
+                    ->orWhere('updated_at', 'like', $filter);
+            });
         }
         
         return $query;


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2921](https://processmaker.atlassian.net/browse/FOUR-2921)

Added filtering by id and dates of process requests, and process request tokens.
