### PR TITLE
ticket 357: Request summary screen/History gateway history item does not show the name of the gateway

### DIFF
--- a/ProcessMaker/Listeners/CommentsSubscriber.php
+++ b/ProcessMaker/Listeners/CommentsSubscriber.php
@@ -52,6 +52,11 @@ class CommentsSubscriber
         $flowSource = $incomingFlow->getProperties()["source"];
         if ($flowSource instanceof GatewayInterface) {
             $properties = $incomingFlow->getProperties();
+            $sourceProps = $flowSource->getProperties();
+            $sourceLabel = array_key_exists('name', $sourceProps) && $sourceProps['name']
+                        ? $sourceProps['name']
+                        : __('Gateway');
+
             $flowLabel = array_key_exists('name', $properties) && $properties['name']
                         ? $properties['name']
                         : __('Label Undefined');
@@ -61,7 +66,7 @@ class CommentsSubscriber
                 'commentable_type' => ProcessRequest::class,
                 'commentable_id' => $token->process_request_id,
                 'subject' => 'Gateway',
-                'body' => __('Gateway: :flow_label', ['flow_label' => $flowLabel]),
+                'body' => $sourceLabel . ': ' . $flowLabel
             ]);
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/ProcessMaker/processmaker/compare/bugfix/ticket-357](https://github.com/ProcessMaker/processmaker/compare/bugfix/ticket-357)

The label that is registered in history has been modified to be in the format GatewayName + FlowName  instead of  "Gateway: " + FlowName. 

QA Notes:
- Items in  request history are stored as comments, so the new forma will be used with new requests only
- If the gateway hasn't a name, "Gateway" will be used as default.

Example process:
![image](https://user-images.githubusercontent.com/14875032/128750203-10ba6322-b808-4189-88a1-7d09d5549ebb.png)

New format for history:
![image](https://user-images.githubusercontent.com/14875032/128750215-b03fb565-c390-4f95-a4bf-f790927916eb.png)

