### PR TITLE
Handle json encoded rows in vuetable (4.2)

### DIFF
--- a/database/factories/ProcessRequestFactory.php
+++ b/database/factories/ProcessRequestFactory.php
@@ -15,7 +15,7 @@ $factory->define(ProcessRequest::class, function (Faker $faker) {
     return [
         'name' => $faker->sentence(3),
         'data' => [],
-        'status' => $faker->randomElement(['DRAFT', 'ACTIVE', 'COMPLETED']),
+        'status' => 'ACTIVE',
         'callable_id' => function () use ($process) {
             $process->save();
             $bpmnProcess = $process->getDefinitions()->getElementsByTagNameNS(BpmnDocument::BPMN_MODEL, 'process')->item(0);

--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -73,7 +73,15 @@ export default {
             data.meta.last_page = data.meta.total_pages;
             data.meta.from = (data.meta.current_page - 1) * data.meta.per_page;
             data.meta.to = data.meta.from + data.meta.count;
+            data.data = this.jsonRows(data.data);
             return data;
+        },
+        // Some controllers return each row as a json object to preserve integer keys (ie saved search)
+        jsonRows(rows) {
+            if (rows.length === 0 || !('_json' in rows[0])) {
+                return rows;
+            }
+            return rows.map(row => JSON.parse(row._json));
         },
         // Handler to set pagination data on our pagination based off of data passed into vuetable
         onPaginationData(data) {

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -237,6 +237,7 @@ export default {
       data.meta.last_page = data.meta.total_pages;
       data.meta.from = (data.meta.current_page - 1) * data.meta.per_page;
       data.meta.to = data.meta.from + data.meta.count;
+      data.data = this.jsonRows(data.data);
       for (let record of data.data) {
         //Format dates
         record["initiated_at"] = this.formatDate(record["initiated_at"]);


### PR DESCRIPTION
Part of https://github.com/ProcessMaker/package-savedsearch/pull/263

- Allows json encoded rows for vuetable to preserve numeric object keys
- Removes random element from test factory to help with debugging