### PR TITLE
Fix older screens loading in Safari

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -510,7 +510,13 @@ export default {
 
         item.inspector.forEach(property => {
           if (property.config.validation) {
-            rules[property.field] = property.config.validation;
+            if (property.config.validation.includes('regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*(?<![.])$/')) {
+              let validationRuleArray = property.config.validation.split('|');
+              validationRuleArray[0] = 'regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*[^.]$/';
+              rules[property.field] = validationRuleArray.join('|');
+            } else {
+              rules[property.field] = property.config.validation;
+            }
           }
         });
 


### PR DESCRIPTION
**Jira Ticket**

https://processmaker.atlassian.net/browse/FOUR-3263

<h2>Changes</h2>

- Replace the negative look behind within the 'Variable Name' regex validation when loading the screen. This fixes the validation error that prevents older screens from loading in Safari.

**Dependency PRs**

https://github.com/ProcessMaker/screen-builder/pull/987

**Test Screen**

Use the below screen to test in Safari

[1-FOUR-3214.json.txt](https://github.com/ProcessMaker/processmaker/files/6460572/1-FOUR-3214.json.txt)

**Video**

https://www.loom.com/share/afb35ca1998c45a0a628f8aff89edb15



