### PR TITLE
Ellucian/check logs changes

### DIFF
--- a/ProcessMaker/Bpmn/MustacheOptions.php
+++ b/ProcessMaker/Bpmn/MustacheOptions.php
@@ -36,18 +36,18 @@ class MustacheOptions
         return urlencode(Hash::make($helper->render($text)));
     }
     
-    public function json($text)
+    public function json($text, Mustache_LambdaHelper $helper)
     {
-        return json_encode($text);
+        return json_encode($helper->render($text));
     }
     
-    public function serialize($text)
+    public function serialize($text, Mustache_LambdaHelper $helper)
     {
-        return serialize($text);
+        return serialize($helper->render($text));
     }
     
-    public function xml($text)
+    public function xml($text, Mustache_LambdaHelper $helper)
     {
-        return xmlrpc_encode($text);
+        return xmlrpc_encode($helper->render($text));
     }
 }

--- a/ProcessMaker/Exception/HttpInvalidArgumentException.php
+++ b/ProcessMaker/Exception/HttpInvalidArgumentException.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ProcessMaker\Exception;
+
+use Exception;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+/**
+ * Thrown if an URL expression failed to be parsed
+ *
+ * @package ProcessMaker\Exceptions
+ */
+
+class HttpInvalidArgumentException extends Exception implements HttpExceptionInterface
+{
+    public $status;
+    public $body;
+    private $headers;
+
+    /**
+     * @param string $message
+     */
+    public function __construct($message)
+    {
+        $this->status = 500;
+        $this->body = $message;
+        $this->headers = [];
+        parent::__construct($message);
+    }
+
+    public function getStatusCode()
+    {
+        return $this->status;
+    }
+
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+}

--- a/ProcessMaker/Exception/HttpResponseException.php
+++ b/ProcessMaker/Exception/HttpResponseException.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Exception;
 use Exception;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 /**
  * Thrown if an expression failed to be parsed
@@ -12,10 +13,11 @@ use Illuminate\Support\Str;
  * @package ProcessMaker\Exceptions
  */
 
-class HttpResponseException extends Exception
+class HttpResponseException extends Exception implements HttpExceptionInterface
 {
     public $status;
     public $body;
+    private $headers;
 
     /**
      * @param Response $response
@@ -24,9 +26,18 @@ class HttpResponseException extends Exception
     {
         $this->status = $response->getStatusCode();
         $this->body = $response->getBody()->getContents();
+        $this->headers = $response->getHeaders();
         parent::__construct(__("Unexpected response (status=:status)\n:body", [
             'status' => $this->status,
             'body' => Str::limit($this->body, 100),
         ]), 0);
+    }
+
+    public function getStatusCode() {
+        return $this->status;
+    }
+
+    public function getHeaders() {
+        return $this->headers;
     }
 }

--- a/ProcessMaker/Helper/helper.php
+++ b/ProcessMaker/Helper/helper.php
@@ -76,3 +76,29 @@ function sanitizeVueExp($expression)
 {
     return SanitizeHelper::sanitizeVueExp($expression);
 }
+
+function packTemporalData($data)
+{
+    // Store data into store/app/private
+    $uid = uniqid('data_', true);
+    $path = storage_path('app/private/' . $uid);
+    file_put_contents($path, \json_encode($data));
+    return $uid;
+}
+
+function unpackTemporalData($uid)
+{
+    $path = storage_path('app/private/' . $uid);
+    if (file_exists($path)) {
+        return \json_decode(file_get_contents($path), true);
+    }
+    return [];
+}
+
+function removeTemporalData($uid)
+{
+    $path = storage_path('app/private/' . $uid);
+    if (file_exists($path)) {
+        unlink($path);
+    }
+}

--- a/ProcessMaker/Jobs/CatchSignalEventProcess.php
+++ b/ProcessMaker/Jobs/CatchSignalEventProcess.php
@@ -19,7 +19,7 @@ class CatchSignalEventProcess implements ShouldQueue
         InteractsWithQueue,
         Queueable;
 
-    public $payload;
+    public $payload_uid;
     public $processId;
     public $signalRef;
 
@@ -30,13 +30,14 @@ class CatchSignalEventProcess implements ShouldQueue
      */
     public function __construct($processId, $signalRef, $payload)
     {
-        $this->payload = $payload;
+        $this->payload_uid = packTemporalData($payload);
         $this->processId = $processId;
         $this->signalRef = $signalRef;
     }
 
     public function handle()
     {
+        $this->payload = unpackTemporalData($this->payload_uid);
         $repository = new DefinitionsRepository;
         $eventDefinition = $repository->createSignalEventDefinition();
         $signal = $repository->createSignal();
@@ -75,6 +76,7 @@ class CatchSignalEventProcess implements ShouldQueue
         }
 
         $engine->runToNextState();
+        removeTemporalData($this->payload_uid);
     }
 
     /**

--- a/ProcessMaker/Jobs/CatchSignalEventRequest.php
+++ b/ProcessMaker/Jobs/CatchSignalEventRequest.php
@@ -16,7 +16,7 @@ class CatchSignalEventRequest implements ShouldQueue
 
     public $chunck;
     public $signalRef;
-    public $payload;
+    public $payload_uid;
 
     /**
      * Create a new job instance.
@@ -26,15 +26,17 @@ class CatchSignalEventRequest implements ShouldQueue
     public function __construct($chunck, $signalRef, $payload)
     {
         $this->chunck = $chunck;
-        $this->payload = $payload;
+        $this->payload_uid = packTemporalData($payload);
         $this->signalRef = $signalRef;
     }
 
     public function handle()
     {
+        $this->payload = unpackTemporalData($this->payload_uid);
         foreach ($this->chunck as $requestId) {
             $request = ProcessRequest::find($requestId);
             CatchSignalEventInRequest::dispatchNow($request, $this->payload, $this->signalRef);
         }
+        removeTemporalData($this->payload_uid);
     }
 }

--- a/ProcessMaker/Jobs/ThrowSignalEvent.php
+++ b/ProcessMaker/Jobs/ThrowSignalEvent.php
@@ -18,7 +18,7 @@ class ThrowSignalEvent implements ShouldQueue
     private const maxJobs = 10;
 
     public $signalRef;
-    public $data;
+    public $data_uid;
     public $excludeProcesses;
     public $excludeRequests;
 
@@ -30,13 +30,14 @@ class ThrowSignalEvent implements ShouldQueue
     public function __construct($signalRef, array $data = [], array $excludeProcesses = [], array $excludeRequests = [])
     {
         $this->signalRef = $signalRef;
-        $this->data = $data;
+        $this->data_uid = packTemporalData($data);
         $this->excludeProcesses = $excludeProcesses;
         $this->excludeRequests = $excludeRequests;
     }
 
     public function handle()
     {
+        $this->data = unpackTemporalData($this->data_uid);
         $processes = Process::whereNotIn('id', $this->excludeProcesses)
             ->whereJsonContains('signal_events', $this->signalRef)
             ->where('status', 'ACTIVE')
@@ -71,5 +72,6 @@ class ThrowSignalEvent implements ShouldQueue
                 )->onQueue('bpmn');
             }
         }
+        removeTemporalData($this->data_uid);
     }
 }

--- a/ProcessMaker/Listeners/CommentsSubscriber.php
+++ b/ProcessMaker/Listeners/CommentsSubscriber.php
@@ -97,7 +97,7 @@ class CommentsSubscriber
                 'type' => 'LOG',
                 'user_id' => $user_id,
                 'commentable_type' => ProcessRequest::class,
-                'commentable_id' => $token->getInstance()->id,
+                'commentable_id' => $token->getInstance()->getId(),
                 'subject' => 'Gateway',
                 'body' => $sourceLabel . ': ' . $flowLabel
             ]);

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -9,8 +9,8 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Arr;
-use InvalidArgumentException;
 use Mustache_Engine;
+use ProcessMaker\Exception\HttpInvalidArgumentException;
 use ProcessMaker\Exception\HttpResponseException;
 use ProcessMaker\Models\FormalExpression;
 use Psr\Http\Message\ResponseInterface;
@@ -568,7 +568,7 @@ trait MakeHttpRequests
         );
         $parts = parse_url($enc_url);
         if ($parts === false) {
-            throw new InvalidArgumentException('Malformed URL: ' . $url);
+            throw new HttpInvalidArgumentException('Malformed URL: ' . $url);
         }
         foreach ($parts as $name => $value) {
             $parts[$name] = urldecode($value);

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -358,7 +358,6 @@ trait MakeHttpRequests
         }, $response->getHeaders());
 
         $merged = array_merge($data, $content, $headers);
-        $responseData = array_merge($content, $headers);
 
         foreach ($config['dataMapping'] as $map) {
             $processVar = $this->getMustache()->render($map['key'], $data);
@@ -367,7 +366,7 @@ trait MakeHttpRequests
 
             // if value is empty all the response is mapped
             if (trim($value) === '') {
-                $mapped[$processVar] = $responseData;
+                $mapped[$processVar] = $content;
                 continue;
             }
 

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -184,8 +184,8 @@ trait MakeHttpRequests
         $headers = $this->addHeaders($endpoint, $config, $requestData);
 
         // Prepare Body
-        $data = $this->prepareData($requestData, $outboundConfig, 'BODY');
-        $body = $this->getMustache()->render($endpoint['body'], $requestData);
+        $data = $this->prepareData($requestData, $outboundConfig, 'BODY', $requestData);
+        $body = $this->getMustache()->render($endpoint['body'], $data);
         $bodyType = null;
         if (isset($endpoint['body_type'])) {
             $bodyType = $this->getMustache()->render($endpoint['body_type'], $data);

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -346,8 +346,6 @@ trait MakeHttpRequests
         }
 
         $mapped = [];
-        $mapped['status'] = $status;
-        $mapped['response'] = $content;
 
         if (!isset($config['dataMapping'])) {
             return $mapped;


### PR DESCRIPTION
## Issue & Reproduction Steps
- In DataSources `response` is removed even if it is mapped
- Mustache helpers: json, serialize, xml  are not working
- Comments subscriber is throwing errors when getting the request ID
- Can not see malformed URL in data sources
- Data source is merging the body response with headers
- When process throws a Signal, the Job serializes all the data, it cause a Redis overflow when request data is huge

## Solution
- Fix remove `response` and `status` from default response (requires: https://github.com/ProcessMaker/package-data-sources/pull/216)
- Fix Mustache helpers: json, serialize, xml  are not working
- Fix Comments subscriber getting the request ID
- Add a visible Http Exception when URL is invalid
- The `response` contains the body content
- Pack the signal data when Job is dispatched

## How to Test
Run the Ellucian Synchronization Process.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5186

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
