### PR TITLE
FOUR-3041: Fix The data in the Data tab disappears when the end Event has a screen

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -582,7 +582,7 @@
            */
           cleanScreenButtons() {
             if (this.showScreenSummary) {
-              this.$refs.screen.screen[0].items.forEach(item => {
+              this.$refs.screen.config[0].items.forEach(item => {
                 item.config.disabled = true;
                 if (item.component === 'FormButton') {
                   item.config.event = '';


### PR DESCRIPTION
Resolves: https://processmaker.atlassian.net/browse/FOUR-3041
The data loading was broken by an script error when disabling the buttons of the screen summary.

This PR fix the wrong reference to disable buttons in summary screen.
