### PR TITLE
Bugfix FOUR-4837 "Console error printed in FireFox after running a data connector"

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -435,7 +435,7 @@
               .catch(error => {
                 // If there are errors, the user will be redirected to the request page
                 // to view error details. This is done in loadTask in Task.vue
-                if (error.response.status && error.response.status === 422) {
+                if (error.response?.status && error.response?.status === 422) {
                   // Validation error
                   Object.entries(error.response.data.errors).forEach(([key, value]) => {
                     window.ProcessMaker.alert(`${key}: ${value[0]}`, 'danger', 0);


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Import the [attached process](https://processmaker.atlassian.net/browse/FOUR-4881)
2. Configure the data connector to any simple GET endpoint
3. Create a request and submit the first task (loop1)

Note: The error also happens with any Simple Task. Right after submitting the task.

## Solution
- Fix `error.response is undefined` console log error using JS optional chaining.

## How to Test
Please follow the reproduction steps from above in order to test the solution.

## Related Tickets & Packages
- [FOUR 4837](https://processmaker.atlassian.net/browse/FOUR-4881)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.