### PR TITLE
Ticket #743: Set default Docker installation path variable in .env (For 4.2)

### DIFF
--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -223,7 +223,7 @@ class Install extends Command
 
         // Check for docker installation path if not under Win OS and set docker env path var
         if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-            $dockerBinPath = system('which docker');
+            $dockerBinPath = exec('which docker');
 
             // If which docker command not found or installation path not found set default
             if ($dockerBinPath == "" || Str::contains($dockerBinPath, 'not found')) {

--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -8,8 +8,10 @@ use Illuminate\Database\Query\Grammars\SqlServerGrammar;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Helper\Table;
 use ProcessMaker\Traits\SupportsNonInteraction;
+
 use UserSeeder;
 use Validator;
 
@@ -21,7 +23,7 @@ use Validator;
 class Install extends Command
 {
     use SupportsNonInteraction;
-    
+
     /**
      * The name and signature of the console command.
      *
@@ -86,14 +88,14 @@ class Install extends Command
      * The encryption key we will use for for fresh install and any encryption during install
      */
     private $key;
-    
+
     /**
      * Installs a fresh copy of ProcessMaker
      *
      * @return mixed If the command succeeds, true
      */
     public function handle()
-    {        
+    {
         // Setup our initial encryption key and set our running laravel app key to it
         $this->key = 'base64:' . base64_encode(Encrypter::generateKey($this->laravel['config']['app.cipher']));
         config(['app.key' => $this->key]);
@@ -163,9 +165,9 @@ class Install extends Command
         } while (!$this->testLocalConnection());
         // Configure the DATA connection
         // $this->infoIfInteractive(__('ProcessMaker requires a DATA database.'));
-        
+
         // if ($this->interactive()) {
-        //     $dataConnection = $this->choice(__('Would you like to setup different credentials or use the same ProcessMaker 
+        //     $dataConnection = $this->choice(__('Would you like to setup different credentials or use the same ProcessMaker
         //     connection?'), ['different', 'same']);
         // } else {
         //     if ($this->option('data-driver') !== 'none') {
@@ -186,11 +188,11 @@ class Install extends Command
         // do {
         //     $dataConnection !== 'different' ?: $this->fetchDataConnectionCredentials();
         // } while (!$this->testDataConnection());
-        
+
         if (! $this->pretending()) {
-            $this->env['DATA_DB_DRIVER'] === 'sqlsrv' ? $this->checkDateFormatSqlServer() : null;            
+            $this->env['DATA_DB_DRIVER'] === 'sqlsrv' ? $this->checkDateFormatSqlServer() : null;
         }
-        
+
         // Ask for URL and validate
         $invalid = false;
         do {
@@ -212,13 +214,26 @@ class Install extends Command
 
         // Set laravel echo server settings
         $this->env['LARAVEL_ECHO_SERVER_AUTH_HOST'] = $this->option('echo-host') ? $this->option('echo-host') : $this->env['APP_URL'];
-        
+
         // Set path and Docker settings
         Storage::disk('local')->makeDirectory('scripts');
         $this->env['PROCESSMAKER_SCRIPTS_HOME'] = storage_path('app/scripts');
         $this->env['DOCKER_HOST_URL'] = $this->env['APP_URL'];
         $this->env['HOME'] = base_path();
-        
+
+        // Check for docker installation path if not under Win OS and set docker env path var
+        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+            $dockerBinPath = system('which docker');
+
+            // If which docker command not found or installation path not found set default
+            if ($dockerBinPath == "" || Str::contains($dockerBinPath, 'not found')) {
+                $this->error(__("Docker not found."));
+                $dockerBinPath = '/usr/bin/docker';
+            }
+
+            $this->env['PROCESSMAKER_SCRIPTS_DOCKER'] = $dockerBinPath;
+        }
+
         if ($this->pretending()) {
             $headers = ['Key', 'Value'];
             $rows = [];
@@ -271,14 +286,14 @@ class Install extends Command
             //Create a symbolic link from "public/storage" to "storage/app/public"
             $this->call('storage:link');
 
-            $this->call('vendor:publish', ['--tag'=>'telescope-assets', '--force' =>true]);            
+            $this->call('vendor:publish', ['--tag'=>'telescope-assets', '--force' =>true]);
 
             $this->info(__("Installing the :lang script executor", ['lang' => 'php']));
             \Artisan::call('docker-executor-php:install');
             $this->info(__("Installing the :lang script executor", ['lang' => 'lua']));
             \Artisan::call('docker-executor-lua:install');
             $this->info(__("Installing the :lang script executor", ['lang' => 'node']));
-            \Artisan::call('docker-executor-node:install'); 
+            \Artisan::call('docker-executor-node:install');
 
             $this->info(__("ProcessMaker installation is complete. Please visit the URL in your browser to continue."));
             $this->info(__("Installer completed. Consult ProcessMaker documentation on how to configure email, jobs and notifications."));
@@ -402,7 +417,7 @@ class Install extends Command
     {
         $this->infoIfInteractive(__('Configure the DATA connection.'));
         $this->env['DATA_DB_DRIVER'] = $this->choiceOptional('data-driver', __('Enter the DB driver'), ['mysql', 'pgsql', 'sqlsrv']);
-        
+
         switch($this->env['DATA_DB_DRIVER']) {
             case 'pgsql':
                 $this->fetchPostgreCredentials();

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are new to ProcessMaker 4 and would like to load the software locally, we
 
 ## Install
 
-Before installing, Nginx needs to be configured to use php-fpm and point to the public folder 
+Before installing, Nginx needs to be configured to use php-fpm and point to the public folder
 
 1. Download and unzip a version from the releases page https://github.com/ProcessMaker/processmaker/releases
 1. Configure Nginx to use php-fpm and point to the public folder in the unzipped code. See https://laravel.com/docs/6.x/deployment#nginx
@@ -79,6 +79,7 @@ You can develop ProcessMaker as well as ProcessMaker packages locally. In order 
   * Specify `homestead` as your local database username
   * Specify `secret` as your local database password
   * Specify `https://processmaker.local.processmaker.com` as your application url
+* Check your .env file to ensure the `PROCESSMAKER_SCRIPTS_DOCKER` variable has the right Docker installation path, especially if you are under macOS (Docker on macOs installs under /usr/local/bin/docker).
 * Visit `https://processmaker.local.processmaker.com` in your browser to access the application
   * Login with the username of `admin` and password of `admin`
 
@@ -90,12 +91,12 @@ APP_DEBUG=TRUE
 
 Optionally, trust the self-signed certificate on your host machine so you don't get the "Not Secure" warnings in chrome and postman.
 
-For macOS: 
+For macOS:
 
-1. In `your-repository-root/storage/ssl`, double-click on `processmaker.local.processmaker.com.crt` 
-2. Click on "Add" to add it to your login keychain 
-3. In the Keychain Access window click on the Certificates category on the bottom left. 
-4. Double-click on the processmaker certificate 
+1. In `your-repository-root/storage/ssl`, double-click on `processmaker.local.processmaker.com.crt`
+2. Click on "Add" to add it to your login keychain
+3. In the Keychain Access window click on the Certificates category on the bottom left.
+4. Double-click on the processmaker certificate
 5. Open the Trust section. For `"When using this certificate"`, select `"always trust"`
 6. Close the window. You will be asked for your password. Close and reopen the processmaker tab in chrome.
 
@@ -118,8 +119,8 @@ LOGIN_LOGO_PATH={{LOGIN PAGE LOGO PATH HERE}}
 
 #### Scheduled tasks/events
 
-To run time based BPMN events like Timer Start Events or Intermediate Timer Events, the laravel scheduler should be enabled. To do this open a console and: 
-1. Execute crontab -e 
+To run time based BPMN events like Timer Start Events or Intermediate Timer Events, the laravel scheduler should be enabled. To do this open a console and:
+1. Execute crontab -e
 2. Add to the cron tab the following line \(replacing the upper cased text with the directory where your proyecto is located \):
 
 ```text
@@ -145,7 +146,7 @@ To keep things dry, you can define 2 schemas. One that inherits the other.
 ```php
 /**
  * ...existing comments above...
- * 
+ *
  * @OA\Schema(
  *   schema="ProcessEditable",
  *   @OA\Property(property="process_category_uuid", type="string", format="uuid"),
@@ -165,7 +166,7 @@ To keep things dry, you can define 2 schemas. One that inherits the other.
  *           @OA\Property(property="updated_at", type="string", format="date-time"),
  *       ),
  *   },
- *   
+ *
  * )
  */
 class Process extends Model implements HasMedia
@@ -187,7 +188,7 @@ Now you can use the reference to the schema when annotating the controllers. See
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
      *     @OA\Parameter(ref="#/components/parameters/per_page"),
      *     @OA\Parameter(ref="#/components/parameters/"),
-     * 
+     *
      *     @OA\Response(
      *         response=200,
      *         description="list of processes",

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can develop ProcessMaker as well as ProcessMaker packages locally. In order 
   * Specify `homestead` as your local database username
   * Specify `secret` as your local database password
   * Specify `https://processmaker.local.processmaker.com` as your application url
-* Check your .env file to ensure the `PROCESSMAKER_SCRIPTS_DOCKER` variable has the right Docker installation path, especially if you are under macOS (Docker on macOs installs under /usr/local/bin/docker).
+* Check your .env file to ensure the `PROCESSMAKER_SCRIPTS_DOCKER` variable has the right Docker installation path, especially if you are under macOS (Docker on macOS installs under /usr/local/bin/docker).
 * Visit `https://processmaker.local.processmaker.com` in your browser to access the application
   * Login with the username of `admin` and password of `admin`
 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -248,6 +248,7 @@
   "display": "display",
   "Display Next Assigned Task to Task Assignee": "Display Next Assigned Task to Task Assignee",
   "Diverging": "Diverging",
+  "Docker not found.": "Docker not found.",
   "Download Name": "Download Name",
   "Download XML": "Download XML",
   "Download": "Download",


### PR DESCRIPTION
- Added default .env variable PROCESSMAKER_SCRIPTS_DOCKER to fix installation issues related with docker path when running the command processmaker:install under macOs.
- Updated readme documentation
