### PR TITLE
Bugfix FOUR-4843 - Conditional Start Event does not work with manual and subprocess

### DIFF
--- a/ProcessMaker/Bpmn/Process.php
+++ b/ProcessMaker/Bpmn/Process.php
@@ -42,7 +42,14 @@ class Process extends ModelsProcess
             $properties = Cache::store('global_variables')->get($key, []);
             $properties[$name] = $value;
             \Log::info(['global_variables', $key, $properties]);
-            Cache::store('global_variables')->forever($key, $properties);
+            try {
+                Cache::store('global_variables')->forever($key, $properties);
+            } catch (\Throwable $e) {
+                \Log::error($e->getMessage());
+                if (in_array('22001', $e->errorInfo)) {
+                    Cache::store('global_variables')->forget($key);
+                }
+            }
             return $this;
         } else {
             return parent::setProperty($name, $value);


### PR DESCRIPTION
## Issue & Reproduction Steps
In `release.testing.processmaker.net` server was using an "old" process "Regression 4.2.24 Start Event". This process generated a "MySQL 22001 Right truncation data exception" error when trying to update the `global_variables` table.

For this reason, no new Requests were generated from the Conditional Start Event.

1. Design a process conditional start event -> manual or subprocess -> end event. Or [import the attached](https://processmaker.atlassian.net/browse/FOUR-4843) processes. 
2. Set up process condition `date('d')%2==0)` or `date('d')%2==1)` .
3. Run on Tinker:

```php
for ($i=0; $i<1500; $i++) { \Artisan::call('bpmn:timer'); }
```

In that way you will get the MySQL error.

## Solution
- Remove the cache key at the moment the MySQL error is generated. So it can continue working after.

## How to Test
1. Replicate the MySQL error locally.
2. Run `php artisan bpmn:timer` 

The record in the DB will be removed and the expected behavior will be obtained: Request must be created with the conditional start event.

## Related Tickets & Packages
- [FOUR 4843](https://processmaker.atlassian.net/browse/FOUR-4843)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
