### PR TITLE
4.2 Fix Filtering request by User when username contains numbers 

### DIFF
--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -143,7 +143,7 @@ trait ExtendedPMQL
                 default: 
                     // Check to see if the value is a date/datetime formatted if not return original value
                     $isDateFormatted = Carbon::hasFormatWithModifiers($value, 'Y#m#d');
-                    $isDateTimeFormatted = Carbon::hasFormatWithModifiers($value, 'Y#m#d h:i:s');
+                    $isDateTimeFormatted = Carbon::hasFormatWithModifiers($value, 'Y#m#d H:i:s');
                     if ($isDateFormatted || $isDateTimeFormatted) {
                         $value = $this->parseDate($value);
                     }

--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -154,13 +154,18 @@ trait ExtendedPMQL
     }
 
     private function parseDate($value) {
-        $parsed = Carbon::parse($value, auth()->user()->timezone);
-        $parsed->setTimezone(config('app.timezone'));
-        if ($parsed->isMidnight()) {
-            return $parsed->toDateString();
-        } else {
+        try {
+            $parsed = Carbon::parse($value, auth()->user()->timezone);
             $parsed->setTimezone(config('app.timezone'));
-            return $parsed->toDateTimeString();
-        }   
+            if ($parsed->isMidnight()) {
+                return $parsed->toDateString();
+            } else {
+                $parsed->setTimezone(config('app.timezone'));
+                return $parsed->toDateTimeString();
+            }  
+        } catch (Throwable $e) {
+            //Ignore parsing errors and just return the original
+            return $value;
+        }  
     }
 }

--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -135,20 +135,32 @@ trait ExtendedPMQL
         }
 
         // Check to see if the value is parsable as a date
-        if ($value instanceof IntervalExpression || (is_string($value) && strlen($value) > 1)) {
-            try {
-                $parsed = Carbon::parse($value, auth()->user()->timezone);
-                if ($parsed->isMidnight()) {
-                    $value = $parsed->toDateString();
-                } else {
-                    $parsed->setTimezone(config('app.timezone'));
-                    $value = $parsed->toDateTimeString();
+        if ((is_string($value) && strlen($value) > 1)) {
+            switch ($value) {
+                case $value instanceof IntervalExpression: 
+                    $value = $this->parseDate($value);
+                    break;
+                default: 
+                    // Check to see if the value is a date/datetime formatted if not return original value
+                    $isDateFormatted = Carbon::hasFormatWithModifiers($value, 'Y#m#d');
+                    $isDateTimeFormatted = Carbon::hasFormatWithModifiers($value, 'Y#m#d h:i:s');
+                    if ($isDateFormatted || $isDateTimeFormatted) {
+                        $value = $this->parseDate($value);
+                    }
+                    break;
                 }
-            } catch (Throwable $e) {
-                //Ignore parsing errors and just return the original
             }
-        }
-
         return $value;
+    }
+
+    private function parseDate($value) {
+        $parsed = Carbon::parse($value, auth()->user()->timezone);
+        $parsed->setTimezone(config('app.timezone'));
+        if ($parsed->isMidnight()) {
+            return $parsed->toDateString();
+        } else {
+            $parsed->setTimezone(config('app.timezone'));
+            return $parsed->toDateTimeString();
+        }   
     }
 }

--- a/tests/Feature/ExtendedPMQLTest.php
+++ b/tests/Feature/ExtendedPMQLTest.php
@@ -9,6 +9,7 @@ use Tests\TestCase;
 use ProcessMaker\Models\ProcessRequest;
 use Tests\Feature\Shared\RequestHelper;
 use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
 
 class ExtendedPMQLTest extends TestCase
 {
@@ -136,5 +137,19 @@ class ExtendedPMQLTest extends TestCase
         $result = $this->apiCall('GET', $url);
         $this->assertCount(1, $result->json()['data']); // Match only F
         $this->assertEquals($processRequest1->id, $result->json()['data'][0]['id'] );
+    }
+
+    public function testFilterUsernameWithNumbers() {
+        $user = factory(User::class)->create([
+            'username' => 'W0584'
+        ]);
+        $processRequest = factory(ProcessRequest::class)->create([
+            'user_id' => $user->id
+        ]);
+
+        $url = route('api.requests.index', ['pmql' => 'requester = "W0584"']);
+        $result = $this->apiCall('GET', $url);
+        $requesterId = $result->json()['data'][0]['user_id'];
+        $this->assertEquals($requesterId, $user->id);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket: [FOUR-4910](https://processmaker.atlassian.net/browse/FOUR-4910)

When doing a PMQL query we are passing the value in a try-catch block to see if the value is a parsable date if not then we return the original string. Values with numbers such as `W0584` are being detected as a parsable date, which is causing this error. 

## Solution

- Standardize a date format in the PMQL query based on the [PMQL Date Comparison documentation ](https://github.com/ProcessMaker/pmql/blob/master/README.md#date-comparison) and check if the value is in this date format before parsing. 

## Note

This does change how users would query for dates. Users now need to properly format the date in the query `yyyy-mm-dd` example query `Started > "1990-01-01"`

## How to Test

1. Create a user that includes numbers in the username (i.e W0584 or 0584123), the rest of the fields does not matter
2. Go to requests, try to filter by the User field, and select the recently created user

**Expected Behavior**
No errors are returned and if data is available that data is listed.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
