### PR TITLE
Bugfix/FOUR-4828: Removed additional info from user profile

### DIFF
--- a/resources/views/shared/users/profile.blade.php
+++ b/resources/views/shared/users/profile.blade.php
@@ -144,7 +144,7 @@
             </div>
         </div>
     </div>
-    @if (config('users.properties'))
+    @if (config('users.properties') && !\Request::is('profile/edit'))
         <hr>
         <h5 class="mt-1 mb-3">{{__('Additional Information')}}</h5>
         @foreach (config('users.properties') as $variable => $label)

--- a/tests/Feature/Admin/UserTest.php
+++ b/tests/Feature/Admin/UserTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Admin;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
+use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
 
@@ -45,5 +46,47 @@ class UserTest extends TestCase
         // check the correct view is called
         $response->assertViewIs('admin.users.edit');
         $response->assertSee('Edit User');
+    }
+
+    /**
+     * Test to make sure the additional information shows in edit user
+     * @return void
+     */
+    public function testCanSeeAditionalInformationInEditRoute()
+    {
+        $user_id = factory(User::class)->create()->id;
+        factory(Setting::class)->create([
+            'key' => 'users.properties',
+            'config' => '{"MyVar":"Test Var"}',
+            'format' => 'object',
+            'group' => 'Users'
+        ]);
+        // get the URL
+        $response = $this->webCall('GET', '/admin/users/' . $user_id . '/edit');
+        $response->assertStatus(200);
+        // check the correct view is called
+        $response->assertViewIs('admin.users.edit');
+        $response->assertSee('Additional Information');
+    }
+
+    /**
+     * Test to make sure the additional information not shows in profile
+     * @return void
+     */
+    public function testCannotSeeAditionalInformationInProfileRoute()
+    {
+        factory(User::class)->create()->id;
+        factory(Setting::class)->create([
+            'key' => 'users.properties',
+            'config' => '{"MyVar":"Test Var"}',
+            'format' => 'object',
+            'group' => 'Users'
+        ]);
+        // get the URL
+        $response = $this->webCall('GET', '/profile/edit');
+        $response->assertStatus(200);
+        // check the correct view is called
+        $response->assertViewIs('profile.edit');
+        $response->assertDontSee('Additional Information');
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Go to user profile and you can see additional info at bottom.

## Solution
- Not show additional info in user profile.

## How to Test
- Go to user profile and you **will not** see additional info at bottom.
- Go to edit some user and you **will** see additional info at bottom.

Run tests
tests/Feature/Admin/UserTest.php

**Working video**


https://user-images.githubusercontent.com/90727999/144668215-baa26767-bd22-4fdb-ac14-e33edaf9ff82.mov


## Related Tickets & Packages
- [FOUR-4828](https://processmaker.atlassian.net/browse/FOUR-4828)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
