### PR TITLE
FOUR-3676: Fix for Super Admin toggle working inconsistently

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/PermissionController.php
+++ b/ProcessMaker/Http/Controllers/Api/PermissionController.php
@@ -61,6 +61,10 @@ class PermissionController extends Controller
         //Obtain the requested user or group
         if ($request->input('user_id')) {
             $entity = User::findOrFail($request->input('user_id'));
+            if ($request->has('is_administrator')) {
+                $entity->is_administrator = filter_var($request->input('is_administrator'), FILTER_VALIDATE_BOOLEAN);
+                $entity->save();
+            }
         } elseif ($request->input('group_id')) {
             $entity = Group::findOrFail($request->input('group_id'));
         }

--- a/ProcessMaker/Http/Controllers/Api/PermissionController.php
+++ b/ProcessMaker/Http/Controllers/Api/PermissionController.php
@@ -29,7 +29,7 @@ class PermissionController extends Controller
      *
      *     @OA\Put(
      *     path="/permissions",
-     *     summary="Update the permissions of an user",
+     *     summary="Update the permissions of a user",
      *     tags={"Permissions"},
      *
      *     @OA\RequestBody(
@@ -38,11 +38,16 @@ class PermissionController extends Controller
      *          @OA\Property(
      *              property="user_id",
      *              type="integer",
-     *              description="Id of the user whose permissions are configured"),
+     *              description="ID of the user whose permissions are configured"),
      *          @OA\Property(
      *              property="group_id",
      *              type="integer",
-     *              description="Id of the group whose permissions are configured"),
+     *              description="ID of the group whose permissions are configured"),
+     *          @OA\Property(
+     *              property="is_administrator",
+     *              type="boolean",
+     *              default=false,
+     *              description="Whether the user should have Super Admin privileges"),
      *          @OA\Property(
      *              property="permission_names",
      *              type="array",

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -412,10 +412,8 @@
               });
           },
           permissionUpdate() {
-            if (this.adminHasChanged) {
-              this.profileUpdate(false)
-            }
             ProcessMaker.apiClient.put("/permissions", {
+              is_administrator: this.formData.is_administrator,
               permission_names: this.selectedPermissions,
               user_id: this.formData.id
             })

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -78,7 +78,7 @@
                         <div class="tab-pane" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
                             <div class="accordion" id="accordionPermissions">
                                 <div class="mb-2 custom-control custom-switch">
-                                    <input v-model="formData.is_administrator" type="checkbox" class="custom-control-input" id="is_administrator" @input="adminHasChanged = true">
+                                    <input v-model="formData.is_administrator" type="checkbox" class="custom-control-input" id="is_administrator">
                                     <label class="custom-control-label" for="is_administrator">{{ __('Make this user a Super Admin') }}</label>
                                 </div>
                                 <div class="mb-3 custom-control custom-switch">
@@ -298,7 +298,6 @@
             selectedPermissions: [],
             selectAll: false,
             newToken: null,
-            adminHasChanged: false,
             apiTokens: [],
             currentUserId: {{ Auth::user()->id }},
             options: [{

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -404,7 +404,9 @@
             ProcessMaker.apiClient.put('users/' + this.formData.id, this.formData)
               .then(response => {
                 ProcessMaker.alert('{{__('User Updated Successfully ')}}', 'success');
-                window.ProcessMaker.events.$emit('update-profile-avatar');
+                if (this.formData.id == window.ProcessMaker.user.id) {
+                  window.ProcessMaker.events.$emit('update-profile-avatar');
+                }
               })
               .catch(error => {
                 this.errors = error.response.data.errors;


### PR DESCRIPTION
## Changes
- Refactors permissions UI and API call to better handle changing the is_administrator property of a user
- Prevents multiple API calls from being made when they are not necessary
- Updates inline API documentation

## Tickets
- http://tickets.pm4overflow.com/tickets/164
- https://processmaker.atlassian.net/browse/FOUR-3676