### PR TITLE
Allow 3 character usernames

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -164,7 +164,7 @@ class User extends Authenticatable implements HasMedia
 
         return [
             // The following characters where not included in the regexp: & %  ' " ? /
-            'username' => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:4', 'max:255' , $unique, $checkUserIsDeleted],
+            'username' => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:3', 'max:255' , $unique, $checkUserIsDeleted],
             'firstname' => ['required', 'max:50'],
             'lastname' => ['required', 'max:50'],
             'email' => ['required', 'email', $unique, $checkUserIsDeleted],

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -605,6 +605,8 @@ class UsersTest extends TestCase
             'mailhost!username@example.org',
             // (local part ending with non-alphanumeric character from the list of allowed printable characters)
             'user-@example.org',
+            '123', 
+            'abc', 
         ];
 
         $faker = Faker::create();
@@ -624,7 +626,8 @@ class UsersTest extends TestCase
 
         // Invalid cases
         $usernames = [
-            "123",
+            "12",
+            "ab",
             "test/test@test.com",
             // (space between the quotes)
             '" "@example.org',


### PR DESCRIPTION
Fixes http://tickets.pm4overflow.com/tickets/664

- Allows for 3 character usernames and modifies existing test

Note: Email addresses as usernames (and tests) were already added by https://github.com/ProcessMaker/processmaker/pull/3889