### PR TITLE
FOUR-3612: Review and improve sql query request_user_permissions

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -392,10 +392,13 @@ class User extends Authenticatable implements HasMedia
     public function updatePermissionsToRequests()
     {
         // Update existing request_user_permissions
-        $permissions = RequestUserPermission::with('request')->whereHas('request', function ($query) {
-            $query->where('request_user_permissions.user_id', $this->getKey());
-            $query->whereRaw('process_requests.updated_at > request_user_permissions.updated_at');
-        })->get();
+        $permissions = RequestUserPermission::with('request')
+            ->select('request_user_permissions.*')
+            ->leftJoin('process_requests', 'request_user_permissions.request_id', '=', 'process_requests.id')
+            ->where('request_user_permissions.user_id', $this->getKey())
+            ->whereRaw('process_requests.updated_at > request_user_permissions.updated_at')
+            ->get();
+
         foreach ($permissions as $permission) {
             $permission->can_view = $this->can('view', $permission->request);
             $permission->save();


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-3612](https://processmaker.atlassian.net/browse/FOUR-3612)

The query was modified to use a join and the user_id index to avoid the subquery that usually is slower
Before the modification the MySql planner didn't use the user_index:

![image](https://user-images.githubusercontent.com/14875032/123810594-87e22f80-d8c0-11eb-91e3-ff37d7ff996a.png)

After the modification the index is used:
![image](https://user-images.githubusercontent.com/14875032/123810628-8f093d80-d8c0-11eb-8621-c4b5c8b45fa2.png)

