### PR TITLE
4.1: Permissions can be changed after a process has started (edit data, cancel)

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -369,42 +369,6 @@ class Process extends Model implements HasMedia, ProcessModelInterface
     }
 
     /**
-     * Get the users who can start this process
-     *
-     */
-    public function usersCanCancel()
-    {
-        return $this->morphedByMany('ProcessMaker\Models\User', 'processable')->wherePivot('method', 'CANCEL');
-    }
-
-    /**
-     * Get the groups who can start this process
-     *
-     */
-    public function groupsCanCancel()
-    {
-        return $this->morphedByMany('ProcessMaker\Models\Group', 'processable')->wherePivot('method', 'CANCEL');
-    }
-
-    /**
-     * Get the users who can start this process
-     *
-     */
-    public function usersCanEditData()
-    {
-        return $this->morphedByMany('ProcessMaker\Models\User', 'processable')->wherePivot('method', 'EDIT_DATA');
-    }
-
-    /**
-     * Get the groups who can start this process
-     *
-     */
-    public function groupsCanEditData()
-    {
-        return $this->morphedByMany('ProcessMaker\Models\Group', 'processable')->wherePivot('method', 'EDIT_DATA');
-    }
-
-    /**
      * Scope a query to include only active processes
      *
      */

--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -87,22 +87,16 @@ class ProcessVersion extends Model implements ProcessModelInterface
 
         foreach ($processables as $relationshipName => $methodName) {
 
-            $process = $this->process;
-
-            if (!$process->$relationshipName() instanceof MorphToMany) {
-                continue;
-            }
-
-            if (!$process->$relationshipName()->exists()) {
+            if (!$this->process->$relationshipName()->exists()) {
                 continue;
             }
 
             $includeWithPivot = [
-                'process_id' => $process->id,
+                'process_id' => $this->process->id,
                 'method' => $methodName
             ];
 
-            $updateWith = $process->$relationshipName->keyBy('id')->map(
+            $updateWith = $this->process->$relationshipName->keyBy('id')->map(
                 function ($model) use ($includeWithPivot) {
                     return $includeWithPivot;
                 }

--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -7,6 +7,7 @@ use ProcessMaker\Contracts\ProcessModelInterface;
 use ProcessMaker\Traits\HasCategories;
 use ProcessMaker\Traits\HasSelfServiceTasks;
 use ProcessMaker\Traits\ProcessTrait;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 /**
  * ProcessVersion is used to store the historical version of a process.
@@ -60,6 +61,56 @@ class ProcessVersion extends Model implements ProcessModelInterface
     protected $hidden = [
         'bpmn'
     ];
+
+    protected static function boot()
+    {
+        static::saved(static function (ProcessVersion $processVersion) {
+            $processVersion->saveProcessableVersions();
+        });
+
+        parent::boot();
+    }
+
+    /**
+     * Ensures there is a matching processable for each process version
+     *
+     * @return void
+     */
+    protected function saveProcessableVersions()
+    {
+        $processables = [
+            'usersCanCancel' => 'CANCEL',
+            'usersCanEditData' => 'EDIT_DATA',
+            'groupsCanCancel' => 'CANCEL',
+            'groupsCanEditData' => 'EDIT_DATA'
+        ];
+
+        foreach ($processables as $relationshipName => $methodName) {
+
+            $process = $this->process;
+
+            if (!$process->$relationshipName() instanceof MorphToMany) {
+                continue;
+            }
+
+            if (!$process->$relationshipName()->exists()) {
+                continue;
+            }
+
+            $includeWithPivot = [
+                'process_id' => $process->id,
+                'method' => $methodName
+            ];
+
+            $updateWith = $process->$relationshipName->keyBy('id')->map(
+                function ($model) use ($includeWithPivot) {
+                    return $includeWithPivot;
+                }
+            );
+
+            $this->$relationshipName()->sync($updateWith->toArray(), false);
+        }
+    }
 
     /**
      * Set multiple|single categories to the process

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -401,7 +401,7 @@ class User extends Authenticatable implements HasMedia
             'id not in (select request_id from request_user_permissions where user_id=?)',
             [$this->getKey()]
         )->select(
-            'id', 'process_id', 'user_id', 'parent_request_id', 'callable_id'
+            'id', 'process_id', 'user_id', 'parent_request_id', 'callable_id', 'process_version_id'
         );
 
         // Process the results in chunks

--- a/ProcessMaker/Policies/ProcessPolicy.php
+++ b/ProcessMaker/Policies/ProcessPolicy.php
@@ -18,25 +18,25 @@ class ProcessPolicy
      *
      * @param  \ProcessMaker\Models\User  $user
      * @return mixed
-     */
+     */    
     public function before(User $user)
     {
         if ($user->is_administrator) {
             return true;
         }
     }
-
+    
     /**
      * Determine whether the user can start the process.
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\Models\Process  $process
+     * @param  \ProcessMaker\Process  $process
      * @return mixed
      */
     public function start(User $user, Process $process)
     {
         $groupIds = $user->groups->pluck('id');
-
+        
         if ($process->groupsCanStart(request()->query('event'))->whereIn('id', $groupIds)->count()) {
             return true;
         }
@@ -45,19 +45,9 @@ class ProcessPolicy
             request()->query('event')
         )->pluck('id');
 
-        $userCanStartAsProcessManager = array_reduce($process->getStartEvents(),
-            function ($carry, $item) use($process, $user) {
-                if (array_key_exists('assignment', $item)) {
-                    $carry = $carry || ($item['assignment'] === 'process_manager' && $process->manager_id === $user->id);
-                }
-                return $carry;
-            },
-            False);
-
         if (
             $usersCanStart->contains($user->id) ||
-            $usersCanStart->contains(app(AnonymousUser::class)->id) ||
-            $userCanStartAsProcessManager
+            $usersCanStart->contains(app(AnonymousUser::class)->id)
         ) {
             return true;
         }
@@ -69,26 +59,18 @@ class ProcessPolicy
      * Determine whether the user can cancel the process.
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\Models\Process  $process
-     *
-     * @return bool
+     * @param  \ProcessMaker\Process  $process
+     * @return mixed
      */
     public function cancel(User $user, Process $process)
     {
         $groupIds = $user->groups->pluck('id');
-
-        if ($process->groupsCanCancel()->whereIn('id', $groupIds)->exists()) {
+        
+        if ($process->groupsCanCancel->whereIn('id', $groupIds)->count()) {
             return true;
         }
-
-        if ($process->usersCanCancel()->where('id', $user->id)->exists()) {
-            return true;
-        }
-
-        if (
-            $process->manager_id === $user->id &&
-            $process->getProperty('manager_can_cancel_request') === true
-        ) {
+        
+        if ($process->usersCanCancel->where('id', $user->id)->count()) {
             return true;
         }
 
@@ -99,19 +81,18 @@ class ProcessPolicy
      * Determine whether the user can edit data.
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\Models\Process  $process
-     *
-     * @return bool
+     * @param  \ProcessMaker\Process  $process
+     * @return mixed
      */
     public function editData(User $user, Process $process)
     {
         $groupIds = $user->groups->pluck('id');
-
-        if ($process->groupsCanEditData()->whereIn('id', $groupIds)->exists()) {
+        
+        if ($process->groupsCanEditData->whereIn('id', $groupIds)->count()) {
             return true;
         }
 
-        if ($process->usersCanEditData()->where('id', $user->id)->exists()) {
+        if ($process->usersCanEditData->where('id', $user->id)->count()) {
             return true;
         }
 

--- a/ProcessMaker/Policies/ProcessRequestPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestPolicy.php
@@ -16,7 +16,7 @@ class ProcessRequestPolicy
      *
      * @param  \ProcessMaker\Models\User  $user
      * @return mixed
-     */    
+     */
     public function before(User $user)
     {
         if ($user->is_administrator) {
@@ -42,10 +42,10 @@ class ProcessRequestPolicy
         }
 
         if ($user->hasPermission('edit-request_data')) {
-                return true;
+            return true;
         }
 
-        if ($processRequest->process->usersCanEditData->where('id', $user->id)->count() > 0) {
+        if ($processRequest->processVersion->usersCanEditData()->where('id', $user->id)->exists()) {
             return true;
         }
 
@@ -66,10 +66,11 @@ class ProcessRequestPolicy
         if ($processRequest->user_id == $user->id) {
             return true;
         }
-        return $user->can('cancel', $processRequest->process)
+
+        return $user->can('cancel', $processRequest->processVersion)
             || $user->hasPermission('edit-request_data')
-            || $user->can('editData', $processRequest->process);
-    }    
+            || $user->can('editData', $processRequest->processVersion);
+    }
 
     /**
      * Determine whether the user can update the process request.
@@ -84,27 +85,25 @@ class ProcessRequestPolicy
             return true;
         }
     }
-    
+
     /**
      * Determine whether the user can edit request data.
      *
      * @param  \ProcessMaker\Models\User  $user
      * @param  \ProcessMaker\Process  $process
      * @return boolean
-     */    
+     */
     public function editData(User $user, ProcessRequest $request)
     {
-        if ($request->status === 'ACTIVE') {
-            $permission = 'edit-task_data';
-        } else {
-            $permission = 'edit-request_data';
-        }
-        
+        $permission = $request->status === 'ACTIVE'
+            ? 'edit-task_data'
+            : 'edit-request_data';
+
         if ($user->can($permission)) {
             return true;
         }
-        
-        return $user->can('editData', $request->process);
+
+        return $user->can('editData', $request->processVersion);
     }
 
     /**

--- a/ProcessMaker/Policies/ProcessVersionPolicy.php
+++ b/ProcessMaker/Policies/ProcessVersionPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ProcessMaker\Policies;
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use ProcessMaker\Models\ProcessVersion;
+use ProcessMaker\Models\User;
+
+class ProcessVersionPolicy
+{
+    use HandlesAuthorization;
+
+     /**
+     * Run before all methods to determine if the
+     * user is an admin and can do everything.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @return mixed
+     */
+    public function before(User $user)
+    {
+        if ($user->is_administrator) {
+            return true;
+        }
+    }
+
+    /**
+     * Determine whether the user can cancel the process version.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @param  \ProcessMaker\Models\ProcessVersion  $processVersion
+     *
+     * @return bool
+     */
+    public function cancel(User $user, ProcessVersion $processVersion)
+    {
+        $groupIds = $user->groups->pluck('id');
+
+        if ($processVersion->groupsCanCancel()->whereIn('id', $groupIds)->exists()) {
+            return true;
+        }
+
+        if ($processVersion->usersCanCancel()->where('id', $user->id)->exists()) {
+            return true;
+        }
+
+        if (
+            $processVersion->manager_id === $user->id &&
+            $processVersion->getProperty('manager_can_cancel_request') === true
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the user can edit data
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @param  \ProcessMaker\Models\ProcessVersion  $processVersion
+     *
+     * @return bool
+     */
+    public function editData(User $user, ProcessVersion $processVersion)
+    {
+        $groupIds = $user->groups->pluck('id');
+
+        if ($processVersion->groupsCanEditData()->whereIn('id', $groupIds)->exists()) {
+            return true;
+        }
+
+        if ($processVersion->usersCanEditData()->where('id', $user->id)->exists()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/ProcessMaker/Policies/ProcessVersionPolicy.php
+++ b/ProcessMaker/Policies/ProcessVersionPolicy.php
@@ -44,13 +44,6 @@ class ProcessVersionPolicy
             return true;
         }
 
-        if (
-            $processVersion->manager_id === $user->id &&
-            $processVersion->getProperty('manager_can_cancel_request') === true
-        ) {
-            return true;
-        }
-
         return false;
     }
 

--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -22,8 +22,10 @@ use Laravel\Passport\Passport;
 use ProcessMaker\Models\Script;
 use Illuminate\Support\Facades\Log;
 use ProcessMaker\Models\AnonymousUser;
+use ProcessMaker\Models\ProcessVersion;
 use ProcessMaker\Policies\UserPolicy;
 use ProcessMaker\Models\Screen;
+use ProcessMaker\Policies\ProcessVersionPolicy;
 use ProcessMaker\Policies\ScreenPolicy;
 use ProcessMaker\Policies\ScriptPolicy;
 
@@ -43,6 +45,7 @@ class AuthServiceProvider extends ServiceProvider
         Media::class => MediaPolicy::class,
         Notification::class => NotificationPolicy::class,
         Process::class => ProcessPolicy::class,
+        ProcessVersion::class => ProcessVersionPolicy::class,
         ProcessRequest::class => ProcessRequestPolicy::class,
         ProcessRequestToken::class => ProcessRequestTokenPolicy::class,
         User::class => UserPolicy::class,

--- a/ProcessMaker/Traits/ProcessTrait.php
+++ b/ProcessMaker/Traits/ProcessTrait.php
@@ -51,62 +51,6 @@ trait ProcessTrait
     }
 
     /**
-     * Set a value on the properties json column
-     *
-     * @param string $name
-     * @param mixed $value
-     * @return void
-     */
-    public function setProperty($name, $value)
-    {
-        $properties = $this->properties;
-        $properties[$name] = $value;
-        $this->properties = $properties;
-    }
-
-    /**
-     * Get a value from the properties json column
-     *
-     * @param string $name
-     * @return mixed
-     */
-    public function getProperty($name)
-    {
-       return isset($this->properties[$name]) ? $this->properties[$name] : null;
-    }
-
-    /**
-     * Set the manager id
-     *
-     * @param int $value
-     * @return void
-     */
-    public function setManagerIdAttribute($value)
-    {
-        $this->setProperty('manager_id', $value);
-    }
-
-    /**
-     * Get the the manager id
-     *
-     * @return int|null
-     */
-    public function getManagerIdAttribute()
-    {
-        return $this->getProperty('manager_id');
-    }
-
-    /**
-     * Get the process manager
-     *
-     * @return User|null
-     */
-    public function manager()
-    {
-        return $this->belongsTo(User::class, 'manager_id');
-    }
-
-    /**
      * Get the users who can start this process
      *
      */

--- a/ProcessMaker/Traits/ProcessTrait.php
+++ b/ProcessMaker/Traits/ProcessTrait.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Traits;
 
+use ProcessMaker\Models\User;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessVersion;

--- a/ProcessMaker/Traits/ProcessTrait.php
+++ b/ProcessMaker/Traits/ProcessTrait.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Traits;
 
+use ProcessMaker\Models\Group;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessVersion;
 use ProcessMaker\Nayra\Contracts\Storage\BpmnDocumentInterface;
 use ProcessMaker\Repositories\BpmnDocument;
@@ -45,5 +47,117 @@ trait ProcessTrait
         $document = new BpmnDocument($this);
         $document->loadXML($this->bpmn);
         return $document;
+    }
+
+    /**
+     * Set a value on the properties json column
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     */
+    public function setProperty($name, $value)
+    {
+        $properties = $this->properties;
+        $properties[$name] = $value;
+        $this->properties = $properties;
+    }
+
+    /**
+     * Get a value from the properties json column
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function getProperty($name)
+    {
+       return isset($this->properties[$name]) ? $this->properties[$name] : null;
+    }
+
+    /**
+     * Set the manager id
+     *
+     * @param int $value
+     * @return void
+     */
+    public function setManagerIdAttribute($value)
+    {
+        $this->setProperty('manager_id', $value);
+    }
+
+    /**
+     * Get the the manager id
+     *
+     * @return int|null
+     */
+    public function getManagerIdAttribute()
+    {
+        return $this->getProperty('manager_id');
+    }
+
+    /**
+     * Get the process manager
+     *
+     * @return User|null
+     */
+    public function manager()
+    {
+        return $this->belongsTo(User::class, 'manager_id');
+    }
+
+    /**
+     * Get the users who can start this process
+     *
+     */
+    public function usersCanCancel()
+    {
+        $query = $this->morphedByMany(User::class, 'processable')
+                      ->wherePivot('method', 'CANCEL');
+
+        return $this instanceof Process
+            ? $query->wherePivot('process_version_id', '=', null)
+            : $query;
+    }
+
+    /**
+     * Get the groups who can start this process
+     *
+     */
+    public function groupsCanCancel()
+    {
+        $query = $this->morphedByMany(Group::class, 'processable')
+                      ->wherePivot('method', 'CANCEL');
+
+        return $this instanceof Process
+            ? $query->wherePivot('process_version_id', '=', null)
+            : $query;
+    }
+
+    /**
+     * Get the users who can start this process
+     *
+     */
+    public function usersCanEditData()
+    {
+        $query = $this->morphedByMany(User::class, 'processable')
+                      ->wherePivot('method', 'EDIT_DATA');
+
+        return $this instanceof Process
+            ? $query->wherePivot('process_version_id', '=', null)
+            : $query;
+    }
+
+    /**
+     * Get the groups who can start this process
+     *
+     */
+    public function groupsCanEditData()
+    {
+        $query = $this->morphedByMany(Group::class, 'processable')
+                      ->wherePivot('method', 'EDIT_DATA');
+
+        return $this instanceof Process
+            ? $query->wherePivot('process_version_id', '=', null)
+            : $query;
     }
 }

--- a/database/factories/ProcessRequestFactory.php
+++ b/database/factories/ProcessRequestFactory.php
@@ -30,6 +30,9 @@ $factory->define(ProcessRequest::class, function (Faker $faker) {
         },
         'process_collaboration_id' => function () {
             return factory(ProcessCollaboration::class)->create()->getKey();
+        },
+        'process_version_id' => function(array $processRequest) {
+            return Process::find($processRequest['process_id'])->getLatestVersion()->id;
         }
     ];
 });

--- a/database/migrations/2021_09_28_202132_add_process_version_to_processables_table.php
+++ b/database/migrations/2021_09_28_202132_add_process_version_to_processables_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProcessVersionToProcessablesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('processables', function (Blueprint $table) {
+            $table->integer('process_version_id')
+                  ->unsigned()
+                  ->after('process_id')
+                  ->nullable();
+
+            $table->foreign('process_version_id')
+                  ->references('id')
+                  ->on('process_versions')
+                  ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('processables', function (Blueprint $table) {
+            $table->dropIfExists('process_version_id');
+        });
+    }
+}

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -416,8 +416,13 @@ class ProcessRequestsTest extends TestCase
         $this->user->saveOrFail();
         $request = factory(ProcessRequest::class)->create(['status' => 'ACTIVE']);
 
-        // give the user editData permission to get passed the route check
-        $request->process->usersCanEditData()->sync([$this->user->id => ['method' => 'EDIT_DATA']]);
+        // give the user editData permission to get past the route check
+        $request->processVersion->usersCanEditData()->sync([
+            $this->user->id => [
+                'method' => 'EDIT_DATA',
+                'process_id' => $request->process->id
+            ]
+        ]);
 
         $route = route('api.requests.update', [$request->id]);
         $response = $this->apiCall('PUT', $route, ['status' => 'COMPLETED']);
@@ -433,8 +438,7 @@ class ProcessRequestsTest extends TestCase
 
         // Confirm only ERROR status can be changed
         $response->assertStatus(422);
-        $this->assertEquals(
-            'Only requests with status: ERROR can be manually completed',
+        $this->assertEquals('Only requests with status: ERROR can be manually completed',
             $response->json()['errors']['status'][0]
         );
 

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -614,6 +614,8 @@ class ProcessRequestsTest extends TestCase
             [$this->user->id => ['method' => 'EDIT_DATA']]
         );
 
+        $process->save();
+
         // Create a new process request with the update process
         // configuration since the process request now honors
         // the process configuration how it existed when the

--- a/tests/Feature/EditDataTest.php
+++ b/tests/Feature/EditDataTest.php
@@ -23,7 +23,7 @@ use Tests\TestCase;
 class EditDataTest extends TestCase
 {
     use RequestHelper;
-    
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -34,7 +34,7 @@ class EditDataTest extends TestCase
             'is_administrator' => true,
         ]);
 
-        // Creates an user
+        // Creates a user
         $this->user = factory(User::class)->create([
             'password' => Hash::make('password'),
             'is_administrator' => false,
@@ -42,13 +42,14 @@ class EditDataTest extends TestCase
 
         // Create a group
         $this->group = factory(Group::class)->create(['name' => 'group']);
+
         factory(GroupMember::class)->create([
             'member_id' => $this->user->id,
             'member_type' => User::class,
             'group_id' => $this->group->id,
         ]);
 
-        //Run the permission seeder
+        // Run the permission seeder
         (new PermissionSeeder)->run();
 
         // Reboot our AuthServiceProvider. This is necessary so that it can
@@ -83,17 +84,19 @@ class EditDataTest extends TestCase
             $editDataUsers[$item] = ['method' => 'EDIT_DATA'];
         }
 
-        //Adding method to groups array            
+        //Adding method to groups array
         $editDataGroups = [];
         foreach ($groups as $item) {
             $editDataGroups[$item] = ['method' => 'EDIT_DATA'];
         }
 
-        //Syncing users and groups that can cancel this process            
+        //Syncing users and groups that can cancel this process
         $process->usersCanEditData()->sync($editDataUsers,
             ['method' => 'EDIT_DATA']);
         $process->groupsCanEditData()->sync($editDataGroups,
             ['method' => 'EDIT_DATA']);
+
+        $process->save();
     }
 
     /**
@@ -262,12 +265,12 @@ class EditDataTest extends TestCase
         $process = $this->createSingleTaskProcessUserAssignment($this->user);
         $request = $this->startProcess($process, 'StartEventUID');
         $task = $request->tokens()->where('element_id', 'UserTaskUID')->first();
-        
+
         //Assign global edit task permission to user
         $this->user->permissions()->attach(Permission::byName('edit-task_data')->id);
         $this->user->refresh();
         $this->flushSession();
-        
+
         //Perform web call and make assertions
         $response = $this->webCall('GET', 'tasks/' . $task->id . '/edit');
         $response->assertStatus(200);


### PR DESCRIPTION
Processes now maintain matching processables with the version of the process when the processable was created.

[Fixes ticket #666](http://tickets.pm4overflow.com/tickets/666)