### PR TITLE
4.2 Permissions can be changed after a process has started (edit data, cancel)

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -379,42 +379,6 @@ class Process extends Model implements HasMedia, ProcessModelInterface
     }
 
     /**
-     * Get the users who can start this process
-     *
-     */
-    public function usersCanCancel()
-    {
-        return $this->morphedByMany('ProcessMaker\Models\User', 'processable')->wherePivot('method', 'CANCEL');
-    }
-
-    /**
-     * Get the groups who can start this process
-     *
-     */
-    public function groupsCanCancel()
-    {
-        return $this->morphedByMany('ProcessMaker\Models\Group', 'processable')->wherePivot('method', 'CANCEL');
-    }
-
-    /**
-     * Get the users who can start this process
-     *
-     */
-    public function usersCanEditData()
-    {
-        return $this->morphedByMany('ProcessMaker\Models\User', 'processable')->wherePivot('method', 'EDIT_DATA');
-    }
-
-    /**
-     * Get the groups who can start this process
-     *
-     */
-    public function groupsCanEditData()
-    {
-        return $this->morphedByMany('ProcessMaker\Models\Group', 'processable')->wherePivot('method', 'EDIT_DATA');
-    }
-
-    /**
      * Scope a query to include only active processes
      *
      */

--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -7,6 +7,7 @@ use ProcessMaker\Contracts\ProcessModelInterface;
 use ProcessMaker\Traits\HasCategories;
 use ProcessMaker\Traits\HasSelfServiceTasks;
 use ProcessMaker\Traits\ProcessTrait;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 /**
  * ProcessVersion is used to store the historical version of a process.
@@ -61,6 +62,56 @@ class ProcessVersion extends Model implements ProcessModelInterface
     protected $hidden = [
         'bpmn'
     ];
+
+    protected static function boot()
+    {
+        static::saved(static function (ProcessVersion $processVersion) {
+            $processVersion->saveProcessableVersions();
+        });
+
+        parent::boot();
+    }
+
+    /**
+     * Ensures there is a matching processable for each process version
+     *
+     * @return void
+     */
+    protected function saveProcessableVersions()
+    {
+        $processables = [
+            'usersCanCancel' => 'CANCEL',
+            'usersCanEditData' => 'EDIT_DATA',
+            'groupsCanCancel' => 'CANCEL',
+            'groupsCanEditData' => 'EDIT_DATA'
+        ];
+
+        foreach ($processables as $relationshipName => $methodName) {
+
+            $process = $this->process;
+
+            if (!$process->$relationshipName() instanceof MorphToMany) {
+                continue;
+            }
+
+            if (!$process->$relationshipName()->exists()) {
+                continue;
+            }
+
+            $includeWithPivot = [
+                'process_id' => $process->id,
+                'method' => $methodName
+            ];
+
+            $updateWith = $process->$relationshipName->keyBy('id')->map(
+                function ($model) use ($includeWithPivot) {
+                    return $includeWithPivot;
+                }
+            );
+
+            $this->$relationshipName()->sync($updateWith->toArray(), false);
+        }
+    }
 
     /**
      * Set multiple|single categories to the process

--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -88,22 +88,16 @@ class ProcessVersion extends Model implements ProcessModelInterface
 
         foreach ($processables as $relationshipName => $methodName) {
 
-            $process = $this->process;
-
-            if (!$process->$relationshipName() instanceof MorphToMany) {
-                continue;
-            }
-
-            if (!$process->$relationshipName()->exists()) {
+            if (!$this->process->$relationshipName()->exists()) {
                 continue;
             }
 
             $includeWithPivot = [
-                'process_id' => $process->id,
+                'process_id' => $this->process->id,
                 'method' => $methodName
             ];
 
-            $updateWith = $process->$relationshipName->keyBy('id')->map(
+            $updateWith = $this->process->$relationshipName->keyBy('id')->map(
                 function ($model) use ($includeWithPivot) {
                     return $includeWithPivot;
                 }

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -406,7 +406,7 @@ class User extends Authenticatable implements HasMedia
             'id not in (select request_id from request_user_permissions where user_id=?)',
             [$this->getKey()]
         )->select(
-            'id', 'process_id', 'user_id', 'parent_request_id', 'callable_id'
+            'id', 'process_id', 'user_id', 'parent_request_id', 'callable_id', 'process_version_id'
         );
 
         // Process the results in chunks

--- a/ProcessMaker/Policies/ProcessPolicy.php
+++ b/ProcessMaker/Policies/ProcessPolicy.php
@@ -18,25 +18,25 @@ class ProcessPolicy
      *
      * @param  \ProcessMaker\Models\User  $user
      * @return mixed
-     */    
+     */
     public function before(User $user)
     {
         if ($user->is_administrator) {
             return true;
         }
     }
-    
+
     /**
      * Determine whether the user can start the process.
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\Process  $process
+     * @param  \ProcessMaker\Models\Process  $process
      * @return mixed
      */
     public function start(User $user, Process $process)
     {
         $groupIds = $user->groups->pluck('id');
-        
+
         if ($process->groupsCanStart(request()->query('event'))->whereIn('id', $groupIds)->count()) {
             return true;
         }
@@ -69,23 +69,24 @@ class ProcessPolicy
      * Determine whether the user can cancel the process.
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\Process  $process
-     * @return mixed
+     * @param  \ProcessMaker\Models\Process  $process
+     *
+     * @return bool
      */
     public function cancel(User $user, Process $process)
     {
         $groupIds = $user->groups->pluck('id');
-        
-        if ($process->groupsCanCancel->whereIn('id', $groupIds)->count()) {
+
+        if ($process->groupsCanCancel()->whereIn('id', $groupIds)->exists()) {
             return true;
         }
-        
-        if ($process->usersCanCancel->where('id', $user->id)->count()) {
+
+        if ($process->usersCanCancel()->where('id', $user->id)->exists()) {
             return true;
         }
 
         if (
-            $process->manager_id === $user->id && 
+            $process->manager_id === $user->id &&
             $process->getProperty('manager_can_cancel_request') === true
         ) {
             return true;
@@ -98,18 +99,19 @@ class ProcessPolicy
      * Determine whether the user can edit data.
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\Process  $process
-     * @return mixed
+     * @param  \ProcessMaker\Models\Process  $process
+     *
+     * @return bool
      */
     public function editData(User $user, Process $process)
     {
         $groupIds = $user->groups->pluck('id');
-        
-        if ($process->groupsCanEditData->whereIn('id', $groupIds)->count()) {
+
+        if ($process->groupsCanEditData()->whereIn('id', $groupIds)->exists()) {
             return true;
         }
 
-        if ($process->usersCanEditData->where('id', $user->id)->count()) {
+        if ($process->usersCanEditData()->where('id', $user->id)->exists()) {
             return true;
         }
 

--- a/ProcessMaker/Policies/ProcessRequestPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestPolicy.php
@@ -16,7 +16,7 @@ class ProcessRequestPolicy
      *
      * @param  \ProcessMaker\Models\User  $user
      * @return mixed
-     */    
+     */
     public function before(User $user)
     {
         if ($user->is_administrator) {
@@ -42,10 +42,10 @@ class ProcessRequestPolicy
         }
 
         if ($user->hasPermission('edit-request_data')) {
-                return true;
+            return true;
         }
 
-        if ($processRequest->process->usersCanEditData->where('id', $user->id)->count() > 0) {
+        if ($processRequest->processVersion->usersCanEditData()->where('id', $user->id)->exists()) {
             return true;
         }
 
@@ -66,10 +66,11 @@ class ProcessRequestPolicy
         if ($processRequest->user_id == $user->id) {
             return true;
         }
+
         return $user->can('cancel', $processRequest->processVersion)
             || $user->hasPermission('edit-request_data')
             || $user->can('editData', $processRequest->processVersion);
-    }    
+    }
 
     /**
      * Determine whether the user can update the process request.
@@ -84,27 +85,25 @@ class ProcessRequestPolicy
             return true;
         }
     }
-    
+
     /**
      * Determine whether the user can edit request data.
      *
      * @param  \ProcessMaker\Models\User  $user
      * @param  \ProcessMaker\Process  $process
      * @return boolean
-     */    
+     */
     public function editData(User $user, ProcessRequest $request)
     {
-        if ($request->status === 'ACTIVE') {
-            $permission = 'edit-task_data';
-        } else {
-            $permission = 'edit-request_data';
-        }
-        
+        $permission = $request->status === 'ACTIVE'
+            ? 'edit-task_data'
+            : 'edit-request_data';
+
         if ($user->can($permission)) {
             return true;
         }
-        
-        return $user->can('editData', $request->process);
+
+        return $user->can('editData', $request->processVersion);
     }
 
     /**

--- a/ProcessMaker/Policies/ProcessVersionPolicy.php
+++ b/ProcessMaker/Policies/ProcessVersionPolicy.php
@@ -16,7 +16,7 @@ class ProcessVersionPolicy
      *
      * @param  \ProcessMaker\Models\User  $user
      * @return mixed
-     */    
+     */
     public function before(User $user)
     {
         if ($user->is_administrator) {
@@ -28,25 +28,24 @@ class ProcessVersionPolicy
      * Determine whether the user can cancel the process version.
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\ProcessVersion  $process
-     * @return mixed
+     * @param  \ProcessMaker\Models\ProcessVersion  $processVersion
+     *
+     * @return bool
      */
     public function cancel(User $user, ProcessVersion $processVersion)
     {
         $groupIds = $user->groups->pluck('id');
-        
-        // TODO: get from current version
-        if ($processVersion->process->groupsCanCancel->whereIn('id', $groupIds)->count()) {
+
+        if ($processVersion->groupsCanCancel()->whereIn('id', $groupIds)->exists()) {
             return true;
         }
-        
-        // TODO: get from current version
-        if ($processVersion->process->usersCanCancel->where('id', $user->id)->count()) {
+
+        if ($processVersion->usersCanCancel()->where('id', $user->id)->exists()) {
             return true;
         }
 
         if (
-            $processVersion->manager_id === $user->id && 
+            $processVersion->manager_id === $user->id &&
             $processVersion->getProperty('manager_can_cancel_request') === true
         ) {
             return true;
@@ -56,27 +55,25 @@ class ProcessVersionPolicy
     }
 
     /**
-     * Determine whether the user can edit data.
+     * Determine whether the user can edit data
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\ProcessVersion  $processVersion
-     * @return mixed
+     * @param  \ProcessMaker\Models\ProcessVersion  $processVersion
+     *
+     * @return bool
      */
     public function editData(User $user, ProcessVersion $processVersion)
     {
         $groupIds = $user->groups->pluck('id');
-        
-        // TODO: get from current version
-        if ($processVersion->process->groupsCanEditData->whereIn('id', $groupIds)->count()) {
+
+        if ($processVersion->groupsCanEditData()->whereIn('id', $groupIds)->exists()) {
             return true;
         }
 
-        // TODO: get from current version
-        if ($processVersion->process->usersCanEditData->where('id', $user->id)->count()) {
+        if ($processVersion->usersCanEditData()->where('id', $user->id)->exists()) {
             return true;
         }
 
         return false;
     }
-
 }

--- a/ProcessMaker/Traits/ProcessTrait.php
+++ b/ProcessMaker/Traits/ProcessTrait.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Traits;
 
+use ProcessMaker\Models\Group;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessVersion;
 use ProcessMaker\Models\User;
 use ProcessMaker\Nayra\Contracts\Storage\BpmnDocumentInterface;
@@ -47,7 +49,7 @@ trait ProcessTrait
         $document->loadXML($this->bpmn);
         return $document;
     }
-    
+
     /**
      * Set a value on the properties json column
      *
@@ -83,7 +85,7 @@ trait ProcessTrait
     {
         $this->setProperty('manager_id', $value);
     }
-    
+
     /**
      * Get the the manager id
      *
@@ -93,7 +95,7 @@ trait ProcessTrait
     {
         return $this->getProperty('manager_id');
     }
-    
+
     /**
      * Get the process manager
      *
@@ -102,5 +104,61 @@ trait ProcessTrait
     public function manager()
     {
         return $this->belongsTo(User::class, 'manager_id');
+    }
+
+    /**
+     * Get the users who can start this process
+     *
+     */
+    public function usersCanCancel()
+    {
+        $query = $this->morphedByMany(User::class, 'processable')
+                      ->wherePivot('method', 'CANCEL');
+
+        return $this instanceof Process
+            ? $query->wherePivot('process_version_id', '=', null)
+            : $query;
+    }
+
+    /**
+     * Get the groups who can start this process
+     *
+     */
+    public function groupsCanCancel()
+    {
+        $query = $this->morphedByMany(Group::class, 'processable')
+                      ->wherePivot('method', 'CANCEL');
+
+        return $this instanceof Process
+            ? $query->wherePivot('process_version_id', '=', null)
+            : $query;
+    }
+
+    /**
+     * Get the users who can start this process
+     *
+     */
+    public function usersCanEditData()
+    {
+        $query = $this->morphedByMany(User::class, 'processable')
+                      ->wherePivot('method', 'EDIT_DATA');
+
+        return $this instanceof Process
+            ? $query->wherePivot('process_version_id', '=', null)
+            : $query;
+    }
+
+    /**
+     * Get the groups who can start this process
+     *
+     */
+    public function groupsCanEditData()
+    {
+        $query = $this->morphedByMany(Group::class, 'processable')
+                      ->wherePivot('method', 'EDIT_DATA');
+
+        return $this instanceof Process
+            ? $query->wherePivot('process_version_id', '=', null)
+            : $query;
     }
 }

--- a/database/migrations/2021_09_28_202132_add_process_version_to_processables_table.php
+++ b/database/migrations/2021_09_28_202132_add_process_version_to_processables_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProcessVersionToProcessablesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('processables', function (Blueprint $table) {
+            $table->integer('process_version_id')
+                  ->unsigned()
+                  ->after('process_id')
+                  ->nullable();
+
+            $table->foreign('process_version_id')
+                  ->references('id')
+                  ->on('process_versions')
+                  ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('processables', function (Blueprint $table) {
+            $table->dropIfExists('process_version_id');
+        });
+    }
+}

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -416,8 +416,13 @@ class ProcessRequestsTest extends TestCase
         $this->user->saveOrFail();
         $request = factory(ProcessRequest::class)->create(['status' => 'ACTIVE']);
 
-        // give the user editData permission to get passed the route check
-        $request->process->usersCanEditData()->sync([$this->user->id => ['method' => 'EDIT_DATA']]);
+        // give the user editData permission to get past the route check
+        $request->processVersion->usersCanEditData()->sync([
+            $this->user->id => [
+                'method' => 'EDIT_DATA',
+                'process_id' => $request->process->id
+            ]
+        ]);
 
         $route = route('api.requests.update', [$request->id]);
         $response = $this->apiCall('PUT', $route, ['status' => 'COMPLETED']);
@@ -433,8 +438,7 @@ class ProcessRequestsTest extends TestCase
 
         // Confirm only ERROR status can be changed
         $response->assertStatus(422);
-        $this->assertEquals(
-            'Only requests with status: ERROR can be manually completed',
+        $this->assertEquals('Only requests with status: ERROR can be manually completed',
             $response->json()['errors']['status'][0]
         );
 

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -614,6 +614,8 @@ class ProcessRequestsTest extends TestCase
             [$this->user->id => ['method' => 'EDIT_DATA']]
         );
 
+        $process->save();
+
         // Create a new process request with the update process
         // configuration since the process request now honors
         // the process configuration how it existed when the

--- a/tests/Feature/EditDataTest.php
+++ b/tests/Feature/EditDataTest.php
@@ -23,7 +23,7 @@ use Tests\TestCase;
 class EditDataTest extends TestCase
 {
     use RequestHelper;
-    
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -34,7 +34,7 @@ class EditDataTest extends TestCase
             'is_administrator' => true,
         ]);
 
-        // Creates an user
+        // Creates a user
         $this->user = factory(User::class)->create([
             'password' => Hash::make('password'),
             'is_administrator' => false,
@@ -42,13 +42,14 @@ class EditDataTest extends TestCase
 
         // Create a group
         $this->group = factory(Group::class)->create(['name' => 'group']);
+
         factory(GroupMember::class)->create([
             'member_id' => $this->user->id,
             'member_type' => User::class,
             'group_id' => $this->group->id,
         ]);
 
-        //Run the permission seeder
+        // Run the permission seeder
         (new PermissionSeeder)->run();
 
         // Reboot our AuthServiceProvider. This is necessary so that it can
@@ -83,17 +84,19 @@ class EditDataTest extends TestCase
             $editDataUsers[$item] = ['method' => 'EDIT_DATA'];
         }
 
-        //Adding method to groups array            
+        //Adding method to groups array
         $editDataGroups = [];
         foreach ($groups as $item) {
             $editDataGroups[$item] = ['method' => 'EDIT_DATA'];
         }
 
-        //Syncing users and groups that can cancel this process            
+        //Syncing users and groups that can cancel this process
         $process->usersCanEditData()->sync($editDataUsers,
             ['method' => 'EDIT_DATA']);
         $process->groupsCanEditData()->sync($editDataGroups,
             ['method' => 'EDIT_DATA']);
+
+        $process->save();
     }
 
     /**
@@ -262,12 +265,12 @@ class EditDataTest extends TestCase
         $process = $this->createSingleTaskProcessUserAssignment($this->user);
         $request = $this->startProcess($process, 'StartEventUID');
         $task = $request->tokens()->where('element_id', 'UserTaskUID')->first();
-        
+
         //Assign global edit task permission to user
         $this->user->permissions()->attach(Permission::byName('edit-task_data')->id);
         $this->user->refresh();
         $this->flushSession();
-        
+
         //Perform web call and make assertions
         $response = $this->webCall('GET', 'tasks/' . $task->id . '/edit');
         $response->assertStatus(200);


### PR DESCRIPTION
Processes now maintain matching processables with the version of the process when the processable was created.

[Fixes ticket #666](http://tickets.pm4overflow.com/tickets/666)