### PR TITLE
[4.2] When importing a process, screens do not change number

### DIFF
--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -211,8 +211,16 @@ class ImportProcess implements ShouldQueue
                 $number = 2;
             }
 
-            //Return the name appended with the number
-            return $name . ' ' . $number;
+            //the name appended with the number
+            $name = $name . ' ' . $number;
+
+            //verify existence of the new name
+            if ($model->where($field, $name)->exists()) {
+                return $this->formatName($name, $field, $class);
+            } else {
+                //Return the new name
+                return $name;
+            }
         } else {
             //Return the original name (if there are no dupes)
             return $name;


### PR DESCRIPTION
## Issue & Reproduction Steps
After importing a process, the name of the screen does not change when having a screen with the same name.

## Solution
- verify exists new name generated.

## How to Test
- import the process several times and check the names of the generated screens

## Related Tickets & Packages
- [FOUR-5081](https://processmaker.atlassian.net/browse/FOUR-5081)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
