### PR TITLE
[4.2] Multiple copies of the process are created and import doesn't finish

### DIFF
--- a/ProcessMaker/Assets/ScreensInProcess.php
+++ b/ProcessMaker/Assets/ScreensInProcess.php
@@ -69,8 +69,12 @@ class ScreensInProcess
         $nodes = $xpath->query("//*[@pm:screenRef!='']");
         foreach ($nodes as $node) {
             $oldRef = $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'screenRef');
-            $newRef = $references[Screen::class][$oldRef]->getKey();
-            $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'screenRef', $newRef);
+            if (array_key_exists($oldRef, $references[Screen::class])) {
+                $newRef = $references[Screen::class][$oldRef]->getKey();
+                $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'screenRef', $newRef);
+            } else {
+                $node->removeAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'screenRef');
+            }
         }
         // interstitialScreenRef
         $nodes = $xpath->query("//*[@pm:interstitialScreenRef!='']");

--- a/ProcessMaker/Assets/ScriptsInProcess.php
+++ b/ProcessMaker/Assets/ScriptsInProcess.php
@@ -25,6 +25,7 @@ class ScriptsInProcess
         // Scripts used in BPMN
         $xpath = new DOMXPath($process->getDefinitions());
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        $xpath->registerNamespace('bpmn', 'http://www.omg.org/spec/BPMN/20100524/MODEL');
         // Used in scriptRef
         $nodes = $xpath->query("//*[@pm:scriptRef!='']");
         foreach ($nodes as $node) {
@@ -47,7 +48,6 @@ class ScriptsInProcess
         $xpath = new DOMXPath($definitions);
         $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
         $xpath->registerNamespace('bpmn', 'http://www.omg.org/spec/BPMN/20100524/MODEL');
-
         // Used in scriptRef
         $nodes = $xpath->query("//*[@pm:scriptRef!='']");
         foreach ($nodes as $node) {

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -95,6 +95,13 @@ class ImportProcess implements ShouldQueue
     protected $user;
 
     /**
+     * Prevent duplicate processes from being imported if this job fails
+     *
+     * @var int
+     */
+    public $tries = 1;
+
+    /**
      * In order to handle backwards compatibility with previous packages, an
      * array with a previous package name as the key, and the updated
      * package name as the value.


### PR DESCRIPTION
## Issue & Reproduction Steps
When attempting to import a process from a file, the import failed and the user was left with the "spinning" import screen without any update and with the process imported three times. This happened because the ImportProcess job ran three times and even though it imported the process, it was failing when attempting to import assets referenced in the BPMN which didn't exist in the import file data itself.

To reproduce the issue:

1. Import the [attached processes](https://github.com/ProcessMaker/processmaker/files/7645849/process-imports.zip) on a 4.2.* instance.
2. See that the process import will not finish and remains "spinning".
3. Navigate back to the processes list
4. Notice there are now 3 incomplete copies of each process after attempting to the import.

## Solution
The ImportProcess job will only be attempted one time in case of a failure (to prevent duplicates). The primary solution was adding a validation to ensure the array of a screens actually contained the references screen id.

## How to Test
You should be able to repeat the steps above without the ImportProcess job failing and without being left on a "spinning"/waiting screen for the import to finish.

## Related Tickets & Packages
[Related JIRA FOUR-4469 ticket](https://processmaker.atlassian.net/browse/FOUR-4469).
[Related PR for package-webentry](https://github.com/ProcessMaker/package-webentry/pull/132).

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
