### PR TITLE
Fix refreshOnSave error

### DIFF
--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -235,7 +235,7 @@ export default {
         this.apiPut(setting).then(response => {
           if (response.status == 204) {
             ProcessMaker.alert(this.$t("The setting was updated."), "success");
-            if (setting.ui.refreshOnSave) {
+            if (_.get(setting, 'ui.refreshOnSave')) {
               this.$emit('refresh-all');
             } else {
               this.refresh();


### PR DESCRIPTION
## Changes
- Fixes an issue where a warning `Cannot read property 'refreshOnSave' of null` was sometimes displayed when saving settings
  - Use Lodash `_.get` function to safely retrieve UI setting and simply return null if it doesn't exist

## Closes
https://processmaker.atlassian.net/browse/FOUR-3285