### PR TITLE
Wait to send activated notification until self-serve is claimed

### DIFF
--- a/ProcessMaker/Listeners/BpmnSubscriber.php
+++ b/ProcessMaker/Listeners/BpmnSubscriber.php
@@ -85,8 +85,12 @@ class BpmnSubscriber
         }
         Log::info('Activity activated: ' . json_encode($token->getProperties()));
 
-        $notifiables = $token->getNotifiables('assigned');
-        Notification::send($notifiables, new ActivityActivatedNotification($token));
+        // Do not send activated notification for self service tasks since
+        // they do not have a user assigned yet.
+        if ($token->user_id) {
+            $token->sendActivityActivatedNotifications();
+        }
+
         event(new ActivityAssigned($event->token));
     }
 

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -7,6 +7,7 @@ use DB;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Notification;
 use Laravel\Scout\Searchable;
 use Log;
 use ProcessMaker\Facades\WorkflowManager;
@@ -20,6 +21,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\FlowElementInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Traits\ExtendedPMQL;
 use ProcessMaker\Traits\SerializeToIso8601;
+use ProcessMaker\Notifications\ActivityActivatedNotification;
 use Throwable;
 
 /**
@@ -870,5 +872,16 @@ class ProcessRequestToken extends Model implements TokenInterface
             return $loop && $loop->isExecutable();
         }
         return false;
+    }
+    
+    /**
+     * Send notifications when the task activates
+     *
+     * @return void
+     */
+    public function sendActivityActivatedNotifications()
+    {
+        $notifiables = $this->getNotifiables('assigned');
+        Notification::send($notifiables, new ActivityActivatedNotification($this));
     }
 }

--- a/tests/Fixtures/self_serve_notifications_process.bpmn
+++ b/tests/Fixtures/self_serve_notifications_process.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false" pm:config="{&#34;web_entry&#34;:null}">
+      <bpmn:outgoing>node_12</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_3" name="Form Task" pm:screenRef="18" pm:allowInterstitial="false" pm:assignment="self_service" pm:assignedUsers="[self_serve_user_id]" pm:assignedGroups="" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+      <bpmn:incoming>node_12</bpmn:incoming>
+      <bpmn:outgoing>node_10</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="node_4" name="End Event">
+      <bpmn:incoming>node_10</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_10" sourceRef="node_3" targetRef="node_4" />
+    <bpmn:sequenceFlow id="node_12" sourceRef="node_1" targetRef="node_3" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="220" y="110" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="180" y="210" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="220" y="340" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_10_di" bpmnElement="node_10">
+        <di:waypoint x="238" y="248" />
+        <di:waypoint x="238" y="358" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_12_di" bpmnElement="node_12">
+        <di:waypoint x="238" y="128" />
+        <di:waypoint x="238" y="248" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Fixes http://tickets.pm4overflow.com/tickets/1125

To test
- Enable "Assigned" notification for any user type for a self-serve task and run the process.
- Verify in `/notifications` that a notification is generated when the self serve task is claimed

Note the bell icon counter and notification list pop over in the navbar may not update due to a separate bug