### PR TITLE
ticket-1019: Group Start Permissions Not Working (for 4.1)

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -769,11 +769,11 @@ class Process extends Model implements HasMedia, ProcessModelInterface
         $response = [];
         foreach ($this->start_events as $startEvent) {
             if (isset($startEvent['assignment']) && $startEvent['assignment'] === 'user') {
-                $users = explode(',', $startEvent['assignedUsers']);
+                $users = explode(',', ($startEvent['assignedUsers'] ?? ''));
                 $access = in_array($user->id, $users);
             } elseif (isset($startEvent['assignment']) && $startEvent['assignment'] === 'group') {
                 $access = false;
-                foreach (explode(',', $startEvent['assignedGroups']) as $groupId) {
+                foreach (explode(',', ($startEvent['assignedGroups'] ?? '')) as $groupId) {
                     $access = $this->doesUserBelongsGroup($user->id, $groupId);
                     if ($access) {
                         break;


### PR DESCRIPTION
Fixes [http://tickets.pm4overflow.com/tickets/1019](http://tickets.pm4overflow.com/tickets/1019)

The steps used to replicate the issue are:
- Create at least 2 processes (process 1, process2)
- Create 1 users (user1) 
- create 1 group (group1)
- Assign user1  to group1
- Configure the Start Event of process1 to group1
- Configure the Start Event of process2 as in the next screenshot, that is Type=group and left empty the group:
![image](https://user-images.githubusercontent.com/14875032/136102897-9777ab7e-ff56-4dac-a664-c1baa39fb33b.png)
- Login as user1 and try to start a request. The process list is empty.

With the fix, the process list (when trying to start a request) returns process1.
