### PR TITLE
Verify if user or group is set to add a process to the start list

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -817,10 +817,10 @@ class Process extends Model implements HasMedia, ProcessModelInterface
         // Filter the start events assigned to the user
         $response = [];
         foreach ($this->start_events as $startEvent) {
-            if (isset($startEvent['assignment']) && $startEvent['assignment'] === 'user') {
+            if (isset($startEvent['assignment']) && $startEvent['assignment'] === 'user' && isset($startEvent['assignedUsers'])) {
                 $users = explode(',', $startEvent['assignedUsers']);
                 $access = in_array($user->id, $users);
-            } elseif (isset($startEvent['assignment']) && $startEvent['assignment'] === 'group') {
+            } elseif (isset($startEvent['assignment']) && $startEvent['assignment'] === 'group' && isset($startEvent['assignedGroups'])) {
                 $access = false;
                 foreach (explode(',', $startEvent['assignedGroups']) as $groupId) {
                     $access = $this->doesUserBelongsGroup($user->id, $groupId);


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2723](https://processmaker.atlassian.net/browse/FOUR-2723)

The issue was replicated in release testing along because it was needed that at least one process (of all the list of processes in the database) to be configured with start permissions as user (or group) and let the user/group empty.


![image](https://user-images.githubusercontent.com/14875032/121746324-b647c880-cad3-11eb-9324-c248f9f38c27.png)
