### PR TITLE
Add option to use a ProcessMaker screen as a setting component

### DIFF
--- a/resources/js/admin/settings/components/SettingObject.vue
+++ b/resources/js/admin/settings/components/SettingObject.vue
@@ -32,7 +32,7 @@
               track-by="name"
               label="name"
               :show-labels="false"
-              class="ml-2 mr-2"
+              class="setting-object-multiselect ml-2 mr-2"
             ></multiselect>
           </div>
         </template>
@@ -250,20 +250,21 @@ export default {
   $disabledBackground: lighten($secondary, 20%);
   $multiselect-height: 38px;
 
-    .setting-add-button {
-      margin-top: 5px;
-    }
+  .setting-add-button {
+    margin-top: 5px;
+  }
 
-    .setting-object-table th,
-    .setting-object-table td {
-      padding: 8px 0;
-    }
+  .setting-object-table th,
+  .setting-object-table td {
+    padding: 8px 0;
+  }
 
-    .thKey {
-      width: 300px;
-    }
+  .thKey {
+    width: 300px !important;
+  }
 
-    .multiselect {
+  .setting-object-multiselect {
+    &.multiselect {
       display: inline-block !important;
       max-width: 300px;
       width: 300px;
@@ -313,4 +314,6 @@ export default {
       min-width: 0;
       margin-bottom: 0;
     }
+    
+  }
 </style>

--- a/resources/js/admin/settings/components/SettingScreen.vue
+++ b/resources/js/admin/settings/components/SettingScreen.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="setting-text">
+    <div v-if="previewScreen('config')">
+      <vue-form-renderer
+        v-model="preview"
+        :config="previewScreen('config')"
+        :computed="previewScreen('computed')"
+        class="preview-renderer"
+      />
+    </div>
+    <div v-else class="font-italic text-black-50">
+      Empty
+    </div>
+    <b-modal class="setting-object-modal" v-model="showModal" size="lg" @hidden="onModalHidden">
+      <template v-slot:modal-header class="d-block">
+        <div>
+          <h5 class="mb-0" v-if="setting.name">{{ $t(setting.name) }}</h5>
+          <h5 class="mb-0" v-else>{{ setting.key }}</h5>
+          <small class="form-text text-muted" v-if="setting.helper">{{ $t(setting.helper) }}</small>
+        </div>
+        <button type="button" aria-label="Close" class="close" @click="onCancel">×</button>
+      </template>
+      <vue-form-renderer
+        v-if="screen('config')"
+        v-model="transformed"
+        :config="screen('config')"
+        :custom-css="screen('custom_css')"
+        :computed="screen('computed')"
+      />
+      <div v-else class="alert alert-danger">{{ $t('Unable to display setting.') }}</div>
+      <div slot="modal-footer" class="w-100 m-0 d-flex">
+        <button type="button" class="btn btn-outline-secondary ml-auto" @click="onCancel">
+            {{ $t('Cancel') }}
+        </button>
+        <button type="button" class="btn btn-secondary ml-3" @click="onSave" :disabled="! changed">
+            {{ $t('Save')}}
+        </button>
+      </div>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+import settingMixin from "../mixins/setting";
+import {VueFormRenderer} from "@processmaker/screen-builder";
+
+export default {
+  mixins: [settingMixin],
+  props: ['value', 'setting'],
+  data() {
+    return {
+      config: null,
+      formData: null,
+      input: null,
+      preview: null,
+      showModal: false,
+      transformed: null,
+    };
+  },
+  computed: {
+    variant() {
+      if (this.disabled) {
+        return 'secondary';
+      } else {
+        return 'success';
+      }
+    },
+    changed() {
+      return JSON.stringify(this.input) !== JSON.stringify(this.transformed);
+    },
+  },
+  watch: {
+    value: {
+      handler: function(value) {
+        this.input = value;
+      },
+    }
+  },
+  methods: {
+    screen(property) {
+      return _.get(this, `setting.ui.screen.screens.0.${property}`, null);
+    },
+    previewScreen(property) {
+      return _.get(this, `setting.ui.preview.screens.0.${property}`, null);
+    },
+    onCancel() {
+      this.showModal = false;
+    },
+    onEdit() {
+      this.showModal = true;
+    },
+    onModalHidden() {
+      this.transformed = this.copy(this.input);
+    },
+    onSave() {
+      this.input = this.copy(this.transformed);
+      this.preview = this.copy(this.transformed);
+      this.showModal = false;
+      this.emitSaved(this.input);
+    },
+  },
+  mounted() {
+    this.input = this.copy(this.value);
+    this.preview = this.copy(this.value);
+    this.transformed = this.copy(this.input);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+  @import '../../../../sass/colors';
+
+  $disabledBackground: lighten($secondary, 20%);
+
+  .btn:disabled,
+  .btn.disabled {
+    background: $disabledBackground;
+    border-color: $disabledBackground;
+    opacity: 1 !important;
+  }
+</style>

--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -93,6 +93,7 @@ import SettingBoolean from './SettingBoolean';
 import SettingCheckboxes from './SettingCheckboxes';
 import SettingChoice from './SettingChoice';
 import SettingObject from './SettingObject';
+import SettingScreen from './SettingScreen';
 import SettingText from './SettingText';
 import SettingTextArea from './SettingTextArea';
 import SettingsImport from './SettingsImport';
@@ -105,6 +106,7 @@ export default {
     SettingChoice,
     SettingCheckboxes,
     SettingObject,
+    SettingScreen,
     SettingText,
     SettingTextArea,
     SettingsImport,
@@ -188,6 +190,9 @@ export default {
         case 'object':
           if (setting.ui && setting.ui.format && setting.ui.format == 'map') {
             return `setting-object`;
+          }
+          if (setting.ui && setting.ui.format && setting.ui.format == 'screen') {
+            return `setting-screen`;
           }
         default:
           return 'setting-text-area';
@@ -297,6 +302,13 @@ export default {
 
 <style lang="scss">
 @import '../../../../sass/colors';
+
+.preview-renderer {
+  .form-group {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+}
 
 .b-pagination {
   .page-item {


### PR DESCRIPTION
## Changes
- Adds the option of using an exported ProcessMaker screen as a setting component
- Used by https://github.com/ProcessMaker/package-auth/pull/9 to add a cron job frequency setting