### PR TITLE
Bugfix/FOUR-4579: Removed force password change from profile edit

### DIFF
--- a/resources/views/shared/users/sidebar.blade.php
+++ b/resources/views/shared/users/sidebar.blade.php
@@ -52,6 +52,7 @@
             <div class="invalid-feedback" :style="{display: (errors.password) ? 'block' : 'none' }" role="alert" v-if="errors.password">@{{errors.password[0]}}</div>
         </div>
 
+        @if (!\Request::is('profile/edit'))
         <div class="form-group">
             {!! Form::label('forceChangePassword', __('User must change password at next login')) !!}
             <div class="grouped">
@@ -61,6 +62,7 @@
                 </div>
             </div>
         </div>
+        @endif
     </div>
 
     @isset($addons)


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR removes the option **User must change password at next login** on edit profile view. Now is only available in edit user view.

## Solution
- Added a condition to show or not the control depending of the URL

## How to Test
- First login with an admin user and go to some user edit. The toggle should be available under login information section.
- Then go to the profile and edit profile. The option should not be available.

**Working video**

https://user-images.githubusercontent.com/90727999/142623532-290d3fde-ee93-4ebe-ae1f-624ede5c4d98.mov


## Related Tickets & Packages
- [FOUR-4579](https://processmaker.atlassian.net/browse/FOUR-4579)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
