### PR TITLE
Bugfix/FOUR-5159: Summary screen is not displayed in sub process 

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -327,8 +327,8 @@
           error(processRequestId) {
             this.redirect(`/requests/${this.task.process_request_id}`);
           },
-          redirectToTask(task) {
-            this.redirect(`/tasks/${task.id}/edit`);
+          redirectToTask(task, force = false) {
+            this.redirect(`/tasks/${task}/edit`, force);
           },
           closed(taskId) {
             // avoid redirection if using a customized renderer
@@ -392,8 +392,8 @@
                 });
             }
           },
-          redirect(to) {
-            if (this.redirectInProcess) {
+          redirect(to, forceRedirect = false) {
+            if (this.redirectInProcess && !forceRedirect) {
               return;
             }
             this.redirectInProcess = true;


### PR DESCRIPTION
## Issue & Reproduction Steps
It was reported as a bug that subprocess inside a main process are not showing the summary screen in the subprocess, but that is not the correct behavior. It was fixed the issue related with the interstitial screen getting stuck and not getting
the next task.

- Steps to Reproduce:
- Create a process with the next configuration
- Start Event -> Task -> Sub Process -> End Event
- Create a sub process 
- Add Start Event -> Task(Assign Screen Interstitial) -> End Event (Assign Summary Screen)
- Create a request 
- Route to the sub process
- Open the sub process
- Complete the task

## Solution
- Modified the flow to follow the next rules (For more clarify please watch the videos for the different scenarios):
1. Summary screen in a subprocess will show only if the process is running as standalone.
2. If a task has the option **Display Next Assigned Task to Task Assignee** checked, it will get the next task (if you are in a subprocess will get the next task in that subprocess, when the subprocess completed all the tasks will get the next task of the parent process)
3. If a task has the option **Display Next Assigned Task to Task Assignee** unchecked, will show the task list
4. If a subprocess is completed and no tasks in the main process, will show the summary screen of the main process

## How to Test
Run e2e test cases in Task.spec.js

Please watch the following videos:

**Case 1**

https://user-images.githubusercontent.com/90727999/150857176-14f48e97-92de-4393-95d7-c712c627d645.mov

**Case 2**

https://user-images.githubusercontent.com/90727999/150857230-4586ab06-467e-4261-a30e-8c779b8f6e70.mov

**Case 3**

https://user-images.githubusercontent.com/90727999/150857244-c2b17879-a9b1-4bce-9fc8-75ad2d6b3edd.mov

**Case 4**

https://user-images.githubusercontent.com/90727999/150857258-d6789f99-b91b-487e-a53a-95366d5b79b5.mov

**Case 5**

https://user-images.githubusercontent.com/90727999/150857214-bd285b96-1ef7-4a97-b211-1c465c8f21e7.mov


## Related Tickets & Packages
- [FOUR-5159](https://processmaker.atlassian.net/browse/FOUR-5159)



## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
