### PR TITLE
Fix CallActivity execution when subprocess is modified

### DIFF
--- a/tests/Feature/Api/processes/child-with-form-task.bpmn
+++ b/tests/Feature/Api/processes/child-with-form-task.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="node_9" name="End Event" pm:screenRef="">
+      <bpmn:incoming>node_6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="node_2" name="w2" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="user_group" pm:assignedUsers="2" pm:assignedGroups="" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_4</bpmn:incoming>
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_4" name="" sourceRef="node_1" targetRef="node_2" />
+    <bpmn:sequenceFlow id="node_6" name="" sourceRef="node_2" targetRef="node_9" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="130" y="120" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="440" y="120" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="260" y="110" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_4_di" bpmnElement="node_4">
+        <di:waypoint x="148" y="138" />
+        <di:waypoint x="318" y="148" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="318" y="148" />
+        <di:waypoint x="458" y="138" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Related: https://processmaker.atlassian.net/browse/SCO-8636

This PR fix:

- CallActivity was loading and listening events for the latest version of the subprocess always not the version at which it was started.
