### PR TITLE
Bugfix FOUR-5061 (4.1) - Console errors in Saved-Search listing when created_by is null

### DIFF
--- a/resources/js/components/AvatarImage.vue
+++ b/resources/js/components/AvatarImage.vue
@@ -93,6 +93,10 @@ export default {
         "px; padding:0; cursor: pointer;";
     },
     formatValue(value) {
+      if (value === null) {
+        value = {};
+      }
+      
       return {
         id: value.id ? "/profile/" + value.id : null,
         src: value.src ? value.src : value.avatar ? value.avatar : "",


### PR DESCRIPTION
## Issue & Reproduction Steps
Console errors are displayed when the user who created the saved search has been deleted.

1. Generate a saved search
2. Delete the user whom created that saved search
3. Go to `/requests/saved-searches` and you will see errors in console

## Solution
- The error is caught when there is no user in the `AvatarImage.vue` component.

## How to Test
1. Generate a saved search.
2. Delete the user whom created that saved search.
3. Go to `/requests/saved-searches` and you won't see errors in console.

## Related Tickets & Packages
- [FOUR-5061](https://processmaker.atlassian.net/browse/FOUR-5061)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
