### PR TITLE
Bugfix/FOUR-4971: Search box for Deleted Users is not working (For 4.1)

### DIFF
--- a/resources/js/admin/users/components/DeletedUsersListing.vue
+++ b/resources/js/admin/users/components/DeletedUsersListing.vue
@@ -125,6 +125,11 @@ export default {
       ]
     };
   },
+  watch: {
+    filter() {
+      this.page = 1;
+    }
+  },
   created() {
     ProcessMaker.EventBus.$on("api-data-deleted-users", (val) => {
       this.localLoadOnStart = val;

--- a/resources/js/admin/users/components/UsersListing.vue
+++ b/resources/js/admin/users/components/UsersListing.vue
@@ -135,6 +135,11 @@ export default {
       ]
     };
   },
+  watch: {
+    filter() {
+      this.page = 1;
+    }
+  },
   created() {
       ProcessMaker.EventBus.$on("api-data-users", (val) => {
         this.localLoadOnStart = val;


### PR DESCRIPTION
## Issue & Reproduction Steps
- Delete more than 10 users
- Deleted users tab. 
- Go to page 2 in navigation 
- Search for some user
- You will see empty list

## Solution
- Reset current page to 1 when filtering users

## How to Test
- Delete more than 10 users
- Deleted users tab. 
- Go to page 2 in navigation 
- Search for some user
- You will see the users filtered

**Working video**

https://user-images.githubusercontent.com/90727999/148094612-d404d6ad-f149-42dc-a1fb-567d90473e23.mov


## Related Tickets & Packages
- [FOUR-4971](https://processmaker.atlassian.net/browse/FOUR-4971)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
