### PR TITLE
Fix relative time parsing and filtering by user timezone (4.2)

### DIFF
--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -57,7 +57,11 @@ trait ExtendedPMQL
         if (is_string($field)) {
             // Parse our value
             $value = $this->parseValue($expression);
-            $expression->value->setValue($value);
+            
+            // PMQL Interval expressions do not have values
+            if (method_exists($expression->value, 'setValue')) {
+                $expression->value->setValue($value);
+            }
             
             // Title case our field name so we can suffix it to our method names
             $fieldMethodName = ucfirst(strtolower($field));
@@ -106,7 +110,7 @@ trait ExtendedPMQL
             $method = "fieldWildcard";
             if (method_exists($model, $method)) {
                 return $model->{$method}($value, $expression, $builder, $user);
-            }    
+            }
         }
     }
     
@@ -132,9 +136,9 @@ trait ExtendedPMQL
         // Check to see if the value is parsable as a date
         if (! is_numeric($value)) {
             try {
-                $parsed = Carbon::parse($value);
-                $timezone = CarbonTimeZone::create(auth()->user()->timezone);
-                $value = $parsed->shiftTimezone($timezone)->toIso8601String();
+                $parsed = Carbon::parse($value, auth()->user()->timezone);
+                $parsed->setTimezone(config('app.timezone'));
+                $value = $parsed->toDateTimeString();
             } catch (Throwable $e) {
                 //Ignore parsing errors and just return the original
             }

--- a/tests/Feature/ExtendedPMQLTest.php
+++ b/tests/Feature/ExtendedPMQLTest.php
@@ -88,7 +88,7 @@ class ExtendedPMQLTest extends TestCase
         $this->assertContains(\DB::select("select @@time_zone as tz")[0]->tz, ['+00:00', 'UTC']);
 
         // Ensure the app timezone is set to UTC
-        \Config::set('timezone', 'UTC');
+        config(['app.timezone' => 'UTC']);
 
         $this->user->timezone = 'America/Los_Angeles';
         $this->user->save();

--- a/tests/Feature/ExtendedPMQLTest.php
+++ b/tests/Feature/ExtendedPMQLTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Carbon\Carbon;
 use DB;
 use Faker\Factory;
 use Tests\TestCase;
@@ -79,5 +80,45 @@ class ExtendedPMQLTest extends TestCase
 
         // Assert that the models match
         $this->assertTrue($processRequestToken->is($pmqlResult));        
+    }
+
+    public function testInUsersTimezone()
+    {
+        // Ensure the mysql server timezone is set to UTC
+        $this->assertContains(\DB::select("select @@time_zone as tz")[0]->tz, ['+00:00', 'UTC']);
+
+        // Ensure the app timezone is set to UTC
+        \Config::set('timezone', 'UTC');
+
+        $this->user->timezone = 'America/Los_Angeles';
+        $this->user->save();
+
+        $processRequest1 = factory(ProcessRequest::class)->create([
+            'completed_at' => '2021-10-05 16:00:00', // UTC
+        ]);
+        $processRequest2 = factory(ProcessRequest::class)->create([
+            'completed_at' => '2021-10-05 18:00:00', // UTC
+        ]);
+
+        $url = route('api.requests.index', ['pmql' => 'completed_at > "2021-10-05 10:00:00"']); // America/Los_Angeles
+        $result = $this->apiCall('GET', $url);
+        $this->assertCount(1, $result->json()['data']); // Match only the one created at 11am Los Angeles Time (18:00/6pm UTC)
+        $this->assertEquals($processRequest2->id, $result->json()['data'][0]['id'] );
+
+    }
+
+    public function testRelativeDate()
+    {
+        $processRequest1 = factory(ProcessRequest::class)->create([
+            'data' => ['date' => Carbon::parse('-10 minutes')->toDateTimeString()],
+        ]);
+        $processRequest2 = factory(ProcessRequest::class)->create([
+            'data' => ['date' => Carbon::parse('-2 hours')->toDateTimeString()],
+        ]);
+
+        $url = route('api.requests.index', ['pmql' => 'data.date > now -1 hour']);
+        $result = $this->apiCall('GET', $url);
+        $this->assertCount(1, $result->json()['data']); // Match only the one that completed 10 minutes ago 
+        $this->assertEquals($processRequest1->id, $result->json()['data'][0]['id'] );
     }
 }


### PR DESCRIPTION
Fixes http://tickets.pm4overflow.com/tickets/1021

- Do not call set value on the expression if its an interval expression
- Fix date parsing in mysql 5 (mysql 5 does not recognize timezones in the date string)

4.1: https://github.com/ProcessMaker/processmaker/pull/4060