### PR TITLE
Fixing missing filesystem entry for private settings

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -88,6 +88,11 @@ return [
             'url' => env('APP_URL').'/storage/setting',
             'visibility' => 'public',
         ],
+        'private_settings' => [
+            'driver' => 'local',
+            'root' => storage_path('app/private/settings'),
+            'visibility' => 'private',
+        ],
     ]
 
 


### PR DESCRIPTION
PR #3930 added functionality to upload files to settings records and uses a 'private_settings' filesystem disk.

This PR adds the default configuration for this disk.
