### PR TITLE
Show Custom Css Button on Form screens

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -276,15 +276,6 @@ export default {
         section: "right",
         items: [
           {
-            id: "button_custom_css",
-            type: "button",
-            title: this.$t("Custom CSS"),
-            name: this.$t("CSS"),
-            variant: "secondary",
-            icon: "fab fa-css3",
-            action: 'openCustomCSS()'
-          },
-          {
             id: "button_watchers",
             type: "button",
             title: this.$t("Watchers"),
@@ -327,6 +318,16 @@ export default {
       variant: "secondary",
       icon: "fas fa-flask",
       action: 'openComputedProperties()'
+    };
+
+    const customCssOption = {
+      id: "button_custom_css",
+      type: "button",
+      title: this.$t("Custom CSS"),
+      name: this.$t("CSS"),
+      variant: "secondary",
+      icon: "fab fa-css3",
+      action: 'openCustomCSS()'
     };
 
     return {
@@ -375,6 +376,7 @@ export default {
       previewComponents: [],
       optionsMenu: options,
       calcsOption: calcsOption,
+      customCssOption: customCssOption,
       rendererKey: 0,
       renderComponent: 'task-screen'
     };
@@ -474,6 +476,7 @@ export default {
     this.mountWhenTranslationAvailable();
     this.countElements();
     this.addCalcsButton();
+    this.addCustomCssBtn();
   },
   methods: {
     addCalcsButton() {
@@ -481,6 +484,12 @@ export default {
         return;
       }
       this.optionsMenu[1].items.unshift(this.calcsOption);
+    },
+    addCustomCssBtn() {
+      if (this.type !== formTypes.form) {
+        return;
+      }
+      this.optionsMenu[1].items.splice(1, 0, this.customCssOption);
     },
     countElements() {
       this.$refs.renderer.countElements(this.config).then(allElements => {


### PR DESCRIPTION
Fixes [Ticket 739](http://tickets.pm4overflow.com/tickets/739)

[4.2 PR](https://github.com/ProcessMaker/processmaker/pull/4019)

<h2>Changes</h2>

- Removes the Custom CSS button for non-form screens (Email, Display, Conversational)