### PR TITLE
Implement Docker Remote Logic

### DIFF
--- a/ProcessMaker/BuildSdk.php
+++ b/ProcessMaker/BuildSdk.php
@@ -5,6 +5,7 @@ use \Exception;
 use \ZipArchive;
 use function GuzzleHttp\json_decode;
 use ProcessMaker\Events\BuildScriptExecutor;
+use ProcessMaker\Facades\Docker;
 
 class BuildSdk {
     private $debug = true;
@@ -54,7 +55,7 @@ class BuildSdk {
 
     private function cp($from, $to)
     {
-        $this->runCmd("docker cp " . $from . " " . $to);
+        $this->runCmd(Docker::command()." cp " . $from . " " . $to);
     }
 
     private function imageWithTag()
@@ -64,13 +65,13 @@ class BuildSdk {
 
     private function startContainer()
     {
-        $this->runCmd("docker run -t -d --entrypoint '/bin/sh' --name generator " . $this->imageWithTag());
+        $this->runCmd(Docker::command()." run -t -d --entrypoint '/bin/sh' --name generator " . $this->imageWithTag());
     }
 
     private function stopContainer()
     {
-        $this->runCmd("docker kill generator || true");
-        $this->runCmd("docker rm generator || true");
+        $this->runCmd(Docker::command()." kill generator || true");
+        $this->runCmd(Docker::command()." rm generator || true");
     }
 
     public function setLang($value)
@@ -87,12 +88,12 @@ class BuildSdk {
         if (!$this->lang) {
             throw new Exception("Language must be specified using setLang()");
         }
-        return $this->runCmd('docker run ' . $this->imageWithTag() . ' config-help -g ' . $this->lang);
+        return $this->runCmd(Docker::command().' run ' . $this->imageWithTag() . ' config-help -g ' . $this->lang);
     }
     
     public function getAvailableLanguages()
     {
-        $result = $this->runCmd('docker run ' . $this->imageWithTag() . ' list -s');
+        $result = $this->runCmd(Docker::command().' run ' . $this->imageWithTag() . ' list -s');
         return explode(",", $result);
     }
 
@@ -123,7 +124,7 @@ class BuildSdk {
 
     private function generator($cmd)
     {
-        return $this->runCmd('docker exec generator docker-entrypoint.sh ' . $cmd);
+        return $this->runCmd(Docker::command().' exec generator docker-entrypoint.sh ' . $cmd);
     }
 
     private function writeOptionsToTmpFile()

--- a/ProcessMaker/Console/Commands/BuildScriptExecutors.php
+++ b/ProcessMaker/Console/Commands/BuildScriptExecutors.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Console\Commands;
 use Illuminate\Console\Command;
 use ProcessMaker\Events\BuildScriptExecutor;
 use ProcessMaker\Models\ScriptExecutor;
+use ProcessMaker\Facades\Docker;
 use \Exception;
 
 class BuildScriptExecutors extends Command
@@ -145,7 +146,7 @@ class BuildScriptExecutors extends Command
         $this->info("Building the docker executor");
 
         $image = $scriptExecutor->dockerImageName();
-        $command = "docker build --build-arg SDK_DIR=/sdk -t ${image} -f ${packagePath}/Dockerfile.custom ${packagePath}";
+        $command = Docker::command()." build --build-arg SDK_DIR=/sdk -t ${image} -f ${packagePath}/Dockerfile.custom ${packagePath}";
 
         if ($this->userId) {
             $this->runProc(
@@ -237,7 +238,7 @@ class BuildScriptExecutors extends Command
 
     private function renameDockerImage($old, $new)
     {
-        system("docker tag $old $new");
-        system("docker rmi $old");
+        system(Docker::command()." tag $old $new");
+        system(Docker::command()." rmi $old");
     }
 }

--- a/ProcessMaker/Facades/Docker.php
+++ b/ProcessMaker/Facades/Docker.php
@@ -1,10 +1,17 @@
 <?php
-
 namespace ProcessMaker\Facades;
 
 use Illuminate\Support\Facades\Facade;
 use ProcessMaker\Managers\DockerManager;
 
+/**
+ * @see \ProcessMaker\Managers\DockerManager
+ * 
+ * @method bool hasRemoteDocker()
+ * @method string getDockerHost()
+ * @method string getDockerExecutable(int)
+ * @method mixed command(int)
+ */
 class Docker extends Facade
 {
     /**

--- a/ProcessMaker/Facades/Docker.php
+++ b/ProcessMaker/Facades/Docker.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ProcessMaker\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use ProcessMaker\Managers\DockerManager;
+
+class Docker extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return DockerManager::class;
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
@@ -11,6 +11,7 @@ use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Jobs\BuildScriptExecutor;
 use ProcessMaker\Models\ScriptExecutor;
 use ProcessMaker\Models\Script;
+use ProcessMaker\Facades\Docker;
 
 class ScriptExecutorController extends Controller
 {
@@ -58,10 +59,10 @@ class ScriptExecutorController extends Controller
             throw ValidationException::withMessages(['delete' => __('Can not delete the only executor for this language.')]);
         }
 
-        $cmd = 'docker images -q ' . $scriptExecutor->dockerImageName(); 
+        $cmd = Docker::command().' images -q ' . $scriptExecutor->dockerImageName(); 
         exec($cmd, $out, $return);
         if (count($out) > 0) {
-            $cmd = 'docker rmi ' . $scriptExecutor->dockerImageName(); 
+            $cmd = Docker::command().' rmi ' . $scriptExecutor->dockerImageName(); 
             exec($cmd, $out, $return);
 
             if ($return !== 0) {

--- a/ProcessMaker/Managers/DockerManager.php
+++ b/ProcessMaker/Managers/DockerManager.php
@@ -1,23 +1,44 @@
 <?php
 namespace ProcessMaker\Managers;
-
+/**
+ * Manager class created to handle ProcessMaker's docker execution globally
+ */
 class DockerManager
 {
+    /**
+     * Returns if the application has set up a remote docker server
+     * @return bool
+     */
     public function hasRemoteDocker()
     {
         return config('app.processmaker_scripts_docker_host') !== '';
     }
 
+    /**
+     * Returns the DOCKER_HOST env injection to be used before command if remote docker it's enabled
+     * @return string
+     */
     public function getDockerHost()
     {
         return self::hasRemoteDocker() ? 'DOCKER_HOST='.config('app.processmaker_scripts_docker_host') : '';
     }
 
+    /**
+     * Returns the docker command executable to be used by the app, includes a timeout command if required
+     * 
+     * @param int $timeout (optional) Default to 0 sec, set the timeout in seconds for the docker
+     * @return string
+     */
     public function getDockerExecutable($timeout = 0)
     {
         return $timeout > 0 ? "timeout -s 9 $timeout ".config('app.processmaker_scripts_docker') : config('app.processmaker_scripts_docker');
     }
-
+    /**
+     * Returns the CLI command to execute docker in ProcessMaker, it includes all logic from configuration (timeout, remote docker, etc).
+     * 
+     * @param int $timeout (optional) Default to 0 sec, set the timeout in seconds for the docker
+     * @return string
+     */
     public function command($timeout = 0){
         if (self::hasRemoteDocker()){
             return self::getDockerHost(). ' '. self::getDockerExecutable($timeout);

--- a/ProcessMaker/Managers/DockerManager.php
+++ b/ProcessMaker/Managers/DockerManager.php
@@ -1,0 +1,27 @@
+<?php
+namespace ProcessMaker\Managers;
+
+class DockerManager
+{
+    public function hasRemoteDocker()
+    {
+        return config('app.processmaker_scripts_docker_host') !== '';
+    }
+
+    public function getDockerHost()
+    {
+        return self::hasRemoteDocker() ? 'DOCKER_HOST='.config('app.processmaker_scripts_docker_host') : '';
+    }
+
+    public function getDockerExecutable($timeout = 0)
+    {
+        return $timeout > 0 ? "timeout -s 9 $timeout ".config('app.processmaker_scripts_docker') : config('app.processmaker_scripts_docker');
+    }
+
+    public function command($timeout = 0){
+        if (self::hasRemoteDocker()){
+            return self::getDockerHost(). ' '. self::getDockerExecutable($timeout);
+        }
+        return self::getDockerExecutable($timeout);
+    }
+}

--- a/ProcessMaker/Managers/DockerManager.php
+++ b/ProcessMaker/Managers/DockerManager.php
@@ -31,7 +31,9 @@ class DockerManager
      */
     public function getDockerExecutable($timeout = 0)
     {
-        return $timeout > 0 ? "timeout -s 9 $timeout ".config('app.processmaker_scripts_docker') : config('app.processmaker_scripts_docker');
+        return $timeout > 0 ? 
+            config('app.processmaker_scripts_timeout') . " -s 9 $timeout " . config('app.processmaker_scripts_docker') : 
+            config('app.processmaker_scripts_docker');
     }
     /**
      * Returns the CLI command to execute docker in ProcessMaker, it includes all logic from configuration (timeout, remote docker, etc).

--- a/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Models;
 use Log;
 use ProcessMaker\Exception\ScriptException;
 use ProcessMaker\Exception\ScriptTimeoutException;
+use ProcessMaker\Facades\Docker;
 
 /**
  * Execute a docker container binding files to interchange information.
@@ -56,13 +57,7 @@ trait ScriptDockerBindingFilesTrait
      */
     private function runContainer($image, $command, $parameters, $bindings, $timeout)
     {
-        $cmd = '';
-
-        if ($timeout > 0) {
-            $cmd .= "timeout -s 9 $timeout ";
-        }
-
-        $cmd .= config('app.processmaker_scripts_docker') . sprintf(
+        $cmd = Docker::command($timeout) . sprintf(
             ' run --rm %s %s %s %s 2>&1',
             $parameters,
             $bindings,

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -123,7 +123,7 @@ class ProcessMakerServiceProvider extends ServiceProvider
          * to manage docker execution over the application.
          */
         $this->app->singleton(DockerManager::class, function($app) {
-            return new DocckerManager();
+            return new DockerManager();
         });
 
         $this->app->singleton(GlobalScriptsManager::class, function($app) {

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Providers;
 use Blade;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Validator;
+use ProcessMaker\Managers\DockerManager;
 use ProcessMaker\Managers\IndexManager;
 use ProcessMaker\Managers\LoginManager;
 use ProcessMaker\Managers\ModelerManager;
@@ -115,6 +116,14 @@ class ProcessMakerServiceProvider extends ServiceProvider
          */
         $this->app->singleton(ScriptBuilderManager::class, function($app) {
             return new ScriptBuilderManager();
+        });
+
+        /**
+         * Maps our Docker Manager as a singleton. The Docker Manager is used
+         * to manage docker execution over the application.
+         */
+        $this->app->singleton(DockerManager::class, function($app) {
+            return new DocckerManager();
         });
 
         $this->app->singleton(GlobalScriptsManager::class, function($app) {

--- a/config/app.php
+++ b/config/app.php
@@ -55,6 +55,7 @@ return [
     'web_client_application_id' => env('PM_CLIENT_ID', 'x-pm-local-client'),
 
     // The processmaker BPM scripts configuration
+    'processmaker_scripts_docker_host' => env('PROCESSMAKER_SCRIPTS_DOCKER_HOST', ''),
     'processmaker_scripts_home' => env('PROCESSMAKER_SCRIPTS_HOME', __DIR__ . '/../storage/app'),
     'processmaker_scripts_docker' => env('PROCESSMAKER_SCRIPTS_DOCKER', '/usr/bin/docker'),
     'processmaker_scripts_docker_mode' => env('PROCESSMAKER_SCRIPTS_DOCKER_MODE', 'binding'),
@@ -159,6 +160,7 @@ return [
         'GlobalScripts' => ProcessMaker\Facades\GlobalScripts::class,
         'WorkspaceManager' => ProcessMaker\Facades\WorkspaceManager::class,
         'SkinManager' => ProcessMaker\Facades\SkinManager::class,
+        'Docker' => ProcessMaker\Facades\Docker::class,
 
         /**
          * Other Facades

--- a/config/app.php
+++ b/config/app.php
@@ -55,10 +55,10 @@ return [
     'web_client_application_id' => env('PM_CLIENT_ID', 'x-pm-local-client'),
 
     // The processmaker BPM scripts configuration
-    'processmaker_scripts_docker_host' => env('PROCESSMAKER_SCRIPTS_DOCKER_HOST', ''),
     'processmaker_scripts_home' => env('PROCESSMAKER_SCRIPTS_HOME', __DIR__ . '/../storage/app'),
     'processmaker_scripts_docker' => env('PROCESSMAKER_SCRIPTS_DOCKER', '/usr/bin/docker'),
     'processmaker_scripts_docker_mode' => env('PROCESSMAKER_SCRIPTS_DOCKER_MODE', 'binding'),
+    'processmaker_scripts_docker_host' => env('PROCESSMAKER_SCRIPTS_DOCKER_HOST', ''),
     'processmaker_scripts_timeout' => env('PROCESSMAKER_SCRIPTS_TIMEOUT', 'timeout'),
     'timer_events_seconds' => env('TIMER_EVENTS_SECONDS', 'truncate'),
     'bpmn_actions_max_lock_time' => intval(env('BPMN_ACTIONS_MAX_LOCK_TIME', 60)),

--- a/config/app.php
+++ b/config/app.php
@@ -59,6 +59,7 @@ return [
     'processmaker_scripts_home' => env('PROCESSMAKER_SCRIPTS_HOME', __DIR__ . '/../storage/app'),
     'processmaker_scripts_docker' => env('PROCESSMAKER_SCRIPTS_DOCKER', '/usr/bin/docker'),
     'processmaker_scripts_docker_mode' => env('PROCESSMAKER_SCRIPTS_DOCKER_MODE', 'binding'),
+    'processmaker_scripts_timeout' => env('PROCESSMAKER_SCRIPTS_TIMEOUT', 'timeout'),
     'timer_events_seconds' => env('TIMER_EVENTS_SECONDS', 'truncate'),
     'bpmn_actions_max_lock_time' => intval(env('BPMN_ACTIONS_MAX_LOCK_TIME', 60)),
 

--- a/tests/Feature/Docker/DockerFacadeTest.php
+++ b/tests/Feature/Docker/DockerFacadeTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Tests\Feature\Docker;
+
+use Tests\TestCase;
+use ProcessMaker\Facades\Docker;
+
+class DockerFacadeTest extends TestCase
+{
+    /**
+     * Default timeout command
+     */
+    const DEFAULT_TIMEOUT_COMMAND = "timeout";
+    /**
+     * Default docker command
+     */
+    const DEFAULT_DOCKER_COMMAND = "/usr/bin/docker";
+
+    protected function setUp() : void
+    {
+        // Set empty env variables
+        config(['app.processmaker_scripts_docker_host' => '']);
+        config(['app.processmaker_scripts_docker' => '']);
+        config(['app.processmaker_scripts_timeout' => '']);
+    }
+
+    public function testValidateDockerDefaultEnvironmentVariables()
+    {
+        $dockerHost = Docker::getDockerHost();
+        $this->assertEquals($dockerHost, '');
+
+        $this->assertFalse(Docker::hasRemoteDocker());
+
+        $command = Docker::command();
+        $this->assertEquals($command, self::DEFAULT_DOCKER_COMMAND);
+
+        $commandWithTimeout = Docker::command($timeout = 30);
+        $this->assertEquals($commandWithTimeout, implode(' ', [
+            self::DEFAULT_TIMEOUT_COMMAND,
+            "-s 9",
+            $timeout,
+            self::DEFAULT_DOCKER_COMMAND
+        ]));   
+    }
+
+
+    public function testEvaluateWhenRemoteDockerHostEnabled()
+    {
+        $dockerHost = "tcp://127.0.0.1:2375";
+        $timeout = 12;
+
+        // Enable remote docker host
+        config(['app.processmaker_scripts_docker_host' => $dockerHost]);
+
+        $this->assertTrue(Docker::hasRemoteDocker());
+
+        $envInjection = Docker::getDockerHost();
+        $this->assertEquals($envInjection, "DOCKER_HOST=" . $dockerHost);
+        
+        $command = Docker::command();
+        $this->assertEquals($command, "DOCKER_HOST=" . $dockerHost." ".self::DEFAULT_DOCKER_COMMAND);
+
+        $commandWithTimeout = Docker::command($timeout);
+        $this->assertEquals($commandWithTimeout,
+            implode(" ", [
+                "DOCKER_HOST=" . $dockerHost,
+                self::DEFAULT_TIMEOUT_COMMAND,
+                "-s 9",
+                $timeout,
+                self::DEFAULT_DOCKER_COMMAND
+            ])
+        );
+    }
+
+    public function testValidateCustomTimeoutEnvironmentVariable()
+    {
+        // Set custom timeout command
+        $customTimeoutCmd = "/usr/local/bin/gtimeout";
+        config(['app.processmaker_scripts_timeout' => $customTimeoutCmd]);
+
+        // Valid Timeout
+        $timeout = 30;
+
+        $command = Docker::command($timeout);
+        $this->assertEquals($command, implode(' ', [
+            $customTimeoutCmd,
+            '-s 9',
+            $timeout,
+            self::DEFAULT_DOCKER_COMMAND
+        ]));
+    }
+
+    public function testValidateCustomDockerEnvironmentVariable()
+    {
+        // Set custom docker command
+        $customDockerCmd = "/usr/local/bin/docker";
+        config(['app.processmaker_scripts_docker' => $customDockerCmd]);
+
+        $command = Docker::command();
+        $this->assertEquals($command, $customDockerCmd);
+    }
+
+    public function testTimeoutZeroDoesNotBeIncluded()
+    {
+        // Define No Timeout
+        $timeout = 0;
+
+        $command = Docker::command($timeout);
+        $this->assertEquals($command, self::DEFAULT_DOCKER_COMMAND);
+    }
+}

--- a/tests/Feature/Docker/DockerFacadeTest.php
+++ b/tests/Feature/Docker/DockerFacadeTest.php
@@ -19,8 +19,8 @@ class DockerFacadeTest extends TestCase
     {
         // Set empty env variables
         config(['app.processmaker_scripts_docker_host' => '']);
-        config(['app.processmaker_scripts_docker' => '']);
-        config(['app.processmaker_scripts_timeout' => '']);
+        config(['app.processmaker_scripts_docker' => self::DEFAULT_DOCKER_COMMAND]);
+        config(['app.processmaker_scripts_timeout' => self::DEFAULT_TIMEOUT_COMMAND]);
     }
 
     public function testValidateDockerDefaultEnvironmentVariables()


### PR DESCRIPTION
This feature adds the capability to use a remote docker server instead a local one, also adds the capability to define a custom timeout command.

In order to enable this on ProcessMaker two new env variables can be included on the `.env` file.

**PROCESSMAKER_SCRIPTS_DOCKER_HOST=
PROCESSMAKER_SCRIPTS_TIMEOUT=**

_PROCESSMAKER_SCRIPTS_DOCKER_HOST_ allows to define the URI required to connect to the remote docker server (example: 'tcp://10.10.0.1:2376')
_PROCESSMAKER_SCRIPTS_TIMEOUT_ allows to define the path for the custom timeout command (example: In MacOS timeout command is '/usr/local/bin/gtimeout')

