### PR TITLE
Fix datasource response

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -339,7 +339,7 @@ trait MakeHttpRequests
                 $content = json_decode($bodyContent, true);
                 break;
             case $status > 200 && $status < 300:
-                $content = [];
+                $content = !empty($bodyContent) ? json_decode($bodyContent, true) : [];
                 break;
             default:
                 throw new HttpResponseException($response);

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -303,7 +303,7 @@ trait MakeHttpRequests
                 $content = json_decode($bodyContent, true);
                 break;
             case $status > 200 && $status < 300:
-                $content = [];
+                $content = !empty($bodyContent) ? json_decode($bodyContent, true) : [];
                 break;
             default:
                 throw new HttpResponseException($response);
@@ -367,6 +367,10 @@ trait MakeHttpRequests
             // if value is empty all the response is mapped
             if (trim($value) === '') {
                 $mapped[$processVar] = $content;
+                continue;
+            }
+            if (trim($value) === '$status') {
+                $mapped[$processVar] = $status;
                 continue;
             }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
201 response not consumed by Data Connectors.

## Solution
- Parse content if exists for status > 200 and <300

## How to Test

1. Create a DS
2. Call to a random endpoint that returns a response but with status 201
3. The response should by parsed

## Related Tickets & Packages
- [201 response not consumed by Data Connectors](https://processmaker.atlassian.net/browse/FOUR-5298)
- Requires: https://github.com/ProcessMaker/package-data-sources/pull/217

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
