### PR TITLE
Comments: send notifications for users tagged in replies

### DIFF
--- a/ProcessMaker/Models/Comment.php
+++ b/ProcessMaker/Models/Comment.php
@@ -123,4 +123,44 @@ class Comment extends Model
             ->where('commentable_type', Comment::class)
             ->with('user');
     }
+    
+    /**
+     * Get element_name attribute for notifications
+     */
+    public function getElementNameAttribute()
+    {
+        if ($this->commentable instanceof ProcessRequest) {
+            return $this->commentable->name;
+        } elseif ($this->commentable instanceof ProcessRequestToken) {
+            return $this->commentable->getDefinition()['name'];
+        } elseif ($this->commentable instanceof Media) {
+            return $this->commentable->manager_name;
+        } elseif ($this->commentable instanceof Comment) {
+            return $this->commentable->element_name;
+        } else {          
+            return get_class($this->commentable);
+        }
+    }
+    
+    /**
+     * Get url attribute for notifications
+     */
+    public function getUrlAttribute($id = null)
+    {
+        if (! $id) {
+            $id = $this->id;
+        }
+        
+        if ($this->commentable instanceof ProcessRequest) {
+            return sprintf('/requests/%s#comment-%s', $this->commentable->id, $id);
+        } elseif ($this->commentable instanceof ProcessRequestToken) {
+            return sprintf('/tasks/%s/edit#comment-%s', $this->commentable->id, $id);
+        } elseif ($this->commentable instanceof Media) {
+            return $this->commentable->manager_url;
+        } elseif ($this->commentable instanceof Comment) {
+            return $this->commentable->getUrlAttribute($this->id);
+        } else {          
+            return '/';
+        }
+    }
 }


### PR DESCRIPTION
## Changes
- Adds support for comments _and their replies_ to send notifications
  - Adds `element_name` and `url` attributes to the Comments model to allow for both comments and replies to send notifications

## Required By
- https://github.com/ProcessMaker/package-comments/pull/71

## Tickets
- http://tickets.pm4overflow.com/tickets/155
- https://processmaker.atlassian.net/browse/FOUR-3535