### PR TITLE
Bugfix/memory leak

### DIFF
--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -283,4 +283,12 @@ abstract class BpmnAction implements ShouldQueue
         sleep($seconds);
         usleep($microseconds);
     }
+
+    public function __destruct()
+    {
+        $this->instance = null;
+        $this->engine = null;
+        $this->lock = null;
+        gc_collect_cycles();
+    }
 }

--- a/ProcessMaker/Repositories/ExecutionInstanceRepository.php
+++ b/ProcessMaker/Repositories/ExecutionInstanceRepository.php
@@ -56,7 +56,8 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         $process->getTransitions($storage->getFactory());
 
         //Load tokens:
-        foreach ($instance->tokens as $token) {
+        $tokens = $instance->tokens()->where('status', '!=', 'CLOSED')->get();
+        foreach ($tokens as $token) {
             $tokenInfo = [
                 'id' => $token->getKey(),
                 'status' => $token->status,


### PR DESCRIPTION
## Issue & Reproduction Steps
When a request has lots of tokens (up to 1000) it presents memory problems.

## Solution
- Run GC when the BPMN jobs completes.
- Do not load closed tokens to the BPMN engine.

## How to Test
Create a process with a loop to create thousand of tokens (sequential or parallel) load into the process large data.
While you are completing the process it requires more and more memory.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5337

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
