### PR TITLE
Bugfix/FOUR-4550: Fixed total pages values in signals pagination (For 4.2)

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SignalController.php
+++ b/ProcessMaker/Http/Controllers/Api/SignalController.php
@@ -107,10 +107,19 @@ class SignalController extends Controller
             'sort_order' => strtolower($orderDirection),
             'to' => $perPage * ($page - 1) + $perPage,
             'total' => $signals->count(),
-            'total_pages' => $lastPage
+            'total_pages' => ceil($signals->count() / $perPage)
         ];
 
-        $signals = $signals->count() === 0 ? $signals : $signals->chunk($perPage)[$page - 1];
+        if ($signals->count() === 0) {
+            $signals = $signals;
+        } else {
+            $chunked = $signals->chunk($perPage);
+            if (isset($chunked[$page - 1])) {
+                $signals = $chunked[$page - 1];
+            } else {
+                $signals = collect([]);
+            }
+        }
         $meta['count'] = $signals->count();
 
         return response()->json([

--- a/tests/Feature/Api/SignalTest.php
+++ b/tests/Feature/Api/SignalTest.php
@@ -86,6 +86,7 @@ class SignalTest extends TestCase
             'count' => $perPage,
             'per_page' => $perPage,
             'current_page' => $page,
+            'total_pages' => 2
         ], $meta);
         //Verify the data size
         $this->assertCount($meta['count'], $data);
@@ -118,6 +119,40 @@ class SignalTest extends TestCase
             'count' => $perPage,
             'per_page' => $perPage,
             'current_page' => $page,
+            'total_pages' => 2
+        ], $meta);
+        //Verify the data size
+        $this->assertCount($meta['count'], $data);
+    }
+
+    /**
+     * Get a list of Signals first page with ten records should return one total_pages.
+     */
+    public function testListSignalOnPageWithTenRecordsShouldReturnOneTotalPages()
+    {
+        // Create some signals
+        $countSignals = 10;
+        $signals = $this->createSignal($countSignals);
+
+        //Get a page of signals
+        $page = 1;
+        $perPage = 10;
+
+        $route = route($this->resource . '.index');
+        $response = $this->apiCall('GET', $route . '?page=' . $page . '&per_page=' . $perPage);
+        //Verify the status
+        $response->assertStatus(200);
+        //Verify the structure
+        $response->assertJsonStructure(['data' => [$this->structure]]);
+        $data = $response->json('data');
+        $meta = $response->json('meta');
+        // Verify the meta values
+        $this->assertArraySubset([
+            'total' => $countSignals,
+            'count' => $perPage,
+            'per_page' => $perPage,
+            'current_page' => $page,
+            'total_pages' => 1
         ], $meta);
         //Verify the data size
         $this->assertCount($meta['count'], $data);


### PR DESCRIPTION
## Issue & Reproduction Steps
This new issue is related to a wrong total_pages value calculation that was returning the value two(2) when you create exactly ten(10) signals, so when trying to move to page 2 that will fail because an index violation.

## Solution
- Added a new total_pages calculation for signal pagination.

## How to Test
Create exactly 10 signals and you should have only page number 1 in pagination.
Create 11 signals and you should have page number 1 and 2 in pagination.
Run tests under tests/Feature/Api/SignalTest

## Related Tickets & Packages
- [FOUR-4550](https://processmaker.atlassian.net/browse/FOUR-4550)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
