### PR TITLE
Bugfix/ticket FOUR-4469: Multiple copies of the process are create and import doesn't finish

### DIFF
--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -30,6 +30,11 @@ class ImportProcess implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, PluginServiceProviderTrait;
 
     /**
+     * @var int
+     */
+    public $tries = 1;
+
+    /**
      * The original contents of the imported file.
      *
      * @var string

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -820,6 +820,8 @@ class ImportProcess implements ShouldQueue
             $this->file = base64_decode($this->fileContents);
             $this->file = json_decode($this->file);
         }
+
+        $this->standardizeBpmnNodePrefix();
     }
 
     /**

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -335,7 +335,7 @@ class ImportProcess implements ShouldQueue
             ]);
         }
     }
-    
+
     /**
      * Look for any watchers in screens and add them to the assignable list.
      *
@@ -429,7 +429,7 @@ class ImportProcess implements ShouldQueue
             $this->finishStatus('screens', true);
         }
     }
-    
+
     /**
      * Create a new Screen model for an individual screen, then save it.
      *
@@ -459,12 +459,12 @@ class ImportProcess implements ShouldQueue
                     $new->categories()->save($category);
                 }
             }
-            
+
             return $new;
         } catch (\Exception $e) {
             return false;
         }
-    }    
+    }
 
     /**
      * Pass an old script ID and a new script ID, then replace any references
@@ -815,6 +815,35 @@ class ImportProcess implements ShouldQueue
             $this->file = base64_decode($this->fileContents);
             $this->file = json_decode($this->file);
         }
+    }
+
+    /**
+     * Some processes are exported with bpmn2: as the bpmn namespace prefix which is
+     * not recognized by the package-actions-by-email. This finds and replaces those
+     * instances in the BPMN XML to the standard bpmn:.
+     *
+     * @return void
+     */
+    protected function standardizeBpmnNodePrefix()
+    {
+        if (!is_object($this->file)) {
+            return;
+        }
+
+        if (!property_exists($this->file, 'process')) {
+            return;
+        }
+
+        if (!property_exists($this->file->process, 'bpmn')) {
+            return;
+        }
+
+        if (!is_string($this->file->process->bpmn)) {
+            return;
+        }
+
+        $this->file->process->bpmn = str_replace('bpmn2:', 'bpmn:', $this->file->process->bpmn);
+        $this->file->process->bpmn = str_replace('bpmn2=', 'bpmn=', $this->file->process->bpmn);
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Import the [attached process](https://github.com/ProcessMaker/processmaker/files/7557742/Update.Product.Marketing.Content_v2.1.json.zip) on a 4.2.* instance.
2. See that the process import will not finish and remains "spinning".
3. Navigate back to the processes list
4. Notice there are now 3 incomplete copies of the process.

## Identified Problem and Solution
The attached process contains BPMN XML which uses a namespace prefix not recognized by the hardcoded xpath query contained within [package-actions-by-email](https://github.com/ProcessMaker/package-actions-by-email). If that package is present, the import will fail, otherwise it will work.

The erroroneous namespace prefix in the attached process is "bpmn2:" instead of the recognized "bpmn". The solution was to find and replace instances of "bpmn2:" and "bpmn2=" and replace them with "bpmn:" and "bpmn=" in the ImportProcess job before it attempts to persist the process.

## How to Test
You should be able to upload any exported process file and in particular, the one attached to this PR.

## Related Tickets & Packages
Resolves [ticket FOUR-4469](https://processmaker.atlassian.net/browse/FOUR-4469).

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
