### PR TITLE
Refactor counters on Requests index page

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -152,6 +152,8 @@ class ProcessRequestController extends Controller
         try {
             if ($getTotal === true) {
                 return $query->count();
+            } elseif ($request->input('total') == 'true') {
+                return ['meta' => ['total' => $query->count()]];
             } else {
                 $response = $query->orderBy(
                     str_ireplace('.', '->', $request->input('order_by', 'name')),

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -39,17 +39,6 @@ class RequestController extends Controller
             $this->authorize('view-all_requests');
         }
 
-        //load counters
-        $query = ProcessRequest::query();
-        if (!Auth::user()->is_administrator && !Auth::user()->can('view-all_requests')) {
-            $query->startedMe(Auth::user()->id);
-        }
-
-        $allRequest = $this->calculate('allRequest');
-        $startedMe = $this->calculate('startedMe');
-        $inProgress = $this->calculate('inProgress');
-        $completed = $this->calculate('completed');
-
         $title = 'My Requests';
 
         $types = ['all'=>'All Requests','in_progress'=>'Requests In Progress','completed'=>'Completed Requests'];
@@ -61,37 +50,8 @@ class RequestController extends Controller
         $currentUser = Auth::user()->only(['id', 'username', 'fullname', 'firstname', 'lastname', 'avatar']);
 
         return view('requests.index', compact(
-            ['allRequest', 'startedMe', 'inProgress', 'completed', 'type','title', 'currentUser']
+            ['type','title', 'currentUser']
         ));
-    }
-    private function calculate($type)
-    {
-        $result = 0;
-        $query = ProcessRequest::query();
-        if (!Auth::user()->is_administrator && !Auth::user()->can('view-all_requests')) {
-            $query->startedMe(Auth::user()->id);
-        }
-
-        $hiddenProcessIds = Process::whereHas('category', function($q) {
-            $q->where('is_system', true);
-        })->pluck('id');
-        $query->whereNotIn('process_id', $hiddenProcessIds);
-
-        switch ($type) {
-            case 'allRequest':
-               $result = $query->nonSystem()->count();
-               break;
-            case 'startedMe':
-                $result = ProcessRequest::startedMe(Auth::user()->id)->nonSystem()->inProgress()->count();
-                break;
-            case 'inProgress':
-                $result =$query->inProgress()->nonSystem()->count();
-                break;
-            case 'completed':
-                $result = $query->completed()->nonSystem()->count();
-                break;
-        }
-        return $result;
     }
 
     /**

--- a/resources/js/requests/components/CounterCard.vue
+++ b/resources/js/requests/components/CounterCard.vue
@@ -1,0 +1,109 @@
+<template>
+  <b-card
+    header-class="card-size-header px-4 px-xl-5 d-flex d-md-none d-lg-flex align-items-center justify-content-center border-0"
+    text-variant="white"
+    class="flex-row card-border border-0"
+    :class="cardClass"
+  >
+    <i slot="header" class="fas fa-2x" :class="iconClass"></i>
+    <a :href="link" class="card-link text-light">
+      <h1 v-if="showCount" class="m-0 font-weight-bold">{{ currentCount }}</h1>
+      <h6 class="card-text">{{ $t(title) }}</h6>
+    </a>
+  </b-card>
+</template>
+
+<script>
+  export default {
+    data () {
+      return {
+        currentCount: null,
+        loaded: false,
+      }
+    },
+    props: {
+      color: {
+        type: String,
+        default: 'secondary',
+      },
+      count: {
+        type: Number,
+        default: null,
+      },
+      countId: {
+        default: null,
+      },
+      icon: {
+        type: String,
+        default: 'chart-line',
+      },
+      link: {
+        type: String,
+        default: '/',
+      },
+      title: {
+        type: String,
+        default: 'Count',
+      },
+      url: {
+        type: String,
+        default: null,
+      }
+    },
+    mounted() {
+      this.loadCount();
+      
+      if (this.countId !== null) {
+        ProcessMaker.EventBus.$on('sidebar-count-updated-' + this.countId, count => {
+          this.currentCount = count;
+        });
+      }
+    },
+    computed: {
+      cardClass() {
+        let classes = [];
+        if (this.loaded) {
+          classes.push('d-flex');
+        } else {
+          classes.push('d-none');
+        }
+        classes.push('bg-' + this.color)
+        return classes.join(' ');
+      },
+      iconClass() {
+        return 'fa-' + this.icon;
+      },
+      isInGroup() {
+        return this.$parent.$options._componentTag == 'counter-card-group';
+      },
+      showCount() {
+        return this.currentCount !== null;
+      }
+    },
+    methods: {
+      loadCount() {
+        if (this.count !== null) {
+          this.currentCount = this.count;
+        } else if (this.url !== null) {
+          if (! this.isInGroup) {
+            ProcessMaker.apiClient.get(this.url)
+              .then(response => {
+                this.currentCount = response.data.meta.total;
+                this.loaded = true;
+              })
+              .catch(error => {
+                console.error(error);
+              });
+          }
+        }
+      },
+      setCount(count) {
+        this.currentCount = count;
+        this.loaded = true;
+      },
+      show() {
+        this.loaded = true;
+      }
+    }
+  }
+</script>

--- a/resources/js/requests/components/CounterCard.vue
+++ b/resources/js/requests/components/CounterCard.vue
@@ -88,18 +88,17 @@
           if (! this.isInGroup) {
             ProcessMaker.apiClient.get(this.url)
               .then(response => {
-                this.currentCount = response.data.meta.total;
-                this.loaded = true;
+                this.setCount(response.data.meta.total);
               })
               .catch(error => {
-                console.error(error);
+                this.show();
               });
           }
         }
       },
       setCount(count) {
         this.currentCount = count;
-        this.loaded = true;
+        this.show();
       },
       show() {
         this.loaded = true;

--- a/resources/js/requests/components/CounterCardGroup.vue
+++ b/resources/js/requests/components/CounterCardGroup.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="card-deck-flex">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+  import CounterCard from "./CounterCard";
+
+  export default {
+    components: { CounterCard },
+    mounted() {
+      this.retrieveCounts();
+    },
+    computed: {
+      cards() {
+        return this.$children.filter(child => {
+          return child.$options._componentTag == 'counter-card';
+        });
+      },
+    },
+    methods: {
+      retrieveCounts() {
+        let requests = [];
+        
+        this.cards.forEach(card => {
+          requests.push(ProcessMaker.apiClient.get(card.url));
+        });
+        
+        ProcessMaker.apiClient.all(requests)
+          .then(ProcessMaker.apiClient.spread((...responses) => {
+            responses.forEach(response => {
+              this.getCard(response.config.url).setCount(response.data.meta.total);
+            });
+          }))
+          .catch(errors => {
+            this.cards.forEach(card => {
+              card.show();
+            });
+          });
+      },
+      getCard(url) {
+        return this.cards.find(card => {
+          return card.url == url;
+        });
+      },
+    }
+  }
+</script>

--- a/resources/js/requests/index.js
+++ b/resources/js/requests/index.js
@@ -1,4 +1,6 @@
 import Vue from "vue";
+import CounterCard from "./components/CounterCard";
+import CounterCardGroup from "./components/CounterCardGroup";
 import RequestsListing from "./components/RequestsListing";
 import Multiselect from 'vue-multiselect'
 import AdvancedSearch from "../components/AdvancedSearch";
@@ -13,7 +15,7 @@ new Vue({
         requester: [],
     },
     el: "#requests-listing",
-    components: { RequestsListing, Multiselect, AdvancedSearch },
+    components: { CounterCard, CounterCardGroup, RequestsListing, Multiselect, AdvancedSearch },
     created() {
       let params = {};
 

--- a/resources/views/requests/index.blade.php
+++ b/resources/views/requests/index.blade.php
@@ -18,49 +18,39 @@
 <div class="px-3 page-content mb-0" id="requests-listing">
     <div class="row">
         <div class="col-sm-12">
-            <template>
-                <div class="card-deck-flex">
-
-                    <b-card header-class="card-size-header px-4 px-xl-5 d-flex d-md-none d-lg-flex align-items-center justify-content-center border-0"
-                        text-variant="white" class="bg-info d-flex flex-row card-border border-0">
-                        <i slot="header" class='fas fa-id-badge fa-2x'></i>
-                        <a href="{{ route('requests_by_type', ['type' => '']) }}" class="card-link text-light">
-                            <h1 class="m-0 font-weight-bold">{{$startedMe}}</h1>
-                            <h6 class="card-text">{{__('My Requests')}}</h6>
-                        </a>
-                    </b-card>
-
-                    <b-card header-class="card-size-header px-4 px-xl-5 d-flex d-md-none d-lg-flex align-items-center justify-content-center border-0"
-                        text-variant="white" class="bg-success d-flex flex-row card-border border-0">
-                        <i slot="header" class='fas fa-clipboard-list fa-2x'></i>
-                        <a href="{{ route('requests_by_type', ['type' => 'in_progress']) }}" class="card-link text-light">
-                            <h1 class="m-0 font-weight-bold">{{$inProgress}}</h1>
-                            <h6 class="card-text">{{__('In Progress')}}</h6>
-                        </a>
-                    </b-card>
-
-                    <b-card header-class="card-size-header px-4 px-xl-5 d-flex d-md-none d-lg-flex align-items-center justify-content-center border-0"
-                        text-variant="white" class="bg-primary d-flex flex-row card-border border-0">
-                        <i slot="header" class='fas fa-clipboard-check fa-2x'></i>
-                        <a href="{{ route('requests_by_type', ['type' => 'completed']) }}" class="card-link text-light">
-                            <h1 class="m-0 font-weight-bold">{{$completed}}</h1>
-                            <h6 class="card-text">{{__('Completed')}}</h6>
-                        </a>
-                    </b-card>
-                    @can('view-all_requests')
-                    <b-card header-class="card-size-header px-4 px-xl-5 d-flex d-md-none d-lg-flex align-items-center justify-content-center border-0"
-                        text-variant="white" class="bg-warning d-flex flex-row  card-border border-0">
-                        <i slot="header" class='fas fa-clipboard fa-2x'></i>
-                        <a href="{{ route('requests_by_type', ['type' => 'all']) }}" class="card-link text-light">
-                            <h1 class="m-0 font-weight-bold">{{$allRequest}}</h1>
-                            <h6 class="card-text">{{__('All Requests')}}</h6>
-                        </a>
-                    </b-card>
-                    @endcan
-
-                </div>
-                <advanced-search ref="advancedSearch" type="requests" :permission="{{ Auth::user()->hasPermissionsFor('users', 'groups') }}" :param-status="status" :param-requester="requester" @change="onChange" @submit="onSearch"></advanced-search>
-            </template>
+            <counter-card-group>
+                <counter-card
+                    color="info"
+                    icon="id-badge"
+                    link="{{ route('requests_by_type', ['type' => '']) }}"
+                    title="My Requests"
+                    url='requests?total=true&pmql=(status = "In Progress") AND (requester = "{{ Auth::user()->username }}")'
+                ></counter-card>
+                <counter-card
+                    color="success"
+                    icon="clipboard-list"
+                    link="{{ route('requests_by_type', ['type' => 'in_progress']) }}"
+                    title="In Progress"
+                    url='requests?total=true&pmql=(status = "In Progress")'
+                ></counter-card>
+                <counter-card
+                    color="primary"
+                    icon="clipboard-check"
+                    link="{{ route('requests_by_type', ['type' => 'completed']) }}"
+                    title="Completed"
+                    url='requests?total=true&pmql=(status = "Completed")'
+                ></counter-card>
+                @can('view-all_requests')
+                    <counter-card
+                        color="warning"
+                        icon="clipboard"
+                        link="{{ route('requests_by_type', ['type' => 'all']) }}"
+                        title="All Requests"
+                        url='requests?total=true'
+                    ></counter-card>
+                @endcan
+            </counter-card-group>
+            <advanced-search ref="advancedSearch" type="requests" :permission="{{ Auth::user()->hasPermissionsFor('users', 'groups') }}" :param-status="status" :param-requester="requester" @change="onChange" @submit="onSearch"></advanced-search>
             <requests-listing ref="requestList" :filter="filter" :pmql="pmql"></requests-listing>
         </div>
     </div>

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -151,8 +151,7 @@ class RequestTest extends TestCase
             'status' => 'CANCELED',
         ]);
 
-        $response = $this->webCall('GET', '/requests/completed');
-        $crawler = new Crawler($response->getContent());
-        $this->assertContains('2', trim($crawler->filter('.bg-primary h1')->first()->text()));
+        $response = $this->apiCall('GET', '/requests?total=true&pmql=(status = "Completed")');
+        $response->assertJson(['meta' => ['total' => 2]]);
     }
 }


### PR DESCRIPTION
## Changes
- Fixes an issue where counts displayed at the top of the Requests index page could be inaccurate
  - Utilizes same code as Requests API and Saved Searches to return counts
    - Returns counts asynchronously via API rather than on page load, increasing page load speed
    - Streamlines API calls to only return the total amount and not the entire data set
  - Refactors counter cards as Vue components

## Closes
- https://processmaker.atlassian.net/browse/FOUR-3260
- https://processmaker.atlassian.net/browse/FOUR-3261