### PR TITLE
Fixed misspelled "escalate" word on line 58

### DIFF
--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -55,7 +55,7 @@
 
           <form-checkbox
               v-if="configurables.includes('ESCALATE_TO_MANAGER')"
-              :label="$t('Escalte to Manager')"
+              :label="$t('Escalate to Manager')"
               :checked="escalateToManagerGetter"
               toggle="true"
               @change="escalateToManagerSetter">


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3000
Escalte => Escalate -- This will need a translations update.