### PR TITLE
Apply fix from PR 3897 to avoid double submit

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -245,6 +245,7 @@
           hasErrors: false,
           redirectInProcess: false,
           formData: {},
+          submitting: false,
         },
         watch: {
           task: {
@@ -396,8 +397,13 @@
             this.$set(this, 'task', val);
           },
           submit(task) {
+            if (this.submitting) {
+              return;
+            }
+
             let message = this.$t('Task Completed Successfully');
             const taskId = task.id;
+            this.submitting = true;
             ProcessMaker.apiClient
             .put("tasks/" + taskId, {status:"COMPLETED", data: this.formData})
             .then(() => {
@@ -406,7 +412,9 @@
             .catch(error => {
               // If there are errors, the user will be redirected to the request page
               // to view error details. This is done in loadTask in Task.vue
-            });
+            }).finally(() => {
+              this.submitting = false;
+            })
 
           },
           taskUpdated(task) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Issue similar  to https://processmaker.atlassian.net/browse/FOUR-3631 that was solved in 4.1.23 onward.
Requests are duplicated when double clicking on the submit button

## Solution
- Apply to branch 4.1.20 the solution implemented in PR https://github.com/ProcessMaker/processmaker/pull/3897

## How to Test

1.     log in
2.     create a screen that has a signature
3.     create a process   with two tasks
4.     assign the screen
5.     start a new request
6.     complete the form
7.     perform a long signature, so that the signature saving requests are displayed on the screen
8.     press submit multiple times

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
