### PR TITLE
Bugfix/Ticket-1088: Added params to query

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -455,12 +455,11 @@ trait MakeHttpRequests
                     $query[$key] = $value;
                 }
             }
-        }
-
-        // Add params to query ..
-        foreach ($params as $key => $value) {
-            if ($value !== '') {
-                $query[$key] = $value;
+        } else {
+            foreach ($params as $key => $value) {
+                if ($value !== '') {
+                    $query[$key] = $value;
+                }
             }
         }
 


### PR DESCRIPTION
Ticket [1088](http://tickets.pm4overflow.com/tickets/1088)

According with the ticket 1088, reported as a bug, when you adding a pmql with calculated properties in a select list control mustache does not receive current screen values, but it does.
Instead of adding a pmql like:
`data.name = "{{ form_input_1 }}" and data.age > {{calc_1}}`

you should add your pmql with prefix "data" before of the variables like:
`data.name = "{{ data.form_input_1 }}" and data.age > {{data.calc_1}}`

In spite of this, PMQL was not working in select list because before make the request, params was not adding to the query, so, this was the reason why PMQL was not working

**Working example**


https://user-images.githubusercontent.com/90727999/138340683-08a619e5-6d88-4362-b0c5-18ad4bb1e819.mov



