### PR TITLE
FOUR-5269: Escalate to manager does not work

### DIFF
--- a/ProcessMaker/Listeners/CommentsSubscriber.php
+++ b/ProcessMaker/Listeners/CommentsSubscriber.php
@@ -26,6 +26,11 @@ class CommentsSubscriber
         $token     = $event->token;
         $user_id   = $token->user ? $token->user_id : null;
         $user_name = $token->user ? $token->user->fullname : __('The System');
+
+        if (!is_int($token->process_request_id)) {
+            return;
+        }
+
         Comment::create([
             'type' => 'LOG',
             'user_id' => $user_id,
@@ -46,6 +51,11 @@ class CommentsSubscriber
     public function onActivitySkipped(ActivityInterface $activity, ProcessRequestToken $token)
     {
         $taskName = $token->getOwnerElement()->getName();
+
+        if (!is_int($token->getInstance()->getId())) {
+            return;
+        }
+
         Comment::create([
             'type' => 'LOG',
             'user_id' => null,
@@ -93,6 +103,11 @@ class CommentsSubscriber
             $flowLabel = array_key_exists('name', $flowProps) && $flowProps['name']
                 ? $flowProps['name']
                 : __('Label Undefined');
+
+            if (!is_int($token->getInstance()->getId())) {
+                return;
+            }
+
             Comment::create([
                 'type' => 'LOG',
                 'user_id' => $user_id,


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a process with 2 tasks
- Configure the 2nd task to escalate to manager
- The process will fail and the manager will not be assigned


## Solution
The problem was caused when trying to register comments in auto generated requests, because they are strings and not integers.

## How to Test
Verify that the escalate to manager manager works.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-5269](https://processmaker.atlassian.net/browse/FOUR-5269)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
