### PR TITLE
Bugfix/FOUR-4404: User screen goes blank if adding a variable with spaces in Setting/Extended Properties

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SettingController.php
+++ b/ProcessMaker/Http/Controllers/Api/SettingController.php
@@ -204,6 +204,7 @@ class SettingController extends Controller
      */
     public function update(Setting $setting, Request $request)
     {
+        $request->validate(Setting::rules($setting), Setting::messages());
         $setting->config = $request->input('config');
         $setting->save();
 

--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -110,7 +110,15 @@ class Setting extends Model implements HasMedia
 
         return [
             'key' => ['required', $unique],
-            'config' => 'required',
+            'config' => ['required'],
+            'config.*' => ['required', 'valid_variable']
+        ];
+    }
+
+    public static function messages()
+    {
+        return [
+            'config.*.valid_variable' => trans('environmentVariables.validation.name.invalid_variable_name'),
         ];
     }
 

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -63,6 +63,12 @@ class ProcessMakerServiceProvider extends ServiceProvider
             return preg_match('/^[\pL\s\-\_\d\.\']+$/u', $val);
         });
 
+        //Custom validator for variable names. Eg: correct var names _myvar, myvar, myvar1, _myvar1. Eg: incorrect variable names 1_myvar, 1myvar, myvar a
+        Validator::extend('valid_variable', function ($attr, $val) {
+            $key = explode(".", $attr)[1];
+            return preg_match('/^[a-zA-Z_-][a-zA-Z0-9_-]*$/', $key);
+        });
+
         parent::boot();
     }
 
@@ -79,7 +85,7 @@ class ProcessMakerServiceProvider extends ServiceProvider
         $this->app->singleton(PackageManager::class, function () {
             return new PackageManager();
         });
-        
+
         $this->app->singleton(LoginManager::class, function () {
             return new LoginManager();
         });
@@ -129,11 +135,11 @@ class ProcessMakerServiceProvider extends ServiceProvider
         $this->app->singleton(GlobalScriptsManager::class, function($app) {
             return new GlobalScriptsManager();
         });
-        
+
         $this->app->singleton(AnonymousUser::class, function($app) {
             return AnonymousUser::where('username', AnonymousUser::ANONYMOUS_USERNAME)->firstOrFail();
         });
-        
+
         $this->app->singleton(PolicyExtension::class, function($app) {
             return new PolicyExtension();
         });

--- a/resources/js/admin/settings/components/SettingObject.vue
+++ b/resources/js/admin/settings/components/SettingObject.vue
@@ -22,8 +22,13 @@
       </div>
       <b-table class="setting-object-table" :items="table" :fields="fields" striped>
         <template #cell(key)="data">
-          <div class="d-flex w-100" v-if="ui('fixedKeys') === false">
-            <b-form-input class="ml-2 mr-2" v-model="data.item.key.name" @keyup.enter="onSave()" spellcheck="false" autocomplete="off"></b-form-input>
+          <div v-if="ui('fixedKeys') === false">
+            <div class="d-flex w-100 flex-wrap">
+              <b-form-input class="ml-2 mr-2" v-model="data.item.key.name" @keyup.enter="onSave()" spellcheck="false" autocomplete="off"></b-form-input>
+              <small class="form-text text-danger mx-2" v-if="!data.item.isValid">
+                {{ $t('Invalid variable name') }}
+              </small>
+            </div>
           </div>
           <div v-else>
             <multiselect
@@ -48,7 +53,7 @@
         <button type="button" class="btn btn-outline-secondary ml-auto" @click="onCancel">
             {{ $t('Cancel') }}
         </button>
-        <button type="button" class="btn btn-secondary ml-3" @click="onSave" :disabled="! changed">
+        <button type="button" class="btn btn-secondary ml-3" @click="onSave" :disabled="! changed || haveInvalid">
             {{ $t('Save')}}
         </button>
       </div>
@@ -69,6 +74,7 @@ export default {
       showModal: false,
       table: [],
       transformed: null,
+      haveInvalid: false,
       fields: [
         {
           key: 'key',
@@ -156,6 +162,17 @@ export default {
                 this.transformed[row.key.name] = row.value;
               }
             });
+            this.haveInvalid = false;
+            value.forEach(item => {
+              this.keys.forEach(key => {
+                if (item.key && item.key.name == key.name) {
+                  item.isValid = this.isValid(item.key.name);
+                  if (!item.isValid) {
+                    this.haveInvalid = true;
+                  }
+                }
+              });
+            });
           }
         }
       },
@@ -163,6 +180,10 @@ export default {
     }
   },
   methods: {
+    isValid(key) {
+      let pattern = /^[a-zA-Z_-][a-zA-Z0-9_-]*$/g;
+      return pattern.test(key);
+    },
     keyLabel() {
       if (this.ui('keyLabel')) {
         return this.$t(this.ui('keyLabel'));
@@ -227,6 +248,7 @@ export default {
           this.table.push({
             key: key,
             value: this.input[key.name],
+            isValid: this.isValid(key.name)
           })
         }
       });
@@ -313,6 +335,6 @@ export default {
       min-width: 0;
       margin-bottom: 0;
     }
-    
+
   }
 </style>

--- a/resources/js/admin/settings/components/SettingObject.vue
+++ b/resources/js/admin/settings/components/SettingObject.vue
@@ -24,7 +24,7 @@
         <template #cell(key)="data">
           <div v-if="ui('fixedKeys') === false">
             <div class="d-flex w-100 flex-wrap">
-              <b-form-input class="ml-2 mr-2" v-model="data.item.key.name" @keyup.enter="onSave()" spellcheck="false" autocomplete="off"></b-form-input>
+              <b-form-input class="ml-2 mr-2" :class="{'is-invalid': !data.item.isValid}" v-model="data.item.key.name" @keyup.enter="onSave()" spellcheck="false" autocomplete="off"></b-form-input>
               <small class="form-text text-danger mx-2" v-if="!data.item.isValid">
                 {{ $t('Invalid variable name') }}
               </small>
@@ -164,14 +164,12 @@ export default {
             });
             this.haveInvalid = false;
             value.forEach(item => {
-              this.keys.forEach(key => {
-                if (item.key && item.key.name == key.name) {
-                  item.isValid = this.isValid(item.key.name);
-                  if (!item.isValid) {
-                    this.haveInvalid = true;
-                  }
+              if (item.key) {
+                item.isValid = this.isValid(item.key.name);
+                if (!item.isValid) {
+                  this.haveInvalid = true;
                 }
-              });
+              }
             });
           }
         }
@@ -182,7 +180,7 @@ export default {
   methods: {
     isValid(key) {
       let pattern = /^[a-zA-Z_-][a-zA-Z0-9_-]*$/g;
-      return pattern.test(key);
+      return pattern.test(key) && key != '';
     },
     keyLabel() {
       if (this.ui('keyLabel')) {
@@ -214,6 +212,7 @@ export default {
             $isDisabled: false,
           },
           value: null,
+          isValid: false,
         });
       }
     },

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -925,6 +925,7 @@
   "Variable": "Variable",
   "Variables": "Variables",
   "Variable Name": "Variable Name",
+  "Invalid variable name": "Invalid variable name",
   "Variable to Watch": "Variable to Watch",
   "Variant": "Variant",
   "Vertical alignment of the text": "Vertical alignment of the text",

--- a/tests/Feature/Api/SettingsTest.php
+++ b/tests/Feature/Api/SettingsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use ProcessMaker\Models\Setting;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\Feature\Shared\ResourceAssertionsTrait;
+use Tests\TestCase;
+
+class SettingsTest extends TestCase
+{
+    use ResourceAssertionsTrait;
+    use WithFaker;
+    use RequestHelper;
+
+    protected $resource = 'setting';
+    protected $structure = [
+        'config',
+        'process_request_id',
+        'user_id',
+        'element_id',
+        'element_type',
+        'element_name',
+        'status',
+        'completed_at',
+        'due_at',
+        'initiated_at',
+        'riskchanges_at',
+        'updated_at',
+        'created_at',
+    ];
+
+    /**
+     * Test extended properties variable valid name validation
+     */
+    public function testUpdateExtendedPropertiesWithValidVariableName()
+    {
+        $setting = factory(Setting::class)->create(['key' => 'users.properties']);
+
+        $params = [
+            // Test data different valid variable names
+            'config' => [
+                '_myVar' => 'This is my variable 1',
+                'myVar' => 'This is my variable 2',
+                'myVar1' => 'This is my variable 3'
+            ],
+            'key' => $setting->key,
+            'id' => $setting->id
+        ];
+
+        //Update setting config
+        $route = route('api.settings.update', [$setting->id]);
+        $response = $this->apiCall('PUT', $route, $params);
+        //Verify the status
+        $response->assertStatus(204);
+        //Verify variables were updated
+        $this->assertDatabaseHas('settings', ['config' => '{"_myVar":"This is my variable 1","myVar":"This is my variable 2","myVar1":"This is my variable 3"}']);
+    }
+
+    /**
+     * Test extended properties variable invalid name validation
+     */
+    public function testUpdateExtendedPropertiesWithInvalidVariableName()
+    {
+        $setting = factory(Setting::class)->create(['key' => 'users.properties']);
+        $params = [
+            // Test data different valid variable names
+            'config' => [
+                '1myVar' => 'This is my variable 1',
+                'myVar space' => 'This is my variable 2',
+            ],
+            'key' => $setting->key,
+            'id' => $setting->id
+        ];
+        //Update setting config
+        $route = route('api.settings.update', [$setting->id]);
+        $response = $this->apiCall('PUT', $route, $params);
+        //Verify the status
+        $response->assertStatus(422);
+        //Verify response error
+        $response->assertJson (
+            [
+                'message' => 'The given data was invalid.',
+                'errors' => [
+                    'config.1myVar' => [
+                        'Name has to start with a letter and can contain only letters, numbers, and underscores (_).'
+                    ],
+                    'config.myVar space' => [
+                        'Name has to start with a letter and can contain only letters, numbers, and underscores (_).'
+                    ]
+                ]
+            ]
+        );
+        //Verify variable were not updated
+        $this->assertDatabaseMissing('settings', ['config' => '{"1myVar":"This is my variable 1","myVar space":"This is my variable 2"}']);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Variables should not have any spaces. The issue happen when you create an extended property with an incorrect variable name in Admin > Settings > Users > Extended properties.

- Variable names should have numbers, letters and underscores. 
- Variable names should not start with a number
- Variable names should not have any space

## Solution
- Added backend validation for variable names when updating an extended property.
- Added frontend validation for variable names when updating an extended property.

## How to Test
Try to create an incorrect variable name, and a validation error message should be displayed.
Run unit tests under tests/Feature/Api/SettingsTest

**Working video**

https://user-images.githubusercontent.com/90727999/143056994-1e483ece-e026-4659-85a3-be6239922e3a.mov


## Related Tickets & Packages
- [FOUR-4404](https://processmaker.atlassian.net/browse/FOUR-4404)
- Packages for manually testing, package-advanced-user-manager and package-auth

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
