### PR TITLE
FOUR-2337: Start Conditional Event does not work 

### DIFF
--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -9,6 +9,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use PDOException;
@@ -549,7 +550,7 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
      */
     public function evaluateConditionals()
     {
-        $processes = Process::where('conditional_events', '!=', '[]')->get();
+        $processes = Process::where('conditional_events', '!=', DB::raw("json_array()"))->get();
         foreach ($processes as $process) {
             StartEventConditional::dispatchNow($process);
         }


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2337](https://processmaker.atlassian.net/browse/FOUR-2337)

The condition to test if JSON column had and empty array has been fixed

Documentation for the conditions syntax has been added in 
https://docs.google.com/document/d/10J7f7351vGmv7UFvTI7oVwsHsynLg9qlkvBiNgfR1NY/edit?usp=sharing