### PR TITLE
Update security logs migration to use connection (v4.2)

### DIFF
--- a/database/migrations/2020_11_16_215424_create_security_logs_table.php
+++ b/database/migrations/2020_11_16_215424_create_security_logs_table.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use ProcessMaker\Models\Permission;
+use ProcessMaker\Models\SecurityLog;
 
 class CreateSecurityLogsTable extends Migration
 {
@@ -14,15 +15,14 @@ class CreateSecurityLogsTable extends Migration
      */
     public function up()
     {
-        Schema::create('security_logs', function (Blueprint $table) {
+        $model = new SecurityLog;
+        Schema::connection($model->getConnectionName())->create('security_logs', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('event', 40)->index();
             $table->string('ip', 40)->index()->nullable();
             $table->json('meta')->nullable();
             $table->unsignedInteger('user_id')->nullable();
             $table->timestamp('occurred_at');
-            
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
         
         if (! Permission::where('name', 'view-security-logs')->first()) {


### PR DESCRIPTION
## Changes
- Fixes an issue where the security logs migration was not specifying the proper connection, which is needed in a two-database system

Closes https://processmaker.atlassian.net/browse/FOUR-2969 