### PR TITLE
[4.2] Ticket #727: Saved Search Issues

### DIFF
--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -2,10 +2,13 @@
 
 namespace ProcessMaker\Traits;
 
+use Carbon\Carbon;
+use Carbon\CarbonTimeZone;
 use Illuminate\Database\Eloquent\Builder;
 use ProcessMaker\Models\User;
 use ProcessMaker\Query\Expression;
 use ProcessMaker\Query\Traits\PMQL;
+use Throwable;
 
 trait ExtendedPMQL
 {
@@ -52,14 +55,9 @@ trait ExtendedPMQL
         $model = $builder->getModel();
         
         if (is_string($field)) {
-            // Check the type of our value; set as string if possible
-            if (is_a($expression->value, 'ProcessMaker\\Query\\LiteralValue')) {
-                $value = $expression->value->value();
-            } elseif (is_a($expression->value, 'ProcessMaker\\Query\\ArrayValue')) {
-                $value = $expression->value->value();
-            } else {
-                $value = $expression->value;
-            }
+            // Parse our value
+            $value = $this->parseValue($expression);
+            $expression->value->setValue($value);
             
             // Title case our field name so we can suffix it to our method names
             $fieldMethodName = ucfirst(strtolower($field));
@@ -110,5 +108,38 @@ trait ExtendedPMQL
                 return $model->{$method}($value, $expression, $builder, $user);
             }    
         }
+    }
+    
+    /**
+     * Set the value as a string if possible. Also convert to the logged-in
+     * user's timezone if the value is parsable by Carbon as a date.
+     *
+     * @param \ProcessMaker\Query\Expression $expression
+     *
+     * @return mixed
+     */
+    private function parseValue($expression)
+    {
+        // Check the type of our value; set as string if possible
+        if (is_a($expression->value, 'ProcessMaker\\Query\\LiteralValue')) {
+            $value = $expression->value->value();
+        } elseif (is_a($expression->value, 'ProcessMaker\\Query\\ArrayValue')) {
+            $value = $expression->value->value();
+        } else {
+            $value = $expression->value;
+        }
+        
+        // Check to see if the value is parsable as a date
+        if (! is_numeric($value)) {
+            try {
+                $parsed = Carbon::parse($value);
+                $timezone = CarbonTimeZone::create(auth()->user()->timezone);
+                $value = $parsed->shiftTimezone($timezone)->toIso8601String();
+            } catch (Throwable $e) {
+                //Ignore parsing errors and just return the original
+            }
+        }
+        
+        return $value;
     }
 }

--- a/resources/js/components/AdvancedSearch.vue
+++ b/resources/js/components/AdvancedSearch.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="search-bar" class="search mb-3">
+    <div id="search-bar" class="search advanced-search mb-3">
         <div class="d-flex">
             <div class="flex-grow-1">
                 <div v-if="! advanced" class="search-bar-advanced d-flex flex-column flex-md-row w-100">
@@ -18,7 +18,7 @@
                                      :aria-label="$t('Process')"
                                      :placeholder="$t('Process')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -40,7 +40,7 @@
                                      :aria-label="$t('Status')"
                                      :placeholder="$t('Status')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -64,7 +64,7 @@
                                      :aria-label="$t('Requester')"
                                      :placeholder="$t('Requester')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -93,7 +93,7 @@
                                      :aria-label="$t('Participants')"
                                      :placeholder="$t('Participants')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -125,7 +125,7 @@
                                      :aria-label="$t('Request')"
                                      :placeholder="$t('Request')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -149,7 +149,7 @@
                                      :aria-label="$t('Task')"
                                      :placeholder="$t('Task')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -172,7 +172,7 @@
                                      :aria-label="$t('Status')"
                                      :placeholder="$t('Status')">
                             <template slot="noResult">
-                                {{ $t('No elements found. Consider changing the search query.') }}
+                                {{ $t('No Results') }}
                             </template>
                             <template slot="noOptions">
                                 {{ $t('No Data Available') }}
@@ -519,13 +519,34 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-    .multiselect__placeholder {
-        padding-top: 1px;
-    }
-
-    .multiselect__single {
-        padding-bottom: 2px;
-        padding-top: 2px;
+<style lang="scss">
+    .advanced-search {
+        .multiselect__placeholder {
+            padding-top: 1px;
+        }
+        
+        .multiselect,
+        .multiselect__input,
+        .multiselect__single {
+            font-size: 14px;
+        }
+        
+        .multiselect__input {
+            left: 1px;
+            padding: 2px 0 2px 10px;
+            position: absolute;
+            top: 8px;
+        }
+        
+        .multiselect--active {
+            .multiselect__input {
+                width: 99% !important;
+            }
+        }
+        
+        .multiselect__single {
+            padding-bottom: 2px;
+            padding-top: 2px;
+        }
     }
 </style>

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -91,7 +91,8 @@ export default {
         }
       ],
       fields: [],
-      previousFilter: ""
+      previousFilter: "",
+      previousPmql: "",
     };
   },
   computed: {
@@ -272,6 +273,12 @@ export default {
             }
 
             this.previousFilter = filter;
+            
+            if (this.previousPmql !== pmql) {
+              this.page = 1;
+            }
+            
+            this.previousPmql = pmql;
 
             // Load from our api client
             ProcessMaker.apiClient

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -339,7 +339,7 @@ export default {
                 pmql = `(${pmql}) and (${filter})`;
                 filter = '';
               } else {
-                let filterParams =
+                filterParams =
                     "&user_id=" +
                     window.ProcessMaker.user.id +
                     "&filter=" +

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -120,7 +120,8 @@ export default {
         }
       ],
       fields: [],
-      previousFilter: ""
+      previousFilter: "",
+      previousPmql: "",
     };
   },
   computed: {
@@ -352,6 +353,12 @@ export default {
             }
 
             this.previousFilter = filter;
+            
+            if (this.previousPmql !== pmql) {
+              this.page = 1;
+            }
+            
+            this.previousPmql = pmql;
             
             // Load from our api client
             ProcessMaker.apiClient


### PR DESCRIPTION
## Fixes
- [FOUR-3996](https://processmaker.atlassian.net/browse/FOUR-3996) Screen building inspector chart select showing only 10 charts - should show all
- [FOUR-4036](https://processmaker.atlassian.net/browse/FOUR-4036) No results in a search changing tabs
- [FOUR-3633](https://processmaker.atlassian.net/browse/FOUR-3633) Swagger example results in 422 error
- [FOUR-4024](https://processmaker.atlassian.net/browse/FOUR-4024) Searching with PMQL input should be expected to be in the logged in user's timezone
- [FOUR-3360](https://processmaker.atlassian.net/browse/FOUR-3360) Super-Admin permission must allow user to see ALL saved searches
- [FOUR-3932](https://processmaker.atlassian.net/browse/FOUR-3932) After clearing Task saved search you cannot search by Request name
- [FOUR-3933](https://processmaker.atlassian.net/browse/FOUR-3933) Text Search in filters not working
- [FOUR-3951](https://processmaker.atlassian.net/browse/FOUR-3951) Task Saved Search includes unrelated results
- Cannot use greater than in PMQL with Saved Search API
- Swagger docs do not generate due to syntax error

## Requires
- https://github.com/ProcessMaker/package-savedsearch/pull/270

## 4.1 Equivalent
- https://github.com/ProcessMaker/processmaker/pull/4024

## Ticket
- http://tickets.pm4overflow.com/tickets/727