### PR TITLE
Fix 401s redirecting to home page for data source tests

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -223,8 +223,11 @@ window.ProcessMaker.apiClient.interceptors.response.use((response) => {
     window.ProcessMaker.EventBus.$emit("api-client-error", error);
     if (error.response && error.response.status && error.response.status === 401) {
         //stop 401 error consuming endpoints with data-sources
-        if (error.config.url.includes('requests/') && error.config.url.includes('/data_sources/')) {
-          return;
+        const url = error.config.url;
+        if (url.includes('/data_sources/')) {
+          if (url.includes('requests/') || url.includes('/test')) {
+            throw error;
+          }
         }
         window.location = "/login";
     } else {


### PR DESCRIPTION
Part of https://processmaker.atlassian.net/browse/FOUR-4317

When we get 401s from any api call it automatically redirects the user to the home page. Data sources can return 401s that we do not want to redirect. There was already an exception if the URL contains 'request'. This fix adds one for the 'test' endpoint.