### PR TITLE
Search nested json for self-serve groups and users

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -130,8 +130,10 @@ class TaskController extends Controller
                             $user = User::find($fieldFilter);
                             $query->where(function ($query) use ($user) {
                                 foreach($user->groups as $group) {
-                                    $query->orWhereJsonContains('process_request_tokens.self_service_groups', strval($group->getKey()));
+                                    $query->orWhereJsonContains('process_request_tokens.self_service_groups', strval($group->getKey())); // backwards compatibility
+                                    $query->orWhereJsonContains('process_request_tokens.self_service_groups->groups', strval($group->getKey()));
                                 }
+                                $query->orWhereJsonContains('process_request_tokens.self_service_groups->users', strval($user->getKey()));
                             });
                         });
                     });


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3648?focusedCommentId=228305

- At some point self_service_groups column was changed to an object with user and group arrays, instead of just an array of group ids. This fix searches those values too.