### PR TITLE
Task/FOUR-4565 Ticket-1234: Show custom summary screen for end event and Request Detail Screen select 

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -82,6 +82,7 @@ class ProcessController extends Controller
             ->toArray();
 
         $screenCancel = Screen::find($process->cancel_screen_id);
+        $screenRequestDetail = Screen::find($process->request_detail_screen_id);
 
         $list = $this->listUsersAndGroups();
 
@@ -92,7 +93,7 @@ class ProcessController extends Controller
         $canEditData = $this->listCan('EditData', $process);
         $addons = $this->getPluginAddons('edit', compact(['process']));
 
-        return view('processes.edit', compact(['process', 'categories', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons']));
+        return view('processes.edit', compact(['process', 'categories', 'screenRequestDetail', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons']));
     }
 
     /**

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -134,6 +134,25 @@
                                 </multiselect>
                             </div>
                             <div class="form-group">
+                                {!! Form::label('requestDetailScreen', __('Request Detail Screen')) !!}
+                                <multiselect aria-label="{{ __('Request Detail Screen') }}"
+                                             v-model="screenRequestDetail"
+                                             :options="screens"
+                                             :multiple="false"
+                                             :show-labels="false"
+                                             placeholder="{{ __('Type to search') }}"
+                                             @search-change="loadScreens($event)"
+                                             @open="loadScreens()"
+                                             track-by="id"
+                                             label="title">
+                                    <span slot="noResult">{{ __('Oops! No elements found. Consider changing the search query.') }}</span>
+                                    <template slot="noOptions">
+                                        {{ __('No Data Available') }}
+                                    </template>
+                                </multiselect>
+                                <div class="invalid-feedback" v-if="errors.request_detail_screen_id">@{{errors.request_detail_screen_id[0]}}</div>
+                            </div>
+                            <div class="form-group">
                                 {!! Form::label('status', __('Status')) !!}
                                 <select-status v-model="formData.status" :multiple="false"></select-status>
                             </div>
@@ -288,6 +307,7 @@
             screens: [],
             canCancel: @json($canCancel),
             canEditData: @json($canEditData),
+            screenRequestDetail: @json($screenRequestDetail),
             screenCancel: @json($screenCancel),
             activeUsersAndGroups: @json($list),
             pause_timer_start_events: false,
@@ -357,6 +377,7 @@
             this.formData.cancel_request = this.formatAssigneePermissions(this.canCancel);
             this.formData.edit_data = this.formatAssigneePermissions(this.canEditData);
             this.formData.cancel_screen_id = this.formatValueScreen(this.screenCancel);
+            this.formData.request_detail_screen_id = this.formatValueScreen(this.screenRequestDetail);
             this.formData.manager_id = this.formatValueScreen(this.manager);
             ProcessMaker.apiClient.put('processes/' + that.formData.id, that.formData)
               .then(response => {

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -115,7 +115,14 @@
                                         <vue-form-renderer ref="screen" :config="screenSummary.config" v-model="dataSummary" :computed="screenSummary.computed"/>
                                     </div>
                                 </template>
-                                <template v-else>
+                                <template v-if="showScreenRequestDetail && !showScreenSummary">
+                                    <div class="card">
+                                        <div class="card-body">
+                                          <vue-form-renderer ref="screenRequestDetail" :config="screenRequestDetail" v-model="dataSummary"/>
+                                        </div>
+                                    </div>
+                                </template>
+                                <template v-if="!showScreenSummary && !showScreenRequestDetail">
                                     <template v-if="summary.length > 0">
                                         <div class="card border-0">
                                             <data-summary :summary="dataSummary"></data-summary>
@@ -394,6 +401,18 @@
             });
             return options;
           },
+          /**
+           * If the screen request detail is configured.
+           **/
+          showScreenRequestDetail() {
+            return !!this.request.request_detail_screen;
+          },
+          /**
+           * Get Screen request detail
+           * */
+          screenRequestDetail() {
+            return this.request.request_detail_screen ? this.request.request_detail_screen.config : null;
+          },
           classStatusCard() {
             let header = {
               "ACTIVE": "bg-success",
@@ -438,7 +457,7 @@
         },
         methods: {
           switchTab(tab) {
-            ProcessMaker.EventBus.$emit('tab-switched', tab);  
+            ProcessMaker.EventBus.$emit('tab-switched', tab);
           },
           requestStatusClass(status) {
             status = status.toLowerCase();

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -32,7 +32,7 @@
                                        aria-controls="errors" aria-selected="false">{{__('Errors')}}</a>
                                 </li>
                             @endif
-                            <li class="nav-item" v-if="!showSummary">
+                            <li class="nav-item" v-if="status !== 'COMPLETED' || status !== 'PENDING'">
                                 <a class="nav-link" :class="{ active: activePending }" id="pending-tab"
                                    data-toggle="tab" @click="switchTab('pending')" href="#pending" role="tab"
                                    aria-controls="pending" aria-selected="true">{{__('Tasks')}}</a>
@@ -40,7 +40,7 @@
                             <li class="nav-item" v-if="showSummary">
                                 <a id="summary-tab" data-toggle="tab" href="#summary" role="tab"
                                    aria-controls="summary" @click="switchTab('summary')" aria-selected="false"
-                                   v-bind:class="{ 'nav-link':true, active: showSummary }">
+                                   v-bind:class="{ 'nav-link':true, active: showSummary && !activePending }">
                                     {{__('Summary')}}
                                 </a>
                             </li>
@@ -103,11 +103,11 @@
                             <request-errors :errors="errorLogs"></request-errors>
                         </div>
                         <div class="tab-pane fade show card card-body border-top-0 p-0" :class="{ active: activePending }" id="pending" role="tabpanel"
-                             aria-labelledby="pending-tab" v-if="!showSummary">
+                             aria-labelledby="pending-tab" v-if="status !== 'COMPLETED' || status !== 'PENDING'">
                             <request-detail ref="pending" :process-request-id="requestId" status="ACTIVE" :is-admin="{{Auth::user()->is_administrator ? 'true' : 'false'}}">
                             </request-detail>
                         </div>
-                        <div class="card card-body border-top-0 p-0" v-bind:class="{ 'tab-pane':true, active: showSummary }" id="summary"
+                        <div class="card card-body border-top-0 p-0" v-bind:class="{ 'tab-pane':true, active: showSummary && !activePending}" id="summary"
                              role="tabpanel" aria-labelledby="summary-tab">
                             <template v-if="showSummary">
                                 <template v-if="showScreenSummary">
@@ -124,9 +124,27 @@
                                 </template>
                                 <template v-if="!showScreenSummary && !showScreenRequestDetail">
                                     <template v-if="summary.length > 0">
-                                        <div class="card border-0">
-                                            <data-summary :summary="dataSummary"></data-summary>
-                                        </div>
+                                        <template v-if="!activePending">
+                                            <div class="card border-0">
+                                                <data-summary :summary="dataSummary"></data-summary>
+                                            </div>
+                                        </template>
+                                        <template v-else>
+                                            <div class="card border-0">
+                                                <div class="card-header bg-white">
+                                                    <h5 class="m-0">
+                                                        {{ __('Request In Progress') }}
+                                                    </h5>
+                                                </div>
+
+                                                <div class="card-body">
+                                                    <p class="card-text">
+                                                        {{__('This Request is currently in progress.')}}
+                                                        {{__('This screen will be populated once the Request is completed.')}}
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </template>
                                     </template>
                                     <template v-else>
                                         <div class="card border-0">
@@ -370,7 +388,7 @@
            *
            */
           showSummary() {
-            return this.request.status === 'COMPLETED' || this.request.status === 'CANCELED';
+            return this.request.status === 'ACTIVE' || this.request.status === 'COMPLETED' || this.request.status === 'CANCELED';
           },
           /**
            * If the screen summary is configured.


### PR DESCRIPTION
## Issue & Reproduction Steps
Removed functionality to allows show end event custom detail screen and select custom detail screen for a request. Now it is posible to see the custom screen if we configure it in the end event of a process or within the Request Detail Screen select in process configuration.

## Solution
- Reverted changes from [PR 4043](https://github.com/ProcessMaker/processmaker/pull/4043) and changed the conditionals to show or not each summary screen.
- If no custom summary screen is configure will show the default summary
- If summary screen is configure in process > configure > Request Detail Screen select, will show the custom summary configured there.
- If summary screen is configured in the end event of a process will show the custom summary screen for the end event
- If summary screen is configure in process > configure > Request Detail Screen select and if summary screen is also configured in the end event of a process will show the custom summary screen for the end event

## How to Test
All the cases are described on the following video

**Working video**

https://user-images.githubusercontent.com/90727999/144502965-ba254349-9342-4939-8237-035214530e1d.mov


## Related Tickets & Packages
- [FOUR-4565](https://processmaker.atlassian.net/browse/FOUR-4565)
- [TICKET-1234](http://tickets.pm4overflow.com/tickets/1234)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
