### PR TITLE
Fix _parent data for MultiInstance CallActivity

### DIFF
--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -64,12 +64,14 @@ class CallActivity implements CallActivityInterface
         $dataManager = new DataManager();
         $data = $dataManager->getData($token);
 
-        // Add info about parent
-        $data['_parent'] = [
-            'process_id' => $token->getInstance()->process_id,
-            'request_id' => $token->getInstance()->id,
-            'node_id' => $token->element_id,
-        ];
+        // Add info about parent (Note MultiInstance also adds _parent info)
+        if (!isset($data['_parent'])) {
+            $data['_parent'] = [];
+        }
+
+        $data['_parent']['process_id'] = $token->getInstance()->process_id;
+        $data['_parent']['request_id'] = $token->getInstance()->id;
+        $data['_parent']['node_id'] = $token->element_id;
 
         $configString = $this->getProperty('config');
         if ($configString) {


### PR DESCRIPTION
Resolves: https://processmaker.atlassian.net/browse/FOUR-3323

Fix `_parent` variable, before the fix MultiInstance SubProcesses did not receive the parent variables inside `_parent` as expected for MultiInstance.

Fixed example:
```
{
    "name": "bbb",
    "row_id": "bkqmc2hdxgdkr3nbmek",
    "_parent": {
        "users": [
            {
                "name": "aaa",
                "row_id": "ofqsst7l03kr3nbkv8"
            },
            {
                "name": "bbb",
                "row_id": "bkqmc2hdxgdkr3nbmek"
            },
            {
                "name": "ccc",
                "row_id": "1j9nxhu50l2kr3nboks"
            }
        ],
        "config": {
            "name": "Sub Process",
            "processId": 5,
            "startEvent": "node_1",
            "calledElement": "ProcessId-5"
        },
        "node_id": "node_6",
        "process_id": 6,
        "request_id": 1
    },
    "loopCounter": 2,
    "numberOfInstances": 3,
    "numberOfActiveInstances": 3,
    "numberOfCompletedInstances": 0
}
```