### PR TITLE
Fix Subprocess triggered by a Webhook to an Intermediate Catch Event

### DIFF
--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -33,6 +33,8 @@ abstract class BpmnAction implements ShouldQueue
 
     protected $tokenId = null;
 
+    protected $disableGlobalEvents = false;
+
     /**
      * Execute the job.
      *
@@ -82,12 +84,12 @@ abstract class BpmnAction implements ShouldQueue
             }
             $processModel = $instance->process;
             $definitions = ($instance->processVersion ?? $instance->process)->getDefinitions(true);
-            $engine = app(BpmnEngine::class, ['definitions' => $definitions]);
+            $engine = app(BpmnEngine::class, ['definitions' => $definitions, 'globalEvents' => !$this->disableGlobalEvents]);
             $instance = $engine->loadProcessRequest($instance);
         } else {
             $processModel = Definitions::find($this->definitionsId);
             $definitions = $processModel->getDefinitions();
-            $engine = app(BpmnEngine::class, ['definitions' => $definitions]);
+            $engine = app(BpmnEngine::class, ['definitions' => $definitions, 'globalEvents' => !$this->disableGlobalEvents]);
             $instance = null;
         }
 

--- a/ProcessMaker/Jobs/CatchSignalEventInRequest.php
+++ b/ProcessMaker/Jobs/CatchSignalEventInRequest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Arr;
+use ProcessMaker\Managers\SignalManager;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Providers\WorkflowServiceProvider;
+use ProcessMaker\Repositories\BpmnDocument;
+use ProcessMaker\Repositories\DefinitionsRepository;
+
+class CatchSignalEventInRequest extends BpmnAction implements ShouldQueue
+{
+    public $definitionsId;
+    public $instanceId;
+    public $tokenId;
+    public $data;
+    public $signalRef;
+    public $disableGlobalEvents;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param \ProcessMaker\Models\ProcessRequest $instance
+     * @param array $data
+     * @param string $signalRef
+     */
+    public function __construct(ProcessRequest $instance, array $data, $signalRef)
+    {
+        $this->instanceId = $instance->getKey();
+        $this->data = $data;
+        $this->signalRef = $signalRef;
+        // Disable global events for this job to do not repeat the same signal
+        $this->disableGlobalEvents = true;
+    }
+
+    /**
+     * Dispatch the signal event into de request $instance
+     *
+     * @return void
+     */
+    public function action(ProcessRequest $instance, BpmnDocument $definitions)
+    {
+        // Prepare the signal
+        $repository = new DefinitionsRepository;
+        $eventDefinition = $repository->createSignalEventDefinition();
+        $signal = $repository->createSignal();
+        $signal->setId($this->signalRef);
+        $eventDefinition->setPayload($signal);
+        $eventDefinition->setProperty('signalRef', $this->signalRef);
+
+        // Dispatch the signal to the engine
+        $this->engine->getEventDefinitionBus()->dispatchEventDefinition(
+            null,
+            $eventDefinition,
+            null
+        );
+
+        // Get all the catch events defined in the $definitions
+        $catches = SignalManager::getSignalCatchEvents($this->signalRef, $definitions);
+        foreach ($catches as $catch) {
+            $catchEvent = $catch['catchEvent'];
+            if ($catchEvent->getTokens($instance)->count() < 1) {
+                continue;
+            }
+            // Put the payload into the configured variable of each catch event
+            // if not defined in the variable, put the payload into the root request data
+            $processVariable = $catchEvent->getBpmnElement()->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config');
+            if ($processVariable) {
+                $data = $instance->getDataStore()->getData();
+                Arr::set($data, $processVariable, $this->data);
+                $instance->getDataStore()->setData($data);
+            } else {
+                if ($this->data) {
+                    foreach ($this->data as $key => $value) {
+                        $instance->getDataStore()->putData($key, $value);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ProcessMaker/Jobs/CatchSignalEventInRequest.php
+++ b/ProcessMaker/Jobs/CatchSignalEventInRequest.php
@@ -60,7 +60,7 @@ class CatchSignalEventInRequest extends BpmnAction implements ShouldQueue
         // Get all the catch events defined in the $definitions
         $catches = SignalManager::getSignalCatchEvents($this->signalRef, $definitions);
         foreach ($catches as $catch) {
-            $catchEvent = $catch['catchEvent'];
+            $catchEvent = $definitions->getElementInstanceById($catch['id']);
             if ($catchEvent->getTokens($instance)->count() < 1) {
                 continue;
             }

--- a/ProcessMaker/Jobs/CatchSignalEventRequest.php
+++ b/ProcessMaker/Jobs/CatchSignalEventRequest.php
@@ -6,10 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use ProcessMaker\BpmnEngine;
-use ProcessMaker\Managers\SignalManager;
 use ProcessMaker\Models\ProcessRequest;
-use ProcessMaker\Repositories\DefinitionsRepository;
 
 class CatchSignalEventRequest implements ShouldQueue
 {
@@ -35,42 +32,9 @@ class CatchSignalEventRequest implements ShouldQueue
 
     public function handle()
     {
-        $repository = new DefinitionsRepository;
-        $eventDefinition = $repository->createSignalEventDefinition();
-        $signal = $repository->createSignal();
-        $signal->setId($this->signalRef);
-        $eventDefinition->setPayload($signal);
-        $eventDefinition->setProperty('signalRef', $this->signalRef);
-
         foreach ($this->chunck as $requestId) {
             $request = ProcessRequest::find($requestId);
-            $definitions = ($request->processVersion ?? $request->process)->getDefinitions(true, null);
-            $engine = app(BpmnEngine::class, ['definitions' => $definitions, 'globalEvents' => false]);
-            $instance = $engine->loadProcessRequest($request);
-            $engine->getEventDefinitionBus()->dispatchEventDefinition(
-                null,
-                $eventDefinition,
-                null
-            );
-
-            $catches = SignalManager::getSignalCatchEvents($this->signalRef, $definitions);
-            $processVariable = '';
-            foreach($catches as $catch) {
-                $processVariable = $definitions->getStartEvent($catch['id'])->getBpmnElement()->getAttribute('pm:config');
-            }
-            if ($processVariable) {
-                foreach ($engine->getExecutionInstances() as $instance) {
-                    $instance->getDataStore()->putData($processVariable, $this->payload);
-                }
-            }
-            else {
-                if ($this->payload) {
-                    foreach ($this->payload as $key => $value) {
-                        $instance->getDataStore()->putData($key, $value);
-                    }
-                }
-            }
-            $engine->runToNextState();
+            CatchSignalEventInRequest::dispatchNow($request, $this->payload, $this->signalRef);
         }
     }
 }

--- a/ProcessMaker/Managers/SignalManager.php
+++ b/ProcessMaker/Managers/SignalManager.php
@@ -212,7 +212,6 @@ class SignalManager
                     'id' => $node->parentNode->getAttribute('id'),
                     'name' => $node->parentNode->getAttribute('name'),
                     'type' => $node->parentNode->localName,
-                    'catchEvent' => $node->parentNode->getBpmnElementInstance(),
                 ]);
             }
             return $carry;

--- a/ProcessMaker/Managers/SignalManager.php
+++ b/ProcessMaker/Managers/SignalManager.php
@@ -211,7 +211,8 @@ class SignalManager
                 $carry->push ([
                     'id' => $node->parentNode->getAttribute('id'),
                     'name' => $node->parentNode->getAttribute('name'),
-                    'type' => $node->parentNode->localName
+                    'type' => $node->parentNode->localName,
+                    'catchEvent' => $node->parentNode->getBpmnElementInstance(),
                 ]);
             }
             return $carry;

--- a/public/definitions/ProcessMaker.xsd
+++ b/public/definitions/ProcessMaker.xsd
@@ -104,6 +104,7 @@
                 <xsd:attribute name="allowedUsers" type="xsd:string" use="optional"/>
                 <xsd:attribute name="allowedGroups" type="xsd:string" use="optional"/>
                 <xsd:attribute name="whitelist" type="xsd:string" use="optional"/>
+                <xsd:attribute name="config" type="xsd:string" use="optional"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>


### PR DESCRIPTION
Fixes: http://tickets.pm4overflow.com/tickets/326

The problem was caused because the signal catch was processed by an stand alone engine, causing that the parent process instance did not receive the end event from the subprocess.

To fix it the code to process the catch was moved to a BpmnAction Job.

**Sub Process:**
![image](https://user-images.githubusercontent.com/8028650/128255532-844c4a00-31a6-4c5b-8395-03fbbbde2270.png)

**Parent Process:**
![image](https://user-images.githubusercontent.com/8028650/128255546-6a4c230d-d53f-4c71-b67a-02b59f8b927c.png)
