### PR TITLE
Bugfix FOUR-4789 - Searches for the date or date time in a collection are not working

### DIFF
--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -138,8 +138,12 @@ trait ExtendedPMQL
         if ($value instanceof IntervalExpression || (is_string($value) && strlen($value) > 1)) {
             try {
                 $parsed = Carbon::parse($value, auth()->user()->timezone);
-                $parsed->setTimezone(config('app.timezone'));
-                $value = $parsed->toDateTimeString();
+                if ($parsed->isMidnight()) {
+                    $value = $parsed->toDateString();
+                } else {
+                    $parsed->setTimezone(config('app.timezone'));
+                    $value = $parsed->toDateTimeString();
+                }
             } catch (Throwable $e) {
                 //Ignore parsing errors and just return the original
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
When using a PMQL query like `(data.form_date_picker_1 ="2021-12-31")` to search a record of a collection, it does not work.

1. Log in
2. Import collection [attached](https://processmaker.atlassian.net/browse/FOUR-4789) 
3. Open the collection
4. Fill following query (data.form_date_picker_1 = "2021-12-31")

## Solution
- The `parseValue` function for dates in `ProcessMaker/Traits/ExtendedPMQL.php` always returned a "date with timestamp", so `2021-12-31 14:00` is different than `2021-12-31` and no records are found.

## How to Test
Please follow the reproduction steps of above to manually tests the search functionality by PMQL date in `/collections/{id}`.

You can also run `vendor/bin/phpunit tests/Feature/ExtendedPMQLTest.php`.

## Related Tickets & Packages
- [FOUR-4789](https://processmaker.atlassian.net/browse/FOUR-4789)
- [Package Collections](https://github.com/ProcessMaker/package-collections)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
