### PR TITLE
Error when trying to configure a Data Connector with third-party API endpoints

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -87,9 +87,9 @@ trait MakeHttpRequests
 
         $headers = $this->addHeaders($endpoint, $config, $data);
 
-        if (isset($config['outboundConfig']) || isset($config['dataMapping'])) {
+        if (isset($config['dataMapping'])) {
             // If it is the old version of data sources use dataMapping
-            $configParameter = isset($config['outboundConfig']) ? 'outboundConfig' : 'dataMapping';
+            $configParameter = $config['dataMapping'];
             $mappedData = [];
             foreach ($config[$configParameter] as $map) {
                 $mappedData[$map['key']] =  $map['value'];


### PR DESCRIPTION
Fixed [FOUR-3142](https://processmaker.atlassian.net/browse/FOUR-3142)

- remove old parameter outboundConfig