### PR TITLE
Bugfix FOUR 4965 - The user reactivation window does not work

### DIFF
--- a/resources/js/admin/users/components/AddUserModal.vue
+++ b/resources/js/admin/users/components/AddUserModal.vue
@@ -87,7 +87,8 @@ export default {
                         deletedUserExists + ' ' + this.$t('Would you like to save and reactivate their account?')
                     ]);
                     let restoreData = {
-                        email: this.email
+                        email: this.email,
+                        username: this.username,
                     };
                     this.showMsgBox(messageVNode, restoreData);
                 }

--- a/resources/js/admin/users/components/DeletedUsersListing.vue
+++ b/resources/js/admin/users/components/DeletedUsersListing.vue
@@ -152,7 +152,8 @@ export default {
     },
     restoreUser(data, index) {
       const $body = {
-        "email" : data.email
+        "email": data.email,
+        "username": data.username,
       };
       ProcessMaker.confirmModal(
         this.$t('Caution!'),

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -501,8 +501,10 @@ class UsersTest extends TestCase
         $response->assertJsonMissing(['id' => $id]);
 
         // Restore the user by email
+        // The end-user may enter a wrong email, it is better to send the username as well.
         $response = $this->apiCall('PUT', self::API_TEST_URL .'/restore', [
-            'email' => $user->email
+            'email' => $user->email,
+            'username' => $user->username,
         ]);
         $response->assertStatus(200);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
It does not allow to reactivate the recently deleted user, a 500 error is displayed.

1. Go to Admin > users
2. Delete some user
3. Click on "+ user"
4. Try to create another user with the same "username" from which it was removed
5. Enter a WRONG email address
6. Click on "save"
7. In the window that shows the reactivation of the user, click on "yes"

## Solution
- The query param `username` was added. In this way, if the email does not exist, the user is found by his username.
- Searching for the user by his `username` is more convenient, since the email field is not unique.

## How to Test
Please follow the Reproduction Steps of above.

Clicking "yes" should reactivate the deleted user normally

## Related Tickets & Packages
- [FOUR-4965](https://processmaker.atlassian.net/browse/FOUR-4965)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
