### PR TITLE
Fix mustache variables not rendering Test Request JSON

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -185,7 +185,7 @@ trait MakeHttpRequests
 
         // Prepare Body
         $data = $this->prepareData($requestData, $outboundConfig, 'BODY');
-        $body = $this->getMustache()->render($endpoint['body'], $data);
+        $body = $this->getMustache()->render($endpoint['body'], $requestData);
         $bodyType = null;
         if (isset($endpoint['body_type'])) {
             $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket: [FOUR-4876](https://processmaker.atlassian.net/browse/FOUR-4876)

When using mustache variables in a data connector's body and using the Test Request JSON to fill in that data the response body is returning `null` values. This is due to passing in an empty `data` variable when rendering mustache. The `data` variable does not contain the `requestData` needed to render properly.

1. Configure a new data resource using the POST method
2. In body use mustache variables
3. In the Response Body tab configure the Test Request JSON to populate the mustache variables
4. Select the 'Send' button

**Behavior**
The response values are null. The response should contain the values set in the Test Request JSON. 


## Solution

- Fix the rendering of Mustache variables by passing in the `requestData` variable that contains the values needed to render the mustache variables.

## How to Test

1. Configure a new data resource using the POST method
2. In body use mustache variables
3. In the Response Body tab configure the Test Request JSON to populate the mustache variables
4. Select the 'Send' button

**Behavior**
The response contains the values set in the Test Request JSON. 

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
