### PR TITLE
Fix: Get BPMN definitions from the request's version

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -375,7 +375,7 @@ class ProcessRequestController extends Controller
     {
         // Get the process definition
         $process = $request->process;
-        $catchEvent = $process->getDefinitions()->findElementById($event)->getBpmnElementInstance();
+        $catchEvent = $request->getVersionDefinitions()->findElementById($event)->getBpmnElementInstance();
         if (!($catchEvent instanceof CatchEventInterface)) {
             return abort(423, __('Invalid element, not a catch event ' . get_class($catchEvent)));
         }

--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -259,9 +259,10 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
         }
 
         $process = Process::find($id);
+        /** @var ProcessRequest $request */
         $request = ProcessRequest::find($task->process_request_id);
 
-        $definitions = $process->getDefinitions();
+        $definitions = $request->getVersionDefinitions();
         if (!$definitions->findElementById($config->element_id)) {
             return;
         }

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -490,7 +490,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
             return $userByRule;
         }
 
-        $definitions = $token->getInstance()->process->getDefinitions();
+        $definitions = $token->getInstance()->getVersionDefinitions();
         $properties = $definitions->findElementById($activity->getId())->getBpmnElementInstance()->getProperties();
         $assignmentLock = array_key_exists('assignmentLock', $properties) ? $properties['assignmentLock']  : false;
 

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -22,7 +22,7 @@ use ProcessMaker\Traits\SqlsrvSupportTrait;
 use Spatie\MediaLibrary\HasMedia\HasMedia;
 use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
 use Throwable;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use ProcessMaker\Repositories\BpmnDocument;
 use ProcessMaker\Traits\HideSystemResources;
 
 /**
@@ -42,6 +42,7 @@ use ProcessMaker\Traits\HideSystemResources;
  * @property \Carbon\Carbon $created_at
  * @property Process $process
  * @property ProcessRequestLock[] $locks
+ * @method static ProcessRequest find($id)
  *
  * @OA\Schema(
  *   schema="processRequestEditable",
@@ -773,5 +774,19 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
     {
         $first = $this->locks()->orderBy('id')->first();
         return !$first || $first->getKey() === $lock->getKey();
+    }
+
+    /**
+     * Get the BPMN definitions version of the process that is running.
+     *
+     * @param boolean $forceParse
+     * @param mixed $engine
+     *
+     * @return BpmnDocument
+     */
+    public function getVersionDefinitions($forceParse = false, $engine = null)
+    {
+        $processVersion = $this->processVersion ?: $this->process;
+        return $processVersion->getDefinitions($forceParse, $engine);
     }
 }

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -301,7 +301,9 @@ class ProcessRequestToken extends Model implements TokenInterface
      */
     public function getBpmnDefinition()
     {
-        $definitions = $this->processRequest->process->getDefinitions();
+        /** @var ProcessRequest $request */
+        $request = $this->processRequest ?: $this->getInstance();
+        $definitions = $request->getVersionDefinitions();
         return $definitions->findElementById($this->element_id);
     }
 


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-3021

This PR fixes:
- Get BPMN definitions from the request's version
