### PR TITLE
Restrict users without "view all requests" permission to participated-in requests

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -136,6 +136,10 @@ class ProcessRequestController extends Controller
             }
         }
 
+        if (! $user->can('view-all_requests')) {
+            $query->pmql('requester = "' . $user->username . '" OR participant = "' . $user->username . '"');
+        }
+
         $query->nonSystem();
 
         try {


### PR DESCRIPTION
## Changes
- Adds a restriction to the Requests index endpoint to prevent users without "view all requests" permission from seeing requests in which they have not participated

https://processmaker.atlassian.net/browse/FOUR-2309