### PR TITLE
Prevent errors during validation break the screen builder loading

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -521,7 +521,7 @@ export default {
         try {
           passes = validator.passes();
         } catch (err) {
-          console.warn(`${item.component} (${item.config && item.config.name})`, err.message, err, rules);
+          // Prevent errors during validation break the screen builder loading
           passes = false;
         }
         if (!passes) {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -517,7 +517,14 @@ export default {
         const validator = new Validator(data, rules);
 
         // Validation will not run until you call passes/fails on it
-        if (!validator.passes()) {
+        let passes;
+        try {
+          passes = validator.passes();
+        } catch (err) {
+          console.warn(`${item.component} (${item.config && item.config.name})`, err.message, err, rules);
+          passes = false;
+        }
+        if (!passes) {
           Object.keys(validator.errors.errors).forEach(field => {
             validator.errors.errors[field].forEach(error => {
               validationErrors.push({


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-3699

Safari does not support regular expressions with **lookbehind**. This was stored in the json definition of some screens in the inspector section.

https://caniuse.com/js-regexp-lookbehind

This PR prevents that errors during validation check break the screen builder loading
