### PR TITLE
4.2 Fix Cannot read properties of undefined (reading 'countElements') Console Error

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -484,6 +484,9 @@ export default {
       this.optionsMenu[1].items.splice(1, 0, this.customCssOption);
     },
     countElements() {
+      if (!this.$refs.renderer) {
+        return;
+      }
       this.$refs.renderer.countElements(this.config).then(allElements => {
         this.numberOfElements = allElements.length;
       });


### PR DESCRIPTION
TICKET [1016](http://tickets.pm4overflow.com/tickets/1016)

The issue is caused by rendering a custom component that does not have  `renderer` set as a `ref`.  (i.e Conversational Forms)

<h2>Changes</h2>

- Check if the `refs` renderer is set. 