### PR TITLE
Bugfix/FOUR-4986: The fileUpload control inside a loop in the record list, is duplicating itself with the second item of the loop (For 4.2)

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -402,7 +402,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
                 ->with('user')
                 ->whereNotIn('element_type', ['scriptTask']);
     }
-    
+
     /**
      * Filter processes with a string
      *
@@ -418,7 +418,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
                 $query->whereIn('id', [$filter]);
             } else {
                 $matches = ProcessRequest::search($filter)->take(10000)->get()->pluck('id');
-                $query->whereIn('id', $matches);            
+                $query->whereIn('id', $matches);
             }
         } else {
             $filter = '%' . mb_strtolower($filter) . '%';
@@ -432,7 +432,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
                     ->orWhere('updated_at', 'like', $filter);
             });
         }
-        
+
         return $query;
     }
 
@@ -873,7 +873,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
      */
     public function requestFiles(bool $includeToken = false)
     {
-        return (object) $this->getMedia()->mapToGroups(function($file) use ($includeToken) {
+        $grouped = (object) $this->getMedia()->mapToGroups(function($file) use ($includeToken) {
             $dataName = $file->getCustomProperty('data_name');
             $info = [
                 'id' => $file->id,
@@ -885,5 +885,10 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
             }
             return [ $dataName => $info ];
         })->toArray();
+        $groupedById = [];
+        foreach ($grouped as $value) {
+            $groupedById[$value[0]['id']] = $value;
+        }
+        return $groupedById;
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
There were a lot of issue related with this:
- File uploads inside recordlist were not showing the correct name of files inside a loop when adding more than one file
- File download for a fileupload inside recordlist were not allowing to download files and displaying they names
- If you uploaded some files in a record list row and after that tried to add another row with more files, some files were deleted.

Reproduction Steps
- Import the following process 
[26955 (1).json.zip](https://github.com/ProcessMaker/screen-builder/files/7862708/26955.1.json.zip)
- Run a new request
- Add a new record in the record list control
- Add document on the loop control
- Add another loop and upload another document
- Repeat step 3 - 4 - 5
- Submit the task  or  click on edit  to  record list 
- The documents uploaded are not correct or are repeated or are simply be deleted.

## Solution
- Added unique file ID as index for requestFiles variable
- Fixed rowID that was sent as null for files inside a loop in recordlist (this fixes the files deleting)
- Retrieve files mapped with file id index and grouped by first file ID of each group, this fixes the download option.

## How to Test
Test the steps above (Watch working video)

**Working video**

https://user-images.githubusercontent.com/90727999/149571039-103526d5-b5d3-4a67-baf3-2ae559180c7f.mov


## Related Tickets & Packages
- [FOUR-4986](https://processmaker.atlassian.net/browse/FOUR-4986)
- [Screenbuilder PR](https://github.com/ProcessMaker/screen-builder/pull/1158)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
