### PR TITLE
Fix ability for Requester to claim Self Service Tasks when assigned or in a assigned group

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -71,7 +71,7 @@ class Task extends ApiResource
          * @deprecated since 4.1 Use instead `/api/1.0/users`
          */
         
-         // Used to assign users for self service tasks
+         // Used to retrieve the assignable users for self service tasks
         if (in_array('assignableUsers', $include)) {
             $definition = $this->getDefinition();
             $assignment = $definition['assignment'];

--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -70,14 +70,27 @@ class Task extends ApiResource
         /**
          * @deprecated since 4.1 Use instead `/api/1.0/users`
          */
+        
+         // Used to assign users for self service tasks
         if (in_array('assignableUsers', $include)) {
-            $currentUser = \Auth::user();
-            $users = User::where('status', 'ACTIVE')
-                ->where('id', '!=', $currentUser->id)
-                ->where('is_system', 'false')
-                ->limit(100)
-                ->get();
-            $array['assignable_users'] = $users;
+            $definition = $this->getDefinition();
+            $assignment = $definition['assignment'];
+            $users = [];
+            if ($assignment == 'self_service') {
+                $selfServiceUsers = $array['self_service_groups']['users'];
+                $selfServiceGroups = $array['self_service_groups']['groups'];
+
+                if ($selfServiceUsers !== [""]) {
+                    $assignedUsers = $this->getAssignedUsers($selfServiceUsers);
+                    $users = array_unique(array_merge($users, $assignedUsers));
+                }
+
+                if ($selfServiceGroups !== [""]) {
+                    $assignedUsers = $this->getAssignedGroupMembers($selfServiceGroups);
+                    $users = array_unique(array_merge($users, $assignedUsers));
+                }
+            } 
+            $array['assignable_users'] = $users;   
         }
         return $array;
     }
@@ -92,5 +105,24 @@ class Task extends ApiResource
         unset($userData['remember_token']);
 
         return array_merge($data, ['_user' => $userData]);
+    }
+
+    private function getAssignedUsers($users)
+    {
+        foreach($users as $user) {
+            $assignedUsers[] = User::where('status', 'ACTIVE')->where('id', $user)->first();
+        }
+        return $assignedUsers;
+    }
+
+    private function getAssignedGroupMembers($groups)
+    {
+        foreach($groups as $group) {
+            $groupMembers = GroupMember::where('group_id', $group)->get();
+            foreach ($groupMembers as $member) {
+                $assignedUsers[] = User::where('status', 'ACTIVE')->where('id', $member->member_id)->first();
+            }
+        }
+        return $assignedUsers;
     }
 }


### PR DESCRIPTION
**Jira Ticket**

https://processmaker.atlassian.net/browse/FOUR-3106

The `assignableUsers` was deprecated in [PR 3704](https://github.com/ProcessMaker/processmaker/pull/3704) for setting the 'Reassign to' user dropdown, however, `assignableUsers` is still being used to retrieve the users that can claim a self-service task.

<h2>Changes</h2>

- Remove the deprecated code for setting the 'Reassign to' users dropdown that also affected the assignable users for claiming a self-service task. This code prevented the 'Requester' from claiming a task if they were assigned as a self-service user or a member within an assigned group.
- Retrieve all active assigned users and group members, including the 'Requester' when Self Service is enabled.


**Video**

https://www.loom.com/share/b38807aab23d4bbdb6a59e79e77570d3
