### PR TITLE
Bugfix/Four-4970: PMQL not working when comparing less or more than values (For 4.1)

### DIFF
--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -108,13 +108,22 @@ trait ExtendedPMQL
             $value = $expression->value;
         }
 
+        // Check to see if the value is parsable as float
+        if (is_numeric($value) && strpos($value, ".")) {
+            $value = floatval($value);
+        }
+        // Check to see if the value is parsable as integer
+        if (is_numeric($value) && is_int($value)) {
+            $value = intval($value);
+        }
+
         // Check to see if the value is parsable as a date
         if ((is_string($value) && strlen($value) > 1)) {
             switch ($value) {
-                case $value instanceof IntervalExpression: 
+                case $value instanceof IntervalExpression:
                     $value = $this->parseDate($value);
                     break;
-                default: 
+                default:
                     // Check to see if the value is a date/datetime formatted if not return original value
                     $isDateFormatted = Carbon::hasFormatWithModifiers($value, 'Y#m#d');
                     $isDateTimeFormatted = Carbon::hasFormatWithModifiers($value, 'Y#m#d H:i:s');


### PR DESCRIPTION
## Issue & Reproduction Steps
PDO doesn't have a type float for binding params, so float numbers are treated as string (PDO::PARAM_STR). When using less than operator for example, the comparison is like a string so if we compare if 100 < 80 the result will be true.

When passing an integer, e.g. 80, parsing function was converting this integer to a float value (80.0) and using it with less than operator was causing the issue. So to fix that, when integer is passed to parser now, parser will return an integer (80) and the less than operator will work as it should work. But according with the PDO limitation, when passing a float number it will be treated as string.

Reproduction steps
- Import the process (see attached file)
- Start 4 requests and put the data 9, 30, 39, 35 for the input2 
- Search by custom PMQL `(request = "Regression 4.1.25 Requests") AND (data.input2 >= 5)`
- You will see only one record and should be 4 records for the search 9, 30, 35 and 39

[Regression 4.1.25 Requests.json.zip](https://github.com/ProcessMaker/processmaker/files/7838729/Regression.4.1.25.Requests.json.zip)

## Solution
Parese data if float or integer in extendedPMQL

## How to Test
- Import the process (see attached file)
- Start 4 requests and put the data 9, 30, 39, 35 for the input2 
- Search by custom PMQL `(request = "Regression 4.1.25 Requests") AND (data.input2 >= 5)`
- You should see 4 records for the search 9, 30, 35 and 39
- NOTE: you can test with different searches using the operators >, <, >=, <= and different values

Run test cases under tests/Feature/Pegf18Test.php

**Working video**

https://user-images.githubusercontent.com/90727999/147966602-1ba30c46-583f-4e26-bd3e-af6964bdc719.mov

## Related Tickets & Packages
- [FOUR-4970](https://processmaker.atlassian.net/browse/FOUR-4970)