### PR TITLE
[4.2] Shows the edit process link for active or inactive processes

### DIFF
--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -72,7 +72,7 @@
                       @click="onAction('edit-designer', props.rowData, props.rowIndex)"
                       v-b-tooltip.hover
                       :title="$t('Edit')"
-                      v-if="permission.includes('edit-processes') && props.rowData.status === 'ACTIVE'"
+                      v-if="permission.includes('edit-processes') && (props.rowData.status === 'ACTIVE' || props.rowData.status === 'INACTIVE')"
               >
                 <i class="fas fa-pen-square fa-lg fa-fw"></i>
               </b-btn>


### PR DESCRIPTION
Processes can be edited whether they're active or inactive, but previously the vue table row only displayed the edit link if the process was active instead of active or inactive.

Fixes [ticket #1074](http://tickets.pm4overflow.com/tickets/1074)