### PR TITLE
Fix missing package error not displayed on process import

### DIFF
--- a/ProcessMaker/Notifications/ImportReady.php
+++ b/ProcessMaker/Notifications/ImportReady.php
@@ -58,7 +58,7 @@ class ImportReady extends Notification
             'code' => $this->code,
             'data' => $this->data,
             'name' => __('Process imported'),
-            'processName' => $this->data['process']['name'],
+            'processName' => $this->data['process']['name'] ?? '',
         ];
     }
 


### PR DESCRIPTION
When an import process is aborted because of a missing package, the import screen hangs.

This PR includes:
- Fix the issue when no process name is included in the import response
- 
![image](https://user-images.githubusercontent.com/8028650/138175906-38492438-c6c6-4ad0-b5b5-07eabfc19f61.png)
