### PR TITLE
Updated to register the "bpmn" namespace for all DOMXPath instances

### DIFF
--- a/ProcessMaker/Assets/ScreensInProcess.php
+++ b/ProcessMaker/Assets/ScreensInProcess.php
@@ -26,7 +26,7 @@ class ScreensInProcess
         // Screens used in BPMN
         $xpath = new DOMXPath($process->getDefinitions());
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
-        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', 'http://www.omg.org/spec/BPMN/20100524/MODEL');
         // Used in screenRef
         $nodes = $xpath->query("//*[@pm:screenRef!='']");
         foreach ($nodes as $node) {
@@ -63,7 +63,7 @@ class ScreensInProcess
         $definitions = $process->getDefinitions();
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
-        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', 'http://www.omg.org/spec/BPMN/20100524/MODEL');
 
         // Used in screenRef
         $nodes = $xpath->query("//*[@pm:screenRef!='']");

--- a/ProcessMaker/Assets/ScreensInProcess.php
+++ b/ProcessMaker/Assets/ScreensInProcess.php
@@ -26,6 +26,7 @@ class ScreensInProcess
         // Screens used in BPMN
         $xpath = new DOMXPath($process->getDefinitions());
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
         // Used in screenRef
         $nodes = $xpath->query("//*[@pm:screenRef!='']");
         foreach ($nodes as $node) {
@@ -62,6 +63,7 @@ class ScreensInProcess
         $definitions = $process->getDefinitions();
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
 
         // Used in screenRef
         $nodes = $xpath->query("//*[@pm:screenRef!='']");

--- a/ProcessMaker/Assets/ScriptsInProcess.php
+++ b/ProcessMaker/Assets/ScriptsInProcess.php
@@ -46,7 +46,7 @@ class ScriptsInProcess
         $definitions = $process->getDefinitions();
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
-        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', 'http://www.omg.org/spec/BPMN/20100524/MODEL');
 
         // Used in scriptRef
         $nodes = $xpath->query("//*[@pm:scriptRef!='']");

--- a/ProcessMaker/Assets/ScriptsInProcess.php
+++ b/ProcessMaker/Assets/ScriptsInProcess.php
@@ -46,6 +46,7 @@ class ScriptsInProcess
         $definitions = $process->getDefinitions();
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
 
         // Used in scriptRef
         $nodes = $xpath->query("//*[@pm:scriptRef!='']");

--- a/ProcessMaker/Managers/PMConfigGenericExportManager.php
+++ b/ProcessMaker/Managers/PMConfigGenericExportManager.php
@@ -71,6 +71,7 @@ class PMConfigGenericExportManager
         $definitions = $process->getDefinitions();
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
 
         // Used in config
         $nodes = $xpath->query("//{$this->tag}[@pm:config!='']");
@@ -95,4 +96,4 @@ class PMConfigGenericExportManager
         $process->bpmn = $definitions->saveXML();
         $process->save();
     }
-} 
+}

--- a/ProcessMaker/Managers/PMConfigGenericExportManager.php
+++ b/ProcessMaker/Managers/PMConfigGenericExportManager.php
@@ -71,7 +71,7 @@ class PMConfigGenericExportManager
         $definitions = $process->getDefinitions();
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
-        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', 'http://www.omg.org/spec/BPMN/20100524/MODEL');
 
         // Used in config
         $nodes = $xpath->query("//{$this->tag}[@pm:config!='']");

--- a/tests/Managers/PMConfigGenericExportManagerTest.php
+++ b/tests/Managers/PMConfigGenericExportManagerTest.php
@@ -52,7 +52,7 @@ class PMConfigGenericExportManagerTest extends TestCase {
         $definitions = $process->refresh()->getDefinitions();
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
-        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', 'http://www.omg.org/spec/BPMN/20100524/MODEL');
 
         $nodes = $xpath->query("//bpmn:callActivity");
         $abeConfig = json_decode(

--- a/tests/Managers/PMConfigGenericExportManagerTest.php
+++ b/tests/Managers/PMConfigGenericExportManagerTest.php
@@ -52,6 +52,7 @@ class PMConfigGenericExportManagerTest extends TestCase {
         $definitions = $process->refresh()->getDefinitions();
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', WorkflowServiceProvider::PROCESS_MAKER_NS);
 
         $nodes = $xpath->query("//bpmn:callActivity");
         $abeConfig = json_decode(


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Import the [attached process](https://github.com/ProcessMaker/processmaker/files/7557742/Update.Product.Marketing.Content_v2.1.json.zip) on a 4.2.* instance.
2. See that the process import will not finish and remains "spinning".
3. Navigate back to the processes list
4. Notice there are now 3 incomplete copies of the process.

## Solution
Among this codebase and various packages, when querying the BPMN XML document for a given process, it was assumed the bpmn: namespace either existed or was registered already. The attached process has a namespace of bpmn2, which caused the import to fail. The solution was to explictly register the bpmn namespace before querying the XML document.

## How to Test
You should be able to upload any exported process file and in particular, the one attached to this PR without any duplication or be left with a "spinning" process import page.

**Note: You must have all of the packages updated to the correct branch in the PRs (listed below) for this solution to function correctly.**

## Related Tickets and Packages
- Resolves [ticket FOUR-4469](https://processmaker.atlassian.net/browse/FOUR-4469).
- [PR for connect-pdf-print](https://github.com/ProcessMaker/connector-pdf-print/pull/49/files)
- [PR for connector-send-email](https://github.com/ProcessMaker/connector-send-email/pull/193/files)
- [PR for package-webentry](https://github.com/ProcessMaker/package-webentry/pull/129/files)
- [PR for package-vocabularies](https://github.com/ProcessMaker/package-vocabularies/pull/47/files)
- [PR for package-actions-by-email](https://github.com/ProcessMaker/package-actions-by-email/pull/53/files)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
