### PR TITLE
Revert "4.2 Remove Request Detail Screen select"

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -82,6 +82,7 @@ class ProcessController extends Controller
             ->toArray();
 
         $screenCancel = Screen::find($process->cancel_screen_id);
+        $screenRequestDetail = Screen::find($process->request_detail_screen_id);
 
         $list = $this->listUsersAndGroups();
 
@@ -92,7 +93,7 @@ class ProcessController extends Controller
         $canEditData = $this->listCan('EditData', $process);
         $addons = $this->getPluginAddons('edit', compact(['process']));
 
-        return view('processes.edit', compact(['process', 'categories', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons']));
+        return view('processes.edit', compact(['process', 'categories', 'screenRequestDetail', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons']));
     }
 
     /**

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -134,6 +134,25 @@
                                 </multiselect>
                             </div>
                             <div class="form-group">
+                                {!! Form::label('requestDetailScreen', __('Request Detail Screen')) !!}
+                                <multiselect aria-label="{{ __('Request Detail Screen') }}"
+                                             v-model="screenRequestDetail"
+                                             :options="screens"
+                                             :multiple="false"
+                                             :show-labels="false"
+                                             placeholder="{{ __('Type to search') }}"
+                                             @search-change="loadScreens($event)"
+                                             @open="loadScreens()"
+                                             track-by="id"
+                                             label="title">
+                                    <span slot="noResult">{{ __('Oops! No elements found. Consider changing the search query.') }}</span>
+                                    <template slot="noOptions">
+                                        {{ __('No Data Available') }}
+                                    </template>
+                                </multiselect>
+                                <div class="invalid-feedback" v-if="errors.request_detail_screen_id">@{{errors.request_detail_screen_id[0]}}</div>
+                            </div>
+                            <div class="form-group">
                                 {!! Form::label('status', __('Status')) !!}
                                 <select-status v-model="formData.status" :multiple="false"></select-status>
                             </div>
@@ -288,6 +307,7 @@
             screens: [],
             canCancel: @json($canCancel),
             canEditData: @json($canEditData),
+            screenRequestDetail: @json($screenRequestDetail),
             screenCancel: @json($screenCancel),
             activeUsersAndGroups: @json($list),
             pause_timer_start_events: false,
@@ -357,6 +377,7 @@
             this.formData.cancel_request = this.formatAssigneePermissions(this.canCancel);
             this.formData.edit_data = this.formatAssigneePermissions(this.canEditData);
             this.formData.cancel_screen_id = this.formatValueScreen(this.screenCancel);
+            this.formData.request_detail_screen_id = this.formatValueScreen(this.screenRequestDetail);
             this.formData.manager_id = this.formatValueScreen(this.manager);
             ProcessMaker.apiClient.put('processes/' + that.formData.id, that.formData)
               .then(response => {

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -139,6 +139,31 @@
 
                                 </template>
                             </template>
+                            <template v-else>
+                                <template v-if="showScreenRequestDetail">
+                                    <div class="card">
+                                        <div class="card-body">
+                                          <vue-form-renderer ref="screenRequestDetail" :config="screenRequestDetail" v-model="dataSummary"/>
+                                        </div>
+                                    </div>
+                                </template>
+                                <template v-else>
+                                    <div class="card border-0">
+                                        <div class="card-header bg-white">
+                                            <h5 class="m-0">
+                                                {{ __('Request In Progress') }}
+                                            </h5>
+                                        </div>
+
+                                        <div class="card-body">
+                                            <p class="card-text">
+                                                {{__('This Request is currently in progress.')}}
+                                                {{__('This screen will be populated once the Request is completed.')}}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </template>
+                            </template>
                         </div>
                         @if ($request->status === 'COMPLETED')
                             @can('editData', $request)
@@ -393,6 +418,18 @@
               options[option.key] = option.value
             });
             return options;
+          },
+          /**
+           * If the screen request detail is configured.
+           **/
+          showScreenRequestDetail() {
+            return !!this.request.request_detail_screen;
+          },
+          /**
+           * Get Screen request detail
+           * */
+          screenRequestDetail() {
+            return this.request.request_detail_screen ? this.request.request_detail_screen.config : null;
           },
           classStatusCard() {
             let header = {

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -37,7 +37,7 @@
                                    data-toggle="tab" @click="switchTab('pending')" href="#pending" role="tab"
                                    aria-controls="pending" aria-selected="true">{{__('Tasks')}}</a>
                             </li>
-                            <li class="nav-item" v-if="showSummary">
+                            <li class="nav-item">
                                 <a id="summary-tab" data-toggle="tab" href="#summary" role="tab"
                                    aria-controls="summary" @click="switchTab('summary')" aria-selected="false"
                                    v-bind:class="{ 'nav-link':true, active: showSummary }">


### PR DESCRIPTION
## Issue & Reproduction Steps

Resolves Ticket: [FOUR-4565](https://processmaker.atlassian.net/browse/FOUR-4565)

This ticket reverts a change where the Request Detail Screen select was removed along with the summary tab. 

## Solution
Reverts [PR 4043](https://github.com/ProcessMaker/processmaker/pull/4043)

## How to Test

- Ensure the Request Detail Screen select is still available in the process configuration
- Ensure the screen selected as the Request Detail Screen displays in the Summary tab while a request is in progress.
- Ensure the End Event page displays when the process is completed if configured in the process.

## Related Tickets & Packages
- https://github.com/ProcessMaker/processmaker/pull/4160


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and do not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
