### PR TITLE
Re-render when switching to design mode too

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -521,8 +521,8 @@ export default {
       }
       this.mode = mode;
       this.previewData = this.previewInputValid ? JSON.parse(this.previewInput) : {};
+      this.rendererKey++;
       if (mode == 'preview') {
-        this.rendererKey++;
         this.preview.config = cloneDeep(this.config);
         this.preview.computed = cloneDeep(this.computed);
         this.preview.customCSS = cloneDeep(this.customCSS);


### PR DESCRIPTION
Found while fixing http://tickets.pm4overflow.com/tickets/510

- Re-render when switching back to design mode because it was throwing errors on nested vars (like `foo.bar`)