### PR TITLE
Updating openapitools/openapi-generator-cli to version 5.1.1

### DIFF
--- a/ProcessMaker/BuildSdk.php
+++ b/ProcessMaker/BuildSdk.php
@@ -9,7 +9,7 @@ use ProcessMaker\Events\BuildScriptExecutor;
 class BuildSdk {
     private $debug = true;
     private $image = "openapitools/openapi-generator-cli";
-    private $tag = "v4.2.2";
+    private $tag = "v5.1.1";
     private $lang = null;
     private $outputPath = null;
     private $jsonPath = null;


### PR DESCRIPTION
PR to update openapitools/openapi-generator-cli to version 5.1.1.

Version Details: https://github.com/OpenAPITools/openapi-generator/releases/tag/v5.1.1

Highlights:
- [Enhancement] added support for custom type & format mapping #9285
- [Docker] support multi-arch build #9246
- Gradle plugin - @Input and @Internal should not be apply on the same property #9059
- [core] Allow using lists as global property in config files #8339
- Add executionId to filehash in OpenAPI Generator Maven Plugin #7848
- Image based on JDK 11

Development Interests:
- Add docker image support for ARM/Apple Silicon.