### PR TITLE
FOUR-4917: Wokflow is followed according to the nodes (or sequence of design) and not as expected for users

### DIFF
--- a/ProcessMaker/Listeners/CommentsSubscriber.php
+++ b/ProcessMaker/Listeners/CommentsSubscriber.php
@@ -36,41 +36,52 @@ class CommentsSubscriber
     }
 
     /**
-     * When the an activity is activated
-     *
-     * @param $event
+     * @param $gateway
+     * @param $tokens
+     * @param $transition
      */
-    public function onActivityActivated(ActivityActivatedEvent $event)
-    {
-        $token     = $event->token;
-        $user_id   = $token->user ? $token->user_id : null;
-        $user_name = $token->user ? $token->user->fullname : __('The System');
+    public function onGatewayPassed($gateway, $transition = null, $tokens = null) {
+        if ($transition === null || $tokens === null) {
+            return;
+        }
+        $flows = collect($gateway->getProperties()['outgoing']->toArray());
 
-        $incomingArray = $event->activity->getProperties()["incoming"];
-        $incomingFlow = $incomingArray->item(0);
+        // Find the flows that corresponds to the transition condition
+        // If the flow does not have a condition Expressions, it is an inclusive
+        // gateway transition so that it is used.
+        $usedFlows = $flows->filter(function ($flow) use ($transition) {
+            return $transition->outgoing()->item(0)->target()->getOwner()->getProperty('id')
+                === $flow->getProperties()['target']->getProperty('id');
+        });
 
-        $flowSource = $incomingFlow->getProperties()["source"];
-        if ($flowSource instanceof GatewayInterface) {
-            $properties = $incomingFlow->getProperties();
-            $sourceProps = $flowSource->getProperties();
+        if (count($usedFlows) === 0) {
+            return;
+        }
+
+        // wee need just one token to get the user data
+        $token = $tokens->item(0);
+
+        foreach($usedFlows as $flow) {
+            $user_id   = $token->user ? $token->user_id : null;
+            $flowProps = $flow->getProperties();
+            $sourceProps = $gateway->getProperties();
             $sourceLabel = array_key_exists('name', $sourceProps) && $sourceProps['name']
-                        ? $sourceProps['name']
-                        : __('Gateway');
+                ? $sourceProps['name']
+                : __('Gateway');
 
-            $flowLabel = array_key_exists('name', $properties) && $properties['name']
-                        ? $properties['name']
-                        : __('Label Undefined');
+            $flowLabel = array_key_exists('name', $flowProps) && $flowProps['name']
+                ? $flowProps['name']
+                : __('Label Undefined');
             Comment::create([
                 'type' => 'LOG',
                 'user_id' => $user_id,
                 'commentable_type' => ProcessRequest::class,
-                'commentable_id' => $token->process_request_id,
+                'commentable_id' => $token->getInstance()->id,
                 'subject' => 'Gateway',
                 'body' => $sourceLabel . ': ' . $flowLabel
             ]);
         }
     }
-
 
     /**
      * Subscription.
@@ -80,6 +91,6 @@ class CommentsSubscriber
     public function subscribe($events)
     {
         $events->listen(ActivityInterface::EVENT_ACTIVITY_COMPLETED, static::class . '@onActivityCompleted');
-        $events->listen(ActivityInterface::EVENT_ACTIVITY_ACTIVATED, static::class . '@onActivityActivated');
+        $events->listen(GatewayInterface::EVENT_GATEWAY_TOKEN_PASSED, static::class . '@onGatewayPassed');
     }
 }

--- a/resources/js/components/Timeline.vue
+++ b/resources/js/components/Timeline.vue
@@ -90,6 +90,7 @@ export default {
             commentable_id: this.commentable_id,
             commentable_type: this.commentable_type,
             includes: 'children',
+            order_by: 'id',
           }
         })
         .then(response => {


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-4917](https://processmaker.atlassian.net/browse/FOUR-4917)

## Solution
- Listen to gateway transitions instead of activity activate
- Order comments by id instead of created_at 

## How to Test
- Use the next Nayra branch: **bugfix/FOUR-4923** 
- Upload the following process:
[FOUR4923.zip](https://github.com/ProcessMaker/processmaker/files/7757373/FOUR4923.zip)
- Start a request and in the first screen,  select false for the field "End Loop?"
![image](https://user-images.githubusercontent.com/14875032/146982825-3623dcce-fd3e-428a-9998-9650132ef37a.png)
- Advance the request until the 2 gateways are traversed
![image](https://user-images.githubusercontent.com/14875032/146982912-4afef6f8-cd26-4e8a-b1e3-1c15e4577b05.png)

- Go to the request (url requests/{request_id}) and look at the request's history. Flows transitions from the gateways should look like this:
![image](https://user-images.githubusercontent.com/14875032/146983027-05bac603-aabf-4c21-995c-b63f87c9922e.png)
Before the fix, no gateway transitions were registered:
![image](https://user-images.githubusercontent.com/14875032/146983106-5a316bb0-6f6b-47f0-8c0b-382312f4a54f.png)



## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-4923](https://processmaker.atlassian.net/browse/FOUR-4923)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
