### PR TITLE
Fix params replacing

### DIFF
--- a/ProcessMaker/Http/Requests/RecordRequest.php
+++ b/ProcessMaker/Http/Requests/RecordRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ProcessMaker\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RecordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -326,6 +326,10 @@ trait MakeHttpRequests
         //           item['type'] location of the property defined in 'key'. It can be BODY, PARAM (in the query string), HEADER
 
         $url = $endpoint['url'];
+        // If url does not include the protocol and server name complete it with the local server
+        if (substr($url, 0,1) === '/') {
+            $url = url($url);
+        }
 
         // If exists a query string in the call, add it to the URL
         if (array_key_exists('queryString', $config)) {

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use Mustache_Engine;
 use ProcessMaker\Exception\HttpResponseException;
 use ProcessMaker\Models\FormalExpression;
@@ -53,14 +54,8 @@ trait MakeHttpRequests
     public function request(array $data = [], array $config = [])
     {
         try {
-            // if using the new version of data connectors
-            if (array_key_exists('outboundConfig', $config) || array_key_exists('dataMapping', $config)) {
-                $request = $this->prepareRequestWithOutboundConfig($data, $config);
-                return $this->responseWithHeaderData($this->call(...$request), $data, $config);
-            } else {
-                $request = $this->prepareRequest($data, $config);
-                return $this->response($this->call(...$request), $data, $config);
-            }
+            $request = $this->prepareRequestWithOutboundConfig($data, $config);
+            return $this->responseWithHeaderData($this->call(...$request), $data, $config);
         } catch (ClientException $exception) {
             throw new HttpResponseException($exception->getResponse());
         }
@@ -88,7 +83,10 @@ trait MakeHttpRequests
         $headers = $this->addHeaders($endpoint, $config, $data);
 
         $body = $this->getMustache()->render($endpoint['body'], $data);
-        $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);
+        $bodyType = null;
+        if (isset($endpoint['body_type'])) {
+            $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);
+        }
         $request = [$method, $url, $headers, $body, $bodyType];
         $request = $this->addAuthorizationHeaders(...$request);
         return $request;
@@ -108,20 +106,26 @@ trait MakeHttpRequests
         $data = $requestData;
         foreach ($outboundConfig as $outbound) {
             if ($outbound['type'] === $type) {
-                $data[$outbound['key']] = $this->evalExpression($outbound['value'], $requestData);
+                // Default format for mapping input is { Mustache }
+                if (isset($outbound['format']) && $outbound['format'] === 'feel') {
+                    $data[$outbound['key']] = $this->evalExpression($outbound['value'], $requestData);
+                } else {
+                    $data[$outbound['key']] = $this->evalMustache($outbound['value'], $requestData);
+                }
             }
         }
         return $data;
     }
 
     /**
-     * Evaluate a BPMN expression
+     * Evaluate a BPMN FEEL expression
      * ex.
-     *      foo
-     *      _request.id
-     *      _user.id
-     *      {{ form.age }}
-     *      "{{ form.lastname }} {{ form.firstname }}"
+     *      foo             => bar
+     *      _request.id     => 1001
+     *      _user.id        => 101
+     *      10              => 10
+     *      {{ form.age }}  => 21
+     *      "{{ form.lastname }} {{ form.firstname }}" => John Doe
      *
      * @return mixed
      */
@@ -137,6 +141,25 @@ trait MakeHttpRequests
     }
 
     /**
+     * Evaluate a mustache expression
+     * ex.
+     *      foo             => "foo"
+     *      10              => "10"
+     *      {{ user.id }}  => "101"
+     *      {{ form.age }}  => "21"
+     *      {{ form.lastname }} {{ form.firstname }} => "John Doe"
+     * @return string
+     */
+    private function evalMustache($expression, array $data)
+    {
+        try {
+            return $this->getMustache()->render($expression, $data);
+        } catch (Exception $exception) {
+            return "{$expression}: " . $exception->getMessage();
+        }
+    }
+
+    /**
      * Prepares data for the http request replacing mustache with pm instance and OutboundConfig
      *
      * @param array $data, request data
@@ -146,24 +169,29 @@ trait MakeHttpRequests
      */
     private function prepareRequestWithOutboundConfig(array $requestData, array &$config)
     {
-        $data = $this->prepareData($requestData, $config['outboundConfig'], 'PARAM');
+        $outboundConfig = $config['outboundConfig'] ?? [];
         $endpoint = $this->endpoints[$config['endpoint']];
-        $method = $this->getMustache()->render($endpoint['method'], $data);
-
-        $url = $this->addQueryStringsParamsToUrl($endpoint, $config, $data);
-
         $this->verifySsl = array_key_exists('verify_certificate', $this->credentials)
             ? $this->credentials['verify_certificate']
             : true;
 
-        $data = $this->prepareData($requestData, $config['outboundConfig'], 'HEADER');
+        // Prepare URL
+        $data = $this->prepareData($requestData, $outboundConfig, 'PARAM');
+        $method = $this->evalMustache($endpoint['method'], $data);
+        $url = $this->addQueryStringsParamsToUrl($endpoint, $config, $data);
+
+        // Prepare Headers
+        $data = $this->prepareData($requestData, $outboundConfig, 'HEADER');
         $headers = $this->addHeaders($endpoint, $config, $data);
-        $data = $this->prepareData($requestData, $config['outboundConfig'], 'BODY');
+
+        // Prepare Body
+        $data = $this->prepareData($requestData, $outboundConfig, 'BODY');
         $body = $this->getMustache()->render($endpoint['body'], $data);
         $bodyType = null;
         if (isset($endpoint['body_type'])) {
             $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);
         }
+
         $request = [$method, $url, $headers, $body, $bodyType];
         $request = $this->addAuthorizationHeaders(...$request);
         return $request;
@@ -351,11 +379,13 @@ trait MakeHttpRequests
                 $value = $this->addCollectionsRootObject($value);
             }
 
-            //If mustache, a process variable can be used as the property name of the API response
-            $evaluatedApiVar = (str_contains($value, '{{'))
-                ? $this->getMustache()->render($value, $merged)
-                : Arr::get($responseData, $value);
-
+            // Default format for mapping response is FEEL unless $value contains {{}}
+            $format = $map['format'] ?? (str_contains($value, '{{') ? 'mustache' : 'feel');
+            if ($format === 'mustache') {
+                $evaluatedApiVar = $this->evalMustache($map['value'], $merged);
+            } else {
+                $evaluatedApiVar = $this->evalExpression($map['value'], $merged);
+            }
             $mapped[$processVar] = $evaluatedApiVar;
         }
 
@@ -394,7 +424,7 @@ trait MakeHttpRequests
      *
      * @return string
      */
-    private function addQueryStringsParamsToUrl($endpoint, array $config,  array $data)
+    private function addQueryStringsParamsToUrl($endpoint, array $config, array $data)
     {
         // Note that item['key'] corresponds to an endpoint property (in the header, querystring, etc.)
         //           item['value'] corresponds to a PM request variable or mustache expression
@@ -412,54 +442,23 @@ trait MakeHttpRequests
             $url .= $separator . $config['queryString'];
         }
 
-        if (!array_key_exists('outboundConfig', $config)) {
-            $url = $this->getMustache()->render($url, $data);
-            return $url;
-        }
-
-        $outboundConfig = $config['outboundConfig'];
-
-        $dataSourceParams = [];
-        if(array_key_exists('params', $endpoint)) {
-            $dataSourceParams = array_filter($endpoint['params'], function ($item) {
-                return $item['required'] === true;
-            });
-        }
-
-        $configParams = array_filter($outboundConfig, function ($item) {
-            return $item['type'] === 'PARAM';
-        });
-
-        foreach ($configParams as $cfgParam) {
-            $existsInDataSourceParams = false;
-            foreach ($dataSourceParams as &$param) {
-                if ($param['key'] === $cfgParam['key']) {
-                    $param['value'] = $cfgParam['value'];
-                    $existsInDataSourceParams = true;
+        // Evaluate mustache expressions in URL
+        $url = $this->evalMustache($url, $data);
+        // Add params from datasource configuration
+        $parsedUrl = $this->parseUrl($url);
+        $query = [];
+        parse_str($parsedUrl['query'], $query);
+        if (array_key_exists('params', $endpoint)) {
+            foreach ($endpoint['params'] as $param) {
+                $key = $this->evalMustache($param['key'], $data);
+                $value = $this->evalMustache($param['value'], $data);
+                if ($value !== '' || $param['required']) {
+                    $query[$key] = $value;
                 }
             }
-            if (!$existsInDataSourceParams) {
-                array_push($dataSourceParams, [
-                    'key' => $cfgParam['key'],
-                    'value' => $cfgParam['value']
-                ]);
-            }
         }
-
-        $dataForUrl = [];
-        foreach ($dataSourceParams as $param) {
-            $separator = strpos($url, '?') ? '&' : '?';
-            $url .= $separator .
-                    $this->getMustache()->render($param['key'], $data) .
-                    '=' .
-                    $this->getMustache()->render($param['value'], $data);
-            $dataForUrl[$param['key']] = $this->getMustache()->render($param['value'], $data);
-        }
-
-
-        // if some placeholders are left, use directly request data
-        $url = $this->getMustache()->render($url, array_merge($data, $dataForUrl));
-
+        $parsedUrl['query'] = http_build_query($query);
+        $url = $this->unparseUrl($parsedUrl);
         return $url;
     }
 
@@ -538,5 +537,50 @@ trait MakeHttpRequests
             }
         }
         return $value;
+    }
+
+    /**
+     * Multibyte parse_url
+     *
+     * @param string $url
+     * @return array
+     */
+    public function parseUrl($url)
+    {
+        $enc_url = preg_replace_callback(
+            '%[^:/@?&=#]+%usD',
+            function ($matches) {
+                return urlencode($matches[0]);
+            },
+            $url
+        );
+        $parts = parse_url($enc_url);
+        if ($parts === false) {
+            throw new InvalidArgumentException('Malformed URL: ' . $url);
+        }
+        foreach ($parts as $name => $value) {
+            $parts[$name] = urldecode($value);
+        }
+        return $parts;
+    }
+
+    /**
+     * Unparse url array
+     *
+     * @param array $parsed_url
+     * @return string
+     */
+    private function unparseUrl(array $parsed_url)
+    {
+        $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+        $host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+        $port     = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+        $user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+        $pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass']  : '';
+        $pass     = ($user || $pass) ? "$pass@" : '';
+        $path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+        $query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+        $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+        return "$scheme$user$pass$host$port$path$query$fragment";
     }
 }

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -213,7 +213,11 @@ trait MakeHttpRequests
 
         if (isset($config['dataMapping'])) {
             foreach ($config['dataMapping'] as $map) {
-                $value = Arr::get($merged, $map['value'], '');
+                if ($map['value']) {
+                    $value = Arr::get($merged, $map['value'], '');
+                } else {
+                    $value = $content;
+                }
                 Arr::set($mapped, $map['key'], $value);
             }
         }

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -87,22 +87,6 @@ trait MakeHttpRequests
 
         $headers = $this->addHeaders($endpoint, $config, $data);
 
-        if (isset($config['dataMapping']) && !isset($config['outboundConfig'])) {
-            // If it is the old version of data sources use dataMapping
-            $configParameter = isset($config['outboundConfig']) ? 'outboundConfig' : 'dataMapping';
-            $mappedData = [];
-            foreach ($config[$configParameter] as $map) {
-                $mappedData[$map['key']] =  $map['value'];
-            }
-            if (empty($endpoint['body'])) {
-                $endpoint['body'] = json_encode($mappedData);
-            } else {
-                foreach ($config[$configParameter] as $map) {
-                    $data[$map['key']] = $this->getMustache()->render($map['value'], $data);
-                }
-            }
-        }
-
         $body = $this->getMustache()->render($endpoint['body'], $data);
         $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);
         $request = [$method, $url, $headers, $body, $bodyType];
@@ -271,13 +255,28 @@ trait MakeHttpRequests
 
         $merged = array_merge($data, $content, $headers);
         $responseData = array_merge($content, $headers);
-        foreach ($config['dataMapping'] as $map) {
-            //If mustache, a process variable can be used as the property name of the API response
-            $evaluatedApiVar = (str_contains( $map['value'], '{{'))
-                ? $this->getMustache()->render($map['value'], $merged)
-                : Arr::get($responseData, $map['value']);
 
+        foreach ($config['dataMapping'] as $map) {
             $processVar = $this->getMustache()->render($map['key'], $data);
+            $value = $map['value'];
+            $url = $this->endpoints[$config['endpoint']]['url'];
+
+            // if value is empty all the response is mapped
+            if (trim($value) === '') {
+                $mapped[$processVar] = $responseData;
+                continue;
+            }
+
+            // if is a collection connector, by default it is not necessary to send data.data and we add it by default
+            if (preg_match('/\/api\/[0-9\.]+\/collections/m', $url) === 1) {
+                $value = $this->addCollectionsRootObject($value);
+            }
+
+            //If mustache, a process variable can be used as the property name of the API response
+            $evaluatedApiVar = (str_contains($value, '{{'))
+                ? $this->getMustache()->render($value, $merged)
+                : Arr::get($responseData, $value);
+
             $mapped[$processVar] = $evaluatedApiVar;
         }
 
@@ -428,5 +427,33 @@ trait MakeHttpRequests
     function isJson($str) {
         json_decode($str);
         return (json_last_error() == JSON_ERROR_NONE);
+    }
+
+    private function addCollectionsRootObject($value)
+    {
+        preg_match_all('/\{\{(.*?)\}\}/m', $value, $matches, PREG_SET_ORDER, 0);
+        if (count($matches) > 0) {
+            $matchesWithNewVal = [];
+            foreach ($matches as $match) {
+                $val = $match[1];
+                if (strpos($val, 'data.data') === false && strpos($val, 'data') === false) {
+                    $match[] = 'data.data.' . trim($val);
+                } else {
+                    $match[] = trim($val);
+                }
+                $matchesWithNewVal[] = $match;
+            }
+
+            foreach ($matchesWithNewVal as $match) {
+                $value = str_replace($match[0], '{{' . $match[2] . '}}', $value);
+            }
+        } else {
+            if (strpos($value, 'data.data') === false && strpos($value, 'data') === false) {
+                $value = 'data.data.' . trim($value);
+            } else {
+                $value = trim($value);
+            }
+        }
+        return $value;
     }
 }

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -2,15 +2,16 @@
 
 namespace ProcessMaker\Traits;
 
-use GuzzleHttp\Exception\GuzzleException;
-use Illuminate\Support\Facades\Log;
-use Mustache_Engine;
+use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Arr;
+use Mustache_Engine;
 use ProcessMaker\Exception\HttpResponseException;
+use ProcessMaker\Models\FormalExpression;
 use Psr\Http\Message\ResponseInterface;
 
 trait MakeHttpRequests
@@ -52,13 +53,12 @@ trait MakeHttpRequests
     public function request(array $data = [], array $config = [])
     {
         try {
-            $request = $this->prepareRequest($data, $config);
-
             // if using the new version of data connectors
-            if (array_key_exists('outboundConfig', $config)) {
+            if (array_key_exists('outboundConfig', $config) || array_key_exists('dataMapping', $config)) {
+                $request = $this->prepareRequestWithOutboundConfig($data, $config);
                 return $this->responseWithHeaderData($this->call(...$request), $data, $config);
-            }
-            else {
+            } else {
+                $request = $this->prepareRequest($data, $config);
                 return $this->response($this->call(...$request), $data, $config);
             }
         } catch (ClientException $exception) {
@@ -89,6 +89,81 @@ trait MakeHttpRequests
 
         $body = $this->getMustache()->render($endpoint['body'], $data);
         $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);
+        $request = [$method, $url, $headers, $body, $bodyType];
+        $request = $this->addAuthorizationHeaders(...$request);
+        return $request;
+    }
+
+    /**
+     * Prepare data to be used in body (mustache)
+     *
+     * @param array $requestData
+     * @param array $outboundConfig
+     * @param string $type PARAM HEADER BODY
+     *
+     * @return array
+     */
+    private function prepareData(array $requestData, array $outboundConfig, $type)
+    {
+        $data = $requestData;
+        foreach ($outboundConfig as $outbound) {
+            if ($outbound['type'] === $type) {
+                $data[$outbound['key']] = $this->evalExpression($outbound['value'], $requestData);
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Evaluate a BPMN expression
+     * ex.
+     *      foo
+     *      _request.id
+     *      _user.id
+     *      {{ form.age }}
+     *      "{{ form.lastname }} {{ form.firstname }}"
+     *
+     * @return mixed
+     */
+    private function evalExpression($expression, array $data)
+    {
+        try {
+            $formal = new FormalExpression();
+            $formal->setBody($expression);
+            return $formal($data);
+        } catch (Exception $exception) {
+            return "{$expression}: " . $exception->getMessage();
+        }
+    }
+
+    /**
+     * Prepares data for the http request replacing mustache with pm instance and OutboundConfig
+     *
+     * @param array $data, request data
+     * @param array $config, datasource configuration
+     *
+     * @return array
+     */
+    private function prepareRequestWithOutboundConfig(array $requestData, array &$config)
+    {
+        $data = $this->prepareData($requestData, $config['outboundConfig'], 'PARAM');
+        $endpoint = $this->endpoints[$config['endpoint']];
+        $method = $this->getMustache()->render($endpoint['method'], $data);
+
+        $url = $this->addQueryStringsParamsToUrl($endpoint, $config, $data);
+
+        $this->verifySsl = array_key_exists('verify_certificate', $this->credentials)
+            ? $this->credentials['verify_certificate']
+            : true;
+
+        $data = $this->prepareData($requestData, $config['outboundConfig'], 'HEADER');
+        $headers = $this->addHeaders($endpoint, $config, $data);
+        $data = $this->prepareData($requestData, $config['outboundConfig'], 'BODY');
+        $body = $this->getMustache()->render($endpoint['body'], $data);
+        $bodyType = null;
+        if (isset($endpoint['body_type'])) {
+            $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);
+        }
         $request = [$method, $url, $headers, $body, $bodyType];
         $request = $this->addAuthorizationHeaders(...$request);
         return $request;


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-3735

This PR fixes the outbound configuration and check the parameters arrives properly

- Fix list of params
- Add `mustache`, `feel` labels to clarify the expressions format
- Add `mustache/feel` switch to choose the right format when required
- Fix the returned error message from endpoint

### Examples
_**Request variables:**_
1. foo = "bar"
2. number = 100
3. _request = { id: 1001 }
4. array = [1, 2, 3]
_**Dataconnector:**_

- URL = `http`://example.com/api/`{{version}}`/resource?param1=`{{param1}}`
- Params:
  - param2 = value
  - param3 = {{ param3 }}
  - param4 = {{ param4 }} *required

_**Outbound configuration:**_
- version = {{ number }}   // `{ Mustache }`
- param1 = foo   // `{ Mustache }`
- param3 = foo   // `feel`

_**Result:**_
URL: `http`://example.com/api/`100`/resource?param1=`foo`&param2=`value`&param3=`bar`&param4=
**Note**: `param4` is mandatory but it is empty, therefore it is added to the URL but with an empty value

Mustache syntax: 
![image](https://user-images.githubusercontent.com/8028650/127562339-278fe24b-03e2-4e94-a012-55a5ac290f00.png)
FEEL syntax:
![image](https://user-images.githubusercontent.com/8028650/127562778-e74badb3-d9d3-427a-a50d-3a176bd99687.png)
Outbound configuration:
![image](https://user-images.githubusercontent.com/8028650/127562166-dbbe58d4-775d-4a94-ab64-8638d37a0f66.png)
