### PR TITLE
Bugfix Ticket 1034 for 4.2 - User Security Logs search returning wonky results

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
+++ b/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
@@ -20,10 +20,6 @@ class SecurityLogController extends Controller
     {
         $query = SecurityLog::query();
         
-        if ($pmql = $request->input('pmql')) {
-            $query->pmql($pmql);
-        }
-        
         if ($filter = $request->input('filter')) {
             $filter = '%' . mb_strtolower($filter) . '%';
             $query->where('event', 'like', $filter)
@@ -42,6 +38,10 @@ class SecurityLogController extends Controller
             }
             
             $query->orderBy($orderBy, $orderDirection);
+        }
+
+        if ($pmql = $request->input('pmql')) {
+            $query->pmql($pmql);
         }
         
         $response = $query->get();

--- a/database/factories/SecurityLogFactory.php
+++ b/database/factories/SecurityLogFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+use Faker\Generator as Faker;
+use ProcessMaker\Models\SecurityLog;
+
+$factory->define(SecurityLog::class, function (Faker $faker) {
+    return [
+        'event' => $faker->word(),
+        'ip' => $faker->localIpv4(),
+        'meta' => '',
+        'user_id' => null,
+        'occurred_at' => '2021-12-01 09:41:32',
+    ];
+});

--- a/tests/Feature/Api/PerformanceModelsTest.php
+++ b/tests/Feature/Api/PerformanceModelsTest.php
@@ -33,6 +33,7 @@ class PerformanceModelsTest extends TestCase
     private $exceptions = [
         // Hi payload because of password hash
         //'ProcessMaker\Models\User' => 27*6/100,
+        'ProcessMaker\Models\SecurityLog' => 0,
     ];
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
User Security Logs search returning results from other users.

1. Under a users profile, navigate to the **'Security Logs'** tab
2. Take note of the number of _Logged Events_ in the pagination. 
3. Search by browser **`chrome`** or platform **`windows`**
4. Take note of the number of _Logged Events_ in the pagination.

## Solution
- The `pmql()` scope was moved to the end.

## How to Test
Please do a search query by "OS Name" (windows) or "Browser name" (chrome, firefox). Make sure you get results exclusively from the logged in user.

## Related Tickets & Packages
- [Ticket 1034](http://tickets.pm4overflow.com/tickets/1034)
- [FOUR-4809](https://processmaker.atlassian.net/browse/FOUR-4809)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.