### PR TITLE
Feature/four-5129: upgrade command (4.2)

### DIFF
--- a/ProcessMaker/Console/Commands/CreateUpgradeMigration.php
+++ b/ProcessMaker/Console/Commands/CreateUpgradeMigration.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class CreateUpgradeMigration extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'upgrade:create {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create an upgrade migration';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->call('make:migration', [
+            'name' => $this->argument('name'),
+            '--path' => 'upgrades'
+        ]);
+    }
+}

--- a/ProcessMaker/Console/Commands/RunUpgradeMigrations.php
+++ b/ProcessMaker/Console/Commands/RunUpgradeMigrations.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class RunUpgradeMigrations extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'upgrade';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run the upgrade migrations';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->call('migrate', [
+            '--path' => 'upgrades'
+        ]);
+    }
+}

--- a/upgrades/2022_01_21_225111_upgrade_email_connector_settings_from41to42.php
+++ b/upgrades/2022_01_21_225111_upgrade_email_connector_settings_from41to42.php
@@ -1,0 +1,189 @@
+<?php
+
+use ProcessMaker\Models\Setting;
+use ProcessMaker\Packages\Connectors\Email\EmailConfig;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Database\Migrations\Migration;
+
+class UpgradeEmailConnectorSettingsFrom41to42 extends Migration
+{
+    /**
+     * @var array
+     */
+    protected $drivers;
+
+    /**
+     * @var array
+     */
+    protected $encryption;
+
+    /**
+     * @var string
+     */
+    protected $prefix;
+
+    /**
+     * @var array
+     */
+    protected $settings_groups;
+
+    /**
+     * @param  \ProcessMaker\Packages\Connectors\Email\EmailConfig  $config
+     */
+    public function __construct()
+    {
+        $config = new EmailConfig();
+
+        $this->drivers = $config::drivers;
+        $this->encryption = $config::encryption;
+        $this->prefix = $config::prefix;
+        $this->settings_groups = $config::settings_groups;
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function up()
+    {
+        // Clear out any cached environment variable
+        Artisan::call('optimize:clear', [
+            '--quiet' => true
+        ]);
+
+        // If the .env file doesn't exist, we have nothing to upgrade from
+        if (!$this->envFileExists()) {
+            throw new RuntimeException('Upgrade migration failed: .env file is missing');
+        }
+
+        $driver = env('MAIL_DRIVER');
+
+        // If we don't know which driver we're taking from the
+        // .env file, then we shouldn't continue since we won't
+        // know where to set all of the other settings, e.g.
+        // MAIL_HOST, MAIL_ENCRYPTION, etc.
+        if (!$driver) {
+            throw new RuntimeException('Upgrade migration failed: The MAIL_DRIVER environment variable was not found in the .env file. This is required to run the upgrade process.');
+        }
+
+        // Validate the driver and bail if it's not supported
+        if (!in_array($driver, $this->drivers, true)) {
+            throw new RuntimeException("Unsupported MAIL_DRIVER found in the .env file: \"$driver\"");
+        }
+
+        // First, let's find the primary mail driver setting
+        $mail_driver_key = $this->prefix.'MAIL_DRIVER';
+        $mail_driver_setting = Setting::byKey($mail_driver_key);
+
+        if (!$mail_driver_setting instanceof Setting) {
+            throw new RuntimeException("Setting with key \"$mail_driver_key\" was not found.");
+        }
+
+        // Now update the mail driver setting
+        $mail_driver_setting->config = (string) array_search($driver, $this->drivers, true);
+
+        // Update the setting and remove it from .env
+        if ($mail_driver_setting->save()) {
+            $this->removeEnvValue('MAIL_DRIVER');
+        }
+
+        // Loop through the variables for a given driver
+        // and if we find the value, create a setting with
+        // the variable name/value and then remove it
+        // from the .env file
+        foreach ($this->settings_groups[$driver] as $variable_name) {
+            // We've already set this so we can skip it
+            if ($variable_name === 'MAIL_DRIVER') {
+                continue;
+            }
+
+            $env_value = env($variable_name);
+
+            if (null === $env_value) {
+                continue;
+            }
+
+            if ($variable_name === 'MAIL_ENCRYPTION') {
+                if (!in_array($env_value, $this->encryption, true)) {
+                    continue;
+                }
+
+                $env_value = (string) array_search($env_value, array_values($this->encryption), true);
+            }
+
+            $setting_key = $this->prefix.$variable_name;
+            $setting = Setting::byKey($setting_key);
+
+            if (!$setting instanceof Setting) {
+                logger()->warning("Warning while running upgrade migration: Setting with key: $setting_key not found, skipping...", [
+                    'migration' => __FILE__
+                ]);
+
+                continue;
+            }
+
+            $setting->config = $env_value;
+
+            if ($setting->save()) {
+                $this->removeEnvValue($variable_name);
+
+                logger("Upgrade migration: Setting with key $setting_key successfully updated", [
+                    'migration' => __FILE__
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    protected function envFileExists()
+    {
+        return File::exists(base_path('.env'));
+    }
+
+    /**
+     * Remove any line(s) containing a set variable in .env
+     *
+     * @param  string  $variable_name
+     *
+     * @return void
+     */
+    protected function removeEnvValue(string $variable_name)
+    {
+        if (!$this->envFileExists()) {
+            return;
+        }
+
+        $file_contents = '';
+        $file_path = base_path('.env');
+        $file_handle = fopen($file_path, 'rb');
+
+        if (!is_resource($file_handle)) {
+            return;
+        }
+
+        while (($line = fgets($file_handle)) !== false) {
+            if (!Str::contains($line, $variable_name)) {
+                $file_contents .= $line;
+            }
+        }
+
+        fclose($file_handle);
+        file_put_contents($file_path, $file_contents);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/upgrades/2022_01_21_225111_upgrade_email_connector_settings_from41to42.php
+++ b/upgrades/2022_01_21_225111_upgrade_email_connector_settings_from41to42.php
@@ -50,6 +50,10 @@ class UpgradeEmailConnectorSettingsFrom41to42 extends Migration
      */
     public function up()
     {
+        if (!$this->connectorSendEmailInstalled()) {
+            throw new RuntimeException('The package connector-send-email must be installed to run this upgrade.');
+        }
+
         // Clear out any cached environment variable
         Artisan::call('optimize:clear', [
             '--quiet' => true
@@ -136,6 +140,11 @@ class UpgradeEmailConnectorSettingsFrom41to42 extends Migration
                 ]);
             }
         }
+    }
+
+    protected function connectorSendEmailInstalled()
+    {
+        return File::exists(base_path('vendor/processmaker/connector-send-email'));
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
As part of the 4.2 settings change we need an easy way to upgrade from the 4.1 .env settings to the new settings UI.  

Requirements:
- Should only allow for one run.
- Multiple runs should fail. 
- Bonus points if we can reuse this pattern for future updates that will require commands. Ideally something similar to the php artisan migrate command, but for whatever migration of code/database/etc needed

## Solution
- Two new commands have been added: upgrade:create and upgrade. These commands use the standard migration functionality of laravel but all of the upgrade migration files are stored in a directory called upgrades/ in the project root. 
- All of the upgrade logic should go in the up() method of the migration and the rollback logic (if needed/possible) should go in the down() method. 
- When ready, you can initiate any available upgrades by running `php artisan upgrade` which will look in the upgrades/ directory for upgrade migrations to run. Once run, laravel will make a record of it in the standard migrations table to prevent them from being run again. 
- Packages can publish their own upgrade migration files to the upgrades/ directory as well.

## Related Tickets & Packages
- [Ticket FOUR-5129](https://processmaker.atlassian.net/browse/FOUR-5129)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
