### PR TITLE
Bugfix/FOUR-4886: Translations in Tasks menu are not fully translated

### DIFF
--- a/ProcessMaker/Helper/helper.php
+++ b/ProcessMaker/Helper/helper.php
@@ -20,8 +20,9 @@ function lavaryMenuArray($menu, $includeSubMenus = false)
             $children[] = lavaryMenuArray($child);
         }
     }
+
     return [
-        'title' => $menu->title,
+        'title' => __($menu->title),
         'id' => $menu->id,
         'attributes' => $menu->attributes,
         'url' => $menu->url(),
@@ -43,9 +44,9 @@ function lavaryMenuJson($menu)
 
 /**
  * Check if a package exists based on its provider name
- * 
+ *
  * @param string $name
- * 
+ *
  * @return bool
  */
 function hasPackage($name)
@@ -57,7 +58,7 @@ function hasPackage($name)
 
 /**
  * Check both the web and api middleware for an existing user
- * 
+ *
  * @return User
  */
 function pmUser()

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -716,6 +716,7 @@
   "Select...": "Select...",
   "Select": "Select",
   "Self Service": "Self Service",
+  "Self-Service": "Self-Service",
   "Set the periodic interval to trigger this element again": "Set the periodic interval to trigger this element again",
   "Sequence flow is missing condition": "Sequence flow is missing condition",
   "Sequence Flow": "Sequence Flow",


### PR DESCRIPTION
## Issue & Reproduction Steps
When you hover on a tasks on sidebar menu item, translation is not working
- Got to Admin and select a user to edit. 
- Change the language under settings section.
- Got to Tasks
- Hover on menu item, title is not translated

## Solution
- Added __() to $menu->title.

## How to Test
- Got to Admin and select a user to edit. 
- Change the language under settings section.
- Got to Tasks
- Hover on menu item, title should be translated based on the language selected for the user

**IMPORTANT!**
**Self service title for German is missing**

**Working video**

https://user-images.githubusercontent.com/90727999/145821108-615a9835-c333-4157-8c87-dbf0df1a067d.mov


## Related Tickets & Packages
- [FOUR-4886](https://processmaker.atlassian.net/browse/FOUR-4886)
- You should install [package-translations](https://github.com/ProcessMaker/package-translations)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
