### PR TITLE
Bugfix/FOUR-4465: Fixed pagination in signals (For 4.2)

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SignalController.php
+++ b/ProcessMaker/Http/Controllers/Api/SignalController.php
@@ -42,7 +42,7 @@ class SignalController extends Controller
 
         if(hasPackage('package-collections')) {
             $collection = \ProcessMaker\Plugins\Collections\Models\Collection::get();
-            
+
             foreach ($collection as $item) {
                 $collectionsEnabled[] = $item->id;
                 if (!$item->signal_create) {
@@ -114,7 +114,7 @@ class SignalController extends Controller
         $meta['count'] = $signals->count();
 
         return response()->json([
-            'data' => $signals,
+            'data' => $signals->values(),
             'meta' => $meta
         ]);
     }

--- a/tests/Feature/Api/SignalTest.php
+++ b/tests/Feature/Api/SignalTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use ProcessMaker\Managers\SignalManager;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\SignalData;
+use SignalSeeder;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class SignalTest extends TestCase
+{
+    use RequestHelper;
+
+    protected $resource = 'api.signals';
+    protected $structure = [
+        'id',
+        'detail',
+        'name',
+        'processes',
+        'type'
+    ];
+
+    public function createSignal($count)
+    {
+        // Create global process for signals..
+        factory(Process::class)->create(['name' => 'global_signals']);
+        $faker = Faker::create();
+
+        $signals = [];
+
+        for ($i=0; $i < $count; $i++) {
+            // Create signal data ..
+            $signalData = [
+                'id' => $faker->unique()->lexify('????'),
+                'name' => $faker->unique()->lexify('??????????????????'),
+                'detail' => $faker->sentence(5)
+            ];
+
+            $newSignal = new SignalData(
+                $signalData['id'],
+                $signalData['name'],
+                $signalData['detail'],
+            );
+
+            $errorValidations = SignalManager::validateSignal($newSignal, null);
+            if (count($errorValidations) > 0) {
+                return response(['errors' => $errorValidations], 422);
+            }
+
+            SignalManager::addSignal($newSignal, ['detail' => $signalData['detail']]);
+
+            $signals[] = ['id' => $newSignal->getId(), 'name' => $newSignal->getName()];
+        }
+        return $signals;
+    }
+
+    /**
+     * Get a list of Signals on first page.
+     * @group agustin
+     */
+    public function testListSignalOnFirstPage()
+    {
+        // Create some signals
+        $countSignals = 20;
+        $signals = $this->createSignal($countSignals);
+
+        //Get a page of signals
+        $page = 1;
+        $perPage = 10;
+
+        $route = route($this->resource . '.index');
+        $response = $this->apiCall('GET', $route . '?page=' . $page . '&per_page=' . $perPage);
+        //Verify the status
+        $response->assertStatus(200);
+        //Verify the structure
+        $response->assertJsonStructure(['data' => [$this->structure]]);
+        $data = $response->json('data');
+        $meta = $response->json('meta');
+        // Verify the meta values
+        $this->assertArraySubset([
+            'total' => $countSignals,
+            'count' => $perPage,
+            'per_page' => $perPage,
+            'current_page' => $page,
+        ], $meta);
+        //Verify the data size
+        $this->assertCount($meta['count'], $data);
+    }
+
+    /**
+     * Get a list of Signals on second page.
+     * @group agustin
+     */
+    public function testListSignalOnSecondPage()
+    {
+        // Create some signals
+        $countSignals = 20;
+        $signals = $this->createSignal($countSignals);
+
+        //Get a page of signals
+        $page = 2;
+        $perPage = 10;
+
+        $route = route($this->resource . '.index');
+        $response = $this->apiCall('GET', $route . '?page=' . $page . '&per_page=' . $perPage);
+        //Verify the status
+        $response->assertStatus(200);
+        //Verify the structure
+        $response->assertJsonStructure(['data' => [$this->structure]]);
+        $data = $response->json('data');
+        $meta = $response->json('meta');
+        // Verify the meta values
+        $this->assertArraySubset([
+            'total' => $countSignals,
+            'count' => $perPage,
+            'per_page' => $perPage,
+            'current_page' => $page,
+        ], $meta);
+        //Verify the data size
+        $this->assertCount($meta['count'], $data);
+    }
+}

--- a/tests/Feature/Api/SignalTest.php
+++ b/tests/Feature/Api/SignalTest.php
@@ -61,7 +61,6 @@ class SignalTest extends TestCase
 
     /**
      * Get a list of Signals on first page.
-     * @group agustin
      */
     public function testListSignalOnFirstPage()
     {
@@ -94,7 +93,6 @@ class SignalTest extends TestCase
 
     /**
      * Get a list of Signals on second page.
-     * @group agustin
      */
     public function testListSignalOnSecondPage()
     {


### PR DESCRIPTION
## Issue & Reproduction Steps
Trying to move to another page in signals listing pagination throws an error and could not move to the page clicked. The issue was related with the returning data from controller, that was returning an object instead an array.

## Solution
- Added $signals->value to get the array

**Working video**

https://user-images.githubusercontent.com/90727999/142414992-c4d27040-d815-426b-a4b0-a968864e2dc4.mov


## How to Test
Go to Designer > Signals and ensure pagination is working.

## Related Tickets & Packages
- [FOUR-4213](https://processmaker.atlassian.net/browse/FOUR-4213)
- **Related in 4.1** [FOUR-4465](https://processmaker.atlassian.net/browse/FOUR-4465)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
