### PR TITLE
ticket 714 - File Upload: Multiple Option

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -265,6 +265,7 @@ class ProcessRequestFileController extends Controller
         $data_name = $laravelRequest->input('data_name', $file->getClientOriginalName());
         $rowId = $laravelRequest->input('row_id', null);
         $parent = (int)$laravelRequest->input('parent', null);
+        $multiple = $laravelRequest->input('multiple', null);
 
         foreach($processRequest->getMedia() as $mediaItem) {
             if(
@@ -273,7 +274,9 @@ class ProcessRequestFileController extends Controller
                 $mediaItem->getCustomProperty('row_id') == $rowId)
             {
                 $originalCreatedBy = $mediaItem->getCustomProperty('createdBy');
-                $mediaItem->delete();
+                if (empty($multiple)) {
+                    $mediaItem->delete();
+                }
             }
         }
 


### PR DESCRIPTION
As part of fixes for [http://tickets.pm4overflow.com/tickets/714](http://tickets.pm4overflow.com/tickets/714)

Modifies the Request File Controller so that the uploaded file is not removed if it the store API is called with the option multiple=true. In this way the request can accumulate many files for the same variables.