### PR TITLE
[v4.2] Ticket 1179: Fix JSON support in Data Connector Send

### DIFF
--- a/ProcessMaker/Bpmn/MustacheOptions.php
+++ b/ProcessMaker/Bpmn/MustacheOptions.php
@@ -15,9 +15,12 @@ class MustacheOptions
             'base64' => [$this, 'base64'],
             'html64' => [$this, 'html64'],
             'key' => [$this, 'key'],
+            'json' => [$this, 'json'],
+            'serialize' => [$this, 'serialize'],
+            'xml' => [$this, 'xml'],
         ];
     }
-
+    
     public function html64($text, Mustache_LambdaHelper $helper)
     {
         return base64_encode('<html><body>' . $helper->render($text) . '</body></html>');
@@ -31,5 +34,20 @@ class MustacheOptions
     public function key($text, Mustache_LambdaHelper $helper)
     {
         return urlencode(Hash::make($helper->render($text)));
+    }
+    
+    public function json($text)
+    {
+        return json_encode($text);
+    }
+    
+    public function serialize($text)
+    {
+        return serialize($text);
+    }
+    
+    public function xml($text)
+    {
+        return xmlrpc_encode($text);
     }
 }

--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -188,6 +188,7 @@ class WorkflowServiceProvider extends ServiceProvider
             $op = new MustacheOptions;
             return new Mustache_Engine([
                 'helpers' => $op->helpers,
+                'pragmas' => [Mustache_Engine::PRAGMA_FILTERS],
             ]);
         });
 

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -185,7 +185,7 @@ trait MakeHttpRequests
 
         // Prepare Body
         $data = $this->prepareData($requestData, $outboundConfig, 'BODY');
-        $body = $this->getMustache()->render($endpoint['body'], $data);
+        $body = $this->getMustache()->render($endpoint['body'], $requestData);
         $bodyType = null;
         if (isset($endpoint['body_type'])) {
             $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);


### PR DESCRIPTION
## Changes
- Adds support for the following filters to mustache:
  - `{{{ variable | json }}}`
  - `{{{ variable | xml }}}`
  - `{{{ variable | serialize }}}`
- Fixes an issue where mustache was not receiving data in the body of a data connector

## Requirements
- https://github.com/ProcessMaker/package-data-sources/pull/205

## Tickets
- http://tickets.pm4overflow.com/tickets/1179