### PR TITLE
Bugfix Ticket 910 - Auth Clients Store (4.2)

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/ClientController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ClientController.php
@@ -49,7 +49,7 @@ class ClientController extends PassportClientController
         $redirect = in_array('authorization_code_grant', $request->types) ? $request->redirect : '';
 
         $client = $this->clients->create(
-            $request->user()->getKey(), $request->name, $redirect, $personalAccess, $password
+            $request->user()->getKey(), $request->name, $redirect, null, $personalAccess, $password
         )->makeVisible('secret');
 
         return new AuthClientResource($client);


### PR DESCRIPTION
Issue:
- When creating a new Auth Client, the "Enable Password Grant" checkbox is not stored correctly.

Change:
- The provider parameter was missing in the create function.

Ticket:
- http://tickets.pm4overflow.com/tickets/910