### PR TITLE
Bugfix Ticket 1175 - Added system tasks filter

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -156,8 +156,9 @@ class TaskController extends Controller
         }
 
         //list only display elements type task
+        $nonSystem = filter_var($request->input('non_system'), FILTER_VALIDATE_BOOLEAN);
         $query->where('element_type', '=', 'task')
-            ->when($request->input('non_system', false), function ($query) {
+            ->when($nonSystem, function ($query) {
                 $query->nonSystem();
             });
 

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -156,7 +156,7 @@ class TaskController extends Controller
         }
 
         //list only display elements type task
-        $query->where('element_type', '=', 'task');
+        $query->where('element_type', '=', 'task')->nonSystem();
 
         // order by one or more columns
         $orderColumns = explode(',', $request->input('order_by', 'updated_at'));

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -156,7 +156,10 @@ class TaskController extends Controller
         }
 
         //list only display elements type task
-        $query->where('element_type', '=', 'task')->nonSystem();
+        $query->where('element_type', '=', 'task')
+            ->when($request->input('non_system', false), function ($query) {
+                $query->nonSystem();
+            });
 
         // order by one or more columns
         $orderColumns = explode(',', $request->input('order_by', 'updated_at'));

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Scout\Searchable;
 use Log;
+use ProcessMaker\Traits\HideSystemResources;
 use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Facades\WorkflowUserManager;
 use ProcessMaker\Models\Setting;
@@ -84,6 +85,7 @@ class ProcessRequestToken extends Model implements TokenInterface
     use TokenTrait;
     use SerializeToIso8601;
     use Searchable;
+    use HideSystemResources;
 
     protected $connection = 'processmaker';
 

--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -56,7 +56,7 @@ trait HideSystemResources
         } else if (static::class == User::class) {
             return $query->where('is_system', false);
         } else if (static::class === ProcessRequestToken::class) {
-            return $query->whereHas('process.user', function ($query) {
+            return $query->whereHas('process.categories', function ($query) {
                 $query->where('is_system', false);
             });
         } else {            

--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Traits;
 use Illuminate\Support\Str;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\User;
 
 trait HideSystemResources
@@ -54,6 +55,10 @@ trait HideSystemResources
             $query->whereNotIn('process_id', $systemProcessIds);
         } else if (static::class == User::class) {
             return $query->where('is_system', false);
+        } else if (static::class === ProcessRequestToken::class) {
+            return $query->whereHas('process.user', function ($query) {
+                $query->where('is_system', false);
+            });
         } else {            
             return $query->whereDoesntHave('categories', function ($query) {
                 $query->where('is_system', true);

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -376,7 +376,8 @@ export default {
                   "&per_page=" +
                   this.perPage +
                   filterParams +
-                  this.getSortParam(),
+                  this.getSortParam() +
+                  "&non_system=true",
                 {
                   cancelToken: new CancelToken(c => {
                     this.cancelToken = c;


### PR DESCRIPTION
## Issue & Reproduction Steps
System tasks were being shown to users.

Reproduction Steps:
1. Install DocuSign package.
2. Create an application in DocuSign that has not been granted Access.
3. Go the next page.

![image](https://user-images.githubusercontent.com/90741874/144326649-22cb0159-5a6a-4b17-989f-f1dbb4a2bd5a.png)

4. Do not click "Authorize Access". Then go to `/tasks` and you should see the next records:

![image](https://user-images.githubusercontent.com/90741874/144326734-38948244-7e5a-402b-8c24-3f7b7f2ed82d.png)


## Solution
- The `HideSystemResources` trait was used to exclude system-type records from the `process_request_tokens` table.

## How to Test
Please follow the "Reproduction Steps" of above. You should not see system tasks.

Run `vendor/bin/phpunit --filter testGetListNonSystemTasks tests/Feature/Api/TasksTest.php`

## Related Tickets & Packages
- [Ticket 1175](http://tickets.pm4overflow.com/tickets/1175)
- [FOUR-4808](https://processmaker.atlassian.net/browse/FOUR-4808)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

