### PR TITLE
ticket 517: Boundary timer events getting wrong bpmn version

### DIFF
--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -315,10 +315,10 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
         }
 
         $request = ProcessRequest::find($task->process_request_id);
-        $process = $request->process;
 
-        $definitions = $process->getDefinitions();
+        $definitions = $request->getVersionDefinitions();
         $catch = $definitions->getBoundaryEvent($config->element_id);
+
         if (!$catch) {
             return;
         }
@@ -330,7 +330,7 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
 
         $executed = false;
         foreach ($tokens as $token) {
-            WorkflowManager::triggerBoundaryEvent($process, $request, $token, $catch, []);
+            WorkflowManager::triggerBoundaryEvent($request->process, $request, $token, $catch, []);
             $executed = true;
         }
 


### PR DESCRIPTION
Fixes bug found in [http://tickets.pm4overflow.com/tickets/517](http://tickets.pm4overflow.com/tickets/517)