### PR TITLE
Add timestamp to screen extensions

### DIFF
--- a/ProcessMaker/Managers/ScreenBuilderManager.php
+++ b/ProcessMaker/Managers/ScreenBuilderManager.php
@@ -40,7 +40,13 @@ class ScreenBuilderManager
      */
     public function getScripts()
     {
-        return $this->javascriptRegistry;
+        $scripts = [];
+        foreach($this->javascriptRegistry as $script) {
+            $path = public_path($script);
+            $time = file_exists($path) ? filemtime($path) : 0;
+            $scripts[] = $script . ($time ? "?t=$time" : '');
+        }
+        return $scripts;
     }
 
     public function addPackageScripts($type = 'DISPLAY')


### PR DESCRIPTION
Problem: When a package is updated, its javascript is not updated in the client browser because of the cache.

This PR adds a timestamp to screen javascript extensions to fix the problem.
