### PR TITLE
Add getter/setter for User->meta

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -72,6 +72,7 @@ class User extends Authenticatable implements HasMedia
      *   @OA\Property(property="birthdate", type="string", format="date"),
      *   @OA\Property(property="delegation_user_id", type="string", format="id"),
      *   @OA\Property(property="manager_id", type="string", format="id"),
+     *   @OA\Property(property="meta", type="object", additionalProperties=true),
      * ),
      * @OA\Schema(
      *   schema="users",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -705,6 +705,59 @@
                 }
             }
         },
+        "/groups/{group_id}/groups": {
+            "get": {
+                "tags": [
+                    "Groups"
+                ],
+                "summary": "Returns all users of a group",
+                "operationId": "getGroupGroupss",
+                "parameters": [
+                    {
+                        "name": "group_id",
+                        "in": "path",
+                        "description": "ID of group",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of members of a group",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "description": "Display the list of groups in a group",
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/groups"
+                                            }
+                                        },
+                                        "meta": {
+                                            "$ref": "#/components/schemas/metadata"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/group_members": {
             "get": {
                 "tags": [
@@ -5568,6 +5621,11 @@
                         "description": "The attributes that are mass assignable.",
                         "type": "string",
                         "format": "id"
+                    },
+                    "meta": {
+                        "description": "The attributes that are mass assignable.",
+                        "type": "object",
+                        "additionalProperties": true
                     }
                 },
                 "type": "object"


### PR DESCRIPTION
This PR adds a getter/setter for User->meta to SDK.
`meta` is of type `Free-Form Object`

Example of use:
```
<?php
$apiInstance = $api->users();
$user = $apiInstance->getUserById(3);
$meta = $user->getMeta();
$meta['bar'] = 'bar';
$user->setMeta($meta);
$apiInstance->updateUser(3, $user);
return [
    'user_meta' => $user->getMeta()
];

```