### PR TITLE
Add signal and webhook permissions

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -7,6 +7,7 @@ use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Managers\ModelerManager;
 use ProcessMaker\Events\ModelerStarting;
+use ProcessMaker\Managers\SignalManager;
 
 class ModelerController extends Controller
 {
@@ -14,7 +15,7 @@ class ModelerController extends Controller
     /**
      * Invokes the Process Modeler for rendering.
      */
-    public function __invoke(ModelerManager $manager, Process $process)
+    public function __invoke(ModelerManager $manager, Process $process, Request $request)
     {
         /**
          * Emit the ModelerStarting event, passing in our ModelerManager instance. This will 
@@ -24,7 +25,8 @@ class ModelerController extends Controller
         event(new ModelerStarting($manager));
         return view('processes.modeler.index', [
             'process' => $process->append('notifications', 'task_notifications'),
-            'manager' => $manager
+            'manager' => $manager,
+            'signalPermissions' => SignalManager::permissions($request->user()),
         ]);
     }
 }

--- a/ProcessMaker/Managers/SignalManager.php
+++ b/ProcessMaker/Managers/SignalManager.php
@@ -247,4 +247,13 @@ class SignalManager
 
         array_push($errors[$field], $message);
     }
+
+    public static function permissions($user) {
+        return [
+            'create-signals' => $user->can('create-signals'),
+            'view-signals' => $user->can('view-signals'),
+            'edit-signals' => $user->can('edit-signals'),
+            'delete-signals' => $user->can('delete-signals'),
+        ];
+    }
 }

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -97,6 +97,12 @@ class PermissionSeeder extends Seeder
             'edit-auth_clients',
             'delete-auth_clients',
         ],
+        'Signals' => [
+            'create-signals',
+            'view-signals',
+            'edit-signals',
+            'delete-signals',
+        ],
     ];
 
     public function run($seedUser = null)

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1444,5 +1444,9 @@
   "The task must be claimed to enable manager escalation.": "The task must be claimed to enable manager escalation.",
   "Run Watcher on Screen Load": "Run Watcher on Screen Load",
   "The Request variable is a new/existing variable": "The Request variable is a new/existing variable",
-  "Leave blank to map all response data": "Leave blank to map all response data"
+  "Leave blank to map all response data": "Leave blank to map all response data",
+  "Create Signals": "Create Signals",
+  "Delete Signals": "Delete Signals",
+  "Edit Signals": "Edit Signals",
+  "View Signals": "View Signals"
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1448,5 +1448,9 @@
   "Create Signals": "Create Signals",
   "Delete Signals": "Delete Signals",
   "Edit Signals": "Edit Signals",
-  "View Signals": "View Signals"
+  "View Signals": "View Signals",
+  "You do not have permission to add new signals": "You do not have permission to add new signals",
+  "You do not have permission to view signals": "You do not have permission to view signals",
+  "You do not have permission to delete signals": "You do not have permission to delete signals",
+  "You do not have permission to edit signals": "You do not have permission to edit signals"
 }

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -58,6 +58,7 @@ div.main {
     process: @json($process),
     xml: @json($process->bpmn),
     processName: @json($process->name),
+    signalPermissions: @json($signalPermissions),
   }
   const warnings = @json($process->warnings);
  

--- a/routes/api.php
+++ b/routes/api.php
@@ -165,11 +165,11 @@ Route::group(
     Route::delete('comments/{comment}', 'CommentController@destroy')->name('comments.destroy')->middleware('can:delete-comments');
 
     // Global signals
-    Route::get('signals', 'SignalController@index')->name('signals.index')->middleware('can:view-processes');
-    Route::get('signals/{signalId}', 'SignalController@show')->name('signals.show')->middleware('can:view-processes');
-    Route::post('signals', 'SignalController@store')->name('signals.store')->middleware('can:edit-processes');
-    Route::put('signals/{signalId}', 'SignalController@update')->name('signals.update')->middleware('can:edit-processes');
-    Route::delete('signals/{signalId}', 'SignalController@destroy')->name('signals.destroy')->middleware('can:edit-processes');
+    Route::get('signals', 'SignalController@index')->name('signals.index')->middleware('can:view-signals');
+    Route::get('signals/{signalId}', 'SignalController@show')->name('signals.show')->middleware('can:view-signals');
+    Route::post('signals', 'SignalController@store')->name('signals.store')->middleware('can:create-signals');
+    Route::put('signals/{signalId}', 'SignalController@update')->name('signals.update')->middleware('can:edit-signals');
+    Route::delete('signals/{signalId}', 'SignalController@destroy')->name('signals.destroy')->middleware('can:delete-signals');
 
     //UI customization
     Route::post('customize-ui', 'CssOverrideController@store')->name('customize-ui.store');

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,8 +40,8 @@ Route::group(['middleware' => ['auth', 'sanitize', 'external.connection']], func
         Route::get('scripts/{script}/edit', 'ScriptController@edit')->name('scripts.edit')->middleware('can:edit-scripts,script');
         Route::get('scripts/{script}/builder', 'ScriptController@builder')->name('scripts.builder')->middleware('can:edit-scripts,script');
 
-        Route::get('signals', 'SignalController@index')->name('signals.index')->middleware('can:view-processes');
-        Route::get('signals/{signalId}/edit', 'SignalController@edit')->name('signals.edit')->middleware('can:edit-processes');
+        Route::get('signals', 'SignalController@index')->name('signals.index')->middleware('can:view-signals');
+        Route::get('signals/{signalId}/edit', 'SignalController@edit')->name('signals.edit')->middleware('can:edit-signals');
     });
 
     Route::get('designer/processes/categories', 'ProcessController@index')->name('process-categories.index') ->middleware ('can:view-process-categories');

--- a/tests/Feature/Api/SignalPermissionsTest.php
+++ b/tests/Feature/Api/SignalPermissionsTest.php
@@ -107,4 +107,33 @@ class PermissionsTest extends TestCase {
         $response = $this->apiCall('DELETE', $deleteRoute);
         $response->assertStatus(201);
     }
+
+    public function testWebViewPermission()
+    {
+        $this->createUser();
+        $indexRoute = route('signals.index');
+        $response = $this->webCall('GET', $indexRoute);
+        $response->assertStatus(403);
+        $this->givePermission('view-signals');
+        $response = $this->webCall('GET', $indexRoute);
+        $response->assertStatus(200);
+    }
+    
+    public function testWebEditPermission()
+    {
+        $storeRoute = route('api.signals.store');
+        $data = [
+            'id' => 'anything',
+            'name' => 'anything',
+        ];
+        $this->apiCall('POST', $storeRoute, $data);
+        
+        $this->createUser();
+        $indexRoute = route('signals.edit', 'anything');
+        $response = $this->webCall('GET', $indexRoute);
+        $response->assertStatus(403);
+        $this->givePermission('edit-signals');
+        $response = $this->webCall('GET', $indexRoute);
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
Fixes part of https://processmaker.atlassian.net/browse/FOUR-3247

- Requires https://github.com/ProcessMaker/package-data-sources/pull/150 for webhook permissions
- Requires https://github.com/ProcessMaker/modeler/pull/1353 for modeler signal permission checks

These seeders need to be run
```
php artisan db:seed --class=PermissionSeeder --force
php artisan db:seed --class="ProcessMaker\Packages\Connectors\DataSources\Seeds\DataSourcePermissionSeeder" --force
```