### PR TITLE
Bugfix/FOUR-4793: "Loading.." It only appears when you refresh the screen in the process searcher

### DIFF
--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -335,6 +335,7 @@
       },
       fetch() {
         this.loading = true;
+        this.apiDataLoading = true;
         //change method sort by user
         this.orderBy = this.orderBy === "user" ? "user.firstname" : this.orderBy;
         //change method sort by slot name


### PR DESCRIPTION
## Issue & Reproduction Steps
When you go to Design > Processes you can see at first the loading message, but when you do some search, the message is not appearing.

## Solution
- Show message before fetch processes on search api request.

## How to Test
- Go to Designer > Processes and see the loading message.
- Filter by something in the processes search bar and the loading message should appear while the request is active and hides when the request finish.

**Working video**

https://user-images.githubusercontent.com/90727999/144898486-4695cfa2-0d68-4850-bb84-85fd8c5fe8af.mov


## Related Tickets & Packages
- [FOUR-4793](https://processmaker.atlassian.net/browse/FOUR-4793)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
