### PR TITLE
Changed "report issue" string

### DIFF
--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -22,7 +22,7 @@
         <hr>
         <div>ProcessMaker 4 v4.2 RC1</div>
         <hr>
-        <a href="https://github.com/ProcessMaker/processmaker/issues/new" target="_blank">{{__('Report Issue')}}  <i class="fas fa-caret-right fa-lg float-right mr-1"></i></a>
+        <a href="https://github.com/ProcessMaker/processmaker/issues/new" target="_blank">{{__('Report an issue')}}  <i class="fas fa-caret-right fa-lg float-right mr-1"></i></a>
         <hr>
         <a href="https://processmaker.gitbook.io/processmaker/" target="_blank">{{__('Documentation')}}  <i class="fas fa-caret-right fa-lg float-right mr-1"></i></a>
         <hr>


### PR DESCRIPTION
While looking through translations, I noticed "Report Issue" was still untranslated. Turns out at some point we changed "Report an issue" to "Report Issue" and this broke all our translations. This fixes https://processmaker.atlassian.net/browse/FOUR-744