### PR TITLE
Allow scripts to be run in sync mode

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -215,7 +215,11 @@ class ScriptController extends Controller
         $watcher = $request->get('watcher', uniqid('scr', true));
         $code = $script->code;
 
-        ExecuteScript::dispatch($script, $request->user(), $code, $data, $watcher, $config)->onQueue('bpmn');
+        if ($request->get('sync') === true) {
+            return ExecuteScript::dispatchNow($script, $request->user(), $code, $data, $watcher, $config, true);
+        } else {
+            ExecuteScript::dispatch($script, $request->user(), $code, $data, $watcher, $config)->onQueue('bpmn');
+        }
         return ['status' => 'success', 'key' => $watcher];
     }
 

--- a/ProcessMaker/Jobs/ExecuteScript.php
+++ b/ProcessMaker/Jobs/ExecuteScript.php
@@ -25,6 +25,7 @@ class ExecuteScript implements ShouldQueue
     protected $data;
     protected $configuration;
     protected $watcher;
+    protected $sync;
 
     /**
      * Create a new job instance to execute a script.
@@ -36,7 +37,7 @@ class ExecuteScript implements ShouldQueue
      * @param $watcher
      * @param array $configuration
      */
-    public function __construct(Script $script, User $current_user, $code, array $data, $watcher, array $configuration = [])
+    public function __construct(Script $script, User $current_user, $code, array $data, $watcher, array $configuration = [], $sync = false)
     {
         $this->script = $script;
         $this->current_user = $current_user;
@@ -44,7 +45,7 @@ class ExecuteScript implements ShouldQueue
         $this->data = $data;
         $this->configuration = $configuration;
         $this->watcher = $watcher;
-        $this->configuration = $configuration;
+        $this->sync = $sync;
     }
 
     /**
@@ -58,6 +59,9 @@ class ExecuteScript implements ShouldQueue
             # Just set the code but do not save the object (preview only)
             $this->script->code = $this->code;
             $response = $this->script->runScript($this->data, $this->configuration);
+            if ($this->sync) {
+                return $response;
+            }
             $this->sendResponse(200, $response);
         } catch (Throwable $exception) {
             $this->sendResponse(500, [

--- a/ProcessMaker/Jobs/ExecuteScript.php
+++ b/ProcessMaker/Jobs/ExecuteScript.php
@@ -64,6 +64,9 @@ class ExecuteScript implements ShouldQueue
             }
             $this->sendResponse(200, $response);
         } catch (Throwable $exception) {
+            if ($this->sync) {
+                throw $exception;
+            }
             $this->sendResponse(500, [
                 'exception' => get_class($exception),
                 'message' => $exception->getMessage(),


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3139

- Api calls to execute scripts run in sync mode instead of waiting for a broadcast event on the queue
- Data sources directly connect to the data source api instead of going through a service task

Requires
- vue-form-elements: https://github.com/ProcessMaker/vue-form-elements/pull/264
- screen-builder: https://github.com/ProcessMaker/screen-builder/pull/972
- web-entry: https://github.com/ProcessMaker/package-webentry/pull/114

Steps to deploy:
- After vue-form-elements is published to npmjs, update the version in the screen-builder pr and core (this pr)