### PR TITLE
Bugfix FOUR 5119 - Enable pagination in Forms tab when a request is complete

### DIFF
--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -21,7 +21,7 @@
       </button>
     </div>
     <div v-for="page in printablePages" :key="page" class="card">
-      <div class="card-body h-100">
+      <div class="card-body h-100" style="pointer-events: none;">
         <component
           ref="print"
           :is="component"
@@ -188,6 +188,7 @@
           json.config.disabled = true;
           json.config.readonly = true;
           json.config.editable = false;
+          json.config._perPage = Number.MAX_SAFE_INTEGER;
         }
         if (json.items !== undefined) {
           this.disableForm(json.items);

--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -21,7 +21,7 @@
       </button>
     </div>
     <div v-for="page in printablePages" :key="page" class="card">
-      <div class="card-body h-100" style="pointer-events: none">
+      <div class="card-body h-100">
         <component
           ref="print"
           :is="component"


### PR DESCRIPTION
## Issue & Reproduction Steps
Can't see all the records within a record list when a request is completed.

1. Create a screen with only a record list control
2. Add one column named ID to the record list
3. Create a new page in order to add values to the record list
4. add a line input with ID as the variable
5. in the first page check the Editable option and choose the new page in the record form field
6. create a process with one task and add the screen to this task.
7. start a new request
8. add more than 5 rows to the records list.
9. submit the screen, it will be set as completed.
10. try to check the second page in the record list, is not possible.

## Solution
- The component had a CSS rule that prevented pagination from working properly.

## How to Test
Please follow the reproduction steps of above in order to test the solution. You should see the following result:

https://user-images.githubusercontent.com/90741874/150428840-9da72426-338b-4b25-b2c4-3db828d3e92c.mov

## Related Tickets & Packages
- [FOUR-5119](https://processmaker.atlassian.net/browse/FOUR-5119)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.