### PR TITLE
Bugfix Ticket 1081: Added exclude scope to screen model to optimize request (For 4.2)

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -73,9 +73,11 @@ class ScreenController extends Controller
      */
     public function index(Request $request)
     {
+        $exclusions = ($request->input('exclude', '') ? explode(',', $request->input('exclude', '')) : []);
+
         $query = Screen::nonSystem()
-            ->select('screens.*')
-            ->leftJoin('screen_categories as category', 'screens.screen_category_id', '=', 'category.id');
+            ->leftJoin('screen_categories as category', 'screens.screen_category_id', '=', 'category.id')
+            ->exclude($exclusions);
 
         $include = $request->input('include', '');
 
@@ -139,12 +141,6 @@ class ScreenController extends Controller
                 $request->input('order_by', 'title'),
                 $request->input('order_direction', 'ASC')
             )->paginate($request->input('per_page', 10));
-
-        $exclude = $request->input('exclude', '');
-        if ($exclude) {
-            $exclusions = explode(',', $exclude);
-            $response->makeHidden($exclusions);
-        }
 
         return new ApiCollection($response);
     }

--- a/ProcessMaker/Models/Screen.php
+++ b/ProcessMaker/Models/Screen.php
@@ -75,6 +75,12 @@ class Screen extends Model implements ScreenInterface
 
     protected $connection = 'processmaker';
 
+    /**
+     * The table name attribute
+     * @var string
+     */
+    protected $table = 'screens';
+
     protected $casts = [
         'config' => 'array',
         'computed' => 'array',
@@ -90,6 +96,27 @@ class Screen extends Model implements ScreenInterface
         'id',
         'created_at',
         'updated_at',
+    ];
+
+    /**
+     * Table columns.
+     *
+     * @var array
+     */
+    protected $columns = [
+        'id',
+        'screen_category_id',
+        'title',
+        'description',
+        'type',
+        'config',
+        'computed',
+        'custom_css',
+        'created_at',
+        'updated_at',
+        'status',
+        'key',
+        'watchers',
     ];
 
     /**
@@ -127,6 +154,13 @@ class Screen extends Model implements ScreenInterface
         return $this->belongsTo(ScreenCategory::class, 'screen_category_id');
     }
 
+    public function scopeExclude($query, $value = [])
+    {
+        $columns = array_diff($this->columns, (array) $value);
+        $columns = array_map(function($column) { return $this->table . '.' . $column; } , $columns);
+        return $query->select($columns);
+    }
+
     /**
      * Set multiple|single categories to the screen
      *
@@ -154,7 +188,7 @@ class Screen extends Model implements ScreenInterface
         }
         return 'ScreenBuilder';
     }
-    
+
     public function renderComponent()
     {
         if (isset($this->config['renderComponent'])) {
@@ -175,7 +209,7 @@ class Screen extends Model implements ScreenInterface
 
     /**
      * Get a recursive list of nested screens IDs in this screen
-     * 
+     *
      * @return int[] nested screen IDs
      */
     public function nestedScreenIds(ProcessRequest $processRequest = null)


### PR DESCRIPTION
Added exclude scope for passing columns to exclude from select when retrieving the list of screens on Designer - Screens
Fix bug [http://tickets.pm4overflow.com/tickets/1081](http://tickets.pm4overflow.com/tickets/1081)

Before when creating screens with a lot of elements, this caused optimization issue trying to get the screens in designer screens, now config is excluded in the query, and screens with a lot of elements can be retrieved.
