### PR TITLE
ticket 671 : Task Assignment Toggles Implementation

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -8,9 +8,11 @@ use ProcessMaker\Models\Process;
 use ProcessMaker\Managers\ModelerManager;
 use ProcessMaker\Events\ModelerStarting;
 use ProcessMaker\Managers\SignalManager;
+use ProcessMaker\Traits\HasControllerAddons;
 
 class ModelerController extends Controller
 {
+    use HasControllerAddons;
 
     /**
      * Invokes the Process Modeler for rendering.

--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -39,10 +39,26 @@
             
           <form-checkbox
               v-if="configurables.includes('LOCK_TASK_ASSIGNMENT')"
-              :label="$t('Lock Task Assignment to User')"
+              :label="$t('Lock User Assignment')"
               :checked="assignmentLockGetter"
               toggle="true"
               @change="assignmentLockSetter">
+          </form-checkbox>
+
+          <form-checkbox
+              v-if="configurables.includes('ESCALATE_TO_MANAGER')"
+              :label="$t('Escalate to Manager')"
+              :checked="escalateToManagerGetter"
+              toggle="true"
+              @change="escalateToManagerSetter">
+          </form-checkbox>
+
+          <form-checkbox
+              v-if="configurables.includes('ASSIGNEE_MANAGER_ESCALATION')"
+              :label="$t('Assignee Manager Escalation')"
+              :checked="assigneeManagerEscalationGetter"
+              toggle="true"
+              @change="assigneeManagerEscalationSetter">
           </form-checkbox>
 
           <form-checkbox
@@ -53,13 +69,6 @@
               @change="allowReassignmentSetter">
           </form-checkbox>
 
-          <form-checkbox
-              v-if="configurables.includes('ESCALATE_TO_MANAGER')"
-              :label="$t('Escalate to User Manager')"
-              :checked="escalateToManagerGetter"
-              toggle="true"
-              @change="escalateToManagerSetter">
-          </form-checkbox>
         </div>
     </div>
 </template>
@@ -79,42 +88,13 @@
       configurables: {
         type: Array,
         default() {
-          return ['LOCK_TASK_ASSIGNMENT', 'ALLOW_REASSIGNMENT', 'ASSIGN_BY_EXPRESSION', 'ESCALATE_TO_MANAGER'];
+          return ProcessMaker.modeler.configurables;
         },
       },
       assignmentTypes: {
         type: Array,
         default() {
-          return [
-            {
-              value: "user_group",
-              label: "Users / Groups"
-            },
-            {
-              value: "previous_task_assignee",
-              label: "Previous Task Assignee"
-            },
-            {
-              value: "requester",
-              label: "Request Starter"
-            },
-            {
-              value: "user_by_id",
-              label: "By User ID"
-            },
-            {
-              value: "self_service",
-              label: "Self Service"
-            },
-            {
-              value: "rule_expression",
-              label: "Rule Expression"
-            },
-            {
-              value: "process_manager",
-              label: "Process Manager"
-            },
-          ];
+          return ProcessMaker.modeler.assignmentTypes;
         },
       },
     },
@@ -153,6 +133,10 @@
       escalateToManagerGetter () {
         const config = this.node.config && JSON.parse(this.node.config) || {};
         return config.escalateToManager || false;
+      },
+      assigneeManagerEscalationGetter () {
+        const config = this.node.config && JSON.parse(this.node.config) || {};
+        return config.assigneeManagerEscalation || false;
       },
       assignmentLockGetter () {
         return _.get(this.node, "assignmentLock");
@@ -252,6 +236,11 @@
       escalateToManagerSetter (value) {
         const config = this.node.config && JSON.parse(this.node.config) || {};
         config.escalateToManager = value;
+        this.$set(this.node, "config", JSON.stringify(config));
+      },
+      assigneeManagerEscalationSetter (value) {
+        const config = this.node.config && JSON.parse(this.node.config) || {};
+        config.assigneeManagerEscalation = value;
         this.$set(this.node, "config", JSON.stringify(config));
       },
       /**

--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -37,36 +37,12 @@
             v-model="specialAssignments" 
           />
             
-          <form-checkbox
-              v-if="configurables.includes('LOCK_TASK_ASSIGNMENT')"
-              :label="$t('Lock User Assignment')"
-              :checked="assignmentLockGetter"
-              toggle="true"
-              @change="assignmentLockSetter">
-          </form-checkbox>
-
-          <form-checkbox
-              v-if="configurables.includes('ESCALATE_TO_MANAGER')"
-              :label="$t('Escalate to Manager')"
-              :checked="escalateToManagerGetter"
-              toggle="true"
-              @change="escalateToManagerSetter">
-          </form-checkbox>
-
-          <form-checkbox
-              v-if="configurables.includes('ASSIGNEE_MANAGER_ESCALATION')"
-              :label="$t('Assignee Manager Escalation')"
-              :checked="assigneeManagerEscalationGetter"
-              toggle="true"
-              @change="assigneeManagerEscalationSetter">
-          </form-checkbox>
-
-          <form-checkbox
-              v-if="configurables.includes('ALLOW_REASSIGNMENT')"
-              :label="$t('Allow Reassignment')"
-              :checked="allowReassignmentGetter"
-              toggle="true"
-              @change="allowReassignmentSetter">
+          <form-checkbox v-for="configurable in configurables"
+            :key="configurable"
+            :label="configurableLabel(configurable)"
+            :checked="getConfigurableValue(configurable)"
+            toggle="true"
+            @change="setConfigurableValue($event, configurable)">
           </form-checkbox>
 
         </div>
@@ -126,17 +102,6 @@
        */
       process () {
         return this.$root.$children[0].process;
-      },
-      /**
-       * Get the value of the edited property
-       */
-      escalateToManagerGetter () {
-        const config = this.node.config && JSON.parse(this.node.config) || {};
-        return config.escalateToManager || false;
-      },
-      assigneeManagerEscalationGetter () {
-        const config = this.node.config && JSON.parse(this.node.config) || {};
-        return config.assigneeManagerEscalation || false;
       },
       assignmentLockGetter () {
         return _.get(this.node, "assignmentLock");
@@ -230,18 +195,38 @@
       },
     },
     methods: {
-      /**
-       * Update escalateToManager property
-       */
-      escalateToManagerSetter (value) {
-        const config = this.node.config && JSON.parse(this.node.config) || {};
-        config.escalateToManager = value;
-        this.$set(this.node, "config", JSON.stringify(config));
+      getConfigurableValue(configurable) {
+        switch (configurable) {
+          case 'LOCK_TASK_ASSIGNMENT':
+            return this.assignmentLockGetter;
+          case 'ALLOW_REASSIGNMENT':
+            return this.allowReassignmentGetter;
+          default:
+            const config = this.node.config && JSON.parse(this.node.config) || {};
+            return config[window._.camelCase(configurable)] || false;
+        }
       },
-      assigneeManagerEscalationSetter (value) {
-        const config = this.node.config && JSON.parse(this.node.config) || {};
-        config.assigneeManagerEscalation = value;
-        this.$set(this.node, "config", JSON.stringify(config));
+      setConfigurableValue(value, configurable) {
+        switch (configurable) {
+          case 'LOCK_TASK_ASSIGNMENT':
+            return this.assignmentLockSetter(value);
+          case 'ALLOW_REASSIGNMENT':
+            return this.allowReassignmentSetter(value);
+          default:
+            const config = this.node.config && JSON.parse(this.node.config) || {};
+            config[window._.camelCase(configurable)] = value;
+            this.$set(this.node, "config", JSON.stringify(config));
+        }
+      },
+      configurableLabel(configurable) {
+        switch (configurable) {
+          case 'LOCK_TASK_ASSIGNMENT':
+            return this.$t('Lock User Assignment');
+          case 'ALLOW_REASSIGNMENT':
+            return this.$t('Allow Reassignment');
+          default:
+            return window._.startCase(configurable.toLowerCase());
+        }
       },
       /**
        * Update assignmentLock property

--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -355,10 +355,6 @@ ProcessMaker.EventBus.$on(
             assignmentTypes: [
               {
                 value: '',
-                label: ''
-              },
-              {
-                value: '',
                 label: 'Anonymous'
               },
               {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1516,5 +1516,7 @@
   "BPMN validation issues. Request cannot be started.": "BPMN validation issues. Request cannot be started.",
   "Process Manager not configured.": "Process Manager not configured.",
   "Out of Office": "Out of Office",
-  "Scheduled": "Scheduled"
+  "Scheduled": "Scheduled",
+  "Lock User Assignment": "Lock User Assignment",
+  "Assignee Manager Escalation": "Assignee Manager Escalation"
 }

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -60,7 +60,7 @@ div.main {
     xml: @json($process->bpmn),
     processName: @json($process->name),
     // list of toggles in assignment rules
-    configurables: ['LOCK_TASK_ASSIGNMENT', 'ALLOW_REASSIGNMENT', 'ASSIGN_BY_EXPRESSION'],
+    configurables: ['LOCK_TASK_ASSIGNMENT', 'ALLOW_REASSIGNMENT'],
     // list of items for assignment Types dropdown list
     assignmentTypes: [
       { value: "user_group", label: "Users / Groups" },

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -59,7 +59,18 @@ div.main {
     process: @json($process),
     xml: @json($process->bpmn),
     processName: @json($process->name),
-    signalPermissions: @json($signalPermissions),
+    // list of toggles in assignment rules
+    configurables: ['LOCK_TASK_ASSIGNMENT', 'ALLOW_REASSIGNMENT', 'ASSIGN_BY_EXPRESSION'],
+    // list of items for assignment Types dropdown list
+    assignmentTypes: [
+      { value: "user_group", label: "Users / Groups" },
+      { value: "previous_task_assignee", label: "Previous Task Assignee" },
+      { value: "requester", label: "Request Starter" },
+      { value: "user_by_id", label: "By User ID" },
+      { value: "self_service", label: "Self Service" },
+      { value: "rule_expression", label: "Rule Expression" },
+      { value: "process_manager", label: "Process Manager" },
+    ],
   }
   const warnings = @json($process->warnings);
  


### PR DESCRIPTION
Implements [http://tickets.pm4overflow.com/tickets/671](http://tickets.pm4overflow.com/tickets/671)

- Makes Assignment Rules toggles extensible
-  To extend or add toggles a page should add items to the new ProcessMaker.modeler.configurables array
-  The list of items inside the Assignment Rules is also extensible by packages adding items to ProcessMaker.modeler.assignmentTypes array.
