### PR TITLE
Allow packages to use a custom component to add to settings

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/SettingsController.php
+++ b/ProcessMaker/Http/Controllers/Admin/SettingsController.php
@@ -5,9 +5,12 @@ namespace ProcessMaker\Http\Controllers\Admin;
 use Illuminate\Http\Request;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Models\Setting;
+use ProcessMaker\Traits\HasControllerAddons;
 
 class SettingsController extends Controller
 {
+    use HasControllerAddons;
+
     /**
      * Get the list of settings.
      *
@@ -16,7 +19,8 @@ class SettingsController extends Controller
     public function index()
     {
         if (Setting::notHidden()->count()) {
-            return view('admin.settings.index');
+            $addons = $this->getPluginAddons('index', []);
+            return view('admin.settings.index', compact('addons'));
         } else {
             abort(404);
         }

--- a/ProcessMaker/Http/Controllers/Api/PermissionController.php
+++ b/ProcessMaker/Http/Controllers/Api/PermissionController.php
@@ -20,6 +20,22 @@ class PermissionController extends Controller
     public $doNotSanitize = [
        //
     ];
+
+    /**
+     * List permissions
+     *
+     * @param Request $request
+     *
+     * @return Response
+     * 
+     */
+    public function index(Request $request)
+    {
+        $all_permissions = Permission::all();
+        return $all_permissions->sortBy('title')->groupBy('group')->sortKeys();
+    }
+
+
     /**
      * Update permissions
      *

--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -32,7 +32,9 @@
           <b-form-text v-if="row.item.helper">{{ $t(row.item.helper) }}</b-form-text>
         </template>
         <template v-slot:cell(config)="row">
-          <component v-if="row.item" :ref="`settingComponent_${row.index}`" :is="component(row.item)" @saved="onChange" v-model="row.item.config" :setting="settings[row.index]"></component>
+          <keep-alive>
+            <component v-if="row.item" :ref="`settingComponent_${row.index}`" :is="component(row.item)" @saved="onChange" v-model="row.item.config" :setting="settings[row.index]"></component>
+          </keep-alive>
         </template>
         <template v-slot:cell(actions)="row">
           <template v-if="row.item && row.item.format !== 'boolean'">
@@ -211,6 +213,8 @@ export default {
           if (setting.ui && setting.ui.format && setting.ui.format == 'screen') {
             return `setting-screen`;
           }
+        case 'component':
+          return window['__setting_component_' + setting.ui.component];
         default:
           return 'setting-text-area';
       }

--- a/routes/api.php
+++ b/routes/api.php
@@ -110,6 +110,7 @@ Route::group(
     Route::delete('process_categories/{process_category}', 'ProcessCategoryController@destroy')->name('process_categories.destroy')->middleware('can:delete-process-categories');
 
     // Permissions
+    Route::get('permissions', 'PermissionController@index')->name('permissions.index');
     Route::put('permissions', 'PermissionController@update')->name('permissions.update')->middleware('can:edit-users');
 
     // Tasks


### PR DESCRIPTION
Fixes part of https://processmaker.atlassian.net/browse/FOUR-3392

- Allows custom components to be used for settings
- Allows those custom components to be loaded from a package via addons
- Adds an endpoint to get all permissions