### PR TITLE
[4.1][Feature] Show commit hash on about page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,9 @@
         "laravel/dusk",
         "laravel/passport"
       ]
+    },
+    "processmaker": {
+      "build": "1cd9b17f9"
     }
   },
   "scripts": {

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('sidebar')
-@include('layouts.sidebar', ['sidebar'=> Menu::get('sidebar_about')])
+    @include('layouts.sidebar', ['sidebar'=> Menu::get('sidebar_about')])
 @endsection
 
 @section('breadcrumbs')
@@ -13,6 +13,7 @@
       __('About ProcessMaker') => null,
   ]])
 @endsection
+
 @section('content')
  <div class="container">
     <div class="row">
@@ -44,7 +45,8 @@
           @endforeach
         </ul>
         @endif
-        &copy; {{date('Y')}} - {{__('All Rights Reserved')}}
+        &copy; {{ date('Y') }} - {{ __('All Rights Reserved') }}
+        @if($commit_hash)<br><small>Build #{{ $commit_hash }}</small>@endif
       </div>
     </div>
   </div>

--- a/tests/Feature/AboutTest.php
+++ b/tests/Feature/AboutTest.php
@@ -37,9 +37,6 @@ class AboutTest extends TestCase
         $response->assertStatus(200);
         $response->assertViewIs('about.index');
 
-        // test the commit hash it reads from composer.json
-        $response->assertSeeText('Build #');
-
         // Make sure we can find composer.json
         $composer_json_file = base_path('composer.json');
         $this->assertFileExists($composer_json_file);
@@ -50,10 +47,14 @@ class AboutTest extends TestCase
         // Test and make sure our custom property is present
         // and contains a string value
         $this->assertIsObject($composer_json);
-        $this->assertObjectHasAttribute('extra', $composer_json);
-        $this->assertObjectHasAttribute('processmaker', $composer_json->extra);
-        $this->assertObjectHasAttribute('build', $composer_json->extra->processmaker);
-        $this->assertIsString($composer_json->extra->processmaker->build);
+        $this->assertObjectHasAttribute('extra', $composer_json, 'The composer.json file is missing the "extra" attribute.');
+        $this->assertObjectHasAttribute('processmaker', $composer_json->extra, 'The composer.json file is missing the "extra->processmaker" attribute.');
+        $this->assertObjectHasAttribute('build', $composer_json->extra->processmaker, 'The composer.json file is missing the "extra->processmaker->build" attribute.');
+        $this->assertIsString($composer_json->extra->processmaker->build, 'The composer.json file "extra->processmaker->build" attribute is not a string.');
+        $this->assertNotEmpty($composer_json->extra->processmaker->build, 'The composer.json file "extra->processmaker->build" attribute is empty.');
+
+        // Test the commit hash it reads from composer.json
+        $response->assertSeeText('Build #');
 
         // Copy composer.json over to a new backup file
         $composer_json_file_backup = base_path('composer.json.bak');

--- a/tests/Feature/AboutTest.php
+++ b/tests/Feature/AboutTest.php
@@ -11,6 +11,15 @@ class AboutTest extends TestCase
 {
     use RequestHelper;
 
+    protected function tearDown(): void
+    {
+        if (file_exists($composer_json_file_backup = base_path('composer.json.bak'))) {
+            rename($composer_json_file_backup, base_path('composer.json'));
+        }
+
+        parent::tearDown();
+    }
+
     /**
      * Test to make sure the controller and route work with the view
      *
@@ -18,15 +27,59 @@ class AboutTest extends TestCase
      */
     public function testIndexRoute()
     {
-      // user without any permissions
-      $this->user = factory(User::class)->create();
+        // user without any permissions
+        $this->user = factory(User::class)->create();
 
-      // get the URL
-      $response = $this->webCall('GET', '/about');
-      // check the correct view is called
-      $response->assertStatus(200);
-      $response->assertViewIs('about.index');
+        // get the URL
+        $response = $this->webCall('GET', '/about');
 
+        // check the correct view is called
+        $response->assertStatus(200);
+        $response->assertViewIs('about.index');
 
+        // test the commit hash it reads from composer.json
+        $response->assertSeeText('Build #');
+
+        // Make sure we can find composer.json
+        $composer_json_file = base_path('composer.json');
+        $this->assertFileExists($composer_json_file);
+
+        // Grab the composer JSON and decode it
+        $composer_json = json_decode(file_get_contents($composer_json_file));
+
+        // Test and make sure our custom property is present
+        // and contains a string value
+        $this->assertIsObject($composer_json);
+        $this->assertObjectHasAttribute('extra', $composer_json);
+        $this->assertObjectHasAttribute('processmaker', $composer_json->extra);
+        $this->assertObjectHasAttribute('build', $composer_json->extra->processmaker);
+        $this->assertIsString($composer_json->extra->processmaker->build);
+
+        // Copy composer.json over to a new backup file
+        $composer_json_file_backup = base_path('composer.json.bak');
+        copy($composer_json_file, $composer_json_file_backup);
+        $this->assertFileExists($composer_json_file_backup);
+
+        // Remove the extra->processmaker property so we can
+        // test the about page when the extra->processmaker->build
+        // property isn't present.
+        unset($composer_json->extra->processmaker);
+        file_put_contents($composer_json_file, json_encode($composer_json));
+
+        // New composer.json content
+        $composer_json = json_decode(file_get_contents(base_path('composer.json')));
+
+        // Make sure we removed it
+        $this->assertIsObject($composer_json);
+        $this->assertObjectNotHasAttribute('processmaker', $composer_json->extra);
+
+        // Call the about page again
+        $response = $this->webCall('GET', '/about');
+
+        // Check that the "Build #" isn't present
+        // and no exceptions are thrown
+        $response->assertStatus(200);
+        $response->assertViewIs('about.index');
+        $response->assertDontSeeText('Build #');
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -96,9 +96,9 @@ if (env('POPULATE_DATABASE')) {
 }
 
 if (ScriptExecutor::where('language', 'php')->count() === 0) {
-//    Artisan::call('docker-executor-php:install');
+    Artisan::call('docker-executor-php:install');
 }
 
 if (ScriptExecutor::where('language', 'lua')->count() === 0) {
-//    Artisan::call('docker-executor-lua:install');
+    Artisan::call('docker-executor-lua:install');
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -96,9 +96,9 @@ if (env('POPULATE_DATABASE')) {
 }
 
 if (ScriptExecutor::where('language', 'php')->count() === 0) {
-    Artisan::call('docker-executor-php:install');
+//    Artisan::call('docker-executor-php:install');
 }
 
 if (ScriptExecutor::where('language', 'lua')->count() === 0) {
-    Artisan::call('docker-executor-lua:install');
+//    Artisan::call('docker-executor-lua:install');
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Developer's want to know the exact commit hash for a given build without having to necessarily have command line access. This will enable better debugging for builds deployed to production and other environments.

## Solution
We've added a "processmaker" property to the "extra" property in composer.json. Within that, there is a "build" property which contains a string value representing the commit hash of the build. This is read by the AboutController and shown on the about page (/about) in the footer. This value will be set automatically when builds are released.

If this value isn't present, the exception will be caught and the build commit hash won't be attempted to be shown.

## How to Test
Check the bottom of the /about page and there should be small text under the copyright notice with the commit hash info for the build. If you remove the "processmaker" attribute from the composer.json "extra" attribute, the commit hash info should disappear from the page without any errors or uncaught exceptions.

## Related Tickets & Packages
Related [GitHub issue](https://github.com/ProcessMaker/processmaker/issues/4161).

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
