### PR TITLE
Show task form when uncliamed and disable submit

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1434,5 +1434,6 @@
   "All Request Data": "All Request Data",
   "No Request Data": "No Request Data",
   "Specify Request Variable": "Specify Data Variable",
-  "Specify Expression": "Specify Expression"
+  "Specify Expression": "Specify Expression",
+  "You must claim the task before you can complete it.": "You must claim the task before you can complete it."
 }

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -31,10 +31,17 @@
         <div class="d-flex flex-column flex-md-row">
             <div class="flex-grow-1">
                 <div v-if="isSelfService" class="alert alert-primary" role="alert">
-                    <button type="button" class="btn btn-primary" @click="claimTask">{{__('Claim Task')}}</button>
-                    {{__('This task is unassigned, click Claim Task to assign yourself.')}}
+                    <b-row align-v="center">
+                      <b-col md="auto">
+                        <button type="button" class="btn btn-primary" @click="claimTask">{{__('Claim Task')}}</button>
+                      </b-col>
+                      <b-col>
+                        {{__('This task is unassigned, click Claim Task to assign yourself.')}}
+                        {{__('You must claim the task before you can complete it.')}}
+                      </b-col>
+                    </b-row>
                 </div>
-                <div v-else class="container-fluid h-100 d-flex flex-column">
+                <div class="container-fluid h-100 d-flex flex-column">
                     @can('editData', $task->processRequest)
                         <ul v-if="task.process_request.status === 'ACTIVE'" id="tabHeader" role="tablist" class="nav nav-tabs">
                             <li class="nav-item"><a id="pending-tab" data-toggle="tab" href="#tab-form" role="tab"
@@ -396,6 +403,10 @@
             this.$set(this, 'task', val);
           },
           submit(task) {
+            if (this.isSelfService) {
+              window.ProcessMaker.alert(this.$t('You must claim the task before you can complete it.'), 'danger');
+              return;
+            }
             let message = this.$t('Task Completed Successfully');
             const taskId = task.id;
             ProcessMaker.apiClient


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3647
- Show the task form when the the self-serve task is unclaimed
- Disable the submit button when unclaimed
- Show a warning if the submit button is clicked
- Append the same warning to the claim task banner so the user doesn't spend time filing out a form they can't submit