### PR TITLE
Fix Completed Tasks counter

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -521,8 +521,8 @@ class ProcessRequestToken extends Model implements TokenInterface
     public function valueAliasStatus($value, $expression)
     {
         $statusMap = [
-            'in progress' => 'ACTIVE',
-            'completed' => 'CLOSED',
+            'in progress' => ['ACTIVE'],
+            'completed' => ['CLOSED', 'COMPLETED'],
         ];
         
         $value = mb_strtolower($value);
@@ -536,8 +536,12 @@ class ProcessRequestToken extends Model implements TokenInterface
                     $query->where('is_self_service', 1);
                 }
             } elseif (array_key_exists($value, $statusMap)) {
-                $query->where('status',  $expression->operator, $statusMap[$value])
-                    ->where('is_self_service', 0);
+                $query->where('is_self_service', 0);
+                if ($expression->operator == '=') {
+                    $query->whereIn('status', $statusMap[$value]);
+                } elseif ($expression->operator == '!=') {
+                    $query->whereNotIn('status', $statusMap[$value]);
+                }
             } else {
                 $query->where('status',  $expression->operator, $value)
                     ->where('is_self_service', 0);


### PR DESCRIPTION
## Changes
- Fixes an issue where Saved Searches displaying **completed** tasks may have displayed the wrong count
  - Refactored the task status PMQL alias to use "COMPLETED" as a possible status in addition to "CLOSED," since the workflow engine generally sets tasks to "COMPLETED" status before they are set to "CLOSED"

Closes https://processmaker.atlassian.net/browse/FOUR-3169