### PR TITLE
Bugfix FOUR-5089 - Allow start request with both signal start event and start event

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -588,16 +588,12 @@ class ProcessController extends Controller
             })->values();
 
             // Filter all processes that have event definitions (start events like message event, conditional event, signal event, timer event)
-            if ($request->input('without_event_definitions') && $request->input('without_event_definitions') == 'true') {
-                $startEventDefinitions = $process->events->filter(function ($event) {
-                    $eventDefinitions = collect($event['eventDefinitions'])
-                        ->filter(function ($eventDefinition) {
-                            return $eventDefinition;
-                        })->count() > 0;
-                    return $eventDefinitions;
-                })->values();
+            if ($request->has('without_event_definitions') && $request->input('without_event_definitions') == 'true') {
+                $startEvents = $process->events->filter(function ($event) {
+                    return collect($event['eventDefinitions'])->isEmpty();
+                });
 
-                if (count($startEventDefinitions)) {
+                if ($startEvents->isEmpty()) {
                     $processes->forget($key);
                 }
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
The process is not shown when clicking and searching in the pop up window after clicking request.

1. Import the process `Verify Event Based Gateway Conditional and Message Event (1).json`
2. Set up the configuration
3. Run a request

## Solution
- Allow to start a Request, if the process has at least one "Start Event".

## How to Test
- Please follow the reproduction steps of above
- You can also run `phpunit tests/Feature/Api/ProcessTest.php`

## Related Tickets & Packages
- [FOUR-5089](https://processmaker.atlassian.net/browse/FOUR-5089)
- [FOUR-5090](https://processmaker.atlassian.net/browse/FOUR-5090)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
