### PR TITLE
Bugfix/FOUR-4292: Incorrect page title when you initialize a request through a web entry (For 4.2)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -958,6 +958,7 @@
   "Web Entry": "Web Entry",
   "week": "week",
   "Welcome": "Welcome, :name",
+  "Welcome WebEntry": "Welcome, ",
   "What is the URL of this ProcessMaker installation? (Ex: https://pm.example.com, with no trailing slash)": "What is the URL of this ProcessMaker installation? (Ex: https://pm.example.com, with no trailing slash)",
   "What Screen Should Be Used For Rendering This Interstitial": "What Screen Should Be Used For Rendering This Interstitial",
   "What Screen Should Be Used For Rendering This Task": "What Screen Should Be Used For Rendering This Task",


### PR DESCRIPTION
Ticket [FOUR-4292](https://processmaker.atlassian.net/browse/FOUR-4292)

Added lang for Webentry welcome title
When Webentry mode is Authenticated will display: **Welcome, Agustin Busso - Processmaker**
When Webentry mode is Anonymous will display: **Welcome, Anonymous User - Processmaker**

https://user-images.githubusercontent.com/90727999/142250031-92f8f30f-966c-48ef-8428-1fd659e3d4f2.mov



