### PR TITLE
Add Group Manager

### DIFF
--- a/ProcessMaker/Models/Group.php
+++ b/ProcessMaker/Models/Group.php
@@ -11,7 +11,8 @@ use ProcessMaker\Query\Traits\PMQL;
  * Represents a group definition.
  *
  * @property string $id
- * @property string $name
+ * @property string $descripcion
+ * @property User $manager
  * @property \Carbon\Carbon $updated_at
  * @property \Carbon\Carbon $created_at
  *
@@ -19,6 +20,7 @@ use ProcessMaker\Query\Traits\PMQL;
  *   schema="groupsEditable",
  *   @OA\Property(property="name", type="string"),
  *   @OA\Property(property="description", type="string"),
+ *   @OA\Property(property="manager_id", type="int", format="id"),
  *   @OA\Property(property="status", type="string", enum={"ACTIVE", "INACTIVE"}),
  * ),
  * @OA\Schema(
@@ -45,6 +47,7 @@ class Group extends Model
     protected $fillable = [
         'name',
         'description',
+        'manager_id',
         'status',
     ];
 
@@ -83,6 +86,16 @@ class Group extends Model
         return $this->groupMembers->where('member_type', User::class)->map(function ($member) {
             return $member->member;
         });
+    }
+
+    /**
+     * Manager of the group.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function manager()
+    {
+        return $this->belongsTo(User::class, 'manager_id');
     }
     
     public function getRecursiveUsersAttribute(Group $parent = null)

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -2,6 +2,7 @@
 
 use Faker\Generator as Faker;
 use ProcessMaker\Models\Group;
+use ProcessMaker\Models\User;
 
 /**
  * Model factory for a Group
@@ -10,6 +11,9 @@ $factory->define(Group::class, function (Faker $faker) {
     return [
         'name' => $faker->sentence(3),
         'description' => $faker->sentence,
+        'manager_id' => function () {
+            return factory(User::class)->create()->getKey();
+        },
         'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
     ];
 });

--- a/database/migrations/2021_08_24_064310_add_manager_id_on_groups_table.php
+++ b/database/migrations/2021_08_24_064310_add_manager_id_on_groups_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddManagerIdOnGroupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->unsignedInteger('manager_id')
+            ->nullable();
+            $table->foreign('manager_id', 'groups_manager_id_foreign')
+            ->references('id')->on('users')
+            ->onDelete('restrict');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropForeign('groups_manager_id_foreign');
+            $table->dropColumn('manager_id');
+        });
+    }
+}

--- a/resources/js/admin/groups/edit.js
+++ b/resources/js/admin/groups/edit.js
@@ -1,7 +1,8 @@
 import Vue from "vue";
 import UsersInGroupListing from "./components/UsersInGroupListing.vue";
 import GroupsInGroupListing from "./components/GroupsInGroupListing.vue";
+import UserSelect from "../../processes/modeler/components/inspector/UserSelect.vue";
 
 Vue.component('users-in-group', UsersInGroupListing);
 Vue.component('groups-in-group', GroupsInGroupListing);
-
+Vue.component('user-select', UserSelect);

--- a/resources/js/processes/modeler/components/inspector/UserSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/UserSelect.vue
@@ -47,7 +47,11 @@
     watch: {
       content: {
         handler() {
-          this.$emit("input", this.content.id);
+          if (!this.content) {
+            this.$emit("input", null);
+          } else {
+            this.$emit("input", this.content.id);
+          }
         }
       },
       value: {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -371,6 +371,7 @@
   "Group name must be distinct": "Group name must be distinct",
   "Group Permissions Updated Successfully": "Group Permissions Updated Successfully",
   "Group Permissions": "Group Permissions",
+  "Group Manager": "Group Manager",
   "group": "group",
   "Group": "Group",
   "Groups": "Groups",

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -58,6 +58,14 @@
                             <div class="invalid-feedback" v-if="errors.description">@{{errors.description[0]}}</div>
                         </div>
                         <div class="form-group mt-3">
+                            {!! Form::label('manager_id', __('Group Manager')) !!}
+                            <user-select
+                                id="manager_id"
+                                v-model="formData.manager_id"
+                            ></user-select>
+                            <div class="invalid-feedback" v-if="errors.manager_id">@{{errors.manager_id[0]}}</div>
+                        </div>
+                        <div class="form-group mt-3">
                             {!! Form::label('status', __('Status')) !!}
                             {!! Form::select('status', ['ACTIVE' => __('Active'), 'INACTIVE' => __('Inactive')], null, [
                             'id' => 'status',

--- a/tests/Feature/Admin/GroupTest.php
+++ b/tests/Feature/Admin/GroupTest.php
@@ -42,11 +42,11 @@ class GroupTest extends TestCase
     }
 
     /**
-     * Test to make sure the manager user is loaded
+     * Test to make sure the group manager user is loaded
      *
      * @return void
      */
-    public function testEditRouteHasManager()
+    public function testEditGroupHasManager()
     {
         $group = factory(Group::class)->create();
         $groupId = $group->getKey();
@@ -59,6 +59,28 @@ class GroupTest extends TestCase
         $response->assertSee('Group Manager');
         $response->assertViewHas('group', function ($formData) use ($group) {
             return $formData->manager_id === $group->manager_id;
+        });
+    }
+
+    /**
+     * Test to make sure a group (without manager) can be edited
+     *
+     * @return void
+     */
+    public function testEditGroupWithoutManager()
+    {
+        $groupId = factory(Group::class)->create([
+            'manager_id' => null,
+        ])->getKey();
+        // get the URL
+        $response = $this->webCall('GET', '/admin/groups/' . $groupId . '/edit');
+
+        $response->assertStatus(200);
+        // check the correct view is called
+        $response->assertViewIs('admin.groups.edit');
+        $response->assertSee('Group Manager');
+        $response->assertViewHas('group', function ($formData) {
+            return $formData->manager_id === null;
         });
     }
 }

--- a/tests/Feature/Admin/GroupTest.php
+++ b/tests/Feature/Admin/GroupTest.php
@@ -40,4 +40,25 @@ class GroupTest extends TestCase
         $response->assertViewIs('admin.groups.edit');
         $response->assertSee('Edit Group');
     }
+
+    /**
+     * Test to make sure the manager user is loaded
+     *
+     * @return void
+     */
+    public function testEditRouteHasManager()
+    {
+        $group = factory(Group::class)->create();
+        $groupId = $group->getKey();
+        // get the URL
+        $response = $this->webCall('GET', '/admin/groups/' . $groupId . '/edit');
+
+        $response->assertStatus(200);
+        // check the correct view is called
+        $response->assertViewIs('admin.groups.edit');
+        $response->assertSee('Group Manager');
+        $response->assertViewHas('group', function ($formData) use ($group) {
+            return $formData->manager_id === $group->manager_id;
+        });
+    }
 }

--- a/tests/unit/ProcessMaker/Models/GroupTest.php
+++ b/tests/unit/ProcessMaker/Models/GroupTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ProcessMaker\Models;
+
+use Tests\TestCase;
+
+class GroupTest extends TestCase
+{
+    /**
+     * Test group without manager.
+     *
+     * @return void
+     */
+    public function testGroupWithManager()
+    {
+        $group = \factory(Group::class)->make();
+        $this->assertInstanceOf(Group::class, $group);
+        $this->assertInstanceOf(User::class, $group->manager);
+        $this->assertEquals($group->manager_id, $group->manager->id);
+    }
+
+    /**
+     * Test group without manager.
+     *
+     * @return void
+     */
+    public function testGroupWithoutManager()
+    {
+        $group = \factory(Group::class)->make([
+            'manager_id' => null,
+        ]);
+        $this->assertInstanceOf(Group::class, $group);
+        $this->assertNull($group->manager);
+        $this->assertNull($group->manager_id);
+    }
+}


### PR DESCRIPTION
Fixes: http://tickets.pm4overflow.com/tickets/629

This PR includes:
- Migration to add manager_id to groups table
- Model updated to load Manager
- Group Factory updated to include manager user
- Unit Tests for Group Model
- Test Group Edit page loads properly the new property

Hints: On an already existing database, the new property manager will be filled by null

https://user-images.githubusercontent.com/8028650/130637622-1edb903c-c514-48a2-a3af-f865d05409bf.mp4

