### PR TITLE
Add support for IN and NOT IN operators for value aliases

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -594,7 +594,14 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
     public function valueAliasRequest($value, $expression)
     {
         return function ($query) use ($value, $expression) {
-            $processes = Process::where('name', $expression->operator, $value)->get();
+            if ($expression->operator === 'IN') {
+                $processes = Process::whereIn('name', $value)->get();
+
+            } elseif ($expression->operator === 'NOT IN') {
+                $processes = Process::whereNotIn('name', $value)->get();
+            } else {
+                $processes = Process::where('name', $expression->operator, $value)->get();
+            }
             $query->whereIn('process_id', $processes->pluck('id'));
         };
     }

--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -55,6 +55,8 @@ trait ExtendedPMQL
             // Check the type of our value; set as string if possible
             if (is_a($expression->value, 'ProcessMaker\\Query\\LiteralValue')) {
                 $value = $expression->value->value();
+            } elseif (is_a($expression->value, 'ProcessMaker\\Query\\ArrayValue')) {
+                $value = $expression->value->value();
             } else {
                 $value = $expression->value;
             }

--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -85,7 +85,7 @@ trait ExtendedPMQL
                         $expression->setOperator('='); 
 
                         foreach ($value as $v) {
-                            if($originalOperator === 'IN') {
+                            if($originalOperator === Expression::OPERATOR_IN) {
                                 $query->orWhere(
                                     $model->{$method}($v, $expression, $builder, $user)
                                 );


### PR DESCRIPTION
Fixes part of https://processmaker.atlassian.net/browse/FOUR-3078

- This allows us to use IN and NOT IN operators without modifying the valueAlias* methods