### PR TITLE
Bugfix/FOUR-4408: Textarea Rich Text sanitizing Incorrectly (For 4.2)

### DIFF
--- a/ProcessMaker/SanitizeHelper.php
+++ b/ProcessMaker/SanitizeHelper.php
@@ -78,6 +78,10 @@ class SanitizeHelper {
     public static function sanitizeData($data, $screen)
     {
         $except = self::getExceptions($screen);
+        if (isset($data['_DO_NOT_SANITIZE'])) {
+           $except = array_unique(array_merge(json_decode($data['_DO_NOT_SANITIZE']), $except));
+        }
+        $data['_DO_NOT_SANITIZE'] = json_encode($except);
         return self::sanitizeWithExceptions($data, $except);
     }
 

--- a/tests/Feature/Api/CallActivityTest.php
+++ b/tests/Feature/Api/CallActivityTest.php
@@ -339,7 +339,7 @@ class CallActivityTest extends TestCase
         unset($data['loopCharacteristics']);
 
         // verify data
-        $this->assertEquals(['input_1' => 1, 'input_2' => 2, 'input_3' => 3], $data);
+        $this->assertEquals(['input_1' => 1, 'input_2' => 2, 'input_3' => 3, '_DO_NOT_SANITIZE' => '[]'], $data);
     }
 
     public function testCallActivityWithError()

--- a/tests/Feature/Api/screens/FOUR-4408 B.json
+++ b/tests/Feature/Api/screens/FOUR-4408 B.json
@@ -1,0 +1,258 @@
+[
+    {
+        "name": "FOUR-4408 B",
+        "items": [
+            {
+                "label": "Rich Text",
+                "config": {
+                    "icon": "fas fa-pencil-ruler",
+                    "label": null,
+                    "content": "<p><strong>FORMATED DATA</strong></p>\n<p>{{{form_text_area_1}}}</p>",
+                    "interactive": true,
+                    "renderVarHtml": false
+                },
+                "component": "FormHtmlViewer",
+                "inspector": [
+                    {
+                        "type": "FormTextArea",
+                        "field": "content",
+                        "config": {
+                            "rows": 5,
+                            "label": "Content",
+                            "value": null,
+                            "helper": "The HTML text to display"
+                        }
+                    },
+                    {
+                        "type": "FormCheckbox",
+                        "field": "renderVarHtml",
+                        "config": {
+                            "label": "Render HTML from a Variable",
+                            "value": null,
+                            "helper": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "ariaLabel",
+                        "config": {
+                            "label": "Aria Label",
+                            "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "tabindex",
+                        "config": {
+                            "label": "Tab Order",
+                            "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                            "validation": "regex: [0-9]*"
+                        }
+                    }
+                ],
+                "editor-control": "FormHtmlEditor",
+                "editor-component": "FormHtmlEditor"
+            },
+            {
+                "label": "Submit Button",
+                "config": {
+                    "icon": "fas fa-share-square",
+                    "name": null,
+                    "event": "submit",
+                    "label": "New Submit",
+                    "tooltip": [],
+                    "variant": "primary",
+                    "fieldValue": null,
+                    "defaultSubmit": true
+                },
+                "component": "FormButton",
+                "inspector": [
+                    {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                            "label": "Label",
+                            "helper": "The label describes the button's text"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                            "name": "Variable Name",
+                            "label": "Variable Name",
+                            "helper": "A variable name is a symbolic name to reference information.",
+                            "validation": "regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*(?<![.])$/|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "event",
+                        "config": {
+                            "label": "Type",
+                            "helper": "Choose whether the button should submit the form",
+                            "options": [
+                                {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                },
+                                {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": {
+                            "props": [
+                                "label",
+                                "value",
+                                "helper"
+                            ],
+                            "watch": {
+                                "value": {
+                                    "immediate": true
+                                }
+                            },
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                        },
+                        "field": "tooltip",
+                        "config": {
+                            "label": "Tooltip"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "fieldValue",
+                        "config": {
+                            "label": "Value",
+                            "helper": "The value being submitted"
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                            "label": "Button Variant Style",
+                            "helper": "The variant determines the appearance of the button",
+                            "options": [
+                                {
+                                    "value": "primary",
+                                    "content": "Primary"
+                                },
+                                {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                },
+                                {
+                                    "value": "success",
+                                    "content": "Success"
+                                },
+                                {
+                                    "value": "danger",
+                                    "content": "Danger"
+                                },
+                                {
+                                    "value": "warning",
+                                    "content": "Warning"
+                                },
+                                {
+                                    "value": "info",
+                                    "content": "Info"
+                                },
+                                {
+                                    "value": "light",
+                                    "content": "Light"
+                                },
+                                {
+                                    "value": "dark",
+                                    "content": "Dark"
+                                },
+                                {
+                                    "value": "link",
+                                    "content": "Link"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "ariaLabel",
+                        "config": {
+                            "label": "Aria Label",
+                            "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "tabindex",
+                        "config": {
+                            "label": "Tab Order",
+                            "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                            "validation": "regex: [0-9]*"
+                        }
+                    }
+                ],
+                "editor-control": "FormSubmit",
+                "editor-component": "FormButton"
+            }
+        ]
+    }
+]

--- a/tests/Feature/SanitizeHelperTest.php
+++ b/tests/Feature/SanitizeHelperTest.php
@@ -12,7 +12,6 @@ class SanitizeHelperTest extends TestCase
 {
     /**
      * Test to ensure not sanitizing rich text data
-     * @group agustin
      */
     public function testScreenWillNotSanitizeRichTextData()
     {
@@ -29,7 +28,6 @@ class SanitizeHelperTest extends TestCase
 
     /**
      * Test to ensure IS sanitizing rich text data
-     * @group agustin
      */
     public function testScreenWillSanitizeRichTextDataIfIsEmptyDoNotSanitizeVariable()
     {

--- a/tests/Feature/SanitizeHelperTest.php
+++ b/tests/Feature/SanitizeHelperTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\SanitizeHelper;
+use Tests\TestCase;
+
+class SanitizeHelperTest extends TestCase
+{
+    /**
+     * Test to ensure not sanitizing rich text data
+     * @group agustin
+     */
+    public function testScreenWillNotSanitizeRichTextData()
+    {
+        $screen = factory(Screen::class)->create([
+            'config' => json_decode(file_get_contents(__DIR__ . '/Api/screens/FOUR-4408 B.json'))
+        ]);
+
+        $taskData = json_decode($this->taskData(), true)['data'];
+
+        $data = SanitizeHelper::sanitizeData($taskData, $screen);
+
+        $this->assertEquals('<p><strong>Strong text formatted</strong></p>', $data['form_text_area_1']);
+    }
+
+    /**
+     * Test to ensure IS sanitizing rich text data
+     * @group agustin
+     */
+    public function testScreenWillSanitizeRichTextDataIfIsEmptyDoNotSanitizeVariable()
+    {
+        $screen = factory(Screen::class)->create([
+            'config' => json_decode(file_get_contents(__DIR__ . '/Api/screens/FOUR-4408 B.json'))
+        ]);
+
+        $taskDataDoNotSanitizeEmpty = json_decode($this->taskDataDoNotSanitizeEmpty(), true)['data'];
+
+        $data = SanitizeHelper::sanitizeData($taskDataDoNotSanitizeEmpty, $screen);
+
+        $this->assertEquals('Strong text formatted', $data['form_text_area_1']);
+    }
+
+    private function taskData() {
+        return "{
+            \"status\": \"COMPLETED\",
+            \"data\": {
+                \"_user\": {
+                    \"id\": 2
+                },
+                \"_request\": {
+                    \"id\": 1
+                },
+                \"_DO_NOT_SANITIZE\": \"[\\\"form_text_area_1\\\"]\",
+                \"form_text_area_1\": \"<p><strong>Strong text formatted<\/strong><\/p>\"
+            }
+        }";
+    }
+
+    private function taskDataDoNotSanitizeEmpty() {
+        return "{
+            \"status\": \"COMPLETED\",
+            \"data\": {
+                \"_user\": {
+                    \"id\": 2
+                },
+                \"_request\": {
+                    \"id\": 1
+                },
+                \"_DO_NOT_SANITIZE\": \"[\\\"\\\"]\",
+                \"form_text_area_1\": \"<p><strong>Strong text formatted<\/strong><\/p>\"
+            }
+        }";
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
**Format in rich text is missing when a form text area variable is passed to a second task that use that variable in a rich text control and then is passed again to another task with form text area**

Reproduction steps:

- Create a process with 3 tasks:
The first task will be a screen with a form text area and configured as rich text with the name **form_text_area_1** with submit button.
The second task will be a screen with a rich text control. Inside de control put the name of the previous form text area name in triple mustaches **{{{form_text_area_1}}}** with submit button.
The third task should be the same screen from task 1.
![Screen Shot 2021-11-19 at 16 14 55](https://user-images.githubusercontent.com/90727999/142679896-9ddce429-58c6-4a25-9a39-490173df9deb.png)

- Start a new request, and in the first task add text with some formats (bold, colors, ...), submit the data
In the second task you should see the data formatted, submit the task and in the third task you should see the data without format.

## Solution
- Added a new variable to request _DO_NOT_SANITIZE that have all the form text area controls names that should not be sanitized. This variable is available over all the process tasks.

## How to Test
Same as Reproduction steps. Create a process with 3 task first and last task should have the same screen with a fomr text area control with rich text option enabled. The second task should have a rich text control with the form text area control variable name in triple mustaches. It is a good idea to test it placing the second task of the process inside a subprocess, or inside a loop. **There are attached a zip with some processes that cover a lot of cases:**

[Processes_for_testing.zip](https://github.com/ProcessMaker/processmaker/files/7572533/Processes.for.testing.zip)

**Working video**

https://user-images.githubusercontent.com/90727999/142682774-79c09aa4-0c5f-45f7-b4dc-220c85d44dad.mov

## Related Tickets & Packages
- [FOUR-4408](https://processmaker.atlassian.net/browse/FOUR-4408)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
