### PR TITLE
Bugfix/blocked instance fix

### DIFF
--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -159,7 +159,7 @@ abstract class BpmnAction implements ShouldQueue
                 return $instance;
             }
             if ($instance->collaboration) {
-                $ids = $instance->collaboration->requests->pluck('id')->toArray();
+                $ids = $instance->collaboration->requests()->where('status', 'ACTIVE')->pluck('id')->toArray();
             } else {
                 $ids = [$instance->id];
             }

--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -246,4 +246,27 @@ abstract class BpmnAction implements ShouldQueue
             $this->lock->delete();
         }
     }
+
+    /**
+     * Get the tags that should be assigned to the job.
+     *
+     * @return array
+     */
+    public function tags()
+    {
+        $tags = ['bpmn'];
+        if (isset($this->definitionsId)) {
+            $tags[] = 'processId:' . $this->definitionsId;
+        }
+        if (isset($this->instanceId)) {
+            $tags[] = 'instanceId:' . $this->instanceId;
+        }
+        if (isset($this->tokenId)) {
+            $tags[] = 'tokenId:' . $this->tokenId;
+        }
+        if (isset($this->elementId)) {
+            $tags[] = 'elementId:' . $this->elementId;
+        }
+        return $tags;
+    }
 }

--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -98,7 +98,8 @@ abstract class BpmnAction implements ShouldQueue
 
         //Load the instances of the process and its collaborators
         if ($instance && $instance->collaboration) {
-            foreach ($instance->collaboration->requests as $request) {
+            $activeRequests = $instance->collaboration->requests()->where('status', 'ACTIVE')->get();
+            foreach ($activeRequests as $request) {
                 if ($request->getKey() !== $instance->getKey()) {
                     $engine->loadProcessRequest($request);
                 }

--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -184,7 +184,7 @@ abstract class BpmnAction implements ShouldQueue
                     return $instance;
                 }
                 // average of lock time is 1 second
-                usleep($interval * 1000);
+                $this->mSleep($interval);
             }
         } catch (Throwable $exception) {
             throw new Exception('Unable to lock instance #' . $this->instanceId . ': ' . $exception->getMessage());
@@ -268,5 +268,19 @@ abstract class BpmnAction implements ShouldQueue
             $tags[] = 'elementId:' . $this->elementId;
         }
         return $tags;
+    }
+
+    /**
+     * Sleep in milliseconds
+     *
+     * @param int $milliseconds
+     * 
+     */
+    private function mSleep($milliseconds)
+    {
+        $seconds = floor($milliseconds / 1000);
+        $microseconds = ($milliseconds % 1000) * 1000;
+        sleep($seconds);
+        usleep($microseconds);
     }
 }

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -32,6 +32,7 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
      */
     public function __construct(Definitions $definitions, ProcessRequest $instance, ProcessRequestToken $token, array $data)
     {
+        $this->onQueue('bpmn');
         $this->definitionsId = $definitions->getKey();
         $this->instanceId = $instance->getKey();
         $this->tokenId = $token->getKey();

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -76,7 +76,7 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
             $this->unlock();
             $dataManager = new DataManager();
             $data = $dataManager->getData($token);
-            $response = $script->runScript($data, $configuration);
+            $response = $script->runScript($data, $configuration, $token->getId());
 
             $this->withUpdatedContext(function ($engine, $instance, $element, $processModel, $token) use ($response) {
                 // Exit if the task was completed or closed

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -105,4 +105,26 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
             Log::error($exception->getTraceAsString());
         }
     }
+
+    /**
+     * When Job fails
+     */
+    public function failed(Throwable $exception)
+    {
+        if (!$this->tokenId) {
+            Log::error('Script failed: ' . $exception->getMessage());
+            return;
+        }
+        Log::error('Script (#' . $this->tokenId . ') failed: ' . $exception->getMessage());
+        $token = ProcessRequestToken::find($this->tokenId);
+        if ($token) {
+            $element = $token->getBpmnDefinition();
+            $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
+            $error = $element->getRepository()->createError();
+            $error->setName($exception->getMessage());
+            $token->setProperty('error', $error);
+            Log::error($exception->getTraceAsString());
+            $token->save();
+        }
+    }
 }

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -36,6 +36,7 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
         $this->definitionsId = $definitions->getKey();
         $this->instanceId = $instance->getKey();
         $this->tokenId = $token->getKey();
+        $this->elementId = $token->getProperty('element_ref');
         $this->data = $data;
     }
 

--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -68,8 +68,7 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
             $this->unlock();
             $dataManager = new DataManager();
             $data = $dataManager->getData($token);
-            $response = $script->runScript($data, $configuration);
-
+            $response = $script->runScript($data, $configuration, $token->getId());
             $this->withUpdatedContext(function ($engine, $instance, $element, $processModel, $token) use ($response) {
                 // Exit if the task was completed or closed
                 if (!$token || !$element) {

--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -96,4 +96,26 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
             Log::error($exception->getTraceAsString());
         }
     }
+
+    /**
+     * When Job fails
+     */
+    public function failed(Throwable $exception)
+    {
+        if (!$this->tokenId) {
+            Log::error('Script failed: ' . $exception->getMessage());
+            return;
+        }
+        Log::error('Script (#' . $this->tokenId . ') failed: ' . $exception->getMessage());
+        $token = ProcessRequestToken::find($this->tokenId);
+        if ($token) {
+            $element = $token->getBpmnDefinition();
+            $token->setStatus(ServiceTaskInterface::TOKEN_STATE_FAILING);
+            $error = $element->getRepository()->createError();
+            $error->setName($exception->getMessage());
+            $token->setProperty('error', $error);
+            Log::error($exception->getTraceAsString());
+            $token->save();
+        }
+    }
 }

--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -36,6 +36,7 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
         $this->definitionsId = $definitions->getKey();
         $this->instanceId = $instance->getKey();
         $this->tokenId = $token->getKey();
+        $this->elementId = $token->getProperty('element_ref');
         $this->data = $data;
     }
 

--- a/ProcessMaker/Managers/DataManager.php
+++ b/ProcessMaker/Managers/DataManager.php
@@ -135,7 +135,7 @@ class DataManager
         }
 
         // Magic Variable: _parent
-        if ($token->isMultiInstance()) {
+        if ($token->isMultiInstance() && !$token->getConfigParam('withoutMIParentVariables', false)) {
             if ($whenTokenSaved) {
                 $data['_parent'] = $token->data ?: [];
             } else {

--- a/ProcessMaker/Managers/WorkflowManager.php
+++ b/ProcessMaker/Managers/WorkflowManager.php
@@ -149,7 +149,7 @@ class WorkflowManager
      */
     public function runScripTask(ScriptTaskInterface $scriptTask, Token $token)
     {
-        Log::info('Dispatch a script task: ' . $scriptTask->getId());
+        Log::info('Dispatch a script task: ' . $scriptTask->getId() . ' #' . $token->getId());
         $instance = $token->processRequest;
         $process = $instance->process;
         RunScriptTask::dispatch($process, $instance, $token, [])->onQueue('bpmn');

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -666,11 +666,8 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
         $user = User::where('username', $value)->get()->first();
 
         if ($user) {
-            $requests = ProcessRequest::select('id')
-                ->where('user_id', $expression->operator, $user->id)
-                ->get();
-            return function ($query) use ($requests) {
-                $query->whereIn('id', $requests->pluck('id'));
+            return function ($query) use ($user, $expression) {
+                $query->where('user_id', $expression->operator, $user->id);
             };
         } else {
             throw new PmqlMethodException('requester', 'The specified requester username does not exist.');

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -884,7 +884,25 @@ class ProcessRequestToken extends Model implements TokenInterface
         }
         return false;
     }
-    
+
+    /**
+     * Get a config parameter from the bpmn element definition.
+     * 
+     * @param string $key
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getConfigParam($key, $default = null)
+    {
+        $definition = $this->getDefinition(true);
+        $config = json_decode($definition->getProperty('config', '{}'), true);
+        if (!empty($config) && \is_array($config)) {
+            return Arr::get($config, $key, $default);
+        }
+        return $default;
+    }
+
     /**
      * Send notifications when the task activates
      *

--- a/ProcessMaker/Models/Script.php
+++ b/ProcessMaker/Models/Script.php
@@ -127,12 +127,13 @@ class Script extends Model implements ScriptInterface
      * @param array $data
      * @param array $config
      */
-    public function runScript(array $data, array $config)
+    public function runScript(array $data, array $config, $tokenId = '')
     {
         if (!$this->scriptExecutor) {
             throw new ScriptLanguageNotSupported($this->language);
         }
         $runner = new ScriptRunner($this->scriptExecutor);
+        $runner->setTokenId($tokenId);
         $user = User::find($this->run_as_user_id);
         if (!$user) {
             throw new \RuntimeException("A user is required to run scripts");

--- a/ProcessMaker/Models/ScriptVersion.php
+++ b/ProcessMaker/Models/ScriptVersion.php
@@ -50,13 +50,13 @@ class ScriptVersion extends Model implements ScriptInterface
      * @param array $data
      * @param array $config
      */
-    public function runScript(array $data, array $config)
+    public function runScript(array $data, array $config, $tokenId = '')
     { 
         $script = $this->parent->replicate();
         $except = $script->getGuarded();
         foreach (collect($script->getAttributes())->except($except)->keys() as $prop) {
             $script->$prop = $this->$prop;
         }
-        return $script->runScript($data, $config);
+        return $script->runScript($data, $config, $tokenId);
     }
 }

--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -16,6 +16,8 @@ abstract class Base
     use ScriptDockerCopyingFilesTrait;
     use ScriptDockerBindingFilesTrait;
 
+    private $tokenId = '';
+
     /**
      * Prepare the docker configuration.
      *
@@ -105,7 +107,7 @@ abstract class Base
         // Execute docker
         $executeMethod = config('app.processmaker_scripts_docker_mode') === 'binding'
             ? 'executeBinding' : 'executeCopying';
-        Log::debug('Executing docker', [
+        Log::debug('Executing docker ' . $this->getRunId() . ':', [
             'executeMethod' => $executeMethod,
         ]);
         $response = $this->$executeMethod($dockerConfig);
@@ -119,7 +121,7 @@ abstract class Base
         $returnCode = $response['returnCode'];
         $stdOutput = $response['output'];
         $output = $response['outputs']['response'];
-        \Log::debug("Docker returned: " . substr(json_encode($response), 0, 500));
+        Log::debug("Docker returned " . $this->getRunId(). ': ' . substr(json_encode($response), 0, 500));
         if ($returnCode || $stdOutput) {
             // Has an error code
             throw new RuntimeException("(Code: {$returnCode})" . implode("\n", $stdOutput));
@@ -150,5 +152,22 @@ abstract class Base
         $variablesParameter[] = 'HOST_URL=' . escapeshellarg(config('app.docker_host_url'));
 
         return $variablesParameter;
+    }
+
+    /**
+     * Set the tokenId of reference.
+     * 
+     * @param string $tokenId
+     *
+     * @return void
+     */
+    public function setTokenId($tokenId)
+    {
+        $this->tokenId = $tokenId;
+    }
+
+    private function getRunId()
+    {
+        return $this->tokenId ? '#' . $this->tokenId : '';
     }
 }

--- a/ProcessMaker/ScriptRunners/MockRunner.php
+++ b/ProcessMaker/ScriptRunners/MockRunner.php
@@ -16,4 +16,6 @@ class MockRunner
         $res = eval(str_replace('<?php', '', $code));
         return ['output' => $res];
     }
+
+    public function setTokenId() {}
 }

--- a/ProcessMaker/ScriptRunners/ScriptRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptRunner.php
@@ -55,4 +55,16 @@ class ScriptRunner
             return new $class($executor);
         }
     }
+
+    /**
+     * Set the tokenId of reference.
+     * 
+     * @param string $tokenId
+     *
+     * @return void
+     */
+    public function setTokenId($tokenId)
+    {
+        $this->runner->setTokenId($tokenId);
+    }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -63,9 +63,10 @@ return [
     'processmaker_system_scripts_timeout_seconds' => env('PROCESSMAKER_SYSTEM_SCRIPTS_TIMEOUT_SECONDS', 300),
     'timer_events_seconds' => env('TIMER_EVENTS_SECONDS', 'truncate'),
     'bpmn_actions_max_lock_time' => intval(env('BPMN_ACTIONS_MAX_LOCK_TIME', 60)),
+    // Maximum time to wait for a lock to be released. Default 60000 [ms]
     // If the processes are going to have thousands of concurrent parallel instances, increase this number.
-    'bpmn_actions_max_lock_timeout' => intval(env('BPMN_ACTIONS_MAX_LOCK_TIMEOUT', 6000)),
-    // Lock check interval. Default every second.
+    'bpmn_actions_max_lock_timeout' => intval(env('BPMN_ACTIONS_MAX_LOCK_TIMEOUT', 60000)),
+    // Lock check interval. Default every second. 1000 [ms]
     'bpmn_actions_lock_check_interval' => intval(env('BPMN_ACTIONS_LOCK_CHECK_INTERVAL', 1000)),
 
     // The url of our host from inside the docker

--- a/database/migrations/2022_02_03_133619_add_notifications_index_to_process_request_tokens.php
+++ b/database/migrations/2022_02_03_133619_add_notifications_index_to_process_request_tokens.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNotificationsIndexToProcessRequestTokens extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            // Add index by: user_id, status, due_at, due_notified
+            $table->index(['user_id', 'status', 'due_at', 'due_notified']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            // Remove index by: user_id, status, due_at, due_notified
+            $table->dropIndex(['user_id', 'status', 'due_at', 'due_notified']);
+        });
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Some instances during execution get lock.

## Solution
- In BPMN Actions is not necessary to load closed sub processes
- Increase the lock timeout, and fix a comparison
- Add tags to Bpmn Jobs for a better monitoring

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5186
Requires:
- https://github.com/ProcessMaker/package-ellucian-ethos/pull/53
- https://github.com/ProcessMaker/package-savedsearch/pull/303


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
