### PR TITLE
[4.1] Add display error in form

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -424,6 +424,17 @@
             .catch(error => {
               // If there are errors, the user will be redirected to the request page
               // to view error details. This is done in loadTask in Task.vue
+              if (error.response && error.response.data && error.response.data.errors) {
+                let message = '';
+
+                let errors = Object.values(error.response.data.errors);
+                if (Array.isArray(errors)) {
+                  errors.forEach(error => {
+                    message += error.join('\n') + '\n';
+                  });
+                  window.ProcessMaker.alert(message, 'danger');
+                }
+              }
             }).finally(() => {
               this.submitting = false;
             })

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -424,16 +424,11 @@
             .catch(error => {
               // If there are errors, the user will be redirected to the request page
               // to view error details. This is done in loadTask in Task.vue
-              if (error.response && error.response.data && error.response.data.errors) {
-                let message = '';
-
-                let errors = Object.values(error.response.data.errors);
-                if (Array.isArray(errors)) {
-                  errors.forEach(error => {
-                    message += error.join('\n') + '\n';
-                  });
-                  window.ProcessMaker.alert(message, 'danger');
-                }
+              if (error.response?.status && error.response?.status === 422) {
+                // Validation error
+                Object.entries(error.response.data.errors).forEach(([key, value]) => {
+                  window.ProcessMaker.alert(`${key}: ${value[0]}`, 'danger', 0);
+                });
               }
             }).finally(() => {
               this.submitting = false;


### PR DESCRIPTION
## Issue & Reproduction Steps

- create a screen with a field with text type validation.
- create a vocabulary with an integer validation field.
- add everything to a process.
- run the process, no error messages are displayed.

Expected behavior: display errors of form

Actual behavior: 

## Solution
- add messages in form
- add message error type field

## How to Test

https://user-images.githubusercontent.com/1747025/148108471-6fdb1080-d5a7-4b1e-bb1e-0f8da22f41fc.mp4


## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
