### PR TITLE
Bugfix/FOUR-4792: Test cases for display exception for invalid columns in PMQL saved searches

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -140,6 +140,7 @@
   "Column Width": "Column Width",
   "Column Widths": "Column Widths",
   "Column": "Column",
+  "Column not found: ": "Column not found: ",
   "Comments": "Comments",
   "Common file types: application/msword, image/gif, image/jpeg, application/pdf, application/vnd.ms-powerpoint, application/vnd.ms-excel, text/plain": "Common file types: application/msword, image/gif, image/jpeg, application/pdf, application/vnd.ms-powerpoint, application/vnd.ms-excel, text/plain",
   "Completed Tasks": "Completed Tasks",

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -20,7 +20,6 @@ use ProcessMaker\Providers\AuthServiceProvider;
 use ProcessMaker\Models\ProcessNotificationSetting;
 use Illuminate\Support\Facades\Notification;
 use ProcessMaker\Notifications\ActivityActivatedNotification;
-use ProcessMaker\Package\SavedSearch\Models\SavedSearch;
 
 /**
  * Tests routes related to tokens list and show
@@ -532,40 +531,6 @@ class TasksTest extends TestCase
         $actualIds = collect($response->json()['data'])->pluck('id');
 
         $this->assertEquals($expectedTaskIds, $actualIds);
-    }
-
-    public function testSearchTasksWithPmqlValidColumn()
-    {
-        // Create a saved search
-        factory(SavedSearch::class)->create(['user_id' => $this->user->id, 'type' => 'task']);
-
-        // Get task list
-        $url = route('api.tasks.index') . '?pmql=(status%20%3D%20%22In%20Progress%22)%20';
-        $response = $this->apiCall('GET', $url);
-        $response->assertStatus(200);
-
-        // Check structure
-        $response->assertJsonStructure([
-            'data',
-            'meta'
-        ]);
-    }
-
-    public function testSearchTasksWithPmqlInvalidColumn()
-    {
-        // Create a saved search
-        factory(SavedSearch::class)->create(['user_id' => $this->user->id, 'type' => 'task']);
-        $unknownColumnName = 'my_unknown_column';
-
-        // Get task list
-        $url = route('api.tasks.index') . '?pmql=(status%20%3D%20%22In%20Progress%22)%20AND%20('.$unknownColumnName.'%20%3D%20%22Test%22)';
-        $response = $this->apiCall('GET', $url);
-        $response->assertStatus(422);
-
-        // Check request throw error
-        $response->assertJsonFragment([
-            'message' => 'PMQL Is Invalid. Column not found: "'.$unknownColumnName.'"'
-        ]);
     }
 
     public function testSelfServeNotifications()


### PR DESCRIPTION
## Issue & Reproduction Steps
When trying to add a PMQL with an unknown column name, the exception message is showing as internal server error 500. Go to tasks and in advance search mode add a PMQL with an unknown column eg: (my_unknown_column = "Test"). Press search, you will see an internal server error 500.

## Solution
- Added exception message for unknown column names.

## How to Test
- Go to tasks and in advance search mode add a PMQL with an unknown column eg: (my_unknown_column = "Test").
- Press search, you will see an informative error message **PMQL Is Invalid. Column not found: "my_unknown_column".**

**Working video**

https://user-images.githubusercontent.com/90727999/144459963-a7ee3aab-827f-4b5f-8480-388bae70ca24.mov


## Related Tickets & Packages
- [FOUR-4792](https://processmaker.atlassian.net/browse/FOUR-4792)
- [Saved Search PR](https://github.com/ProcessMaker/package-savedsearch/pull/289)
- [Package Saved Search](https://github.com/ProcessMaker/package-savedsearch/)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
