### PR TITLE
Add onOneServer to all commands

### DIFF
--- a/ProcessMaker/Console/Kernel.php
+++ b/ProcessMaker/Console/Kernel.php
@@ -30,11 +30,11 @@ class Kernel extends ConsoleKernel
         $schedule->call(function() {
             $scheduleManager = new TaskSchedulerManager();
             $scheduleManager->scheduleTasks();
-        })->everyMinute();
+        })->everyMinute()->onOneServer();
         $schedule->call(function() {
             $scheduleManager = new TaskSchedulerManager();
             $scheduleManager->evaluateConditionals();
-        })->everyMinute();
+        })->everyMinute()->onOneServer();
     }
 
     /**


### PR DESCRIPTION
This change is for High Availability configurations with clustering. The first server to obtain the task will secure an atomic lock on the job to prevent other servers from running the same task at the same time.

https://laravel.com/docs/6.x/scheduling#running-tasks-on-one-server