### PR TITLE
Tune DataSource Performance

### DIFF
--- a/ProcessMaker/Contracts/ServiceTaskImplementationInterface.php
+++ b/ProcessMaker/Contracts/ServiceTaskImplementationInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ProcessMaker\Contracts;
+
+/**
+ * Can be executed as a ServiceTask
+ *
+ * @package ProcessMaker\Contracts
+ */
+interface ServiceTaskImplementationInterface
+{
+    /**
+     * Run the service task implementation
+     *
+     * @param array $data
+     * @param array $config
+     * @param string $tokenId
+     *
+     * @return string $tokenId
+     */
+    public function run(array $data, array $config, $tokenId = '');
+}

--- a/ProcessMaker/Facades/WorkflowManager.php
+++ b/ProcessMaker/Facades/WorkflowManager.php
@@ -18,6 +18,9 @@ use ProcessMaker\Bpmn\Process;
  * @method static void onDataValidation(callable $callback)
  * @method static void validateData(array $data, $definitions, $element)
  * @method static array runProcess(Process $process, $startEventId, array $data)
+ * @method static bool registerServiceImplementation($implementation, $class)
+ * @method static bool existsServiceImplementation($implementation)
+ * @method static bool runServiceImplementation($implementation, array $data, array $config, $tokenId = '')
  */
 class WorkflowManager extends Facade
 {

--- a/ProcessMaker/Managers/WorkflowManager.php
+++ b/ProcessMaker/Managers/WorkflowManager.php
@@ -2,9 +2,10 @@
 
 namespace ProcessMaker\Managers;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Arr;
+use ProcessMaker\Contracts\ServiceTaskImplementationInterface;
 use ProcessMaker\Jobs\BoundaryEvent;
 use ProcessMaker\Jobs\CallProcess;
 use ProcessMaker\Jobs\CatchEvent;
@@ -28,7 +29,6 @@ use ProcessMaker\Nayra\Contracts\Bpmn\ThrowEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
-
 class WorkflowManager
 {
 
@@ -45,6 +45,13 @@ class WorkflowManager
      * @var \Illuminate\Contracts\Validation\Validator $validator
      */
     protected $validator;
+
+    /**
+     * Service Task implementations
+     *
+     * @var array $serviceTaskImplementations
+     */
+    protected $serviceTaskImplementations = [];
 
     /**
      * Complete a task.
@@ -302,5 +309,57 @@ class WorkflowManager
         $startEvent = $definitions->getDefinitions()->getStartEvent($startId);
         $instance = $this->triggerStartEvent($definitions, $startEvent, $data);
         return $instance->getDataStore()->getData();
+    }
+
+    /**
+     * Check if service task implementation exists
+     *
+     * @param string $implementation
+     *
+     * @return bool
+     */
+    public function registerServiceImplementation($implementation, $class)
+    {
+        if (!class_exists($class)) {
+            return false;
+        }
+
+        // check class instance of ServiceTaskImplementationInterface
+        if (!is_subclass_of($class, ServiceTaskImplementationInterface::class)) {
+            return false;
+        }
+
+        $this->serviceTaskImplementations[$implementation] = $class;
+
+        return true;
+    }
+
+    /**
+     * Check if service task implementation exists
+     *
+     * @param string $implementation
+     *
+     * @return bool
+     */
+    public function existsServiceImplementation($implementation)
+    {
+        return isset($this->serviceTaskImplementations[$implementation]) &&
+            class_exists($this->serviceTaskImplementations[$implementation]);
+    }
+
+    /**
+     * Run the service task implementation
+     * @param string $implementation
+     * @param array $dat
+     * @param array $config
+     * @param string $tokenId
+     *
+     * @return mixed
+     */
+    public function runServiceImplementation($implementation, array $data, array $config, $tokenId = '')
+    {
+        $class = $this->serviceTaskImplementations[$implementation];
+        $service = new $class();
+        return $service->run($data, $config, $tokenId);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently the DataSource is running an unnecessary extra Docker instance to call the configured endpoints.

## Solution
- Improve the ServiceTask - DataSource implementation to reduce the resources required to perform the endpoint call.

## How to Test
Create a process that use lots of DataSources.
Check the performace should increase.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5344
- https://github.com/ProcessMaker/package-data-sources/pull/218

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
