### PR TITLE
Bugfix/FOUR-4812: Error "The given data was invalid." when we try reset configuration in dynamic UI

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SettingController.php
+++ b/ProcessMaker/Http/Controllers/Api/SettingController.php
@@ -204,6 +204,7 @@ class SettingController extends Controller
      */
     public function update(Setting $setting, Request $request)
     {
+        $request->validate(Setting::rules($setting, $request->input('key') == 'users.properties'), Setting::messages());
         $setting->config = $request->input('config');
         $setting->save();
 
@@ -275,7 +276,7 @@ class SettingController extends Controller
             }
         }
     }
-    
+
     private function createStoragePathIfNotExists($path)
     {
         $dir = pathinfo($path, PATHINFO_DIRNAME);

--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -104,13 +104,13 @@ class Setting extends Model implements HasMedia
      *
      * @return array
      */
-    public static function rules($existing = null)
+    public static function rules($existing = null, $validateConfig = false)
     {
         $unique = Rule::unique('settings')->ignore($existing);
 
         return [
             'key' => ['required', $unique],
-            'config.*' => ['required', 'valid_variable']
+            'config.*' => ($validateConfig ? ['required', 'valid_variable'] : [])
         ];
     }
 

--- a/tests/Feature/Api/CssOverrideTest.php
+++ b/tests/Feature/Api/CssOverrideTest.php
@@ -42,10 +42,21 @@ class CssOverrideTest extends TestCase
         $response->assertStatus(422);
     }
 
+    /**
+     * Verifies that the reset css works
+     */
+    public function testResetCss()
+    {
+        $data = $this->cssValues('#ff0000');
+        $data['reset'] = true;
+        $response = $this->actingAs($this->user, 'api')->call('POST', '/api/1.0/customize-ui', $data);
+        $response->assertStatus(201);
+    }
+
     private function cssValues($testColor)
     {
         return [
-           'key'  => 'css-override',
+            'key' => 'css-override',
             'variables' => json_encode([
                 [
                     'id' => '$primary',


### PR DESCRIPTION
## Issue & Reproduction Steps
Invalid data error shows when clicking reset button in customize-ui because trying to validate config.* with valid_variable rule.

## Solution
- Added conditional to only validate the rule config.* for extended properties (user.properties).

## How to Test
- Got o Admin > Customize UI
- Click Reset button. UI settings should save.

Run test **tests/Feature/Api/CssOverrideTest.php**

**Working video**


https://user-images.githubusercontent.com/90727999/144868607-e4cf049d-3c0d-4516-aa74-7358e89c677a.mov


## Related Tickets & Packages
- [FOUR-4812](https://processmaker.atlassian.net/browse/FOUR-4812)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
