### PR TITLE
[4.2] Fix missing data evaluating Data connector

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -184,8 +184,8 @@ trait MakeHttpRequests
         $headers = $this->addHeaders($endpoint, $config, $requestData);
 
         // Prepare Body
-        $data = $this->prepareData($requestData, $outboundConfig, 'BODY');
-        $body = $this->getMustache()->render($endpoint['body'], $requestData);
+        $data = $this->prepareData($requestData, $outboundConfig, 'BODY', $requestData);
+        $body = $this->getMustache()->render($endpoint['body'], $data);
         $bodyType = null;
         if (isset($endpoint['body_type'])) {
             $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);


### PR DESCRIPTION
## Issue & Reproduction Steps
Data connector task does not save the information the outbound configuration.
1. Create a collection
2. Add end-point  with method post and configure body parameters
3. Create a process with Data-connectors
4. Configure parameter of body in data-connector in the task

Note: Do not use the same variable names, use different like:

| Parameter | Value |
| ------------- | ------------- |
| doctorName  | {{form_input_1}}  |
| doctorID  | {{form_input_2}}  |

and in the DataSource POST body, something like:

```
{
  "data": {
    "id": "{{doctorID}}",
    "name": "{{doctorName}}"
  }
}
```


## Solution
- Merge request data and params values.

## How to Test
Run a process with data source.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-4333 (for 4.2)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
