### PR TITLE
FOUR-5118: Issue - Save search - CreditAccess dev server (for 4.1.develop)

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -658,7 +658,10 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
         $user = User::where('username', $value)->get()->first();
 
         if ($user) {
-            $requests = ProcessRequest::where('user_id', $expression->operator, $user->id)->get();
+            $requests = ProcessRequest::select('id')
+                ->where('user_id', $expression->operator, $user->id)
+                ->distinct()
+                ->get();
             return function ($query) use ($requests) {
                 $query->whereIn('id', $requests->pluck('id'));
             };
@@ -679,7 +682,11 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
         $user = User::where('username', $value)->get()->first();
 
         if ($user) {
-            $tokens = ProcessRequestToken::where('user_id', $expression->operator, $user->id)->get();
+            $tokens = ProcessRequestToken::select('process_request_id')
+                ->where('user_id', $expression->operator, $user->id)
+                ->whereIn('element_type', ['task', 'userTask', 'startEvent'])
+                ->distinct()
+                ->get();
 
             return function ($query) use ($tokens) {
                 $query->whereIn('id', $tokens->pluck('process_request_id'));


### PR DESCRIPTION
## Issue & Reproduction Steps
When there are 1000+ requests and in every one of the the "data" json field contains a very large attribute, the endpoint requests returns a 500 error. This is noticeable when accessing the site remotely. In local dev. environments the problem is not as critical as in the remote access.  Saved search uses the controller of this endpoint (/requests)

## Solution
- To avoid that Laravel parses the larga data column of tokens and requests, the queries used to filter by request starter and participant were modified to get just ids.

## How to Test
Verify that the list requests (endpoint /requests) behavior has not changed. 

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-5118](https://processmaker.atlassian.net/browse/FOUR-5118)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
