### PR TITLE
FOUR-3598 (for dev branch): In many servers requests are blocked by the process_request_locks table

### DIFF
--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -38,7 +38,7 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
 
     /**
      * Removes from the process_request_lock table all locks that are active more
-     * time that the threshold defined in with MAX_REQUEST_LOCK_MINUTES env. variable
+     * time that the threshold configured with BPMN_ACTIONS_MAX_LOCK_TIME env. variable
      */
     private function removeExpiredLocks()
     {

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -20,6 +20,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\EventBasedGatewayInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\GatewayInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\ServiceTaskInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\StartEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ThrowEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
@@ -471,6 +472,10 @@ class TokenRepository implements TokenRepositoryInterface
     {
         if ($activity instanceof  ScriptTaskInterface) {
             return 'scriptTask';
+        }
+
+        if ($activity instanceof  ServiceTaskInterface) {
+            return 'serviceTask';
         }
 
         if ($activity instanceof  CallActivityInterface) {


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-3598](https://processmaker.atlassian.net/browse/FOUR-3598)

- Stores service task activities with the correct label "serviceTask" in the process_request_tokens table
- Support to retry service tasks when the command  processmaker:retry-script-tasks   is run
- Remove lock from requests that are blocked for more time than the configured by the environment variable BPMN_ACTIONS_MAX_LOCK_TIME