### PR TITLE
Bugfix FOUR 4920 - Error in the BMPN when edit a task of the type action by email

### DIFF
--- a/public/definitions/Semantic.xsd
+++ b/public/definitions/Semantic.xsd
@@ -1468,7 +1468,9 @@
 	<xsd:element name="task" type="tTask" substitutionGroup="flowElement"/>
 	<xsd:complexType name="tTask">
 		<xsd:complexContent>
-			<xsd:extension base="tActivity"/>
+			<xsd:extension base="tActivity">
+				<xsd:attribute name="calledElement" type="xsd:QName" use="optional"/>
+      </xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Log in 
2. Import a process with action by email from a previous version
3. open the process
4. click on the Action By Email task
5. edit the data, for example edit the options
6. save the process
7. click on the AbE task

## Solution
- The schema for Tasks was updated and now the warning "calledElement attribute is not allowed" is gone.

## How to Test
1. Import the attached process
2. Click on Action by Email Task
3. Edit data, for example edit the options
4. Save the process
5. Toggle "Auto Validate" Switch.

The BPMN should be VALID.

## Related Tickets & Packages
- [FOUR 4920](https://processmaker.atlassian.net/browse/FOUR-4920)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
