### PR TITLE
Fix Saved Search To Do & Self Service Task counts 

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -518,7 +518,7 @@ class ProcessRequestToken extends Model implements TokenInterface
      * 
      * @return callback
      */        
-    public function valueAliasStatus($value, $expression)
+    public function valueAliasStatus($value, $expression, $callback = null, User $user = null)
     {
         $statusMap = [
             'in progress' => 'ACTIVE',
@@ -527,10 +527,14 @@ class ProcessRequestToken extends Model implements TokenInterface
         
         $value = mb_strtolower($value);
     
-        return function($query) use ($value, $statusMap, $expression) {
+        return function($query) use ($value, $statusMap, $expression, $user) {
             if ($value === 'self service') {
-                if (auth()->user()) {
-                    $taskIds = auth()->user()->availableSelfServiceTaskIds();
+                if (!$user) {
+                    $user = auth()->user();
+                }
+                
+                if ($user) {
+                    $taskIds = $user->availableSelfServiceTaskIds();
                     $query->whereIn('id', $taskIds);
                 } else {
                     $query->where('is_self_service', 1);

--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -2,9 +2,10 @@
 
 namespace ProcessMaker\Traits;
 
+use Illuminate\Database\Eloquent\Builder;
+use ProcessMaker\Models\User;
 use ProcessMaker\Query\Expression;
 use ProcessMaker\Query\Traits\PMQL;
-use Illuminate\Database\Eloquent\Builder;
 
 trait ExtendedPMQL
 {
@@ -22,12 +23,12 @@ trait ExtendedPMQL
      *
      * @return mixed
      */    
-    public function scopePMQL(Builder $builder, string $query, callable $callback = null)
+    public function scopePMQL(Builder $builder, string $query, callable $callback = null, User $user = null)
     {
         if (! $callback) {
             // If a callback isn't passed to the scope, we handle it here
-            return $this->parentScopePMQL($builder, $query, function($expression) use ($builder) {
-                return $this->handle($expression, $builder);
+            return $this->parentScopePMQL($builder, $query, function($expression) use ($builder, $user) {
+                return $this->handle($expression, $builder, $user);
             });
         } else {
             // If a callback is passed to the scope, we skip handling it here
@@ -44,7 +45,7 @@ trait ExtendedPMQL
      *
      * @return mixed
      */    
-    private function handle(Expression $expression, Builder $builder)
+    private function handle(Expression $expression, Builder $builder, User $user = null)
     {
         // Setup our needed variables
         $field = $expression->field->field();
@@ -72,7 +73,7 @@ trait ExtendedPMQL
             // function if its field name matches a specific word.
             $method = "valueAlias{$fieldMethodName}";
             if (method_exists($model, $method)) {
-                return $model->{$method}($value, $expression, $builder);
+                return $model->{$method}($value, $expression, $builder, $user);
             }
 
             // A field wildcard passes any fields not caught by a field or value
@@ -81,7 +82,7 @@ trait ExtendedPMQL
             // no callback.
             $method = "fieldWildcard";
             if (method_exists($model, $method)) {
-                return $model->{$method}($value, $expression, $builder);
+                return $model->{$method}($value, $expression, $builder, $user);
             }    
         }
     }


### PR DESCRIPTION
## Changes
- Fixes an issue where the task counts on built-in To Do & Self Service Saved Searches were incorrect
  - Refactors PMQL to accept a user parameter so that only self service tasks for the Saved Search owner are counted

## Fixes
- https://processmaker.atlassian.net/browse/FOUR-3095
- https://processmaker.atlassian.net/browse/FOUR-3099

## Requires
- https://github.com/ProcessMaker/package-savedsearch/pull/237