### PR TITLE
Import and export process manager settings

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -908,7 +908,6 @@ class ProcessController extends Controller
             }
 
             $process->bpmn = $definitions->saveXML();
-            $process->saveOrFail();
         }
 
         //If we are specifying cancel assignments...
@@ -920,6 +919,13 @@ class ProcessController extends Controller
         if ($request->has('edit_data')) {
             $this->editDataAssignments($process, $request);
         }
+
+        //If we are specifying a manager id
+        if ($request->has('manager_id')) {
+            $process->manager_id = $request->input('manager_id');
+        }
+            
+        $process->saveOrFail();
 
         return response([
             'process' => $process->refresh()

--- a/ProcessMaker/Jobs/ExportProcess.php
+++ b/ProcessMaker/Jobs/ExportProcess.php
@@ -116,6 +116,14 @@ class ExportProcess implements ShouldQueue
         }
 
         $this->process->bpmn = $this->definitions->saveXML();
+
+        if (!is_array($this->process->properties)) {
+            $this->process->properties = [];
+        }
+        
+        $properties = $this->process->properties;
+        $properties['manager_id'] = null;
+        $this->process->properties = $properties;
     }
 
     private function assignedToAnonymous($task)

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -588,7 +588,7 @@ class ImportProcess implements ShouldQueue
             $new->status = $process->status;
             $new->created_at = $this->formatDate($process->created_at);
             $new->deleted_at = $this->formatDate($process->deleted_at);
-            $new->properties = $process->properties;
+            $new->properties = isset($process->properties) ? (array) $process->properties : null;
             $new->save();
 
             $new->categories()->saveMany($this->new['process_categories']);

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -588,6 +588,7 @@ class ImportProcess implements ShouldQueue
             $new->status = $process->status;
             $new->created_at = $this->formatDate($process->created_at);
             $new->deleted_at = $this->formatDate($process->deleted_at);
+            $new->properties = $process->properties;
             $new->save();
 
             $new->categories()->saveMany($this->new['process_categories']);

--- a/resources/views/processes/import.blade.php
+++ b/resources/views/processes/import.blade.php
@@ -359,26 +359,20 @@
         },
         computed: {
           usersAndGroupsWithManger() {
-
-
-
-            console.log('usersAndGroupsWithManger computed', this.usersAndGroups);
-
-
-
-            
             const usersAndGroups = _.cloneDeep(this.usersAndGroups);
             const users = _.get(usersAndGroups, '0.items');
             if (!users) {
               return [];
             }
-            users.unshift({
+            users.unshift(this.managerOption);
+            _.set(usersAndGroups, '0.items', users);
+            return usersAndGroups;
+          },
+          managerOption() {
+            return {
                 id: 'manager',
                 fullname: this.$t('Process Manager')
-            });
-            _.set(usersAndGroups, '0.items', users);
-            console.log('usersAndGroups', usersAndGroups);
-            return usersAndGroups;
+            };
           },
         },
         methods: {
@@ -538,6 +532,11 @@
             }
             this.assignable = response.data.assignable;
             this.processId = response.data.process.id;
+            
+            if (_.get(response, 'data.process.properties.manager_can_cancel_request', false)) {
+              this.cancelRequest.push(this.managerOption);
+            }
+
             message = this.$t('The process was imported.');
             let variant = 'success';
             for (let item in this.options) {

--- a/resources/views/processes/import.blade.php
+++ b/resources/views/processes/import.blade.php
@@ -169,6 +169,16 @@
                                         <tr>
                                             <td class="assignable-name text-right">
                                                 {{ __('Assign') }}
+                                                <strong>{{ __('Process Manager') }}</strong> {{ __('to') }}
+                                                <i class="assignable-arrow fas fa-long-arrow-alt-right"></i>
+                                            </td>
+                                            <td class="assignable-entity">
+                                              <select-user v-model="manager" :multiple="false"></select-user>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="assignable-name text-right">
+                                                {{ __('Assign') }}
                                                 <strong>{{ __('Cancel Request') }}</strong> {{ __('to') }}
                                                 <i class="assignable-arrow fas fa-long-arrow-alt-right"></i>
                                             </td>
@@ -177,7 +187,7 @@
                                                 <multiselect id="search-user-groups-text"
                                                             v-model="cancelRequest"
                                                              placeholder="{{__('Type to search')}}"
-                                                             :options="usersAndGroups"
+                                                             :options="usersAndGroupsWithManger"
                                                              :multiple="true"
                                                              track-by="id"
                                                              :show-labels="false"
@@ -336,6 +346,7 @@
           usersAndGroups: [],
           users: [],
           processes: [],
+          manager: null,
           cancelRequest: [],
           processEditData: [],
           importingCode: importingCode ? importingCode[1] : null,
@@ -345,6 +356,30 @@
             value = value.toString();
             return value.charAt(0).toUpperCase() + value.slice(1);
           }
+        },
+        computed: {
+          usersAndGroupsWithManger() {
+
+
+
+            console.log('usersAndGroupsWithManger computed', this.usersAndGroups);
+
+
+
+            
+            const usersAndGroups = _.cloneDeep(this.usersAndGroups);
+            const users = _.get(usersAndGroups, '0.items');
+            if (!users) {
+              return [];
+            }
+            users.unshift({
+                id: 'manager',
+                fullname: this.$t('Process Manager')
+            });
+            _.set(usersAndGroups, '0.items', users);
+            console.log('usersAndGroups', usersAndGroups);
+            return usersAndGroups;
+          },
         },
         methods: {
           loadUsers(filter, getGroups, type) {
@@ -420,7 +455,9 @@
             response['groups'] = [];
 
             data.forEach(item => {
-              if (typeof item.id === "number") {
+              if (item.id === 'manager') {
+                response['pseudousers'] = ['manager'];
+              } else if (typeof item.id === "number") {
                 response['users'].push(parseInt(item.id));
               } else {
                 id = item.id.split('-');
@@ -434,7 +471,8 @@
               {
                 "assignable": this.assignable,
                 'cancel_request': this.formatAssignee(this.cancelRequest),
-                'edit_data': this.formatAssignee(this.processEditData)
+                'edit_data': this.formatAssignee(this.processEditData),
+                'manager_id': this.manager,
               })
               .then(response => {
                 ProcessMaker.alert(this.$t('All assignments were saved.'), 'success');

--- a/tests/Feature/Processes/ExportImportTest.php
+++ b/tests/Feature/Processes/ExportImportTest.php
@@ -604,4 +604,49 @@ class ExportImportTest extends TestCase
         $processId = $result->process->id;
         $this->apiCall('POST', "/processes/{$processId}/export");
     }
+
+    public function testExportImportWithProcessManager()
+    {
+        $process = factory(Process::class)->create(['name' => 'Manager test']);
+        $process->manager_id = 123;
+        $process->setProperty('manager_can_cancel_request', true);
+        $process->saveOrFail();
+        
+        $response = $this->apiCall('POST', "/processes/{$process->id}/export");
+        $response = $this->webCall('GET', $response->json('url'));
+        // Get our file contents (we have to do it this way because of
+        // Symfony's weird response API)
+        ob_start();
+        $content = $response->sendContent();
+        $content = ob_get_clean();
+
+        // Save the file contents and convert them to an UploadedFile
+        $fileName = tempnam(sys_get_temp_dir(), 'exported');
+        file_put_contents($fileName, $content);
+        $file = new UploadedFile($fileName, 'test.json', null, null, null, true);
+        
+        // Import the process
+        $response = $this->apiCall('POST', "/processes/import", ['file' => $file]);
+        $process = Process::find($response->json('process')['id']);
+        
+        $this->assertNull($process->manager);
+        $this->assertTrue($process->getProperty('manager_can_cancel_request'));
+
+        $managerUser = factory(User::class)->create();
+
+        $response = $this->apiCall('POST', '/processes/' . $process->id . '/import/assignments', [
+            'assignable' => [],
+            'manager_id' => $managerUser->id,
+            'cancel_request' => [
+                'users' => [],
+                'groups' => [],
+                'pseudousers' => [] // Remove the permission
+            ],
+        ]);
+
+        $process->refresh();
+        $this->assertFalse($process->getProperty('manager_can_cancel_request'));
+        $this->assertEquals($managerUser->id, $process->manager->id);
+
+    }
 }


### PR DESCRIPTION
Fixes http://tickets.pm4overflow.com/tickets/673

- Removes the process manager assignment on export
- Allows the user to choose a process manager on import
- If the process manager had permission to cancel a request, that value is pre-populated on import

![image](https://user-images.githubusercontent.com/2546850/131572826-1b9bc53f-a603-4f7b-b4a2-c172d6ea8453.png)
