### PR TITLE
Fix issue where settings path does not exist

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SettingController.php
+++ b/ProcessMaker/Http/Controllers/Api/SettingController.php
@@ -259,6 +259,7 @@ class SettingController extends Controller
                 }
                 $copyTo = $mustache->render(str_replace('.', '_', $setting->ui->copy_to), $settingsData);
                 if ($copyTo) {
+                    $this->createStoragePathIfNotExists(storage_path($copyTo));
                     copy (
                         storage_path('app/private/settings/') . $collectionName,
                         // Saving upload file into storage folder
@@ -272,6 +273,14 @@ class SettingController extends Controller
                 $eventClass = $setting->ui->dispatch_event;
                 event(new $eventClass($setting));
             }
+        }
+    }
+    
+    private function createStoragePathIfNotExists($path)
+    {
+        $dir = pathinfo($path, PATHINFO_DIRNAME);
+        if (!file_exists($dir)) {
+            mkdir($dir, 0755, true);
         }
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR fixes an issue where LDAP certificates could not be uploaded because the default storage location for them did not exist.

## Solution
This PR tests to ensure that the directory does exist prior to attempting to write to it. If it does not exist, it creates it.

## How to Test
1. Ensure your test instance _does not_ have an `etc` directory under your storage directory
2. Go to Settings page
3. Click the LDAP tab
4. Attempt to upload a certificate

## Related Tickets & Packages
- Requires https://github.com/ProcessMaker/package-auth

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
