### PR TITLE
Prevent submitting a task multiple times

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -256,6 +256,7 @@
           hasErrors: false,
           redirectInProcess: false,
           formData: {},
+          submitting: false,
         },
         watch: {
           task: {
@@ -434,8 +435,13 @@
             if (this.isSelfService) {
               ProcessMaker.alert(this.$t('Claim the Task to continue.'), 'warning');
             } else {
+              if (this.submitting) {
+                return;
+              }
+
               let message = this.$t('Task Completed Successfully');
               const taskId = task.id;
+              this.submitting = true;
               ProcessMaker.apiClient
               .put("tasks/" + taskId, {status:"COMPLETED", data: this.formData})
               .then(() => {
@@ -444,7 +450,9 @@
               .catch(error => {
                 // If there are errors, the user will be redirected to the request page
                 // to view error details. This is done in loadTask in Task.vue
-              });
+              }).finally(() => {
+                this.submitting = false;
+              })
             }
 
           },


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3631
Fixes https://processmaker.atlassian.net/browse/FOUR-3606

- Disable the submit functionality if the api call is still in progress