### PR TITLE
Add missing GroupMember Class

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -6,6 +6,7 @@ use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\Users;
 use ProcessMaker\Models\User;
 use ProcessMaker\Http\Resources\Screen as ScreenResource;
+use ProcessMaker\Models\GroupMember;
 use StdClass;
 
 class Task extends ApiResource


### PR DESCRIPTION
<h2>Changes</h2>

PR [3810](https://github.com/ProcessMaker/processmaker/pull/3810) was missing declaration for the `GroupMember` class causing an error when trying to claim a self-service task. This PR adds the missing class.