### PR TITLE
Fix request locks

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -43,6 +43,7 @@ use ProcessMaker\Traits\HideSystemResources;
  * @property Process $process
  * @property ProcessRequestLock[] $locks
  * @method static ProcessRequest find($id)
+ * @method static ProcessRequest findOrFail($id)
  *
  * @OA\Schema(
  *   schema="processRequestEditable",
@@ -757,23 +758,27 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
      *
      * @return ProcessRequestLock
      */
-    public function lock($tokenId)
+    public function requestLock($tokenId)
     {
         return $this->locks()->create(['process_request_token_id' => $tokenId]);
     }
 
+    /**
+     * @return void
+     */
     public function unlock()
     {
-        $first = $this->locks()->orderBy('id')->first();
-        if ($first) {
-            $first->delete();
-        }
+        $this->locks()->whereNotNull('due_at')->delete();
     }
 
-    public function hasLock(ProcessRequestLock $lock)
+    /**
+     * Get current lock for $this request
+     *
+     * @return ProcessRequestLock
+     */
+    public function currentLock()
     {
-        $first = $this->locks()->orderBy('id')->first();
-        return !$first || $first->getKey() === $lock->getKey();
+        return $this->locks()->whereNotDue()->orderBy('id')->limit(1)->first();
     }
 
     /**

--- a/ProcessMaker/Models/ProcessRequestLock.php
+++ b/ProcessMaker/Models/ProcessRequestLock.php
@@ -30,10 +30,40 @@ class ProcessRequestLock extends Model
         'id',
         'created_at',
         'updated_at',
+        'due_at',
+    ];
+
+    protected $casts = [
+        'due_at' => 'datetime',
     ];
 
     public function processRequest()
     {
         return $this->belongsTo(ProcessRequest::class);
+    }
+
+    /**
+     * Active block that did not overcome.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWhereNotDue($query)
+    {
+        return $query->where(function ($query) {
+            $numSeconds = config('app.bpmn_actions_max_lock_time', 1) ?: 60;
+            return $query->whereNull('due_at')
+            ->whereOr('due_at', '<', now()->modify("+{$numSeconds} seconds"));
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function activate()
+    {
+        $numSeconds = config('app.bpmn_actions_max_lock_time', 1) ?: 60;
+        $this->due_at = now()->modify(now()->modify("+{$numSeconds} seconds"));
+        $this->save();
     }
 }

--- a/database/migrations/2021_06_28_115443_add_due_at_process_request_locks.php
+++ b/database/migrations/2021_06_28_115443_add_due_at_process_request_locks.php
@@ -18,9 +18,6 @@ class AddDueAtProcessRequestLocks extends Migration
         Schema::connection($model->getConnectionName())->table('process_request_locks', function (Blueprint $table) {
             $table->datetime('due_at')->nullable();
             $table->index(['id', 'process_request_id', 'due_at']);
-            $table->foreign('process_request_id')
-            ->references('id')->on('process_requests')
-            ->onDelete('cascade');
         });
     }
 
@@ -35,7 +32,6 @@ class AddDueAtProcessRequestLocks extends Migration
         Schema::connection($model->getConnectionName())->table('process_request_locks', function (Blueprint $table) {
             $table->dropColumn('due_at');
             $table->dropIndex(['id', 'process_request_id', 'due_at']);
-            $table->dropForeign(['process_request_id']);
         });
     }
 }

--- a/database/migrations/2021_06_28_115443_add_due_at_process_request_locks.php
+++ b/database/migrations/2021_06_28_115443_add_due_at_process_request_locks.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDueAtProcessRequestLocks extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('process_request_locks', function (Blueprint $table) {
+            $table->datetime('due_at')->nullable();
+            $table->index(['id', 'process_request_id', 'due_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('process_request_locks', function (Blueprint $table) {
+            $table->dropColumn('due_at');
+            $table->dropIndex(['id', 'process_request_id', 'due_at']);
+        });
+    }
+}

--- a/database/migrations/2021_06_28_115443_add_due_at_process_request_locks.php
+++ b/database/migrations/2021_06_28_115443_add_due_at_process_request_locks.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use ProcessMaker\Models\ProcessRequest;
 
 class AddDueAtProcessRequestLocks extends Migration
 {
@@ -13,9 +14,13 @@ class AddDueAtProcessRequestLocks extends Migration
      */
     public function up()
     {
-        Schema::table('process_request_locks', function (Blueprint $table) {
+        $model = new ProcessRequest();
+        Schema::connection($model->getConnectionName())->table('process_request_locks', function (Blueprint $table) {
             $table->datetime('due_at')->nullable();
             $table->index(['id', 'process_request_id', 'due_at']);
+            $table->foreign('process_request_id')
+            ->references('id')->on('process_requests')
+            ->onDelete('cascade');
         });
     }
 
@@ -26,9 +31,11 @@ class AddDueAtProcessRequestLocks extends Migration
      */
     public function down()
     {
-        Schema::table('process_request_locks', function (Blueprint $table) {
+        $model = new ProcessRequest();
+        Schema::connection($model->getConnectionName())->table('process_request_locks', function (Blueprint $table) {
             $table->dropColumn('due_at');
             $table->dropIndex(['id', 'process_request_id', 'due_at']);
+            $table->dropForeign(['process_request_id']);
         });
     }
 }

--- a/tests/Feature/RequestLockTest.php
+++ b/tests/Feature/RequestLockTest.php
@@ -65,4 +65,26 @@ class RequestLockTest extends TestCase
         $this->assertCount(2, $locksInQueue);
         $this->assertCount(1, $locksActive);
     }
+
+    public function testActivateLocksThenUnlock()
+    {
+        $request = factory(ProcessRequest::class)->create();
+        $tokenId = null;
+        $lock1 = $request->requestLock($tokenId);
+        $lock2 = $request->requestLock($tokenId);
+        $request->unlock();
+        $lock1->activate();
+        $request->unlock();
+        $locksInQueue = $request->locks()->get();
+        $locksActive = $request->locks()->whereNotNull('due_at')->get();
+        $this->assertCount(1, $locksInQueue);
+        $this->assertCount(0, $locksActive);
+
+        $lock2->activate();
+        $request->unlock();
+        $locksInQueue = $request->locks()->get();
+        $locksActive = $request->locks()->whereNotNull('due_at')->get();
+        $this->assertCount(0, $locksInQueue);
+        $this->assertCount(0, $locksActive);
+    }
 }

--- a/tests/Feature/RequestLockTest.php
+++ b/tests/Feature/RequestLockTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use ProcessMaker\Models\ProcessRequest;
+use Tests\TestCase;
+
+class RequestLockTest extends TestCase
+{
+    public function testExitJobWithoutUnlock()
+    {
+        $request = factory(ProcessRequest::class)->create();
+        $tokenId = null;
+        $request->requestLock($tokenId);
+        $locks = $request->locks()->get();
+        $this->assertCount(1, $locks);
+        $this->assertNull($locks[0]->due_at);
+    }
+
+    public function testCurrentLock()
+    {
+        $request = factory(ProcessRequest::class)->create();
+        $tokenId = null;
+        $request->requestLock($tokenId);
+        $currentLock = $request->currentLock();
+        $this->assertNotNull($currentLock);
+        $this->assertNull($currentLock->due_at);
+    }
+
+    public function testRequestLockInParallel()
+    {
+        $request = factory(ProcessRequest::class)->create();
+        $tokenId = null;
+        $lock = $request->requestLock($tokenId);
+        $request->requestLock($tokenId);
+        $currentLock = $request->currentLock();
+        $this->assertNotNull($currentLock);
+        $this->assertNull($currentLock->due_at);
+        $this->assertEquals($lock->id, $currentLock->id);
+    }
+
+    public function testUnlock()
+    {
+        $request = factory(ProcessRequest::class)->create();
+        $tokenId = null;
+        $request->requestLock($tokenId);
+        $request->requestLock($tokenId);
+        $request->unlock();
+        $locksInQueue = $request->locks()->get();
+        $locksActive = $request->locks()->whereNotNull('due_at')->get();
+        $this->assertCount(2, $locksInQueue);
+        $this->assertCount(0, $locksActive);
+    }
+
+    public function testActivateLock()
+    {
+        $request = factory(ProcessRequest::class)->create();
+        $tokenId = null;
+        $lock = $request->requestLock($tokenId);
+        $request->requestLock($tokenId);
+        $request->unlock();
+        $lock->activate();
+        $locksInQueue = $request->locks()->get();
+        $locksActive = $request->locks()->whereNotNull('due_at')->get();
+        $this->assertCount(2, $locksInQueue);
+        $this->assertCount(1, $locksActive);
+    }
+}


### PR DESCRIPTION
This PR includes:

- Catch exceptions while executing a Request, and log the errors in the Request
- Prevent infinite lock, implement `config('app.bpmn_actions_max_lock_time')` per BPMN element lock and lock retries
