### PR TITLE
Fix the start permissions of a user nested in a group

### DIFF
--- a/ProcessMaker/Policies/ProcessPolicy.php
+++ b/ProcessMaker/Policies/ProcessPolicy.php
@@ -7,6 +7,7 @@ use ProcessMaker\Models\Process;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Http\Request;
 use ProcessMaker\Models\AnonymousUser;
+use ProcessMaker\Models\GroupMember;
 
 class ProcessPolicy
 {
@@ -35,8 +36,10 @@ class ProcessPolicy
      */
     public function start(User $user, Process $process)
     {
-        $groupIds = $user->groups->pluck('id');
-
+        $userGroupIds = $user->groups->pluck('id')->all();
+        $nestedGroupIds = GroupMember::whereIn('member_id', $userGroupIds)->pluck('group_id')->all();
+        $groupIds = array_merge($userGroupIds, $nestedGroupIds);
+        
         if ($process->groupsCanStart(request()->query('event'))->whereIn('id', $groupIds)->count()) {
             return true;
         }

--- a/ProcessMaker/Policies/ProcessPolicy.php
+++ b/ProcessMaker/Policies/ProcessPolicy.php
@@ -8,6 +8,7 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Http\Request;
 use ProcessMaker\Models\AnonymousUser;
 use ProcessMaker\Models\GroupMember;
+use ProcessMaker\Models\Group;
 
 class ProcessPolicy
 {
@@ -37,7 +38,7 @@ class ProcessPolicy
     public function start(User $user, Process $process)
     {
         $userGroupIds = $user->groups->pluck('id')->all();
-        $nestedGroupIds = GroupMember::whereIn('member_id', $userGroupIds)->pluck('group_id')->all();
+        $nestedGroupIds = GroupMember::where('member_type', Group::class)->whereIn('member_id', $userGroupIds)->pluck('group_id')->all();
         $groupIds = array_merge($userGroupIds, $nestedGroupIds);
         
         if ($process->groupsCanStart(request()->query('event'))->whereIn('id', $groupIds)->count()) {


### PR DESCRIPTION
Ticket: [1056](http://tickets.pm4overflow.com/tickets/1056)

<h2>Changes</h2>

- Update the Process Policy to enable start permissions for users in a group that is nested.

<h2>To Test</h2>

- Create Groups **"Group1"** and **"Group2"**
- Create User **"User2"**
- Assign **"Group2"** as a member of **"Group1"**
- Assign **"User2"** to **"Group2"**
- Create a process **"Test Process**" and configure its Start Event to be started by **"Group1"**
- Login as **"User2"**
- Try to Start **"Test Process"**

**Expected Behavior**

The User assigned as request starters via a group of groups should be able to start a request.