### PR TITLE
Disable file upload for unclaimed self service tasks (4.2)

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -448,6 +448,7 @@
         },
         mounted() {
           this.prepareData();
+          window.ProcessMaker.isSelfService = this.isSelfService;
         }
       });
       window.ProcessMaker.breadcrumbs.taskTitle = @json($task->element_name)


### PR DESCRIPTION
Fixes http://tickets.pm4overflow.com/tickets/142

Disables the select file button and drag/drop when the task is self service

Requires: https://github.com/ProcessMaker/screen-builder/pull/1057

4.1 Equivalent: https://github.com/ProcessMaker/processmaker/pull/4029