### PR TITLE
Fix SSO users not redirecting to intended URL after login

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -54,7 +54,11 @@ class LoginController extends Controller
         $manager = App::make(LoginManager::class);
         $addons = $manager->list();
         $block = $manager->getBlock();
-        return view('auth.login', compact('addons', 'block'));
+        // cookie required here because SSO redirect resets the session
+        $cookie = cookie("processmaker_intended", redirect()->intended()->getTargetUrl(), 10, '/');
+        $response = response(view('auth.login', compact('addons', 'block')));
+        $response->withCookie($cookie);
+        return $response;
     }
 
     public function loginWithIntendedCheck(Request $request) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket [FOUR-4912](https://processmaker.atlassian.net/browse/FOUR-4912)

A user logging into ProcessMaker via SSO is not redirected to their original intended URL `/tasks/{task_id}/edit`  They are instead redirected to the `/requests` page.  

## Solution
- When being redirected to the login page create a `processmaker_intended` cookie for the intended URL. This cookie is then read by the Auth package when being redirected via the `acs` callback 

## How to Test
1. Ensure you have the Auth & Dynamic UI packages installed
2. Create a process and assign an SSO user to a task.
3. Run the process and COPY the task URL assigned to the SSO user
4. In incognito mode paste the task URL in the browser
5. When redirected to the login page, Login via SSO as the assigned user

**Expected Behavior**
You are redirected to the `task/{task_id}/edit` page NOT the `/requests` page



## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
