### PR TITLE
Fix Search Group Users

### DIFF
--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -83,7 +83,7 @@
                                 <div class="flex-grow-1">
                                     <div id="search" class="mb-3 mb-md-0">
                                         <div class="input-group w-100">
-                                            <input v-model="filter" class="form-control" placeholder="{{__('Search')}}">
+                                            <input v-model="usersFilter" class="form-control" placeholder="{{__('Search')}}">
                                             <div class="input-group-append">
                                                 <button type="button" class="btn btn-primary" data-original-title="Search"><i class="fas fa-search"></i></button>
                                             </div>
@@ -99,7 +99,7 @@
                                 </div>
                             </div>
                         </div>
-                        <users-in-group ref="listing" :filter="filter" :group-id="formData.id"></users-in-group>
+                        <users-in-group ref="listing" :filter="usersFilter" :group-id="formData.id"></users-in-group>
                     </div>
                     <div class="card card-body border-top-0 tab-pane p-3" id="nav-groups" role="tabpanel" aria-labelledby="nav-profile-tab">
                         <div id="search-bar" class="search mb-3" vcloak>
@@ -107,7 +107,7 @@
                                 <div class="flex-grow-1">
                                     <div id="search" class="mb-3 mb-md-0">
                                         <div class="input-group w-100">
-                                            <input v-model="filter" class="form-control" placeholder="{{__('Search')}}">
+                                            <input v-model="groupsFilter" class="form-control" placeholder="{{__('Search')}}">
                                             <div class="input-group-append">
                                                 <button type="button" class="btn btn-primary" data-original-title="Search"><i class="fas fa-search"></i></button>
                                             </div>
@@ -123,7 +123,7 @@
                                 </div>
                             </div>
                         </div>
-                        <groups-in-group ref="groupListing" :filter="filter" :group-id="formData.id"></groups-in-group>
+                        <groups-in-group ref="groupListing" :filter="groupsFilter" :group-id="formData.id"></groups-in-group>
                     </div>
                     <div class="card card-body border-top-0 tab-pane p-3" id="nav-permissions" role="tabpanel" aria-labelledby="nav-permissions">
                         <div class="accordion" id="accordionPermissions">
@@ -274,7 +274,8 @@
           return {
             showAddUserModal: false,
             formData: @json($group),
-            filter: '',
+            usersFilter: '',
+            groupsFilter: '',
             errors: {
               'name': null,
               'description': null,


### PR DESCRIPTION
**Jira Ticket**
https://processmaker.atlassian.net/browse/FOUR-3327

<h2>Changes</h2>

The `users-in-group` and `groups-in-group` components were sharing the same `filter` variable. This clashed with each other and prevented the `users-in-group` search from properly filtering the data. This PR separates the shared `filter` variable and creates a unique variable for each of the components. 

**Video**


https://user-images.githubusercontent.com/52755494/120718419-14dec800-c47e-11eb-806b-a0cd4cb0849c.mov

