### PR TITLE
Return the entire payload when mapped value is blank

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -216,7 +216,11 @@ trait MakeHttpRequests
 
         if (isset($config['dataMapping'])) {
             foreach ($config['dataMapping'] as $map) {
-                $value = Arr::get($merged, $map['value'], '');
+                if ($map['value']) {
+                    $value = Arr::get($merged, $map['value'], '');
+                } else {
+                    $value = $content;
+                }
                 Arr::set($mapped, $map['key'], $value);
             }
         }


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3407

The UI says that if you leave the "Source" field blank in the output setting, the entire returned payload should be put into the Form Variable. It was putting a bunch of other stuff in there too, including the form data for some reason. This fixes that.