### PR TITLE
FOUR-4826 Post Password Change Redirecting Incorrectly

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -62,7 +62,7 @@ class LoginController extends Controller
         if ($intended) {
             // Check if the route is a fallback, meaning it's invalid (like favicon.ico)
             $route = app('router')->getRoutes() ->match(
-                app('request') ->create($intended)
+                app('request')->create($intended)
             );
             if ($route->isFallback) {
                 $intended = false;

--- a/resources/views/auth/passwords/change.blade.php
+++ b/resources/views/auth/passwords/change.blade.php
@@ -131,7 +131,7 @@
                 ProcessMaker.apiClient.put('password/change', this.formData)
                     .then(response => {
                         if (response.status === 200) {
-                            window.location.href = '/requests';
+                            window.location.href = '/';
                         }
                     })
                     .catch(error => {


### PR DESCRIPTION
## Issue & Reproduction Steps
If a user is forced to change their password via "force password change" toggle, then upon the next login the user is taken to the Requests route instead of their assigned dashboard.

1. Install package-dynamic-ui. 
2. Create a dashboard, assign to a user.
3. Check off "User must change password at next login"
4. After changing the password, user will be redirected to Requests

## Solution
- Removed the redirect to `/requests` and instead it will be redirected to `/`. In `/`, the redirect is carried out properly to the custom dashboard or requests.

## How to Test
Follow the reproduction steps above.

## Related Tickets & Packages
- [FOUR-4826](https://processmaker.atlassian.net/browse/FOUR-4826)

## Code Review Checklist
- [X] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [X] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [X] This solution fixes the bug reported in the original ticket.
- [X] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [X] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [X] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [X] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [X] This ticket conforms to the PRD associated with this part of ProcessMaker.