### PR TITLE
Bugfix/FOUR-4837: Start Request modal counts are incorrect

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -578,6 +578,21 @@ class ProcessController extends Controller
                 return !$eventIsTimerStart && !$eventIsWebEntry;
             })->values();
 
+            // Filter all processes that have event definitions (start events like message event, conditional event, signal event, timer event)
+            if ($request->input('without_event_definitions') && $request->input('without_event_definitions') == 'true') {
+                $startEventDefinitions = $process->events->filter(function ($event) {
+                    $eventDefinitions = collect($event['eventDefinitions'])
+                        ->filter(function ($eventDefinition) {
+                            return $eventDefinition;
+                        })->count() > 0;
+                    return $eventDefinitions;
+                })->values();
+
+                if (count($startEventDefinitions)) {
+                    $processes->forget($key);
+                }
+            }
+
             if (count($process->startEvents) === 0) {
                 $processes->forget($key);
             }

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -512,7 +512,12 @@ class ProcessController extends Controller
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
      *     @OA\Parameter(ref="#/components/parameters/per_page"),
      *     @OA\Parameter(ref="#/components/parameters/include"),
-     *     @OA\Parameter(ref="#/components/parameters/without_event_definitions"),
+     *     @OA\Parameter(
+     *         description="If true return only processes that haven't start event definitions",
+     *         in="path",
+     *         name="without_event_definitions",
+     *         required=false
+     *     ),
      *
      *     @OA\Response(
      *         response=200,

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -512,6 +512,7 @@ class ProcessController extends Controller
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
      *     @OA\Parameter(ref="#/components/parameters/per_page"),
      *     @OA\Parameter(ref="#/components/parameters/include"),
+     *     @OA\Parameter(ref="#/components/parameters/without_event_definitions"),
      *
      *     @OA\Response(
      *         response=200,

--- a/database/processes/templates/StartConditionalEvent.bpmn
+++ b/database/processes/templates/StartConditionalEvent.bpmn
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:endEvent id="node_2" name="End Event">
+      <bpmn:incoming>node_13</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="node_4" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_11</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_4" targetRef="node_2" />
+    <bpmn:task id="node_3" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_7</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:intermediateCatchEvent id="node_15" name="Intermediate Signal Catch Event">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_11</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_15" targetRef="node_4" />
+    <bpmn:sequenceFlow id="node_9" name="" sourceRef="node_3" targetRef="node_15" />
+    <bpmn:startEvent id="node_17" name="Conditional Start Event">
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+      <bpmn:conditionalEventDefinition>
+        <bpmn:condition xsi:type="bpmn:tFormalExpression"></bpmn:condition>
+      </bpmn:conditionalEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_7" name="" sourceRef="node_17" targetRef="node_3" />
+  </bpmn:process>
+  <bpmn:signal id="collection_1_create" name="test create" pm:detail="" />
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="810" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="620" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="678" y="188" />
+        <di:waypoint x="828" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="280" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_15_di" bpmnElement="node_15">
+        <dc:Bounds x="490" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+        <di:waypoint x="508" y="188" />
+        <di:waypoint x="678" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="338" y="188" />
+        <di:waypoint x="508" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_17_di" bpmnElement="node_17">
+        <dc:Bounds x="170" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="188" y="188" />
+        <di:waypoint x="338" y="188" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/database/processes/templates/StartMessageEvent.bpmn
+++ b/database/processes/templates/StartMessageEvent.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:endEvent id="node_2" name="End Event">
+      <bpmn:incoming>node_13</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="node_4" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_11</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_4" targetRef="node_2" />
+    <bpmn:task id="node_3" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_7</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:intermediateCatchEvent id="node_15" name="Intermediate Signal Catch Event">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_11</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_15" targetRef="node_4" />
+    <bpmn:sequenceFlow id="node_9" name="" sourceRef="node_3" targetRef="node_15" />
+    <bpmn:startEvent id="node_19" name="Message Start Event">
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+      <bpmn:messageEventDefinition />
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_7" name="" sourceRef="node_19" targetRef="node_3" />
+  </bpmn:process>
+  <bpmn:signal id="collection_1_create" name="test create" pm:detail="" />
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="810" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="620" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="678" y="188" />
+        <di:waypoint x="828" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="280" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_15_di" bpmnElement="node_15">
+        <dc:Bounds x="490" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+        <di:waypoint x="508" y="188" />
+        <di:waypoint x="678" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="338" y="188" />
+        <di:waypoint x="508" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_19_di" bpmnElement="node_19">
+        <dc:Bounds x="170" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="188" y="188" />
+        <di:waypoint x="338" y="188" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/database/processes/templates/StartSignalEvent.bpmn
+++ b/database/processes/templates/StartSignalEvent.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:endEvent id="node_2" name="End Event">
+      <bpmn:incoming>node_13</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="node_4" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_11</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_4" targetRef="node_2" />
+    <bpmn:task id="node_3" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_7</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:intermediateCatchEvent id="node_15" name="Intermediate Signal Catch Event">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_11</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_15" targetRef="node_4" />
+    <bpmn:sequenceFlow id="node_9" name="" sourceRef="node_3" targetRef="node_15" />
+    <bpmn:startEvent id="node_18" name="Signal Start Event">
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_7" name="" sourceRef="node_18" targetRef="node_3" />
+  </bpmn:process>
+  <bpmn:signal id="collection_1_create" name="test create" pm:detail="" />
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="810" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="620" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="678" y="188" />
+        <di:waypoint x="828" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="280" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_15_di" bpmnElement="node_15">
+        <dc:Bounds x="490" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+        <di:waypoint x="508" y="188" />
+        <di:waypoint x="678" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="338" y="188" />
+        <di:waypoint x="508" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_18_di" bpmnElement="node_18">
+        <dc:Bounds x="170" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="188" y="188" />
+        <di:waypoint x="338" y="188" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/database/processes/templates/StartSingleEvent.bpmn
+++ b/database/processes/templates/StartSingleEvent.bpmn
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:endEvent id="node_2" name="End Event">
+      <bpmn:incoming>node_13</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="node_4" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_11</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_4" targetRef="node_2" />
+    <bpmn:task id="node_3" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_7</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:startEvent id="node_12" name="Start Event" pm:allowInterstitial="false" pm:config="{&#34;web_entry&#34;:null}">
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_7" name="" sourceRef="node_12" targetRef="node_3" />
+    <bpmn:intermediateCatchEvent id="node_15" name="Intermediate Signal Catch Event">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_11</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_15" targetRef="node_4" />
+    <bpmn:sequenceFlow id="node_9" name="" sourceRef="node_3" targetRef="node_15" />
+  </bpmn:process>
+  <bpmn:signal id="collection_1_create" name="test create" pm:detail="" />
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="810" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="620" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="678" y="188" />
+        <di:waypoint x="828" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="280" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_12_di" bpmnElement="node_12">
+        <dc:Bounds x="170" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="188" y="188" />
+        <di:waypoint x="338" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_15_di" bpmnElement="node_15">
+        <dc:Bounds x="490" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+        <di:waypoint x="508" y="188" />
+        <di:waypoint x="678" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="338" y="188" />
+        <di:waypoint x="508" y="188" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/database/processes/templates/StartTimerEvent.bpmn
+++ b/database/processes/templates/StartTimerEvent.bpmn
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:endEvent id="node_2" name="End Event">
+      <bpmn:incoming>node_13</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="node_4" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_11</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_4" targetRef="node_2" />
+    <bpmn:task id="node_3" name="Form Task" pm:screenRef="8" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_7</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:intermediateCatchEvent id="node_15" name="Intermediate Signal Catch Event">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_11</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_15" targetRef="node_4" />
+    <bpmn:sequenceFlow id="node_9" name="" sourceRef="node_3" targetRef="node_15" />
+    <bpmn:startEvent id="node_16" name="Start Timer Event">
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle>2021-12-16T18:32:00.000Z|R/2021-12-16T18:32:00.000Z/P1W</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_7" name="" sourceRef="node_16" targetRef="node_3" />
+  </bpmn:process>
+  <bpmn:signal id="collection_1_create" name="test create" pm:detail="" />
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="810" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="620" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="678" y="188" />
+        <di:waypoint x="828" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="280" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_15_di" bpmnElement="node_15">
+        <dc:Bounds x="490" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+        <di:waypoint x="508" y="188" />
+        <di:waypoint x="678" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="338" y="188" />
+        <di:waypoint x="508" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_16_di" bpmnElement="node_16">
+        <dc:Bounds x="170" y="170" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="188" y="188" />
+        <di:waypoint x="338" y="188" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/resources/js/components/requests/modal.vue
+++ b/resources/js/components/requests/modal.vue
@@ -140,7 +140,8 @@
             this.filter +
             "&order_by=category.name,name" +
             "&order_direction=asc,asc" +
-            "&include=events,categories"
+            "&include=events,categories" +
+            "&without_event_definitions=true"
           )
           .then(response => {
             let data = response.data;


### PR DESCRIPTION
## Issue & Reproduction Steps
The badge counts and process number in the pagination are incorrect in the New Request modal, because from backend comes all the process that have start events of type Message, Signal, Conditional, and are filtering in the frontend in the moment to list them but is not calculating the correct number of processes for each category (because are counting all the processes, the visibles and hidden)
- Create a process with a simple start event and assign it for example to "myCategory"
- Create a process with a conditional start event and assign it to the same category
- Create a process with a message start event and assign it to the same category
- Create a process with a signal start event and assign it to the same category
- Create a process with a timer start event and assign it to the same category
- Click on new request button and take a look into the number badge for the created category. You will see the process with the simple start event, but the count will display a higher number, when should be 1 because only one process are listed. If you have your database empty, at the pagination you will see an erroneous total.

## Solution
- Added a new parameter without_events_definitions and condition to retrieve only the processes that can be initiated by the user and not the automatic start event like signal, timer, conditional ...

## How to Test
- Create a process with a simple start event and assign it for example to "myCategory"
- Create a process with a conditional start event and assign it to the same category
- Create a process with a message start event and assign it to the same category
- Create a process with a signal start event and assign it to the same category
- Create a process with a timer start event and assign it to the same category
- Click on new request button and take a look into the number badge for the created category. You will see the process with the simple start event, and the correct count number in the badge. If you have your database empty, at the pagination you will see the correct total.

Run tests in tests/Feature/Api/ProcessTest.php

## Related Tickets & Packages
- [FOUR-4837](https://processmaker.atlassian.net/browse/FOUR-4837)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
