### PR TITLE
Bugfix/FOUR-4179: When adding extended properties they are saved but not showing on Users/Edit section (For 4.2)

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SettingController.php
+++ b/ProcessMaker/Http/Controllers/Api/SettingController.php
@@ -204,7 +204,6 @@ class SettingController extends Controller
      */
     public function update(Setting $setting, Request $request)
     {
-        $request->validate(Setting::rules($setting), Setting::messages());
         $setting->config = $request->input('config');
         $setting->save();
 

--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -110,7 +110,6 @@ class Setting extends Model implements HasMedia
 
         return [
             'key' => ['required', $unique],
-            'config' => ['required'],
             'config.*' => ['required', 'valid_variable']
         ];
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
After adding an extended property it are not showing under user/edit view. There are two settings observers in package-auth and processmaker core. When one of them was triggered the other was triggered causing an infinite loop.

- Go to Admin > Settings > Users
- On Extended Properties Click on Edit  and add some extended properties
- Go to Users and go to edit some user
- The extended properties you added are not visible


## Solution
- Added on the ->save method for setting in the observer of package-auth **withoutEvents** to avoid the infinite loop.
**Working video**

https://user-images.githubusercontent.com/90727999/143292473-63b62af2-8a88-4b98-bae7-00c41dc27c0f.mov

## How to Test
- Go to Admin > Settings > Users
- On Extended Properties Click on Edit and add some extended properties
- Go to Users and then go to edit some user
- The extended properties you added should be visible at bottom of the screen.
![Screen Shot 2021-11-24 at 15 12 41](https://user-images.githubusercontent.com/90727999/143292823-0840b619-07c6-42cf-9ac1-1b2d60ef5851.png)

## Related Tickets & Packages
- [FOUR-4179](https://processmaker.atlassian.net/browse/FOUR-4719)
- package-auth
- package-advanced-user-manager
- [PR in package-auth](https://github.com/ProcessMaker/package-auth/pull/39) 
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
