### PR TITLE
Remove Request Detail Screen select

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -82,7 +82,6 @@ class ProcessController extends Controller
             ->toArray();
 
         $screenCancel = Screen::find($process->cancel_screen_id);
-        $screenRequestDetail = Screen::find($process->request_detail_screen_id);
 
         $list = $this->listUsersAndGroups();
 
@@ -93,7 +92,7 @@ class ProcessController extends Controller
         $canEditData = $this->listCan('EditData', $process);
         $addons = $this->getPluginAddons('edit', compact(['process']));
 
-        return view('processes.edit', compact(['process', 'categories', 'screenRequestDetail', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons']));
+        return view('processes.edit', compact(['process', 'categories', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons']));
     }
 
     /**

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -132,25 +132,6 @@
                                     </template>
                                 </multiselect>
                             </div>
-                            <div class="form-group">
-                                {!! Form::label('requestDetailScreen', __('Request Detail Screen')) !!}
-                                <multiselect aria-label="{{ __('Request Detail Screen') }}"
-                                             v-model="screenRequestDetail"
-                                             :options="screens"
-                                             :multiple="false"
-                                             :show-labels="false"
-                                             placeholder="{{ __('Type to search') }}"
-                                             @search-change="loadScreens($event)"
-                                             @open="loadScreens()"
-                                             track-by="id"
-                                             label="title">
-                                    <span slot="noResult">{{ __('Oops! No elements found. Consider changing the search query.') }}</span>
-                                    <template slot="noOptions">
-                                        {{ __('No Data Available') }}
-                                    </template>
-                                </multiselect>
-                                <div class="invalid-feedback" v-if="errors.request_detail_screen_id">@{{errors.request_detail_screen_id[0]}}</div>
-                            </div>
                             <div class="d-flex justify-content-end mt-2">
                                 {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
                                 {!! Form::button(__('Save'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
@@ -302,7 +283,6 @@
             screens: [],
             canCancel: @json($canCancel),
             canEditData: @json($canEditData),
-            screenRequestDetail: @json($screenRequestDetail),
             screenCancel: @json($screenCancel),
             activeUsersAndGroups: @json($list),
             pause_timer_start_events: false,
@@ -372,7 +352,6 @@
             this.formData.cancel_request = this.formatAssigneePermissions(this.canCancel);
             this.formData.edit_data = this.formatAssigneePermissions(this.canEditData);
             this.formData.cancel_screen_id = this.formatValueScreen(this.screenCancel);
-            this.formData.request_detail_screen_id = this.formatValueScreen(this.screenRequestDetail);
             this.formData.manager_id = this.formatValueScreen(this.manager);
             ProcessMaker.apiClient.put('processes/' + that.formData.id, that.formData)
               .then(response => {

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -37,7 +37,7 @@
                                    data-toggle="tab" @click="switchTab('pending')" href="#pending" role="tab"
                                    aria-controls="pending" aria-selected="true">{{__('Tasks')}}</a>
                             </li>
-                            <li class="nav-item">
+                            <li class="nav-item" v-if="showSummary">
                                 <a id="summary-tab" data-toggle="tab" href="#summary" role="tab"
                                    aria-controls="summary" @click="switchTab('summary')" aria-selected="false"
                                    v-bind:class="{ 'nav-link':true, active: showSummary }">

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -139,31 +139,6 @@
 
                                 </template>
                             </template>
-                            <template v-else>
-                                <template v-if="showScreenRequestDetail">
-                                    <div class="card">
-                                        <div class="card-body">
-                                          <vue-form-renderer ref="screenRequestDetail" :config="screenRequestDetail" v-model="dataSummary"/>
-                                        </div>
-                                    </div>
-                                </template>
-                                <template v-else>
-                                    <div class="card border-0">
-                                        <div class="card-header bg-white">
-                                            <h5 class="m-0">
-                                                {{ __('Request In Progress') }}
-                                            </h5>
-                                        </div>
-
-                                        <div class="card-body">
-                                            <p class="card-text">
-                                                {{__('This Request is currently in progress.')}}
-                                                {{__('This screen will be populated once the Request is completed.')}}
-                                            </p>
-                                        </div>
-                                    </div>
-                                </template>
-                            </template>
                         </div>
                         @if ($request->status === 'COMPLETED')
                             @can('editData', $request)
@@ -412,18 +387,6 @@
               options[option.key] = option.value
             });
             return options;
-          },
-          /**
-           * If the screen request detail is configured.
-           **/
-          showScreenRequestDetail() {
-            return !!this.request.request_detail_screen;
-          },
-          /**
-           * Get Screen request detail
-           * */
-          screenRequestDetail() {
-            return this.request.request_detail_screen ? this.request.request_detail_screen.config : null;
           },
           classStatusCard() {
             let header = {


### PR DESCRIPTION
Ticket [676](http://tickets.pm4overflow.com/tickets/676)

<h2>Changes</h2>

- Hide the 'Summary' tab until a request is Completed or Canceled. Fig 1.
- Remove the `Request Detail Screen` select list from the process configurations Fig. 2
- Remove references to the `screenRequestDetail` 

<h2>Fig 1</h2>

![Screen Shot 2021-09-30 at 9 01 15 AM](https://user-images.githubusercontent.com/52755494/135490620-e6bd1341-edbf-4e58-938d-6eded555a0ba.png)

<h2>Fig 2 </h2>

![Screen Shot 2021-09-30 at 9 03 05 AM](https://user-images.githubusercontent.com/52755494/135490862-5aa4504d-4b87-4a31-950c-bb0744f9486a.png)

