### PR TITLE
Fix Multiple broken SDK doc links in script editor

### DIFF
--- a/resources/js/processes/scripts/customFilters.js
+++ b/resources/js/processes/scripts/customFilters.js
@@ -135,7 +135,7 @@ Vue.filter('python', function(value) {
     line = line.replace('{dataVariable}',  `the data variable`);
     line = line.replace('{configVariable}',  `the config variable`);
     line = line.replace('{apiExample}',  ':');
-    line = line.replace('{apiDocsUrl}', `https://github.com/ProcessMaker/sdk-python#documentation-for-api-endpoints`);
+    line = line.replace('{apiDocsUrl}', `https://processmaker.gitbook.io/processmaker/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples`);
     format = '# ' + line;
     content.push(format);
   });

--- a/resources/js/processes/scripts/customFilters.js
+++ b/resources/js/processes/scripts/customFilters.js
@@ -89,7 +89,7 @@ Vue.filter('csharp', function(value) {
       line = line.replace('{dataVariable}',  `data`);
       line = line.replace('{configVariable}',  `config`);
       line = line.replace('{apiExample}',  `apiInstance.GetUserById(id)`);
-      line = line.replace('{apiDocsUrl}', `https://github.com/ProcessMaker/package-csharp#documentation-for-api-endpoints`);
+      line = line.replace('{apiDocsUrl}', `https://processmaker.gitbook.io/processmaker/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples`);
       format = line;
     }
     content.push(format);

--- a/resources/js/processes/scripts/customFilters.js
+++ b/resources/js/processes/scripts/customFilters.js
@@ -39,7 +39,7 @@ Vue.filter('javascript', function(value) {
       line = line.replace('{dataVariable}',  `data`);
       line = line.replace('{configVariable}',  `config`);
       line = line.replace('{apiExample}',  `getUserById(id, (error, data, response) => {})`);
-      line = line.replace('{apiDocsUrl}', `https://github.com/ProcessMaker/sdk-node#documentation-for-api-endpoints`);
+      line = line.replace('{apiDocsUrl}', `https://github.com/ProcessMaker/docker-executor-node/tree/master/docs/sdk`);
       format = ' * ' + line;
     }
     content.push(format);

--- a/resources/js/processes/scripts/customFilters.js
+++ b/resources/js/processes/scripts/customFilters.js
@@ -64,7 +64,7 @@ Vue.filter('lua', function(value) {
       line = line.replace('{dataVariable}',  `data`);
       line = line.replace('{configVariable}',  `config`);
       line = line.replace('{apiExample}',  `users_api:get_users(filter, order_by, order_direction, per_page, include)`);
-      line = line.replace('{apiDocsUrl}', `https://github.com/ProcessMaker/sdk-lua#documentation-for-api-endpoints`);
+      line = line.replace('{apiDocsUrl}', `https://processmaker.gitbook.io/processmaker/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples`);
       format = '  ' + line;
     }
     content.push(format);

--- a/resources/js/processes/scripts/customFilters.js
+++ b/resources/js/processes/scripts/customFilters.js
@@ -114,7 +114,7 @@ Vue.filter('java', function(value) {
       line = line.replace('{dataVariable}',  `data`);
       line = line.replace('{configVariable}',  `config`);
       line = line.replace('{apiExample}',  `apiInstance.getUserByID(id);`);
-      line = line.replace('{apiDocsUrl}', `https://github.com/ProcessMaker/sdk-java#documentation-for-api-endpoints`);
+      line = line.replace('{apiDocsUrl}', `https://processmaker.gitbook.io/processmaker/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples`);
       format = ' * ' + line;
     }
     content.push(format);


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket [FOUR-4822](https://processmaker.atlassian.net/browse/FOUR-4822)

Broken API Documentation links in the script editor for:

- JavaScript/Node
- LUA
- Java
- Python

## Solution
- Update the links to the proper documentation

## How to Test
Create a script in the above languages and open the API Documentation link in the commented text.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
