### PR TITLE
[4.1] Ticket #727: Saved Search Issues

### DIFF
--- a/resources/js/components/AdvancedSearch.vue
+++ b/resources/js/components/AdvancedSearch.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="search-bar" class="search mb-3">
+    <div id="search-bar" class="search advanced-search mb-3">
         <div class="d-flex">
             <div class="flex-grow-1">
                 <div v-if="! advanced" class="search-bar-advanced d-flex flex-column flex-md-row w-100">
@@ -16,7 +16,7 @@
                                      :multiple="true"
                                      :placeholder="$t('Process')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -36,7 +36,7 @@
                                      :multiple="true"
                                      :placeholder="$t('Status')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -57,7 +57,7 @@
                                      :multiple="true"
                                      :placeholder="$t('Requester')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -84,7 +84,7 @@
                                      :multiple="true"
                                      :placeholder="$t('Participants')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -113,7 +113,7 @@
                                      :multiple="true"
                                      :placeholder="$t('Request')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -134,7 +134,7 @@
                                      :multiple="true"
                                      :placeholder="$t('Task')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -154,7 +154,7 @@
                                      :multiple="true"
                                      :placeholder="$t('Status')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -501,13 +501,34 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-    .multiselect__placeholder {
-        padding-top: 1px;
-    }
-
-    .multiselect__single {
-        padding-bottom: 2px;
-        padding-top: 2px;
+<style lang="scss">
+    .advanced-search {
+        .multiselect__placeholder {
+            padding-top: 1px;
+        }
+        
+        .multiselect,
+        .multiselect__input,
+        .multiselect__single {
+            font-size: 14px;
+        }
+        
+        .multiselect__input {
+            left: 1px;
+            padding: 2px 0 2px 10px;
+            position: absolute;
+            top: 8px;
+        }
+        
+        .multiselect--active {
+            .multiselect__input {
+                width: 99% !important;
+            }
+        }
+        
+        .multiselect__single {
+            padding-bottom: 2px;
+            padding-top: 2px;
+        }
     }
 </style>

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -92,7 +92,8 @@ export default {
         }
       ],
       fields: [],
-      previousFilter: ""
+      previousFilter: "",
+      previousPmql: "",
     };
   },
   computed: {
@@ -265,6 +266,12 @@ export default {
             }
 
             this.previousFilter = filter;
+            
+            if (this.previousPmql !== pmql) {
+              this.page = 1;
+            }
+            
+            this.previousPmql = pmql;
 
             // Load from our api client
             ProcessMaker.apiClient

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -120,7 +120,8 @@ export default {
         }
       ],
       fields: [],
-      previousFilter: ""
+      previousFilter: "",
+      previousPmql: "",
     };
   },
   computed: {
@@ -348,6 +349,12 @@ export default {
             }
 
             this.previousFilter = filter;
+            
+            if (this.previousPmql !== pmql) {
+              this.page = 1;
+            }
+            
+            this.previousPmql = pmql;
             
             // Load from our api client
             ProcessMaker.apiClient

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -335,7 +335,7 @@ export default {
                 pmql = `(${pmql}) and (${filter})`;
                 filter = '';
               } else {
-                let filterParams =
+                filterParams =
                     "&user_id=" +
                     window.ProcessMaker.user.id +
                     "&filter=" +


### PR DESCRIPTION
## Fixes
- [FOUR-3996](https://processmaker.atlassian.net/browse/FOUR-3996) Screen building inspector chart select showing only 10 charts - should show all
- [FOUR-4036](https://processmaker.atlassian.net/browse/FOUR-4036) No results in a search changing tabs
- [FOUR-3633](https://processmaker.atlassian.net/browse/FOUR-3633) Swagger example results in 422 error
- [FOUR-4024](https://processmaker.atlassian.net/browse/FOUR-4024) Searching with PMQL input should be expected to be in the logged in user's timezone
- [FOUR-3360](https://processmaker.atlassian.net/browse/FOUR-3360) Super-Admin permission must allow user to see ALL saved searches
- [FOUR-3932](https://processmaker.atlassian.net/browse/FOUR-3932) After clearing Task saved search you cannot search by Request name
- [FOUR-3933](https://processmaker.atlassian.net/browse/FOUR-3933) Text Search in filters not working
- [FOUR-3951](https://processmaker.atlassian.net/browse/FOUR-3951) Task Saved Search includes unrelated results
- Cannot use greater than in PMQL with Saved Search API

## Requires
- https://github.com/ProcessMaker/package-savedsearch/pull/269

## 4.2 Equivalent
- https://github.com/ProcessMaker/processmaker/pull/4025

## Ticket
- http://tickets.pm4overflow.com/tickets/727