### PR TITLE
[4.2] Missing .card class added to <task> vue component

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -50,6 +50,7 @@
                         <div id="tab-form" role="tabpanel" aria-labelledby="tab-form" class="tab-pane active show h-100">
                           @can('update', $task)
                             <task
+                              class="card border-0"
                               v-model="formData"
                               :initial-task-id="{{ $task->id }}"
                               :initial-request-id="{{ $task->process_request_id }}"


### PR DESCRIPTION
Fixes formatting issue when package-comments is installed. Resolves [ticket #1054](http://tickets.pm4overflow.com/tickets/1054).