### PR TITLE
Return initial data when no token is available (WebEntry StartEvent)

### DIFF
--- a/ProcessMaker/Managers/DataManager.php
+++ b/ProcessMaker/Managers/DataManager.php
@@ -78,6 +78,7 @@ class DataManager
      *
      * @param array $data
      * @param ProcessRequestToken $token
+     *
      * @return array
      */
     private function loadUserData(array $data = [], ProcessRequestToken $token = null)
@@ -98,6 +99,7 @@ class DataManager
      * @param array $data
      * @param ProcessRequestToken|null $token
      * @param boolean $whenTokenSaved
+     *
      * @return array
      */
     private function loadTokenData(array $data = [], ProcessRequestToken $token = null, bool $whenTokenSaved = false)

--- a/ProcessMaker/Managers/DataManager.php
+++ b/ProcessMaker/Managers/DataManager.php
@@ -58,12 +58,49 @@ class DataManager
     /**
      * Get data for the $token
      *
-     * @param ProcessRequestToken $token
+     * @param ProcessRequestToken|null $token
      * @param bool $whenTokenSaved If true returns the Request Data as when the Token was saved
      *
      * @return array
      */
-    public function getData(ProcessRequestToken $token, bool $whenTokenSaved = false)
+    public function getData(ProcessRequestToken $token = null, bool $whenTokenSaved = false)
+    {
+        $data = [];
+        $data = $this->loadUserData($data, $token);
+        if ($token) {
+            $data = $this->loadTokenData($data, $token, $whenTokenSaved);
+        }
+        return $data;
+    }
+
+    /**
+     * Load magic variable _user 
+     *
+     * @param array $data
+     * @param ProcessRequestToken $token
+     * @return array
+     */
+    private function loadUserData(array $data = [], ProcessRequestToken $token = null)
+    {
+        // Magic Variable: _user
+        $user = $token && $token->user ? $token->user : Auth::user();
+        if ($user) {
+            $userData = $user->attributesToArray();
+            unset($userData['remember_token']);
+            $data['_user'] = $userData;
+        }
+        return $data;
+    }
+
+    /**
+     * Load data that $token can see in the $request
+     *
+     * @param array $data
+     * @param ProcessRequestToken|null $token
+     * @param boolean $whenTokenSaved
+     * @return array
+     */
+    private function loadTokenData(array $data = [], ProcessRequestToken $token = null, bool $whenTokenSaved = false)
     {
         if ($token->isMultiInstance()) {
             $data = $token->getProperty('data', ($token->token_properties ?? [])['data'] ?? []) ?: [];

--- a/tests/Feature/DataManagerTest.php
+++ b/tests/Feature/DataManagerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Hash;
+use PermissionSeeder;
+use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Managers\DataManager;
+use ProcessMaker\Models\Group;
+use ProcessMaker\Models\GroupMember;
+use ProcessMaker\Models\Permission;
+use ProcessMaker\Models\PermissionAssignment;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\User;
+use ProcessMaker\Providers\WorkflowServiceProvider;
+use Tests\Feature\Shared\RequestHelper;
+use ProcessMaker\Providers\AuthServiceProvider;
+use Tests\TestCase;
+
+/**
+ * Test edit data
+ */
+class DataManagerTest extends TestCase
+{
+    use RequestHelper;
+    
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Creates an admin user
+        $this->admin = factory(User::class)->create([
+            'password' => Hash::make('password'),
+            'is_administrator' => true,
+        ]);
+
+        // Creates an user
+        $this->user = factory(User::class)->create([
+            'password' => Hash::make('password'),
+            'is_administrator' => false,
+        ]);
+
+        // Create a group
+        $this->group = factory(Group::class)->create(['name' => 'group']);
+        factory(GroupMember::class)->create([
+            'member_id' => $this->user->id,
+            'member_type' => User::class,
+            'group_id' => $this->group->id,
+        ]);
+
+        //Run the permission seeder
+        (new PermissionSeeder)->run();
+
+        // Reboot our AuthServiceProvider. This is necessary so that it can
+        // pick up the new permissions and setup gates for each of them.
+        $asp = new AuthServiceProvider(app());
+        $asp->boot();
+    }
+
+    /**
+     * Verify the magic variables for a valid request token
+     */
+    public function testDataForAValidRequestToken()
+    {
+        $manager = new DataManager();
+        $token = factory(ProcessRequestToken::class)->create();
+        $data = $manager->getData($token);
+        $user = $token->user;
+        $request = $token->processRequest;
+        $this->assertEquals($user->id, $data['_user']['id']);
+        $this->assertEquals($request->id, $data['_request']['id']);
+    }
+
+    /**
+     * Verify the magic variables for a valid webentry screen
+     */
+    public function testDataForAStartEventWebentry()
+    {
+        $manager = new DataManager();
+        $user = $this->user;
+        \Auth::login($this->user);
+        $data = $manager->getData(null);
+        $this->assertEquals($user->id, $data['_user']['id']);
+    }
+}


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-3457

This PR includes:
- Add test for DataManager
- Return magic variable `_user` when no token is available
