### PR TITLE
Remove outdated data connector 'response' stored in request

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -272,7 +272,7 @@ trait MakeHttpRequests
         $status = $response->getStatusCode();
         $bodyContent = $response->getBody()->getContents();
         if (!$this->isJson($bodyContent)) {
-            return ["response" => $bodyContent, "status" => $status];
+            return ["status" => $status];
         }
 
         switch (true) {
@@ -288,7 +288,6 @@ trait MakeHttpRequests
         $mapped = [];
         !is_array($content) ?: $merged = array_merge($data, $content);
         $mapped['status'] = $status;
-        $mapped['response'] = $content;
 
         if (isset($config['dataMapping'])) {
             foreach ($config['dataMapping'] as $map) {
@@ -308,7 +307,7 @@ trait MakeHttpRequests
         $status = $response->getStatusCode();
         $bodyContent = $response->getBody()->getContents();
         if (!$this->isJson($bodyContent)) {
-            return ["response" => $bodyContent, "status" => $status];
+            return ["status" => $status];
         }
 
         switch (true) {
@@ -324,7 +323,6 @@ trait MakeHttpRequests
 
         $mapped = [];
         $mapped['status'] = $status;
-        $mapped['response'] = $content;
 
         if (!isset($config['dataMapping'])) {
             return $mapped;


### PR DESCRIPTION
Fixes [Ticket 736](http://tickets.pm4overflow.com/tickets/736)

[4.1 Fix](https://github.com/ProcessMaker/processmaker/pull/4017)

<h2>Changes</h2>

Remove the outdated data sources `response` stored in the request.  
