### PR TITLE
JointJS version should be resolved by Modeler

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
         "i18next-xhr-backend": "^2.0.1",
         "imports-loader": "^0.8.0",
         "install": "^0.12.2",
-        "jointjs": "^3.1.1",
         "laravel-echo": "^1.9.0",
         "laravel-echo-server": "^1.6.1",
         "lodash": "^4.17.20",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -38,7 +38,6 @@ mix.extract([
   "popper.js",
   "lodash",
   "bootstrap",
-  "jointjs",
   "luxon",
   "bpmn-moddle",
   "@fortawesome/fontawesome-free",


### PR DESCRIPTION
## Issue & Reproduction Steps
JointJS version is different to the Modelers JoinJS version.

1. See the process below
2. Connect a DataObject or DataStore to a Task
3. An validation error is thrown

![image](https://user-images.githubusercontent.com/8028650/151839853-f768a78b-0562-4ac4-afa9-e39d6cc946c0.png)

**Expected behavior:** 
Throw validation errors.

**Actual behavior:** 
No validation errors should be catch when a DataObject/DataStore is connected to a Task.

## Solution
- Fix validation rules: ID is not required for input output specification nodes (Requires: https://github.com/ProcessMaker/bpmnlint-plugin/pull/20)
- JointJS version should be solved by Modeler

## How to Test
Create a process like this:
![image](https://user-images.githubusercontent.com/8028650/151840359-324de944-3bca-42c5-95d4-f9915a913f93.png)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5102
- https://github.com/ProcessMaker/bpmnlint-plugin/pull/20
- https://github.com/ProcessMaker/modeler/pull/1425

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
