### PR TITLE
Fix Custom UI RESET button

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/CssOverrideController.php
+++ b/ProcessMaker/Http/Controllers/Api/CssOverrideController.php
@@ -92,7 +92,7 @@ class CssOverrideController extends Controller
 
         $this->writeColors(json_decode($request->input('variables', '[]'), true));
         $this->writeFonts(json_decode($request->input("sansSerifFont", '')));
-        $this->compileSass(json_decode($request->input('variables', '[]'), true));
+        $this->compileSass($request->user('api')->id, json_decode($request->input('variables', '[]'), true));
 
         return new ApiResource($setting);
     }
@@ -138,7 +138,7 @@ class CssOverrideController extends Controller
 
         $this->writeColors(json_decode($request->input('variables', '[]'), true));
         $this->writeFonts(json_decode($request->input("sansSerifFont", '')));
-        $this->compileSass(json_decode($request->input('variables', '[]'), true));
+        $this->compileSass($request->user('api')->id, json_decode($request->input('variables', '[]'), true));
 
         return response([], 204);
     }
@@ -177,26 +177,26 @@ class CssOverrideController extends Controller
     /**
      * run jobs compile
      */
-    private function compileSass()
+    private function compileSass($userId)
     {
         // Compile the Sass files
         $this->dispatch(new CompileSass([
             'tag' => 'sidebar',
             'origin' => 'resources/sass/sidebar/sidebar.scss',
             'target' => 'public/css/sidebar.css',
-            'user' => Auth::user()->getKey()
+            'user' => $userId
         ]));
         $this->dispatch(new CompileSass([
             'tag' => 'app',
             'origin' => 'resources/sass/app.scss',
             'target' => 'public/css/app.css',
-            'user' => Auth::user()->getKey()
+            'user' => $userId
         ]));
         $this->dispatch(new CompileSass([
             'tag' => 'queues',
             'origin' => 'resources/sass/admin/queues.scss',
             'target' => 'public/css/admin/queues.css',
-            'user' => Auth::user()->getKey()
+            'user' => $userId
         ]));
     }
 


### PR DESCRIPTION
**Jira Ticket**
https://processmaker.atlassian.net/browse/FOUR-3258

The error occurred due to the Auth::user() returning null. There have been a few occurrences of this happening when using Laravel + Passport. 

https://stackoverflow.com/questions/61125681/authuser-returns-null-laravel-passport
https://github.com/laravel/framework/issues/30402

This may be occurring elsewhere, however, the following workaround I was able to find for this endpoint was within this answer on SO number 3.

https://stackoverflow.com/a/46111430

<h2>Changes</h2>

 - Replaces `Auth::user()->getKey()` that returned `null` with `$request->user('api')->id` 

**Video**

https://www.loom.com/share/944cfc9c3e324f1b911b11dc87f55585