### PR TITLE
Bugfix/FOUR-4110: It is not possible to assign different users but with the same firstname to a group

### DIFF
--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -147,15 +147,15 @@
                     <multiselect id="users"
                                  v-model="selectedUsers"
                                  placeholder="{{__('Select user or type here to search users')}}"
-                                 :options="availableUsers"
+                                 :options="availableUsersFormatted"
                                  :multiple="true"
-                                 track-by="fullname"
+                                 track-by="username"
                                  :custom-label="customLabel"
                                  :show-labels="false"
                                  :searchable="true"
                                  :internal-search="false"
                                  @search-change="loadUsers"
-                                 label="fullname">
+                                 label="username">
 
                         <template slot="noResult" >
                             {{ __('No elements found. Consider changing the search query.') }}
@@ -178,7 +178,7 @@
 
                         <template slot="option" slot-scope="props">
                             <div class="option__desc d-flex align-items-center">
-                                <span class="option__title mr-1">@{{ props.option.fullname }} (@{{ props.option.username }})</span>
+                                <span class="option__title mr-1">@{{ props.option.fullname }}</span>
                             </div>
                         </template>
                     </multiselect>
@@ -267,6 +267,11 @@
               this.selectAll = false;
             }
           }
+        },
+        computed: {
+            availableUsersFormatted() {
+                return this.availableUsers.map(user => ({...user, fullname: `${user.fullname} (${user.username})`}));
+            }
         },
         methods: {
           checkCreate(sibling, $event) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Can't add to a group two users with the same first and last name.
- Create two users with same first and last name, but different username
- Create a group
- Try to add those users that have the same fullname to the group.

## Solution
- Changed **track by** option  to track by username instead fullname.
- Changed label of selected users to improve UX to display **fullname (username)**

## How to Test
- Create two users with same first and last name, but different username
- Create a group
- Add those users that have the same fullname to the group.

**Working video**

https://user-images.githubusercontent.com/90727999/146048167-e3c76a3b-f685-4dfb-bc54-a77a6036e751.mov


## Related Tickets & Packages
- [FOUR-4110](https://processmaker.atlassian.net/browse/FOUR-4110)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
