### PR TITLE
Allow reassigning of a self service task before the task is claimed. 

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -263,7 +263,7 @@ class TaskController extends Controller
      *         @OA\JsonContent(ref="#/components/schemas/processRequestToken")
      *     ),
      *     @OA\Response(response=404, ref="#/components/responses/404"),
-     *     @OA\Response(responsTaskControllere=422, ref="#/components/responses/422"),
+     *     @OA\Response(response=422, ref="#/components/responses/422"),
      * )
      */
     public function update(Request $request, ProcessRequestToken $task)

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -263,7 +263,7 @@ class TaskController extends Controller
      *         @OA\JsonContent(ref="#/components/schemas/processRequestToken")
      *     ),
      *     @OA\Response(response=404, ref="#/components/responses/404"),
-     *     @OA\Response(response=422, ref="#/components/responses/422"),
+     *     @OA\Response(responsTaskControllere=422, ref="#/components/responses/422"),
      * )
      */
     public function update(Request $request, ProcessRequestToken $task)
@@ -293,6 +293,7 @@ class TaskController extends Controller
                 $task->authorizeReassignment(Auth::user());
                 // Reassign user
                 $task->user_id = $userToAssign;
+                $task->is_self_service = 0;
                 $task->persistUserData($userToAssign);
             }
             $task->save();


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket: [FOUR-4914](https://processmaker.atlassian.net/browse/FOUR-4914)

A user assigned to a self-service task via reassignment can not claim/complete the task.

Reproduce:
1. Have a task with the Self Service assignment configured to a Group with multiple users.
2. Enable Allow Reassignment on the task
3. As an admin run the process and reassign the task to a user in the Group.
4. log in as the user assigned and open the task.
5. Try to claim the task

**Behavior**
Although the user is already assigned they have to select the claim task button however this button is not working and does not clear the page.

## Solution
- If a user is already assigned to a self-service task before they claim it, set the task boolean `is_self_service` to false allowing the `Claim Task` button to be cleared from the page. 

## How to Test

1. Have a task with the Self Service assignment configured to a Group with multiple users.
2. Enable Allow Reassignment on the task
3. As an admin run the process and reassign the task to a user in the Group.
4. log in as the user assigned and open the task.

**Expected Behavior**

The 'Claim Task' button does not appear and the user can complete the task with no errors.

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
