### PR TITLE
Bugfix Ticket 1081: Added exclude scope to screen model to optimize request (For 4.1)

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -142,8 +142,6 @@ class ScreenController extends Controller
                 $request->input('order_direction', 'ASC')
             )->paginate($request->input('per_page', 10));
 
-        $response->makeHidden($exclusions);
-
         return new ApiCollection($response);
     }
 

--- a/ProcessMaker/Models/Screen.php
+++ b/ProcessMaker/Models/Screen.php
@@ -157,8 +157,9 @@ class Screen extends Model implements ScreenInterface
 
     public function scopeExclude($query, $value = [])
     {
-        $columns = array_map(function($column) { return $this->table . '.' . $column; } , $this->columns);
-        return $query->select(array_diff($columns, (array) $value));
+        $columns = array_diff($this->columns, (array) $value);
+        $columns = array_map(function($column) { return $this->table . '.' . $column; } , $columns);
+        return $query->select($columns);
     }
 
     /**


### PR DESCRIPTION
**For 4.1**
Added exclude scope for passing columns to exclude from select when retrieving the list of screens on Designer - Screens
Fix bug http://tickets.pm4overflow.com/tickets/1081

Before when creating screens with a lot of elements, this caused optimization issue trying to get the screens in designer screens, now config is excluded in the query, and screens with a lot of elements can be retrieved.