### PR TITLE
[4.2] Ticket #734: Undeleting Users blocked by Unique Email requirement

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -434,32 +434,32 @@ class UserController extends Controller
     * ),
     */
     public function restore(Request $request) {
-		$user = null;
+        $user = null;
 
-		// Look through the request data for one of these
-	    // keys and search trashed users with the value
-		foreach (['id', 'email', 'username'] as $input) {
-			// If the key isn't present,
-			// skip ahead
-			if (!$request->has($input)) {
-				continue;
-			}
+        // Look through the request data for one of these
+        // keys and search trashed users with the value
+        foreach (['id', 'email', 'username'] as $input) {
+            // If the key isn't present,
+            // skip ahead
+            if (!$request->has($input)) {
+                continue;
+            }
 
-			// If we already found the user to
-			// restore, skip ahead
-			if ($user instanceof User) {
-				continue;
-			}
+            // If we already found the user to
+            // restore, skip ahead
+            if ($user instanceof User) {
+                continue;
+            }
 
-			// Otherwise, search trashed users
-			// for the user to restore
-			$user = User::onlyTrashed()->where($input, $request->input($input))
-			                           ->first();
-		}
+            // Otherwise, search trashed users
+            // for the user to restore
+            $user = User::onlyTrashed()->where($input, $request->input($input))
+                                       ->first();
+        }
 
-		if ($user instanceof User) {
-			$user->restore();
-		}
+        if ($user instanceof User) {
+            $user->restore();
+        }
 
         return response([], 200);
     }

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -149,32 +149,18 @@ class User extends Authenticatable implements HasMedia
     {
         $unique = Rule::unique('users')->ignore($existing);
 
-        $checkUserIsDeleted = function ($attribute, $value, $fail) use ($existing) {
-            if (!$existing) {
-                $user = User::onlyTrashed()->where($attribute, $value)->first();
-                if ($user) {
-                    $fail(
-                        __(
-                            'A user with the username :username and email :email was previously deleted.',
-                            ['username' => $user->username, 'email' => $user->email]
-                        )
-                    );
-                }
-            }
-        };
-
         return [
             // The following characters where not included in the regexp: & %  ' " ? /
-            'username' => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:3', 'max:255' , $unique, $checkUserIsDeleted],
+            'username' => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:3', 'max:255' , $unique],
             'firstname' => ['required', 'max:50'],
             'lastname' => ['required', 'max:50'],
-            'email' => ['required', 'email', $checkUserIsDeleted],
+            'email' => ['required', 'email'],
             'phone' => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
             'fax' => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
             'cell' => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
             'status' => ['required', 'in:ACTIVE,INACTIVE,OUT_OF_OFFICE,SCHEDULED'],
             'password' => $existing ? 'required|sometimes|min:6' : 'required|min:6',
-            'birthdate' => 'date|nullable' 
+            'birthdate' => 'date|nullable'
         ];
     }
 
@@ -426,10 +412,10 @@ class User extends Authenticatable implements HasMedia
         while ($query->count() > 0) {
             // Retrieve this chunk
             $requests = $query->get();
-            
+
             // Declare our batch array
             $batch = [];
-            
+
             // Process each request
             foreach ($requests as $request) {
                 $batch[] = [
@@ -443,14 +429,14 @@ class User extends Authenticatable implements HasMedia
 
             // Batch insert the new permissions
             RequestUserPermission::query()->insert($batch);
-        }        
+        }
     }
 
     public function removeFromGroups()
     {
         $this->groups()->detach();
     }
-    
+
     public function availableSelfServiceTaskIds()
     {
         $groupIds = $this->groups()->pluck('groups.id');

--- a/resources/js/admin/users/components/DeletedUsersListing.vue
+++ b/resources/js/admin/users/components/DeletedUsersListing.vue
@@ -152,8 +152,9 @@ export default {
     },
     restoreUser(data, index) {
       const $body = {
-        "email" : data.email
+        id: data.id
       };
+
       ProcessMaker.confirmModal(
         this.$t('Caution!'),
         this.$t('Are you sure you want to restore the user {{item}}?', {item: data.fullname}),

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -95,11 +95,11 @@ class UsersTest extends TestCase
 
         $response = $this->apiCall('POST', $url, $params);
 
-		$this->assertArrayHasKey('errors', $response->json());
+        $this->assertArrayHasKey('errors', $response->json());
 
-		$this->assertArrayHasKey('username', $response->json()['errors']);
+        $this->assertArrayHasKey('username', $response->json()['errors']);
 
-		$this->assertEquals('The Username has already been taken.', $response->json()['errors']['username'][0]);
+        $this->assertEquals('The Username has already been taken.', $response->json()['errors']['username'][0]);
     }
 
     public function testDefaultValuesOfUser()


### PR DESCRIPTION
Allows soft deleted users with a non-unique email to be restored without failing.

Ticket #734:
http://tickets.pm4overflow.com/tickets/734