### PR TITLE
Adding client credentials route middleware

### DIFF
--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -67,5 +67,6 @@ class Kernel extends HttpKernel
         'setlocale' => \ProcessMaker\Http\Middleware\SetLocale::class,
         'setskin' => \ProcessMaker\Http\Middleware\SetSkin::class,
         'external.connection' => \ProcessMaker\Http\Middleware\ValidateExternalConnection::class,
+        'client' => \Laravel\Passport\Http\Middleware\CheckClientCredentials::class,
     ];
 }


### PR DESCRIPTION
Adding client_credentials support to routes.

See https://laravel.com/docs/6.x/passport#client-credentials-grant-tokens

```
use Laravel\Passport\Http\Middleware\CheckClientCredentials;

protected $routeMiddleware = [
    'client' => CheckClientCredentials::class,
];
```
After adding this to the core, packages can use this type of granting and attach the middleware to a route:
```
Route::get('/orders', function (Request $request) {
    ...
})->middleware('client');
```