### PR TITLE
Move breadcrumbs into navbar component

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -60,36 +60,6 @@ window.ProcessMaker.nodeTypes.get = function (id) {
   return this.find(node => node.id === id);
 };
 
-// Setup breadcrumbs as a Vue component so that we can cloak it until Vue
-// has finished loading.
-
-if (document.getElementById("breadcrumbs")) {
-  window.ProcessMaker.breadcrumbs = new Vue({
-    el: '#breadcrumbs',
-    data () {
-      return {
-        taskTitle: '',
-      };
-    },
-    methods: {
-      getRoutes() {
-        if (this.$refs.breadcrumbs) {
-          return this.$refs.breadcrumbs.list;
-        } else {
-          return [];
-        }
-      },
-      setRoutes(routes) {
-        if (this.$refs.breadcrumbs) {
-          return this.$refs.breadcrumbs.updateRoutes(routes);
-        } else {
-          return false;
-        }
-      }
-    }
-  });
-}
-
 // Assign our navbar component to our global ProcessMaker object
 window.ProcessMaker.navbar = new Vue({
   el: "#navbar",
@@ -119,7 +89,8 @@ window.ProcessMaker.navbar = new Vue({
       sessionTitle: "",
       sessionMessage: "",
       sessionTime: "",
-      sessionWarnSeconds: ""
+      sessionWarnSeconds: "",
+      taskTitle: "",
     };
   },
   methods: {
@@ -148,6 +119,18 @@ window.ProcessMaker.navbar = new Vue({
     saveLocalAlerts (array) {
       const nextScreenAlerts = array.filter(alert => alert.stayNextScreen);
       window.localStorage.processmakerAlerts = JSON.stringify(nextScreenAlerts);
+    },
+    getRoutes () {
+      if (this.$refs.breadcrumbs) {
+        return this.$refs.breadcrumbs.list;
+      }
+      return [];
+    },
+    setRoutes (routes) {
+      if (this.$refs.breadcrumbs) {
+        return this.$refs.breadcrumbs.updateRoutes(routes);
+      }
+      return false;
     }
   },
   mounted () {
@@ -162,6 +145,9 @@ window.ProcessMaker.navbar = new Vue({
       });
   }
 });
+
+// Breadcrumbs are now part of the navbar component. Alias it here.
+window.ProcessMaker.breadcrumbs = window.ProcessMaker.navbar;
 
 // Set our own specific alert function at the ProcessMaker global object that could
 // potentially be overwritten by some custom theme support

--- a/resources/js/components/Breadcrumbs.vue
+++ b/resources/js/components/Breadcrumbs.vue
@@ -1,6 +1,6 @@
 <template>
     <nav aria-label="breadcrumb">
-        <ol class="breadcrumb border-top border-bottom">
+        <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/"><i class="fas fa-home"></i></a></li>
             <li v-for="(route, index) in list" class="breadcrumb-item" :class="{active: isActive(index)}" :key="index">
               <router-link v-if="route.router" :to="route.link" v-slot="{ href, navigate }">

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -77,12 +77,11 @@
   <div id="sidebar" class="d-print-none" :class="{expanded: expanded}">
       @yield('sidebar')
   </div>
-  <div class="d-flex flex-grow-1 flex-column">
+  <div class="d-flex flex-grow-1 flex-column overflow-hidden">
     <div class="flex-grow-1">
         @include('layouts.navbar')
     </div>
     <div class="flex-grow-1 d-flex flex-column overflow-hidden h-100" id="mainbody">
-      @yield('breadcrumbs')
       <div class="main flex-grow-1 h-100 overflow-auto {{$content_margin ?? 'py-3'}}">
         @yield('content')
       </div>

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -1,13 +1,14 @@
-<b-navbar id="navbar" v-cloak toggleable="lg" type="light" variant="light" class="d-print-none">
+<div id="navbar">
+<b-navbar id="navbar1" v-cloak toggleable="lg" type="light" variant="light" class="d-print-none">
     <div class="d-flex d-lg-none w-100">
         @php
             $loginLogo = \ProcessMaker\Models\Setting::getLogin();
         @endphp
         <b-navbar-brand href="#" class="d-lg-none pl-2"><img class="navbar-logo" src={{$loginLogo}}></b-navbar-brand>
-        <b-navbar-toggle class="ml-auto" target="nav_collapse"></b-navbar-toggle>
+        <b-navbar-toggle class="ml-auto" :target="['nav-collapse', 'breadcrumbs-collapse']"></b-navbar-toggle>
     </div>
 
-    <b-collapse is-nav id="nav_collapse">
+    <b-collapse is-nav id="nav-collapse">
         <confirmation-modal class="d-none d-lg-block" id="confirmModal" v-if='confirmShow' :title="confirmTitle" :message="confirmMessage"
                             :variant="confirmVariant" :callback="confirmCallback"
                             @close="confirmShow=false">
@@ -117,6 +118,16 @@
         </b-navbar-nav>
     </b-collapse>
 </b-navbar>
+
+
+<b-navbar id="navbar2" v-cloak toggleable="lg" type="light" variant="light" class="p-0 d-print-none">
+    <b-collapse is-nav id="breadcrumbs-collapse" class="border-top border-bottom">
+        @yield('breadcrumbs')
+    </b-collapse>
+</b-navbar>
+
+
+</div>
 <style lang="scss" scoped>
     .separator {
         border-right: 1px solid rgb(227, 231, 236);

--- a/resources/views/shared/breadcrumbs.blade.php
+++ b/resources/views/shared/breadcrumbs.blade.php
@@ -1,7 +1,7 @@
-<div id="breadcrumbs" class="d-print-none" v-cloak>
+<div id="breadcrumbs">
     @if (!isset($dynamic))
         <nav aria-label="breadcrumb">
-            <ol class="breadcrumb border-top border-bottom">
+            <ol class="breadcrumb">
                 <li class="breadcrumb-item"><a href="/"><i class="fas fa-home"></i></a></li>
                 @foreach($routes as $title => $link)
                     @php


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2335

- Moves breadcrumbs into navbar so it's hidden by default on mobile
- Brings back necessary overflow-hidden from https://github.com/ProcessMaker/processmaker/commit/65c176dc2619e3e2a7da75337bf1363d2e5ecd23#diff-8a78110b49caab98f3f9257488caad23dc1b9401c91ecf7eca7a747606be73fdL80 (Dante is working on another solution)