### PR TITLE
Add validation rules for User passwords

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ChangePasswordController.php
+++ b/ProcessMaker/Http/Controllers/Api/ChangePasswordController.php
@@ -2,26 +2,46 @@
 
 namespace ProcessMaker\Http\Controllers\Api;
 
-use Illuminate\Http\Request;
+use Exception;
+use ProcessMaker\Models\User;
+use ProcessMaker\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
-use ProcessMaker\Http\Controllers\Controller;
-use ProcessMaker\Models\User;
+use Illuminate\Http\Request;
 
 class ChangePasswordController extends Controller
 {
     public function update(Request $request)
     {
-        $user = User::findOrFail(Auth::user()->id);
+        $user = Auth::user();
 
-        $fields = $request->json()->all();
-
-        if (isset($fields['password'])) {
-            $user->password = Hash::make($fields['password']);
-            $user->force_change_password = 0;
-            $user->save();
+        // On the rare occasion an authenticated user
+        // can't be found, then bail out
+        if (!$user instanceof User) {
+            return response()->json([], 422);
         }
 
-        return response()->json(['success' => 'ok'], 200);
+        // Same if we don't have the required fields
+        if (!$request->has(['password', 'confpassword'])) {
+            return response()->json([], 422);
+        }
+
+        // Make sure the password and password
+        // confirmation are the equivalent
+        $request->validate([
+            'password' => User::passwordRules($user),
+            'confpassword' => ['same:password'],
+        ]);
+
+        $user->setAttribute('password', Hash::make($request->json('password')));
+        $user->setAttribute('force_change_password', 0);
+
+        try {
+            $user = $user->save();
+        } catch (Exception $exception) {
+            $user = false;
+        }
+
+        return response()->json(['success' => $user ? 'ok' : 'false'], 200);
     }
 }

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -16,6 +16,8 @@ use ProcessMaker\Models\RequestUserPermission;
 use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use ProcessMaker\Traits\HideSystemResources;
+use ProcessMaker\Rules\StringHasNumberOrSpecialCharacter;
+use ProcessMaker\Rules\StringHasAtLeastOneUpperCaseCharacter;
 
 class User extends Authenticatable implements HasMedia
 {
@@ -143,27 +145,45 @@ class User extends Authenticatable implements HasMedia
     /**
      * Validation rules
      *
-     * @param $existing
+     * @param  \ProcessMaker\Models\User|null  $existing
      *
      * @return array
      */
-    public static function rules($existing = null)
+    public static function rules(User $existing = null)
     {
         $unique = Rule::unique('users')->ignore($existing);
 
         return [
             // The following characters where not included in the regexp: & %  ' " ? /
-            'username' => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:3', 'max:255' , $unique],
-            'firstname' => ['required', 'max:50'],
-            'lastname' => ['required', 'max:50'],
-            'email' => ['required', 'email'],
-            'phone' => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
-            'fax' => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
-            'cell' => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
-            'status' => ['required', 'in:ACTIVE,INACTIVE,OUT_OF_OFFICE,SCHEDULED'],
-            'password' => $existing ? 'required|sometimes|min:6' : 'required|min:6',
-            'birthdate' => 'date|nullable'
+            'username' /****/ => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:3', 'max:255' , $unique],
+            'firstname' /***/ => ['required', 'max:50'],
+            'lastname' /****/ => ['required', 'max:50'],
+            'email' /*******/ => ['required', 'email'],
+            'birthdate' /***/ => ['nullable', 'date'],
+            'phone' /*******/ => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
+            'fax' /*********/ => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
+            'cell' /********/ => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
+            'status' /******/ => ['required', 'in:ACTIVE,INACTIVE,OUT_OF_OFFICE,SCHEDULED'],
+            'password' /****/ => static::passwordRules($existing)
         ];
+    }
+
+    /**
+     * Validation rules specifically for the password
+     *
+     * @param  \ProcessMaker\Models\User|null  $existing
+     *
+     * @return array
+     */
+    public static function passwordRules(User $existing = null)
+    {
+        return array_filter([
+            'required',
+            $existing ? 'sometimes' : '',
+            'min:8',
+            new StringHasNumberOrSpecialCharacter(),
+            new StringHasAtLeastOneUpperCaseCharacter(),
+        ]);
     }
 
     /**

--- a/ProcessMaker/Rules/StringHasAtLeastOneUpperCaseCharacter.php
+++ b/ProcessMaker/Rules/StringHasAtLeastOneUpperCaseCharacter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ProcessMaker\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class StringHasAtLeastOneUpperCaseCharacter implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return preg_match('/[A-Z]/', $value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The :attribute must contain at least one uppercase character.';
+    }
+}

--- a/ProcessMaker/Rules/StringHasNumberOrSpecialCharacter.php
+++ b/ProcessMaker/Rules/StringHasNumberOrSpecialCharacter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ProcessMaker\Rules;
+
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Validation\Rule;
+
+class StringHasNumberOrSpecialCharacter implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return preg_match('/[^a-zA-Z\d]/', $value) || preg_match( '/\d/', $value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The :attribute must contain either a number or a special character.';
+    }
+}

--- a/resources/views/auth/passwords/change.blade.php
+++ b/resources/views/auth/passwords/change.blade.php
@@ -9,13 +9,9 @@
             @php
             $loginLogo = \ProcessMaker\Models\Setting::getLogin();
             $isDefault = \ProcessMaker\Models\Setting::loginIsDefault();
-            if ($isDefault) {
-                $class = 'login-logo-default';
-            } else {
-                $class = 'login-logo-custom';
-            }
+            $class = $isDefault ? 'login-logo-default' : 'login-logo-custom';
             @endphp
-            <img src={{$loginLogo}} alt="{{ config('logo-alt-text', 'ProcessMaker') }}" class="{{ $class }}">
+            <img src={{ $loginLogo }} alt="{{ config('logo-alt-text', 'ProcessMaker') }}" class="{{ $class }}">
         </div>
 
         <div class="row">
@@ -29,7 +25,7 @@
                         <h5 class="mb-3">{{ __('Please change your account password') }}</h5>
                         <div class="alert alert-primary">Password Requirements:
                             <ul>
-                                <li>{{ __('8 characters in length') }}</li>
+                                <li>{{ __('Minimum of 8 characters in length') }}</li>
                                 <li>{{ __('Contains an uppercase letter') }}</li>
                                 <li>{{ __('Contains a number or symbol') }}</li>
                             </ul>
@@ -49,7 +45,6 @@
                                     'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
                                 </div>
                             </vue-password>
-
                             <small v-if="errors && errors.password && errors.password.length" class="text-danger">@{{ errors.password[0] }}</small>
                         </div>
                         <div class="form-group">
@@ -57,7 +52,6 @@
                             {!!Form::password('confpassword', ['class'=> 'form-control', 'v-model'=> 'formData.confpassword',
                             'v-bind:class' => '{\'form-control\':true}', 'autocomplete' => 'new-password'])!!}
                         </div>
-
                         <div class="form-group pt-3 pb-2">
                             <button type="button" @click.prevent="submit" name="changepassword" class="btn btn-primary btn-block text-uppercase" dusk="changepassword">{{ __('Change Password') }}</button>
                         </div>
@@ -70,14 +64,11 @@
 @endsection
 
 @section('js')
-
 <script src="{{ mix('js/manifest.js') }}"></script>
 <script src="{{ mix('js/vendor.js') }}"></script>
 <script src="{{ mix('js/app.js') }}"></script>
-<script src="{{mix('js/admin/auth/passwords/change.js')}}"></script>
-
+<script src="{{ mix('js/admin/auth/passwords/change.js') }}"></script>
 <script>
-
     var formVueInstance = new Vue({
         el: '#changePassword',
         data() {
@@ -106,33 +97,39 @@
                     this.errors.password = ['Password is too weak']
                     return false
                 }
+
                 if (!this.formData.password && !this.formData.confpassword) {
                     return false;
                 }
+
                 if (this.formData.password.trim() === '' && this.formData.confpassword.trim() === '') {
                     return false
                 }
+
                 if (this.formData.password.trim().length > 0 && this.formData.password.trim().length < 8) {
                     this.errors.password = ['Password must be at least 8 characters']
                     this.formData.password = ''
                     return false
                 }
+
                 if (this.formData.password !== this.formData.confpassword) {
                     this.errors.password = ['Passwords must match']
                     return false
                 }
 
                 this.errors.password = null
-
                 return true
             },
             submit($event) {
                 this.resetErrors();
-                if (!this.validatePassword()) return false;
+
+                if (!this.validatePassword()) {
+                    return false;
+                }
 
                 ProcessMaker.apiClient.put('password/change', this.formData)
                     .then(response => {
-                        if (response.status == 200) {
+                        if (response.status === 200) {
                             window.location.href = '/requests';
                         }
                     })
@@ -147,13 +144,13 @@
 
 @section('css')
   <style media="screen">
-  .formContainer {
-      width:504px;
-  }
-  .formContainer .form {
-    margin-top:85px;
-    text-align: left
-  }
-  </style>
+      .formContainer {
+          width:504px;
+      }
 
+      .formContainer .form {
+        margin-top:85px;
+        text-align: left
+      }
+  </style>
 @endsection

--- a/tests/Feature/Api/ChangePasswordTest.php
+++ b/tests/Feature/Api/ChangePasswordTest.php
@@ -2,65 +2,115 @@
 
 namespace Tests\Feature\Api;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Auth;
-use ProcessMaker\Models\User;
 use Tests\TestCase;
 use Tests\Feature\Shared\RequestHelper;
+use ProcessMaker\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
 
 class ChangePasswordTest extends TestCase
 {
-
     use RequestHelper, RefreshDatabase;
 
     const API_TEST_URL = '/password/change';
 
-    /**
-     * When user change password flag must change to false
-     */
-    public function testUserChangePasswordMustSetFlagToFalse()
+    public function testUserPasswordChangeWithInvalidPassword()
     {
         $this->actingAs($this->user);
 
-        $user = User::where('id', Auth::user()->id)->first();
+        $user = Auth::user();
 
-        //Post data with new password
+        // Send request with an invalid password value
+        // Password must be at least 8 characters long
         $response = $this->apiCall('PUT', self::API_TEST_URL, [
-            'password' => 'new_password'
+            'password' => 'Proce5s',
+            'confpassword' => 'Proce5s'
         ]);
 
-        //Validate the header status code
-        $response->assertStatus(200);
+        $response->assertStatus(422)
+                 ->assertSeeText('Password must be at least 8 characters');
 
-        //Validate updated user password changed
-        $updatedUser = User::where('id', Auth::user()->id)->first();
+        // Password must contain one or more uppercase characters
+        $response = $this->apiCall('PUT', self::API_TEST_URL, [
+            'password' => 'process1',
+            'confpassword' => 'process1'
+        ]);
+
+        $response->assertStatus(422)
+                 ->assertSeeText('The password must contain at least one uppercase character');
+
+        // Password must contain a number or special character
+        $response = $this->apiCall('PUT', self::API_TEST_URL, [
+            'password' => 'ProcessMaker',
+            'confpassword' => 'ProcessMaker'
+        ]);
+
+        $response->assertStatus(422)
+                 ->assertSeeText('The password must contain either a number or a special character');
+
+        // Validate updated user password changed
+        $updatedUser = User::where('id', $user->id)->first();
+
         $this->assertNotEquals($updatedUser, $user);
 
-        //Validate Flag force_change_password was changed to 0 after password change
+        // Validate flag force_change_password was
+        // changed to 0 after password change
         $this->assertDatabaseHas('users', [
-            'id' => Auth::user()->id,
+            'id' => $user->id,
             'force_change_password' => 0
         ]);
     }
 
     /**
-     * When no password sended flag must be true
+     * Once the user changes their password, the flag must set to false
+     */
+    public function testUserChangePasswordMustSetFlagToFalse()
+    {
+        $this->actingAs($this->user);
+
+        $user = Auth::user();
+
+        // Post data with new password
+        $response = $this->apiCall('PUT', self::API_TEST_URL, [
+            'password' => 'ProcessMaker1',
+            'confpassword' => 'ProcessMaker1'
+        ]);
+
+        // Validate the header status code
+        $response->assertStatus(200);
+
+        // Validate updated user password changed
+        $updatedUser = User::where('id', $user->id)->first();
+
+        $this->assertNotEquals($updatedUser, $user);
+
+        // Validate flag force_change_password was
+        // changed to 0 after password change
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'force_change_password' => 0
+        ]);
+    }
+
+    /**
+     * When no password is sent, the flag must be set to true
      */
     public function testUserChangePasswordWithoutSendingPasswordMustKeepFlagInTrue()
     {
         $this->actingAs($this->user);
 
-        //Initial force_change_password flag to true
+        // Initial force_change_password flag to true
         $this->user->force_change_password = 1;
         $this->user->save();
 
-        //Post with empty params
+        // Post with empty params
         $response = $this->apiCall('PUT', self::API_TEST_URL);
 
-        //Validate the header status code
-        $response->assertStatus(200);
+        // Validate the header status code
+        $response->assertStatus(422);
 
-        //Validate Flag force_change_password was not changed when no password sended
+        // Validate flag force_change_password was
+        // not changed when no password was sent
         $this->assertDatabaseHas('users', [
             'id' => Auth::user()->id,
             'force_change_password' => 1,

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -364,7 +364,7 @@ class UsersTest extends TestCase
             'timezone' => $faker->timezone,
             'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
             'birthdate' => $faker->dateTimeThisCentury->format('Y-m-d'),
-            'password' => $faker->password(6, 6),
+            'password' => $faker->password(8).'A'.'1',
             'force_change_password' => $faker->boolean,
         ]);
 
@@ -395,7 +395,7 @@ class UsersTest extends TestCase
             'firstname' => $faker->firstName,
             'lastname' => $faker->lastName,
             'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
-            'password' => $faker->password(6, 6),
+            'password' => $faker->password(8).'A'.'1',
             'force_change_password' => 0,
         ]);
 
@@ -572,9 +572,9 @@ class UsersTest extends TestCase
         $response = $this->apiCall('POST', self::API_TEST_URL, $payload);
         $response->assertStatus(422);
         $json = $response->json();
-        $this->assertEquals('The Password must be at least 6 characters.', $json['errors']['password'][0]);
+        $this->assertEquals('The Password must be at least 8 characters.', $json['errors']['password'][0]);
 
-        $payload['password'] = 'abc123';
+        $payload['password'] = 'Abc12345';
         $response = $this->apiCall('POST', self::API_TEST_URL, $payload);
         $response->assertStatus(201);
         $json = $response->json();
@@ -586,9 +586,9 @@ class UsersTest extends TestCase
         $response = $this->apiCall('PUT', route('api.users.update', $userId), $payload);
         $response->assertStatus(422);
         $json = $response->json();
-        $this->assertEquals('The Password must be at least 6 characters.', $json['errors']['password'][0]);
+        $this->assertEquals('The Password must be at least 8 characters.', $json['errors']['password'][0]);
 
-        $payload['password'] = 'abc123';
+        $payload['password'] = 'Abc12345';
         $response = $this->apiCall('PUT', route('api.users.update', $userId), $payload);
         $response->assertStatus(204);
 


### PR DESCRIPTION
User passwords are now checked when saved (through a controller). Requirements are:

- minimum 8 characters
- must contain an uppercase letter
- must contain either a special character or a number

Resolves [ticket #1032](http://tickets.pm4overflow.com/tickets/1032).