### PR TITLE
  FOUR-4331: Error in auto-validate with Data connector

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -90,6 +90,9 @@ class ProcessController extends Controller
         if ($status === 'archived') {
             $processes = Process::archived()->with($include);
         }
+        if ($status === 'all') {
+            $processes = Process::active()->with($include);
+        }
         $filter = $request->input('filter');
         $processes = $processes->select('processes.*')
             ->leftJoin('process_categories as category', 'processes.process_category_id', '=', 'category.id')

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -414,6 +414,8 @@ class Process extends Model implements HasMedia, ProcessModelInterface
         return $query->where('processes.status', 'ARCHIVED');
     }
 
+
+
     public function getCollaborations()
     {
         $this->bpmnDefinitions = app(BpmnDocumentInterface::class, ['process' => $this]);


### PR DESCRIPTION
## Issue & Reproduction Steps

-     Create a process
-     Add Start Event -> Data Connector -> End Event
-     Configure the data connector
-     Saved the changes
-     Enable auto validate
The error appears in auto validate "Call Activity must have a child process and a start event selected." as data connector was a sub-process

## Solution
Modeler will get all active process (system and not system) so it can search within system process list to validate if the process used by the callActivity exists. Our packages use system sub-processes for actions by email, data connectors, etc.

## How to Test
Use the following branch of modeler https://github.com/ProcessMaker/modeler/tree/bugfix/FOUR-4331
npm link to modeler the following branch of bpmnlint: https://github.com/ProcessMaker/bpmnlint-plugin/tree/bugfix/FOUR-4331
build modeler
use the built modeler with the branch of this PR.
Use the reproduction steps and verify that when adding a Data Connector or Actions By Email, no errors are displayed with the Auto Validate option enabled.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-4331](https://processmaker.atlassian.net/browse/FOUR-4331)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
