### PR TITLE
Bugfix/FOUR-4986: The fileUpload control inside a loop in the record list, is duplicating itself with the second item of the loop.

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -94,18 +94,23 @@ class ProcessRequestFileController extends Controller
 		//Retrieve input variable 'name'
 		$name = $laravel_request->get('name');
 
-		//If no name, retern entire collection; otherwise, filter collection
-		if (! $name) {
-			return new ResourceCollection($media);
-		} else {
+        $id = $laravel_request->get('id');
+
+        if ($id && $id != null) {
+            $filtered = $media->find($id);
+            return new ApiResource($filtered);
+        }
+
+		if ($name) {
 			$filtered = $media->reject(function ($item, $key) use ($name) {
 				if ($item->custom_properties['data_name'] != $name) {
 					return true;
 				}
 			});
-
 	        return new ResourceCollection($filtered);
 		}
+
+        return new ResourceCollection($media);
      }
 
     /**

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -72,16 +72,16 @@ class TaskController extends Controller
         $files = [];
         foreach ($task->processRequest->getMedia() as $file) {
             $dataName = $file->getCustomProperty('data_name');
-            if (isset($files[$dataName])) {
-                if (isset($files[$dataName]['id'])) {
-                    $files[$dataName] = [$files[$dataName]];
+            if (isset($files[$file->id])) {
+                if (isset($files[$file->id]['id'])) {
+                    $files[$file->id] = [$files[$file->id]];
                 }
-                $files[$dataName][] = [
+                $files[$file->id][] = [
                     'id' => $file->id,
                     'file_name' => $file->file_name
                 ];
             } else {
-                $files[$dataName] = [
+                $files[$file->id] = [
                     'id' => $file->id,
                     'file_name' => $file->file_name,
                 ];


### PR DESCRIPTION
## Issue & Reproduction Steps
There were a lot of issue related with this:
- File uploads inside recordlist were not showing the correct name of files inside a loop when adding more than one file
- File download for a fileupload inside recordlist were not allowing to download files and displaying they names
- If you uploaded some files in a record list row and after that tried to add another row with more files, some files were deleted.

Reproduction Steps
- Import the following process 
[26955 (1).json.zip](https://github.com/ProcessMaker/screen-builder/files/7862708/26955.1.json.zip)
- Run a new request
- Add a new record in the record list control
- Add document on the loop control
- Add another loop and upload another document
- Repeat step 3 - 4 - 5
- Submit the task  or  click on edit  to  record list 
- The documents uploaded are not correct or are repeated or are simply be deleted.

## Solution
- Added unique file ID as index for requestFiles variable
- Fixed rowID that was sent as null for files inside a loop in recordlist (this fixes the files deleting)
- Retrieve files mapped with file id index, this fixes the download option.

## How to Test
Test the steps above (Watch working video)

**Working videos**

**File upload / download with single file upload**

https://user-images.githubusercontent.com/90727999/149953381-e6be4c73-0c45-4cf2-9cda-aaa6fac85b0e.mov

**File manager**

https://user-images.githubusercontent.com/90727999/149953413-2145e8e7-bd1c-48a7-8c2f-c965534b246a.mov

**File upload download web entry**

https://user-images.githubusercontent.com/90727999/149953404-85fe8e0c-6317-4423-92ea-f82071c1713c.mov

**File preview**

https://user-images.githubusercontent.com/90727999/149953409-6433a543-12d8-4cba-837e-7d1a2bbe4579.mov

**File upload in collections**

https://user-images.githubusercontent.com/90727999/149953369-771bf9ac-2102-45c3-831a-9aae1bd0cf02.mov


## Related Tickets & Packages
- [FOUR-4986](https://processmaker.atlassian.net/browse/FOUR-4986)
- [Processmaker core PR](https://github.com/ProcessMaker/processmaker/pull/4243)
- [Screenbuilder](https://github.com/ProcessMaker/screen-builder/pull/1157)
- [WebEntry PR](https://github.com/ProcessMaker/package-webentry/pull/134)
- [PackageFiles PR](https://github.com/ProcessMaker/package-files/pull/68)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
