### PR TITLE
Fix execution of incomplete datasource URLs

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -320,6 +320,10 @@ trait MakeHttpRequests
         //           item['type'] location of the property defined in 'key'. It can be BODY, PARAM (in the query string), HEADER
 
         $url = $endpoint['url'];
+        // If url does not include the protocol and server name complete it with the local server
+        if (substr($url, 0,1) === '/') {
+            $url = url($url);
+        }
 
         // If exists a query string in the call, add it to the URL
         if (array_key_exists('queryString', $config)) {


### PR DESCRIPTION
In a previous version of collections/data-connector, some collection's data-sources were created with an incomplete url (without the protocol and server name)

This PR fixes this problem for those data-sources.

![image](https://user-images.githubusercontent.com/8028650/114912368-ea617e80-9ded-11eb-954b-ea3bfaa83361.png)
