### PR TITLE
Boundary Error on a CallActivity can catch errors in tasks inside the subprocess v4.1

### DIFF
--- a/ProcessMaker/Managers/DataManager.php
+++ b/ProcessMaker/Managers/DataManager.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+
+class DataManager
+{
+    private $reservedVariables = [
+        '_user',
+        '_request',
+        '_parent',
+        'loopCounter',
+        'numberOfActiveInstances',
+        'numberOfInstances',
+        'numberOfCompletedInstances',
+        'numberOfTerminatedInstances',
+        'loopCharacteristics',
+    ];
+
+    private $hiddenVariables = [
+        'loopCharacteristics',
+    ];
+
+    /**
+     * Update data through a $token
+     *
+     * @param ProcessRequestToken $token
+     * @param array $data
+     *
+     * @return void
+     */
+    public function updateData(ProcessRequestToken $token, array $data)
+    {
+        if ($token->isMultiInstance()) {
+            $tokenData = $token->getProperty('data');
+            foreach ($data as $key => $value) {
+                if (in_array($key, $this->reservedVariables)) {
+                    continue;
+                }
+                $tokenData[$key] = $value;
+            }
+            $token->setProperty('data', $tokenData);
+        } else {
+            $dataStore = $token->getInstance()->getDataStore();
+            foreach ($data as $key => $value) {
+                if (in_array($key, $this->reservedVariables)) {
+                    continue;
+                }
+                $dataStore->putData($key, $value);
+            }
+        }
+    }
+
+    /**
+     * Get data for the $token
+     *
+     * @param ProcessRequestToken|null $token
+     * @param bool $whenTokenSaved If true returns the Request Data as when the Token was saved
+     *
+     * @return array
+     */
+    public function getData(ProcessRequestToken $token = null, bool $whenTokenSaved = false)
+    {
+        $data = [];
+        $data = $this->loadUserData($data, $token);
+        if ($token) {
+            $data = $this->loadTokenData($data, $token, $whenTokenSaved);
+        }
+        return $data;
+    }
+
+    /**
+     * Load magic variable _user 
+     *
+     * @param array $data
+     * @param ProcessRequestToken $token
+     *
+     * @return array
+     */
+    private function loadUserData(array $data = [], ProcessRequestToken $token = null)
+    {
+        // Magic Variable: _user
+        $user = $token && $token->user ? $token->user : Auth::user();
+        if ($user) {
+            $userData = $user->attributesToArray();
+            unset($userData['remember_token']);
+            $data['_user'] = $userData;
+        }
+        return $data;
+    }
+
+    /**
+     * Load data that $token can see in the $request
+     *
+     * @param array $data
+     * @param ProcessRequestToken|null $token
+     * @param boolean $whenTokenSaved
+     *
+     * @return array
+     */
+    private function loadTokenData(array $data = [], ProcessRequestToken $token = null, bool $whenTokenSaved = false)
+    {
+        if ($token->isMultiInstance()) {
+            $data = $token->getProperty('data', ($token->token_properties ?? [])['data'] ?? []) ?: [];
+            $data = $this->addLoopInstanceProperties($data, $token->getDefinition(true), $token);
+        } else {
+            if ($whenTokenSaved) {
+                $data = $token->data ?: [];
+            } else {
+                $instance = $token->getInstance();
+                if ($instance) {
+                    $data = $instance->getDataStore()->getData();
+                } else {
+                    $data = $token->processRequest->data ?: [];
+                }
+            }
+        }
+
+        // Magic Variable: _user
+        $user = $token->user ?: Auth::user();
+        if ($user) {
+            $userData = $user->attributesToArray();
+            unset($userData['remember_token']);
+            $data['_user'] = $userData;
+        }
+
+        // Magic Variable: _request
+        $request = $token->getInstance() ?: $token->processRequest;
+        if (!(isset($data['not_override_request']) && $data['not_override_request'] === true)) {
+            $data['_request'] = $request->attributesToArray();
+        }
+
+        // Magic Variable: _parent
+        if ($token->isMultiInstance()) {
+            if ($whenTokenSaved) {
+                $data['_parent'] = $token->data ?: [];
+            } else {
+                $data['_parent'] = $this->getRequestData($request, ['_user', '_request', '_parent']);
+            }
+        }
+
+        foreach ($this->hiddenVariables as $key) {
+            unset($data[$key]);
+        }
+        return $data;
+    }
+
+    /**
+     * Get root data from request
+     *
+     * @return array
+     */
+    public function getRequestData(ProcessRequest $request, $hidden = [])
+    {
+        $hidden = \array_merge($this->hiddenVariables, $hidden);
+        $data = $request->data ?: [];
+        foreach ($hidden as $key) {
+            unset($data[$key]);
+        }
+        return $data;
+    }
+
+    private function addLoopInstanceProperties(array $data, ActivityInterface $activity, ProcessRequestToken $token)
+    {
+        $data['numberOfInstances'] = $activity->getLoopCharacteristics()->getLoopInstanceProperty($token, 'numberOfInstances', 0);
+        $data['numberOfActiveInstances'] = $activity->getLoopCharacteristics()->getLoopInstanceProperty($token, 'numberOfActiveInstances', 0);
+        $data['numberOfCompletedInstances'] = $activity->getLoopCharacteristics()->getLoopInstanceProperty($token, 'numberOfCompletedInstances', 0);
+        return $data;
+    }
+}

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -11,7 +11,9 @@ use Log;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
 use ProcessMaker\Nayra\Bpmn\TokenTrait;
+use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowElementInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\MultiInstanceLoopCharacteristicsInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Traits\ExtendedPMQL;
 use ProcessMaker\Traits\SerializeToIso8601;
@@ -755,5 +757,20 @@ class ProcessRequestToken extends Model implements TokenInterface
         $token->process_request_id = $token->getInstance()->getKey();
         $token->saveOrFail();
         $token->setId($token->getKey());        
+    }
+
+    /**
+     * Returns True is the tokens belongs to a MiltiInstance Task
+     *
+     * @return boolean
+     */
+    public function isMultiInstance()
+    {
+        $definition = $this->getDefinition(true);
+        if ($definition instanceof ActivityInterface) {
+            $loop = $definition->getLoopCharacteristics();
+            return $loop && $loop->isExecutable() && $loop instanceof MultiInstanceLoopCharacteristicsInterface;
+        }
+        return false;
     }
 }

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -453,9 +453,10 @@ class TokenRepository implements TokenRepositoryInterface
      *
      * @param TokenInterface $token
      * @param ExecutionInstanceInterface $subprocess
+     * @param string $startId
      * @return void
      */
-    public function persistCallActivityActivated(TokenInterface $token, ExecutionInstanceInterface $subprocess, FlowInterface $sequenceFlow)
+    public function persistCallActivityActivated(TokenInterface $token, ExecutionInstanceInterface $subprocess, $startId)
     {
         $source = $token->getInstance();
         if ($source->process_collaboration_id === null) {
@@ -470,7 +471,8 @@ class TokenRepository implements TokenRepositoryInterface
         $subprocess->parent_request_id = $source->getKey();
         $subprocess->saveOrFail();
         $token->subprocess_request_id = $subprocess->id;
-        $token->subprocess_start_event_id = $sequenceFlow->getProperty('startEvent');
+        $token->subprocess_start_event_id = $startId;
+        $token->updateTokenProperties();
         $token->saveOrFail();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "processmaker/docker-executor-node": "^1.0",
     "processmaker/docker-executor-php": "^1.0",
     "processmaker/laravel-i18next": "dev-master",
-    "processmaker/nayra": "1.2.0",
+    "processmaker/nayra": "1.7.0-RC3",
     "processmaker/pmql": "1.2.0",
     "pusher/pusher-php-server": "^4.0",
     "ralouphie/getallheaders": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "709e66ee228d06ee15dc8f5c2684f786",
+    "content-hash": "1640b1ccc60f5d6cc5f9d61d7c600930",
     "packages": [
         {
             "name": "babenkoivan/elastic-adapter",
@@ -4732,20 +4732,20 @@
         },
         {
             "name": "processmaker/nayra",
-            "version": "1.2.0",
+            "version": "1.7.0-RC3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ProcessMaker/nayra.git",
-                "reference": "ee72116200b39a4685d1ce2c75cdd86bc6d488bf"
+                "reference": "6f4bf27782a3fb210c04b98033ffc1556115edba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ProcessMaker/nayra/zipball/ee72116200b39a4685d1ce2c75cdd86bc6d488bf",
-                "reference": "ee72116200b39a4685d1ce2c75cdd86bc6d488bf",
+                "url": "https://api.github.com/repos/ProcessMaker/nayra/zipball/6f4bf27782a3fb210c04b98033ffc1556115edba",
+                "reference": "6f4bf27782a3fb210c04b98033ffc1556115edba",
                 "shasum": ""
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^7.5"
             },
             "type": "library",
             "autoload": {
@@ -4760,9 +4760,9 @@
             "description": "BPMN compliant engine",
             "support": {
                 "issues": "https://github.com/ProcessMaker/nayra/issues",
-                "source": "https://github.com/ProcessMaker/nayra/tree/v1.2.0"
+                "source": "https://github.com/ProcessMaker/nayra/tree/v1.7.0-RC3"
             },
-            "time": "2021-01-08T15:04:14+00:00"
+            "time": "2021-09-28T23:28:17+00:00"
         },
         {
             "name": "processmaker/pmql",
@@ -11407,5 +11407,5 @@
         "php": ">=7.2.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/tests/Feature/Api/processes/ParentCallActivityBoundaryError.bpmn
+++ b/tests/Feature/Api/processes/ParentCallActivityBoundaryError.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:callActivity id="node_3" name="Sub Process" calledElement="ProcessId-4" pm:config="{&#34;calledElement&#34;:&#34;ProcessId-4&#34;,&#34;processId&#34;:4,&#34;startEvent&#34;:&#34;node_2&#34;,&#34;name&#34;:&#34;subprocess&#34;}">
+      <bpmn:incoming>node_5</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="node_5" sourceRef="node_1" targetRef="node_3" />
+    <bpmn:endEvent id="node_6" name="End Event">
+      <bpmn:incoming>node_8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_8" sourceRef="node_3" targetRef="node_6" />
+    <bpmn:boundaryEvent id="node_9" name="error" attachedToRef="node_3">
+      <bpmn:outgoing>node_12</bpmn:outgoing>
+      <bpmn:errorEventDefinition />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="node_10" name="Error Catch" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_12</bpmn:incoming>
+      <bpmn:outgoing>node_15</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_12" sourceRef="node_9" targetRef="node_10" />
+    <bpmn:endEvent id="node_13" name="End Event">
+      <bpmn:incoming>node_15</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_15" sourceRef="node_10" targetRef="node_13" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="300" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="440" y="220" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="318" y="258" />
+        <di:waypoint x="498" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+        <dc:Bounds x="650" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="498" y="258" />
+        <di:waypoint x="668" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="451" y="278" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+        <dc:Bounds x="410" y="390" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_12_di" bpmnElement="node_12">
+        <di:waypoint x="469" y="296" />
+        <di:waypoint x="468" y="428" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_13_di" bpmnElement="node_13">
+        <dc:Bounds x="450" y="520" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_15_di" bpmnElement="node_15">
+        <di:waypoint x="468" y="428" />
+        <di:waypoint x="468" y="538" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Feature/Api/processes/SubProcessWithError.bpmn
+++ b/tests/Feature/Api/processes/SubProcessWithError.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_2" name="Error" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:scriptTask id="node_6" name="Script Task" scriptFormat="application/x-php">
+      <bpmn:incoming>node_8</bpmn:incoming>
+      <bpmn:outgoing>node_14</bpmn:outgoing>
+      <bpmn:script><![CDATA[<?php return ["geist";]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="node_8" sourceRef="node_2" targetRef="node_6" />
+    <bpmn:endEvent id="node_10" name="End Event">
+      <bpmn:incoming>node_14</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_14" sourceRef="node_6" targetRef="node_10" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="210" y="260" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+        <dc:Bounds x="330" y="240" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="228" y="278" />
+        <di:waypoint x="388" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+        <dc:Bounds x="560" y="260" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_14_di" bpmnElement="node_14">
+        <di:waypoint x="388" y="278" />
+        <di:waypoint x="578" y="278" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Requires: ProcessMaker/nayra#206
Fixes: FOUR-3538

This PR includes:
- Boundary Error on a CallActivity can catch errors in tasks inside the subprocess
- Update CallActivity implementation
- Add DataManager required by the updated CallActivity implementation
- Tests of Activity (ScriptTask) exception catch by a boundary error event
