### PR TITLE
Fixing issue with cache get all into cache_settings when force args is enabled

### DIFF
--- a/ProcessMaker/Helpers/SettingsHelper.php
+++ b/ProcessMaker/Helpers/SettingsHelper.php
@@ -94,6 +94,7 @@ if (!function_exists('cache_settings')) {
                 // are available if they aren't cached yet
                 if (!$cache->has('all')) {
                     $settings = settings();
+                    $cache = cache()->tags('setting');
                 }
 
                 // Iterating through each and calling the byKey()


### PR DESCRIPTION
## Issue & Reproduction Steps
When cache_settings is using a force=true argument and the key 'all' is not defined, the function reset resttings but don't initialize the $cache again.
Issue can be reproduced running php `artisan package-ellucian-ethos:install`


## Solution
- Adding the $cache init command after the reset

## How to Test
Execute `artisan package-ellucian-ethos:install` without errors 

## Related Tickets & Packages
- github.com/ProcessMaker/package-ellucian-ethos [private]

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
