### PR TITLE
Add Title Section in Auth/Passwords views (for 4.2)

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,4 +1,6 @@
 @extends('layouts.minimal')
+@section('title', __('Forgot Your Password?'))
+
 @section('content')
 
 <div align="container">

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,4 +1,5 @@
 @extends('layouts.minimal')
+@section('title', __('Reset Your Password'))
 
 @section('content')
 <div align="center">


### PR DESCRIPTION
It's not a bug, but Password Recovery views lack of Title section and renders the next string "Welcome :name"

Ticket
- http://tickets.pm4overflow.com/tickets/925