### PR TITLE
Bugfix/FOUR-5296: Textarea Rich text change format of data after 2 tasks

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -94,18 +94,18 @@ class TaskController extends Controller
         $query->select('process_request_tokens.*');
 
         $include  = $request->input('include') ? explode(',',$request->input('include')) : [];
-        
+
         if (in_array('data', $include)) {
             unset($include[array_search('data', $include)]);
         }
-        
+
         $query->with($include);
 
         $filter = $request->input('filter', '');
         if (!empty($filter)) {
             $query->filter($filter);
         }
-        
+
         $filterByFields = ['process_id', 'process_request_tokens.user_id' => 'user_id', 'process_request_tokens.status' => 'status', 'element_id', 'element_name', 'process_request_id'];
         $parameters = $request->all();
         foreach ($parameters as $column => $fieldFilter) {
@@ -181,12 +181,12 @@ class TaskController extends Controller
                 return Auth::user()->can('view', $processRequestToken);
             })->values();
         }
-        
+
         //Map each item through its resource
         $response = $response->map(function ($processRequestToken) use ($request) {
             return new Resource($processRequestToken);
         });
-        
+
         $response->inOverdue = $inOverdue;
 
         return new TaskCollection($response);
@@ -198,7 +198,7 @@ class TaskController extends Controller
      * @param ProcessRequestToken $task
      *
      * @return Resource
-     * 
+     *
      * @OA\Get(
      *     path="/tasks/{task_id}",
      *     summary="Get a single task by ID",
@@ -275,7 +275,7 @@ class TaskController extends Controller
             }
             // Skip ConvertEmptyStringsToNull and TrimStrings middlewares
             $data = json_decode($request->getContent(), true);
-            $data = SanitizeHelper::sanitizeData($data['data'], $task->getScreenVersion());
+            $data = SanitizeHelper::sanitizeData($data['data'], $task);
             //Call the manager to trigger the start event
             $process = $task->process;
             $instance = $task->processRequest;

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -129,6 +129,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
         'initiated_at' => 'datetime:c',
         'data' => 'array',
         'errors' => 'array',
+        'do_not_sanitize' => 'array',
         'signal_events' => 'array',
         'locked_at' => 'datetime:c',
     ];
@@ -396,7 +397,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
                 ->with('user')
                 ->whereNotIn('element_type', ['scriptTask']);
     }
-    
+
     /**
      * Filter processes with a string
      *
@@ -412,7 +413,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
                 $query->whereIn('id', [$filter]);
             } else {
                 $matches = ProcessRequest::search($filter)->take(10000)->get()->pluck('id');
-                $query->whereIn('id', $matches);            
+                $query->whereIn('id', $matches);
             }
         } else {
             $filter = '%' . mb_strtolower($filter) . '%';
@@ -426,7 +427,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
                     ->orWhere('updated_at', 'like', $filter);
             });
         }
-        
+
         return $query;
     }
 

--- a/ProcessMaker/SanitizeHelper.php
+++ b/ProcessMaker/SanitizeHelper.php
@@ -73,9 +73,35 @@ class SanitizeHelper {
      *
      * @return string
      */
-    public static function sanitizeData($data, $screen)
+    public static function sanitizeData($data, $task)
     {
-        $except = self::getExceptions($screen);
+        // Get current and nested screens IDs ..
+        $currentScreenExceptions = [];
+        $currentScreenAndNestedIds = $task->getScreenAndNestedIds();
+        foreach ($currentScreenAndNestedIds as $id) {
+            // Find the screen version ..
+            $screen = Screen::findOrFail($id);
+            $screen = $screen->versionFor($task->processRequest)->toArray();
+            // Get exceptions ..
+            $exceptions = self::getExceptions((object) $screen);
+            if (count($exceptions)) {
+                $currentScreenExceptions = array_unique(array_merge($exceptions, $currentScreenExceptions));
+            }
+        }
+
+        // Get process request exceptions stored in do_not_sanitize column ..
+        $processRequestExceptions = $task->processRequest->do_not_sanitize;
+        if (!$processRequestExceptions) {
+            $processRequestExceptions = [];
+        }
+
+        // Merge (nestedSreensExceptions and currentScreenExceptions) with processRequestExceptions ..
+        $except = array_unique(array_merge($processRequestExceptions, $currentScreenExceptions));
+
+        // Update database with all the exceptions ..
+        $task->processRequest->do_not_sanitize = $except;
+        $task->processRequest->save();
+
         return self::sanitizeWithExceptions($data, $except);
     }
 
@@ -85,8 +111,7 @@ class SanitizeHelper {
             if (is_array($value)) {
                 $data[$key] = self::sanitizeWithExceptions($value, $except, $level + 1);
             } else {
-                // Only allow skipping on top-level data for now
-                $strip_tags = $level !== 0 || !in_array($key, $except);
+                $strip_tags = !in_array($key, $except);
                 $data[$key] = self::sanitize($value, $strip_tags);
             }
         }
@@ -115,6 +140,14 @@ class SanitizeHelper {
             if (isset($item['items']) && is_array($item['items'])) {
                 // Inside a table
                 foreach ($item['items'] as $cell) {
+                    if (
+                        isset($cell['component']) &&
+                        $cell['component'] === 'FormTextArea' &&
+                        isset($cell['config']['richtext']) &&
+                        $cell['config']['richtext'] === true
+                    ) {
+                        $elements[] = $cell['config']['name'];
+                    }
                     if (is_array($cell)) {
                         $elements = array_merge($elements, self::getRichTextElements($cell));
                     }

--- a/database/factories/ScreenVersionFactory.php
+++ b/database/factories/ScreenVersionFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator as Faker;
+use ProcessMaker\Model;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\ScreenCategory;
+use ProcessMaker\Models\ScreenVersion;
+
+/**
+ * Model factory for a ScreenVersion
+ */
+$factory->define(ScreenVersion::class, function (Faker $faker) {
+    $screen = factory(Screen::class)->create();
+    return [
+        'screen_id' => $screen->getKey(),
+        'screen_category_id' => function () {
+            return factory(ScreenCategory::class)->create()->getKey();
+        },
+        'title' => $faker->sentence(3),
+        'description' => $faker->sentence(3),
+        'type' => $faker->randomElement(['FORM', 'DYSPLAY', 'CONVERSATIONAL', 'EMAIL']),
+        'config' => $screen->config,
+        'status' => $faker->randomElement(['ACTIVE', 'INACTIVE'])
+    ];
+});

--- a/database/migrations/2022_02_09_204205_add_do_not_sanitize_to_process_requests_table.php
+++ b/database/migrations/2022_02_09_204205_add_do_not_sanitize_to_process_requests_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDoNotSanitizeToProcessRequestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('process_requests', function (Blueprint $table) {
+            $table->json('do_not_sanitize')->after('name')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('process_requests', function (Blueprint $table) {
+            $table->dropColumn('do_not_sanitize');
+        });
+    }
+}

--- a/tests/Feature/Api/SanitizeHelperTest.php
+++ b/tests/Feature/Api/SanitizeHelperTest.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Shared\ProcessTestingTrait;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\ScreenVersion;
+use ProcessMaker\Models\User;
+use ProcessMaker\Repositories\BpmnDocument;
+use ProcessMaker\SanitizeHelper;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class SanitizeHelperTest extends TestCase
+{
+    use ProcessTestingTrait, WithFaker, RequestHelper;
+
+    protected $screen, $screenVersion, $process, $processRequest;
+
+    protected function withUserSetup()
+    {
+        $this->user->is_administrator = true;
+        $this->user->status = 'ACTIVE';
+        $this->user->save();
+    }
+
+    public function testSingleRichTextSanitization()
+    {
+        // Prepare scenario ..
+        $this->createScreen('tests/Fixtures/sanitize_single_rich_text_screen.json');
+        $this->createProcess('tests/Fixtures/sanitize_single_task.bpmn');
+        $this->createProcessRequest();
+        $task = $this->createTask($this->process->id, $this->screenVersion->id, $this->processRequest->id, 'node_9');
+        $data['data'] = $this->dataSingleTask();
+
+        // Call api and do sanitization ..
+        $route = route('api.tasks.update', [$task->id, 'status' => 'COMPLETED']);
+        $response = $this->apiCall('PUT', $route, ['data' => $data]);
+
+        // Assert do_not_sanitize was updated successfully ..
+        $response->assertJsonFragment([
+            'do_not_sanitize' => ['form_text_area_1'],
+        ]);
+
+        // Assert data was sanitized or not if rich text ..
+        $processRequest = ProcessRequest::findOrFail($this->processRequest->id)['data']['data'];
+
+        $this->assertEquals('<p><strong>Do not sanitize<\/strong><\/p>', $processRequest['data']['form_text_area_1']);
+        $this->assertEquals('Sanitize', $processRequest['data']['input_1']);
+    }
+
+    public function testRichTextSanitizationInsideNestedScreen()
+    {
+        // Prepare scenario ..
+        $this->createScreen('tests/Fixtures/sanitize_single_rich_text_screen.json');
+        $childScreen = $this->screen;
+        $this->createScreen('tests/Fixtures/sanitize_single_rich_text_nested_screen.json');
+        // Configure childId screen to nested screen
+        $config = str_replace('"screen":1', '"screen":' . $childScreen->id, json_encode($this->screen->config));
+        $this->screen->config = json_decode($config);
+        $this->screen->save();
+        $this->createProcess('tests/Fixtures/sanitize_single_task_nested.bpmn');
+        $this->createProcessRequest();
+        $task = $this->createTask($this->process->id, $this->screenVersion->id, $this->processRequest->id, 'node_3');
+        $data['data'] = $this->dataSingleTask();
+
+        // Call api and do sanitization ..
+        $route = route('api.tasks.update', [$task->id, 'status' => 'COMPLETED']);
+        $response = $this->apiCall('PUT', $route, ['data' => $data]);
+
+        // Assert do_not_sanitize was updated successfully ..
+        $response->assertJsonFragment([
+            'do_not_sanitize' => ['form_text_area_1'],
+        ]);
+
+        // Assert data was sanitized or not if rich text ..
+        $processRequest = ProcessRequest::findOrFail($this->processRequest->id)['data']['data'];
+
+        $this->assertEquals('<p><strong>Do not sanitize<\/strong><\/p>', $processRequest['data']['form_text_area_1']);
+        $this->assertEquals('Sanitize', $processRequest['data']['input_1']);
+    }
+
+    public function testSingleRichTextSanitizationInsideLoop()
+    {
+        // Prepare scenario ..
+        $this->createScreen('tests/Fixtures/sanitize_single_rich_text_inside_loop_screen.json');
+        $this->createProcess('tests/Fixtures/sanitize_single_task_loop.bpmn');
+        $this->createProcessRequest();
+        $task = $this->createTask($this->process->id, $this->screenVersion->id, $this->processRequest->id, 'node_2');
+        $data['data'] = $this->dataSingleTaskLoop();
+
+        // Call api and do sanitization ..
+        $route = route('api.tasks.update', [$task->id, 'status' => 'COMPLETED']);
+        $response = $this->apiCall('PUT', $route, ['data' => $data]);
+
+        // Assert do_not_sanitize was updated successfully ..
+        $response->assertJsonFragment([
+            'do_not_sanitize' => ['form_text_area_3'],
+        ]);
+
+        // Assert data was sanitized or not if rich text ..
+        $processRequest = ProcessRequest::findOrFail($this->processRequest->id)['data']['data'];
+
+        $this->assertEquals('<p><strong>Do not sanitize<\/strong><\/p>', $processRequest['data']['loop_1'][0]['form_text_area_3']);
+        $this->assertEquals('Sanitize', $processRequest['data']['loop_1'][0]['form_input_1']);
+    }
+
+    public function testRichTextSanitizationInsideLoopInsideNestedScreen()
+    {
+        // Prepare scenario ..
+        $this->createScreen('tests/Fixtures/sanitize_single_rich_text_nested_loop_child_screen.json');
+        $childScreen = $this->screen;
+        $this->createScreen('tests/Fixtures/sanitize_single_rich_text_nested_loop_screen.json');
+        // Configure childId screen to nested screen
+        $config = str_replace('"screen":1', '"screen":' . $childScreen->id, json_encode($this->screen->config));
+        $this->screen->config = json_decode($config);
+        $this->screen->save();
+        $this->createProcess('tests/Fixtures/sanitize_single_task_nested_loop.bpmn');
+        $this->createProcessRequest();
+        $task = $this->createTask($this->process->id, $this->screenVersion->id, $this->processRequest->id, 'node_2');
+        $data['data'] = $this->dataSingleTaskNestedLoop();
+
+        // Call api and do sanitization ..
+        $route = route('api.tasks.update', [$task->id, 'status' => 'COMPLETED']);
+        $response = $this->apiCall('PUT', $route, ['data' => $data]);
+
+        // Assert do_not_sanitize was updated successfully ..
+        $response->assertJsonFragment([
+            'do_not_sanitize' => ['form_text_area_4'],
+        ]);
+
+        // Assert data was sanitized or not if rich text ..
+        $processRequest = ProcessRequest::findOrFail($this->processRequest->id)['data']['data'];
+
+        $this->assertEquals('<p><strong>Do not sanitize<\/strong><\/p>', $processRequest['data']['loop_1'][0]['form_text_area_4']);
+        $this->assertEquals('Sanitize', $processRequest['data']['loop_1'][0]['form_input_1']);
+    }
+
+    public function testPreloadExceptionForDifferentScreenSanitization()
+    {
+        // Prepare scenario ..
+        $this->createScreen('tests/Fixtures/sanitize_single_rich_text_screen.json');
+        $this->createProcess('tests/Fixtures/sanitize_single_task.bpmn');
+        $this->createProcessRequest();
+        // Setup do_not_sanitize variable with some form_text_area from previous screen ..
+        $this->processRequest->do_not_sanitize = ['form_text_area_20'];
+        $this->processRequest->save();
+        $task = $this->createTask($this->process->id, $this->screenVersion->id, $this->processRequest->id, 'node_9');
+        $data['data'] = $this->dataTwoTask();
+
+        // Call api and do sanitization ..
+        $route = route('api.tasks.update', [$task->id, 'status' => 'COMPLETED']);
+        $response = $this->apiCall('PUT', $route, ['data' => $data]);
+
+        // Assert do_not_sanitize was updated successfully ..
+        $response->assertJsonFragment([
+            'do_not_sanitize' => ['form_text_area_1', 'form_text_area_20'],
+        ]);
+
+        // Assert data was sanitized or not if rich text ..
+        $processRequest = ProcessRequest::findOrFail($this->processRequest->id)['data']['data'];
+
+        $this->assertEquals('<p><strong>Do not sanitize<\/strong><\/p>', $processRequest['data']['form_text_area_1']);
+        $this->assertEquals('<p><strong>Do not sanitize<\/strong><\/p>', $processRequest['data']['form_text_area_20']);
+        $this->assertEquals('Sanitize', $processRequest['data']['form_text_area_10']);
+        $this->assertEquals('Sanitize', $processRequest['data']['input_1']);
+    }
+
+    public function testSingleRichTextTwoPagesSanitization()
+    {
+        // Prepare scenario ..
+        $this->createScreen('tests/Fixtures/sanitize_single_rich_text_two_pages_screen.json');
+        $this->createProcess('tests/Fixtures/sanitize_single_task_two_pages.bpmn');
+        $this->createProcessRequest();
+        $task = $this->createTask($this->process->id, $this->screenVersion->id, $this->processRequest->id, 'node_3');
+        $data['data'] = $this->dataSingleTaskTwoPages();
+
+        // Call api and do sanitization ..
+        $route = route('api.tasks.update', [$task->id, 'status' => 'COMPLETED']);
+        $response = $this->apiCall('PUT', $route, ['data' => $data]);
+
+        // Assert do_not_sanitize was updated successfully ..
+        $response->assertJsonFragment([
+            'do_not_sanitize' => ['form_text_area_1', 'form_text_area_2'],
+        ]);
+
+        // Assert data was sanitized or not if rich text ..
+        $processRequest = ProcessRequest::findOrFail($this->processRequest->id)['data']['data'];
+
+        $this->assertEquals('<p><strong>Do not sanitize page 2<\/strong><\/p>', $processRequest['data']['form_text_area_1']);
+        $this->assertEquals('<p><strong>Do not sanitize page 1<\/strong><\/p>', $processRequest['data']['form_text_area_2']);
+        $this->assertEquals('Sanitize', $processRequest['data']['input_1']);
+    }
+
+    private function createScreen($screenConfigFilePath)
+    {
+        $this->screen = factory(Screen::class)->create([
+            'config' => json_decode(file_get_contents(base_path($screenConfigFilePath)))
+        ]);
+
+        $this->screenVersion = factory(ScreenVersion::class)->create([
+            'screen_id' => $this->screen->id,
+            'type' => 'FORM',
+            'config' => $this->screen->config,
+            'status' => 'ACTIVE'
+        ]);
+    }
+
+    private function createProcess($processFilePath)
+    {
+        $bpmn = file_get_contents(base_path($processFilePath));
+        $bpmn = str_replace('pm:screenRef="1"', 'pm:screenRef="' . $this->screen->id .'"', $bpmn);
+        $this->process = factory(Process::class)->create([
+            'bpmn' => $bpmn,
+            'user_id' => $this->user->id,
+        ]);
+    }
+
+    private function createProcessRequest()
+    {
+        $this->processRequest = ProcessRequest::create([
+            'name' => $this->faker->sentence(3),
+            'data' => [],
+            'status' => 'ACTIVE',
+            'callable_id' => 'ProcessId',
+            'user_id' => $this->user->id,
+            'process_id' => $this->process->getKey(),
+            'process_collaboration_id' => null,
+        ]);
+    }
+
+    private function createTask($processId, $screenVersionId, $processRequestId, $node)
+    {
+        $task = factory(ProcessRequestToken::class)->create([
+            'process_id' => $processId,
+            'version_type' => 'ProcessMaker\Models\ScreenVersion',
+            'version_id' => $screenVersionId,
+            'element_id' => $node,
+            'element_type' => 'task',
+            'status' => 'ACTIVE',
+            'process_request_id' => $processRequestId
+        ]);
+        return $task;
+    }
+
+    private function dataSingleTask()
+    {
+        return [
+            "status" => "ACTIVE",
+            "data" => [
+                "_user" => [
+                    "id" => 1
+                ],
+                "_request" => [
+                    "id" => 1
+                ],
+                "form_text_area_1" => "<p><strong>Do not sanitize<\/strong><\/p>",
+                "input_1" => "<p><strong>Sanitize<\/strong><\/p>"
+            ]
+        ];
+    }
+
+    private function dataSingleTaskNestedLoop()
+    {
+       return [
+            "status" => "ACTIVE",
+            "data" => [
+                "_user" => [
+                    "id" => 1
+                ],
+                "_request" => [
+                    "id" => 1
+                ],
+                "loop_1" => [
+                    [
+                        "form_text_area_4" => "<p><strong>Do not sanitize<\/strong><\/p>",
+                        "form_input_1" => "<p><strong>Sanitize<\/strong><\/p>"
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    private function dataTwoTask()
+    {
+        return [
+            "status" => "ACTIVE",
+            "data" => [
+                "_user" => [
+                    "id" => 1
+                ],
+                "_request" => [
+                    "id" => 1
+                ],
+                "form_text_area_1" => "<p><strong>Do not sanitize<\/strong><\/p>",
+                "form_text_area_20" => "<p><strong>Do not sanitize<\/strong><\/p>",
+                "form_text_area_10" => "<p><strong>Sanitize<\/strong><\/p>",
+                "input_1" => "<p><strong>Sanitize<\/strong><\/p>"
+            ]
+        ];
+    }
+
+    private function dataSingleTaskLoop()
+    {
+        return [
+            "status" => "ACTIVE",
+            "data" => [
+                "_user" => [
+                    "id" => 1
+                ],
+                "_request" => [
+                    "id" => 1
+                ],
+                "loop_1" => [
+                    [
+                        "form_text_area_3" => "<p><strong>Do not sanitize<\/strong><\/p>",
+                        "form_input_1" => "<p><strong>Sanitize<\/strong><\/p>"
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    private function dataSingleTaskTwoPages()
+    {
+        return [
+            "status" => "ACTIVE",
+            "data" => [
+                "_user" => [
+                    "id" => 1
+                ],
+                "_request" => [
+                    "id" => 1
+                ],
+                "form_text_area_1" => "<p><strong>Do not sanitize page 2<\/strong><\/p>",
+                "form_text_area_2" => "<p><strong>Do not sanitize page 1<\/strong><\/p>",
+                "input_1" => "<p><strong>Sanitize<\/strong><\/p>"
+            ]
+        ];
+    }
+}

--- a/tests/Fixtures/sanitize_single_rich_text_inside_loop_screen.json
+++ b/tests/Fixtures/sanitize_single_rich_text_inside_loop_screen.json
@@ -1,0 +1,949 @@
+[
+    {
+        "name": "Task Loop A",
+        "items": [
+            {
+                "items": [
+                    {
+                        "label": "Textarea",
+                        "config": {
+                            "icon": "fas fa-paragraph",
+                            "name": "form_text_area_3",
+                            "rows": "2",
+                            "label": "New Textarea",
+                            "helper": null,
+                            "currency": {
+                                "code": "USD",
+                                "name": "US Dollar",
+                                "format": "#,###.##",
+                                "symbol": "$"
+                            },
+                            "readonly": false,
+                            "richtext": true,
+                            "validation": [],
+                            "placeholder": null
+                        },
+                        "component": "FormTextArea",
+                        "inspector": [
+                            {
+                                "type": "FormInput",
+                                "field": "name",
+                                "config": {
+                                    "name": "Variable Name",
+                                    "label": "Variable Name",
+                                    "helper": "A variable name is a symbolic name to reference information.",
+                                    "validation": "regex:/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "label",
+                                "config": {
+                                    "label": "Label",
+                                    "helper": "The label describes the field's name"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "placeholder",
+                                "config": {
+                                    "label": "Placeholder Text",
+                                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "helper",
+                                "config": {
+                                    "label": "Helper Text",
+                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                }
+                            },
+                            {
+                                "type": "FormCheckbox",
+                                "field": "richtext",
+                                "config": {
+                                    "label": "Rich Text",
+                                    "helper": null
+                                }
+                            },
+                            {
+                                "type": "ValidationSelect",
+                                "field": "validation",
+                                "config": {
+                                    "label": "Validation Rules",
+                                    "helper": "The validation rules needed for this field"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "rows",
+                                "config": {
+                                    "label": "Rows",
+                                    "helper": "The number of rows to provide for input",
+                                    "validation": "integer"
+                                }
+                            },
+                            {
+                                "type": "FormCheckbox",
+                                "field": "readonly",
+                                "config": {
+                                    "label": "Read Only",
+                                    "helper": null
+                                }
+                            },
+                            {
+                                "type": "ColorSelect",
+                                "field": "color",
+                                "config": {
+                                    "label": "Text Color",
+                                    "helper": "Set the element's text color",
+                                    "options": [
+                                        {
+                                            "value": "text-primary",
+                                            "content": "primary"
+                                        },
+                                        {
+                                            "value": "text-secondary",
+                                            "content": "secondary"
+                                        },
+                                        {
+                                            "value": "text-success",
+                                            "content": "success"
+                                        },
+                                        {
+                                            "value": "text-danger",
+                                            "content": "danger"
+                                        },
+                                        {
+                                            "value": "text-warning",
+                                            "content": "warning"
+                                        },
+                                        {
+                                            "value": "text-info",
+                                            "content": "info"
+                                        },
+                                        {
+                                            "value": "text-light",
+                                            "content": "light"
+                                        },
+                                        {
+                                            "value": "text-dark",
+                                            "content": "dark"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "type": "ColorSelect",
+                                "field": "bgcolor",
+                                "config": {
+                                    "label": "Background Color",
+                                    "helper": "Set the element's background color",
+                                    "options": [
+                                        {
+                                            "value": "alert alert-primary",
+                                            "content": "primary"
+                                        },
+                                        {
+                                            "value": "alert alert-secondary",
+                                            "content": "secondary"
+                                        },
+                                        {
+                                            "value": "alert alert-success",
+                                            "content": "success"
+                                        },
+                                        {
+                                            "value": "alert alert-danger",
+                                            "content": "danger"
+                                        },
+                                        {
+                                            "value": "alert alert-warning",
+                                            "content": "warning"
+                                        },
+                                        {
+                                            "value": "alert alert-info",
+                                            "content": "info"
+                                        },
+                                        {
+                                            "value": "alert alert-light",
+                                            "content": "light"
+                                        },
+                                        {
+                                            "value": "alert alert-dark",
+                                            "content": "dark"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "type": {
+                                    "props": [
+                                        "value",
+                                        "helper"
+                                    ],
+                                    "watch": {
+                                        "value": {
+                                            "immediate": true
+                                        }
+                                    },
+                                    "methods": [],
+                                    "_scopeId": "data-v-7c18055b",
+                                    "computed": {
+                                        "effectiveValue": []
+                                    },
+                                    "_compiled": true,
+                                    "components": {
+                                        "MonacoEditor": {
+                                            "name": "monaco-editor",
+                                            "_Ctor": [],
+                                            "props": {
+                                                "amdRequire": []
+                                            },
+                                            "extends": {
+                                                "name": "MonacoEditor",
+                                                "model": {
+                                                    "event": "change"
+                                                },
+                                                "props": {
+                                                    "theme": {
+                                                        "default": "vs"
+                                                    },
+                                                    "value": {
+                                                        "required": true
+                                                    },
+                                                    "options": [],
+                                                    "language": [],
+                                                    "original": [],
+                                                    "amdRequire": [],
+                                                    "diffEditor": {
+                                                        "default": false
+                                                    }
+                                                },
+                                                "watch": {
+                                                    "options": {
+                                                        "deep": true,
+                                                        "user": true
+                                                    }
+                                                },
+                                                "methods": []
+                                            },
+                                            "methods": []
+                                        }
+                                    },
+                                    "staticRenderFns": []
+                                },
+                                "field": "defaultValue",
+                                "config": {
+                                    "label": "Default Value",
+                                    "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "conditionalHide",
+                                "config": {
+                                    "label": "Visibility Rule",
+                                    "helper": "This control is hidden until this expression is true"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "customFormatter",
+                                "config": {
+                                    "label": "Custom Format String",
+                                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                    "validation": null
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "customCssSelector",
+                                "config": {
+                                    "label": "CSS Selector Name",
+                                    "helper": "Use this in your custom css rules",
+                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                }
+                            }
+                        ],
+                        "editor-control": "FormTextArea",
+                        "editor-component": "FormTextArea"
+                    },
+                    {
+                        "label": "Line Input",
+                        "config": {
+                            "icon": "far fa-square",
+                            "name": "form_input_1",
+                            "type": "text",
+                            "label": "New Input",
+                            "helper": null,
+                            "dataFormat": "string",
+                            "validation": null,
+                            "placeholder": null
+                        },
+                        "component": "FormInput",
+                        "inspector": [
+                            {
+                                "type": "FormInput",
+                                "field": "name",
+                                "config": {
+                                    "name": "Variable Name",
+                                    "label": "Variable Name",
+                                    "helper": "A variable name is a symbolic name to reference information.",
+                                    "validation": "regex:/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "label",
+                                "config": {
+                                    "label": "Label",
+                                    "helper": "The label describes the field's name"
+                                }
+                            },
+                            {
+                                "type": "FormMultiselect",
+                                "field": "dataFormat",
+                                "config": {
+                                    "name": "Data Type",
+                                    "label": "Data Type",
+                                    "helper": "The data type specifies what kind of data is stored in the variable.",
+                                    "options": [
+                                        {
+                                            "value": "string",
+                                            "content": "Text"
+                                        },
+                                        {
+                                            "value": "int",
+                                            "content": "Integer"
+                                        },
+                                        {
+                                            "value": "currency",
+                                            "content": "Currency"
+                                        },
+                                        {
+                                            "value": "percentage",
+                                            "content": "Percentage"
+                                        },
+                                        {
+                                            "value": "float",
+                                            "content": "Decimal"
+                                        },
+                                        {
+                                            "value": "datetime",
+                                            "content": "Datetime"
+                                        },
+                                        {
+                                            "value": "date",
+                                            "content": "Date"
+                                        },
+                                        {
+                                            "value": "password",
+                                            "content": "Password"
+                                        }
+                                    ],
+                                    "validation": "required"
+                                }
+                            },
+                            {
+                                "type": {
+                                    "extends": {
+                                        "props": [
+                                            "label",
+                                            "error",
+                                            "options",
+                                            "helper",
+                                            "name",
+                                            "value",
+                                            "selectedControl"
+                                        ],
+                                        "mixins": [
+                                            {
+                                                "props": {
+                                                    "validation": {
+                                                        "type": null
+                                                    },
+                                                    "validationData": {
+                                                        "type": null
+                                                    },
+                                                    "validationField": {
+                                                        "type": null
+                                                    },
+                                                    "validationMessages": {
+                                                        "type": null
+                                                    }
+                                                },
+                                                "watch": {
+                                                    "validationData": {
+                                                        "deep": true
+                                                    }
+                                                },
+                                                "methods": [],
+                                                "computed": []
+                                            }
+                                        ],
+                                        "methods": [],
+                                        "computed": [],
+                                        "_compiled": true,
+                                        "components": {
+                                            "Multiselect": {
+                                                "name": "vue-multiselect",
+                                                "props": {
+                                                    "name": {
+                                                        "default": null
+                                                    },
+                                                    "limit": {
+                                                        "default": 99999
+                                                    },
+                                                    "loading": {
+                                                        "default": false
+                                                    },
+                                                    "disabled": {
+                                                        "default": false
+                                                    },
+                                                    "tabindex": {
+                                                        "default": 0
+                                                    },
+                                                    "limitText": [],
+                                                    "maxHeight": {
+                                                        "default": 300
+                                                    },
+                                                    "showLabels": {
+                                                        "default": true
+                                                    },
+                                                    "selectLabel": {
+                                                        "default": "Press enter to select"
+                                                    },
+                                                    "deselectLabel": {
+                                                        "default": "Press enter to remove"
+                                                    },
+                                                    "openDirection": {
+                                                        "default": null
+                                                    },
+                                                    "selectedLabel": {
+                                                        "default": "Selected"
+                                                    },
+                                                    "showNoOptions": {
+                                                        "default": true
+                                                    },
+                                                    "showNoResults": {
+                                                        "default": true
+                                                    },
+                                                    "selectGroupLabel": {
+                                                        "default": "Press enter to select group"
+                                                    },
+                                                    "deselectGroupLabel": {
+                                                        "default": "Press enter to deselect group"
+                                                    }
+                                                },
+                                                "mixins": [
+                                                    {
+                                                        "props": {
+                                                            "id": {
+                                                                "default": null
+                                                            },
+                                                            "max": {
+                                                                "type": [
+                                                                    null,
+                                                                    null
+                                                                ],
+                                                                "default": false
+                                                            },
+                                                            "label": [],
+                                                            "value": {
+                                                                "type": null
+                                                            },
+                                                            "options": {
+                                                                "required": true
+                                                            },
+                                                            "trackBy": [],
+                                                            "multiple": {
+                                                                "default": false
+                                                            },
+                                                            "taggable": {
+                                                                "default": false
+                                                            },
+                                                            "blockKeys": [],
+                                                            "allowEmpty": {
+                                                                "default": true
+                                                            },
+                                                            "groupLabel": [],
+                                                            "resetAfter": {
+                                                                "default": false
+                                                            },
+                                                            "searchable": {
+                                                                "default": true
+                                                            },
+                                                            "customLabel": [],
+                                                            "groupSelect": {
+                                                                "default": false
+                                                            },
+                                                            "groupValues": [],
+                                                            "placeholder": {
+                                                                "default": "Select option"
+                                                            },
+                                                            "tagPosition": {
+                                                                "default": "top"
+                                                            },
+                                                            "hideSelected": {
+                                                                "default": false
+                                                            },
+                                                            "optionsLimit": {
+                                                                "default": 1000
+                                                            },
+                                                            "clearOnSelect": {
+                                                                "default": true
+                                                            },
+                                                            "closeOnSelect": {
+                                                                "default": true
+                                                            },
+                                                            "internalSearch": {
+                                                                "default": true
+                                                            },
+                                                            "preselectFirst": {
+                                                                "default": false
+                                                            },
+                                                            "preserveSearch": {
+                                                                "default": false
+                                                            },
+                                                            "tagPlaceholder": {
+                                                                "default": "Press enter to create a tag"
+                                                            }
+                                                        },
+                                                        "watch": [],
+                                                        "methods": [],
+                                                        "computed": []
+                                                    },
+                                                    {
+                                                        "props": {
+                                                            "showPointer": {
+                                                                "default": true
+                                                            },
+                                                            "optionHeight": {
+                                                                "default": 40
+                                                            }
+                                                        },
+                                                        "watch": [],
+                                                        "methods": [],
+                                                        "computed": []
+                                                    }
+                                                ],
+                                                "computed": [],
+                                                "_compiled": true,
+                                                "beforeCreate": [
+                                                    null
+                                                ],
+                                                "staticRenderFns": []
+                                            }
+                                        },
+                                        "inheritAttrs": false,
+                                        "staticRenderFns": []
+                                    },
+                                    "computed": [],
+                                    "_compiled": true,
+                                    "staticRenderFns": []
+                                },
+                                "field": "dataMask",
+                                "config": {
+                                    "name": "Data Format",
+                                    "label": "Data Format",
+                                    "helper": "The data format for the selected type."
+                                }
+                            },
+                            {
+                                "type": "ValidationSelect",
+                                "field": "validation",
+                                "config": {
+                                    "label": "Validation Rules",
+                                    "helper": "The validation rules needed for this field"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "placeholder",
+                                "config": {
+                                    "label": "Placeholder Text",
+                                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "helper",
+                                "config": {
+                                    "label": "Helper Text",
+                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                }
+                            },
+                            {
+                                "type": "FormCheckbox",
+                                "field": "readonly",
+                                "config": {
+                                    "label": "Read Only"
+                                }
+                            },
+                            {
+                                "type": "ColorSelect",
+                                "field": "color",
+                                "config": {
+                                    "label": "Text Color",
+                                    "helper": "Set the element's text color",
+                                    "options": [
+                                        {
+                                            "value": "text-primary",
+                                            "content": "primary"
+                                        },
+                                        {
+                                            "value": "text-secondary",
+                                            "content": "secondary"
+                                        },
+                                        {
+                                            "value": "text-success",
+                                            "content": "success"
+                                        },
+                                        {
+                                            "value": "text-danger",
+                                            "content": "danger"
+                                        },
+                                        {
+                                            "value": "text-warning",
+                                            "content": "warning"
+                                        },
+                                        {
+                                            "value": "text-info",
+                                            "content": "info"
+                                        },
+                                        {
+                                            "value": "text-light",
+                                            "content": "light"
+                                        },
+                                        {
+                                            "value": "text-dark",
+                                            "content": "dark"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "type": "ColorSelect",
+                                "field": "bgcolor",
+                                "config": {
+                                    "label": "Background Color",
+                                    "helper": "Set the element's background color",
+                                    "options": [
+                                        {
+                                            "value": "alert alert-primary",
+                                            "content": "primary"
+                                        },
+                                        {
+                                            "value": "alert alert-secondary",
+                                            "content": "secondary"
+                                        },
+                                        {
+                                            "value": "alert alert-success",
+                                            "content": "success"
+                                        },
+                                        {
+                                            "value": "alert alert-danger",
+                                            "content": "danger"
+                                        },
+                                        {
+                                            "value": "alert alert-warning",
+                                            "content": "warning"
+                                        },
+                                        {
+                                            "value": "alert alert-info",
+                                            "content": "info"
+                                        },
+                                        {
+                                            "value": "alert alert-light",
+                                            "content": "light"
+                                        },
+                                        {
+                                            "value": "alert alert-dark",
+                                            "content": "dark"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "type": {
+                                    "props": [
+                                        "value",
+                                        "helper"
+                                    ],
+                                    "watch": {
+                                        "value": {
+                                            "immediate": true
+                                        }
+                                    },
+                                    "methods": [],
+                                    "_scopeId": "data-v-7c18055b",
+                                    "computed": {
+                                        "effectiveValue": []
+                                    },
+                                    "_compiled": true,
+                                    "components": {
+                                        "MonacoEditor": {
+                                            "name": "monaco-editor",
+                                            "_Ctor": [],
+                                            "props": {
+                                                "amdRequire": []
+                                            },
+                                            "extends": {
+                                                "name": "MonacoEditor",
+                                                "model": {
+                                                    "event": "change"
+                                                },
+                                                "props": {
+                                                    "theme": {
+                                                        "default": "vs"
+                                                    },
+                                                    "value": {
+                                                        "required": true
+                                                    },
+                                                    "options": [],
+                                                    "language": [],
+                                                    "original": [],
+                                                    "amdRequire": [],
+                                                    "diffEditor": {
+                                                        "default": false
+                                                    }
+                                                },
+                                                "watch": {
+                                                    "options": {
+                                                        "deep": true,
+                                                        "user": true
+                                                    }
+                                                },
+                                                "methods": []
+                                            },
+                                            "methods": []
+                                        }
+                                    },
+                                    "staticRenderFns": []
+                                },
+                                "field": "defaultValue",
+                                "config": {
+                                    "label": "Default Value",
+                                    "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "conditionalHide",
+                                "config": {
+                                    "label": "Visibility Rule",
+                                    "helper": "This control is hidden until this expression is true"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "customFormatter",
+                                "config": {
+                                    "label": "Custom Format String",
+                                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                    "validation": null
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "customCssSelector",
+                                "config": {
+                                    "label": "CSS Selector Name",
+                                    "helper": "Use this in your custom css rules",
+                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                }
+                            }
+                        ],
+                        "editor-control": "FormInput",
+                        "editor-component": "FormInput"
+                    }
+                ],
+                "label": "Loop",
+                "config": {
+                    "icon": "fas fa-redo",
+                    "name": "loop_1",
+                    "label": null,
+                    "settings": {
+                        "add": true,
+                        "type": "new",
+                        "times": "1",
+                        "varname": "loop_1"
+                    }
+                },
+                "component": "FormLoop",
+                "container": true,
+                "inspector": [
+                    {
+                        "type": "LoopInspector",
+                        "field": "settings",
+                        "config": {
+                            "label": null,
+                            "helper": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "Loop",
+                "editor-component": "Loop"
+            },
+            {
+                "label": "Submit Button",
+                "config": {
+                    "icon": "fas fa-share-square",
+                    "name": null,
+                    "event": "submit",
+                    "label": "New Submit",
+                    "variant": "primary",
+                    "fieldValue": null,
+                    "defaultSubmit": true
+                },
+                "component": "FormButton",
+                "inspector": [
+                    {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                            "label": "Label",
+                            "helper": "The label describes the button's text"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                            "name": "Variable Name",
+                            "label": "Variable Name",
+                            "helper": "A variable name is a symbolic name to reference information."
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "event",
+                        "config": {
+                            "label": "Type",
+                            "helper": "Choose whether the button should submit the form",
+                            "options": [
+                                {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                },
+                                {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "fieldValue",
+                        "config": {
+                            "label": "Value",
+                            "helper": "The value being submitted"
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                            "label": "Button Variant Style",
+                            "helper": "The variant determines the appearance of the button",
+                            "options": [
+                                {
+                                    "value": "primary",
+                                    "content": "Primary"
+                                },
+                                {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                },
+                                {
+                                    "value": "success",
+                                    "content": "Success"
+                                },
+                                {
+                                    "value": "danger",
+                                    "content": "Danger"
+                                },
+                                {
+                                    "value": "warning",
+                                    "content": "Warning"
+                                },
+                                {
+                                    "value": "info",
+                                    "content": "Info"
+                                },
+                                {
+                                    "value": "light",
+                                    "content": "Light"
+                                },
+                                {
+                                    "value": "dark",
+                                    "content": "Dark"
+                                },
+                                {
+                                    "value": "link",
+                                    "content": "Link"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "FormSubmit",
+                "editor-component": "FormButton"
+            }
+        ]
+    }
+]

--- a/tests/Fixtures/sanitize_single_rich_text_nested_loop_child_screen.json
+++ b/tests/Fixtures/sanitize_single_rich_text_nested_loop_child_screen.json
@@ -1,0 +1,457 @@
+[
+    {
+        "name": "Task Nested Loop A",
+        "items": [
+            {
+                "items": [
+                    {
+                        "label": "Textarea",
+                        "config": {
+                            "icon": "fas fa-paragraph",
+                            "name": "form_text_area_4",
+                            "rows": 2,
+                            "label": "New Textarea",
+                            "helper": null,
+                            "currency": {
+                                "code": "USD",
+                                "name": "US Dollar",
+                                "format": "#,###.##",
+                                "symbol": "$"
+                            },
+                            "readonly": false,
+                            "richtext": true,
+                            "validation": [],
+                            "placeholder": null
+                        },
+                        "component": "FormTextArea",
+                        "inspector": [
+                            {
+                                "type": "FormInput",
+                                "field": "name",
+                                "config": {
+                                    "name": "Variable Name",
+                                    "label": "Variable Name",
+                                    "helper": "A variable name is a symbolic name to reference information.",
+                                    "validation": "regex:/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "label",
+                                "config": {
+                                    "label": "Label",
+                                    "helper": "The label describes the field's name"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "placeholder",
+                                "config": {
+                                    "label": "Placeholder Text",
+                                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "helper",
+                                "config": {
+                                    "label": "Helper Text",
+                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                }
+                            },
+                            {
+                                "type": "FormCheckbox",
+                                "field": "richtext",
+                                "config": {
+                                    "label": "Rich Text",
+                                    "helper": null
+                                }
+                            },
+                            {
+                                "type": "ValidationSelect",
+                                "field": "validation",
+                                "config": {
+                                    "label": "Validation Rules",
+                                    "helper": "The validation rules needed for this field"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "rows",
+                                "config": {
+                                    "label": "Rows",
+                                    "helper": "The number of rows to provide for input",
+                                    "validation": "integer"
+                                }
+                            },
+                            {
+                                "type": "FormCheckbox",
+                                "field": "readonly",
+                                "config": {
+                                    "label": "Read Only",
+                                    "helper": null
+                                }
+                            },
+                            {
+                                "type": "ColorSelect",
+                                "field": "color",
+                                "config": {
+                                    "label": "Text Color",
+                                    "helper": "Set the element's text color",
+                                    "options": [
+                                        {
+                                            "value": "text-primary",
+                                            "content": "primary"
+                                        },
+                                        {
+                                            "value": "text-secondary",
+                                            "content": "secondary"
+                                        },
+                                        {
+                                            "value": "text-success",
+                                            "content": "success"
+                                        },
+                                        {
+                                            "value": "text-danger",
+                                            "content": "danger"
+                                        },
+                                        {
+                                            "value": "text-warning",
+                                            "content": "warning"
+                                        },
+                                        {
+                                            "value": "text-info",
+                                            "content": "info"
+                                        },
+                                        {
+                                            "value": "text-light",
+                                            "content": "light"
+                                        },
+                                        {
+                                            "value": "text-dark",
+                                            "content": "dark"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "type": "ColorSelect",
+                                "field": "bgcolor",
+                                "config": {
+                                    "label": "Background Color",
+                                    "helper": "Set the element's background color",
+                                    "options": [
+                                        {
+                                            "value": "alert alert-primary",
+                                            "content": "primary"
+                                        },
+                                        {
+                                            "value": "alert alert-secondary",
+                                            "content": "secondary"
+                                        },
+                                        {
+                                            "value": "alert alert-success",
+                                            "content": "success"
+                                        },
+                                        {
+                                            "value": "alert alert-danger",
+                                            "content": "danger"
+                                        },
+                                        {
+                                            "value": "alert alert-warning",
+                                            "content": "warning"
+                                        },
+                                        {
+                                            "value": "alert alert-info",
+                                            "content": "info"
+                                        },
+                                        {
+                                            "value": "alert alert-light",
+                                            "content": "light"
+                                        },
+                                        {
+                                            "value": "alert alert-dark",
+                                            "content": "dark"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "type": {
+                                    "props": [
+                                        "value",
+                                        "helper"
+                                    ],
+                                    "watch": {
+                                        "value": {
+                                            "immediate": true
+                                        }
+                                    },
+                                    "methods": [],
+                                    "_scopeId": "data-v-7c18055b",
+                                    "computed": {
+                                        "effectiveValue": []
+                                    },
+                                    "_compiled": true,
+                                    "components": {
+                                        "MonacoEditor": {
+                                            "name": "monaco-editor",
+                                            "_Ctor": [],
+                                            "props": {
+                                                "amdRequire": []
+                                            },
+                                            "extends": {
+                                                "name": "MonacoEditor",
+                                                "model": {
+                                                    "event": "change"
+                                                },
+                                                "props": {
+                                                    "theme": {
+                                                        "default": "vs"
+                                                    },
+                                                    "value": {
+                                                        "required": true
+                                                    },
+                                                    "options": [],
+                                                    "language": [],
+                                                    "original": [],
+                                                    "amdRequire": [],
+                                                    "diffEditor": {
+                                                        "default": false
+                                                    }
+                                                },
+                                                "watch": {
+                                                    "options": {
+                                                        "deep": true,
+                                                        "user": true
+                                                    }
+                                                },
+                                                "methods": []
+                                            },
+                                            "methods": []
+                                        }
+                                    },
+                                    "staticRenderFns": []
+                                },
+                                "field": "defaultValue",
+                                "config": {
+                                    "label": "Default Value",
+                                    "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "conditionalHide",
+                                "config": {
+                                    "label": "Visibility Rule",
+                                    "helper": "This control is hidden until this expression is true"
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "customFormatter",
+                                "config": {
+                                    "label": "Custom Format String",
+                                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                    "validation": null
+                                }
+                            },
+                            {
+                                "type": "FormInput",
+                                "field": "customCssSelector",
+                                "config": {
+                                    "label": "CSS Selector Name",
+                                    "helper": "Use this in your custom css rules",
+                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                }
+                            }
+                        ],
+                        "editor-control": "FormTextArea",
+                        "editor-component": "FormTextArea"
+                    }
+                ],
+                "label": "Loop",
+                "config": {
+                    "icon": "fas fa-redo",
+                    "name": "loop_1",
+                    "label": null,
+                    "settings": {
+                        "add": true,
+                        "type": "new",
+                        "times": "1",
+                        "varname": "loop_1"
+                    }
+                },
+                "component": "FormLoop",
+                "container": true,
+                "inspector": [
+                    {
+                        "type": "LoopInspector",
+                        "field": "settings",
+                        "config": []
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "Loop",
+                "editor-component": "Loop"
+            },
+            {
+                "label": "Submit Button",
+                "config": {
+                    "icon": "fas fa-share-square",
+                    "name": null,
+                    "event": "submit",
+                    "label": "New Submit",
+                    "variant": "primary",
+                    "fieldValue": null,
+                    "defaultSubmit": true
+                },
+                "component": "FormButton",
+                "inspector": [
+                    {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                            "label": "Label",
+                            "helper": "The label describes the button's text"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                            "name": "Variable Name",
+                            "label": "Variable Name",
+                            "helper": "A variable name is a symbolic name to reference information."
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "event",
+                        "config": {
+                            "label": "Type",
+                            "helper": "Choose whether the button should submit the form",
+                            "options": [
+                                {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                },
+                                {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "fieldValue",
+                        "config": {
+                            "label": "Value",
+                            "helper": "The value being submitted"
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                            "label": "Button Variant Style",
+                            "helper": "The variant determines the appearance of the button",
+                            "options": [
+                                {
+                                    "value": "primary",
+                                    "content": "Primary"
+                                },
+                                {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                },
+                                {
+                                    "value": "success",
+                                    "content": "Success"
+                                },
+                                {
+                                    "value": "danger",
+                                    "content": "Danger"
+                                },
+                                {
+                                    "value": "warning",
+                                    "content": "Warning"
+                                },
+                                {
+                                    "value": "info",
+                                    "content": "Info"
+                                },
+                                {
+                                    "value": "light",
+                                    "content": "Light"
+                                },
+                                {
+                                    "value": "dark",
+                                    "content": "Dark"
+                                },
+                                {
+                                    "value": "link",
+                                    "content": "Link"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "FormSubmit",
+                "editor-component": "FormButton"
+            }
+        ]
+    }
+]

--- a/tests/Fixtures/sanitize_single_rich_text_nested_loop_screen.json
+++ b/tests/Fixtures/sanitize_single_rich_text_nested_loop_screen.json
@@ -1,0 +1,191 @@
+[
+    {
+        "name": "Task Nested Loop AA",
+        "items": [
+            {
+                "label": "Nested Screen",
+                "config": {
+                    "icon": "fas fa-file-invoice",
+                    "name": "Nested Screen",
+                    "label": "Nested Screen",
+                    "value": null,
+                    "screen": 1,
+                    "variant": "primary"
+                },
+                "component": "FormNestedScreen",
+                "inspector": [
+                    {
+                        "type": "ScreenSelector",
+                        "field": "screen",
+                        "config": {
+                            "name": "SelectScreen",
+                            "label": "Screen",
+                            "helper": "Select a screen",
+                            "validate-nested": false
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "FormNestedScreen",
+                "editor-component": "FormNestedScreen"
+            },
+            {
+                "label": "Submit Button",
+                "config": {
+                    "icon": "fas fa-share-square",
+                    "name": null,
+                    "event": "submit",
+                    "label": "New Submit",
+                    "variant": "primary",
+                    "fieldValue": null,
+                    "defaultSubmit": true
+                },
+                "component": "FormButton",
+                "inspector": [
+                    {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                            "label": "Label",
+                            "helper": "The label describes the button's text"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                            "name": "Variable Name",
+                            "label": "Variable Name",
+                            "helper": "A variable name is a symbolic name to reference information."
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "event",
+                        "config": {
+                            "label": "Type",
+                            "helper": "Choose whether the button should submit the form",
+                            "options": [
+                                {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                },
+                                {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "fieldValue",
+                        "config": {
+                            "label": "Value",
+                            "helper": "The value being submitted"
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                            "label": "Button Variant Style",
+                            "helper": "The variant determines the appearance of the button",
+                            "options": [
+                                {
+                                    "value": "primary",
+                                    "content": "Primary"
+                                },
+                                {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                },
+                                {
+                                    "value": "success",
+                                    "content": "Success"
+                                },
+                                {
+                                    "value": "danger",
+                                    "content": "Danger"
+                                },
+                                {
+                                    "value": "warning",
+                                    "content": "Warning"
+                                },
+                                {
+                                    "value": "info",
+                                    "content": "Info"
+                                },
+                                {
+                                    "value": "light",
+                                    "content": "Light"
+                                },
+                                {
+                                    "value": "dark",
+                                    "content": "Dark"
+                                },
+                                {
+                                    "value": "link",
+                                    "content": "Link"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "FormSubmit",
+                "editor-component": "FormButton"
+            }
+        ]
+    }
+]

--- a/tests/Fixtures/sanitize_single_rich_text_nested_screen.json
+++ b/tests/Fixtures/sanitize_single_rich_text_nested_screen.json
@@ -1,0 +1,191 @@
+[
+    {
+        "name": "HTML Nested AA",
+        "items": [
+            {
+                "label": "Nested Screen",
+                "config": {
+                    "icon": "fas fa-file-invoice",
+                    "name": "Nested Screen",
+                    "label": "Nested Screen",
+                    "value": null,
+                    "screen": 1,
+                    "variant": "primary"
+                },
+                "component": "FormNestedScreen",
+                "inspector": [
+                    {
+                        "type": "ScreenSelector",
+                        "field": "screen",
+                        "config": {
+                            "name": "SelectScreen",
+                            "label": "Screen",
+                            "helper": "Select a screen",
+                            "validate-nested": false
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "FormNestedScreen",
+                "editor-component": "FormNestedScreen"
+            },
+            {
+                "label": "Submit Button",
+                "config": {
+                    "icon": "fas fa-share-square",
+                    "name": null,
+                    "event": "submit",
+                    "label": "New Submit",
+                    "variant": "primary",
+                    "fieldValue": null,
+                    "defaultSubmit": true
+                },
+                "component": "FormButton",
+                "inspector": [
+                    {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                            "label": "Label",
+                            "helper": "The label describes the button's text"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                            "name": "Variable Name",
+                            "label": "Variable Name",
+                            "helper": "A variable name is a symbolic name to reference information."
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "event",
+                        "config": {
+                            "label": "Type",
+                            "helper": "Choose whether the button should submit the form",
+                            "options": [
+                                {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                },
+                                {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "fieldValue",
+                        "config": {
+                            "label": "Value",
+                            "helper": "The value being submitted"
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                            "label": "Button Variant Style",
+                            "helper": "The variant determines the appearance of the button",
+                            "options": [
+                                {
+                                    "value": "primary",
+                                    "content": "Primary"
+                                },
+                                {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                },
+                                {
+                                    "value": "success",
+                                    "content": "Success"
+                                },
+                                {
+                                    "value": "danger",
+                                    "content": "Danger"
+                                },
+                                {
+                                    "value": "warning",
+                                    "content": "Warning"
+                                },
+                                {
+                                    "value": "info",
+                                    "content": "Info"
+                                },
+                                {
+                                    "value": "light",
+                                    "content": "Light"
+                                },
+                                {
+                                    "value": "dark",
+                                    "content": "Dark"
+                                },
+                                {
+                                    "value": "link",
+                                    "content": "Link"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "FormSubmit",
+                "editor-component": "FormButton"
+            }
+        ]
+    }
+]

--- a/tests/Fixtures/sanitize_single_rich_text_screen.json
+++ b/tests/Fixtures/sanitize_single_rich_text_screen.json
@@ -1,0 +1,404 @@
+[
+    {
+        "name": "HTML issue task A",
+        "items": [
+            {
+                "label": "Textarea",
+                "config": {
+                    "icon": "fas fa-paragraph",
+                    "name": "form_text_area_1",
+                    "rows": 2,
+                    "label": "New Textarea",
+                    "helper": null,
+                    "currency": {
+                        "code": "USD",
+                        "name": "US Dollar",
+                        "format": "#,###.##",
+                        "symbol": "$"
+                    },
+                    "readonly": false,
+                    "richtext": true,
+                    "validation": [],
+                    "placeholder": null
+                },
+                "component": "FormTextArea",
+                "inspector": [
+                    {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                            "name": "Variable Name",
+                            "label": "Variable Name",
+                            "helper": "A variable name is a symbolic name to reference information.",
+                            "validation": "regex:/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                            "label": "Label",
+                            "helper": "The label describes the field's name"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                            "label": "Placeholder Text",
+                            "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                            "label": "Helper Text",
+                            "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                    },
+                    {
+                        "type": "FormCheckbox",
+                        "field": "richtext",
+                        "config": {
+                            "label": "Rich Text",
+                            "helper": null
+                        }
+                    },
+                    {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                            "label": "Validation Rules",
+                            "helper": "The validation rules needed for this field"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "rows",
+                        "config": {
+                            "label": "Rows",
+                            "helper": "The number of rows to provide for input",
+                            "validation": "integer"
+                        }
+                    },
+                    {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": {
+                            "label": "Read Only",
+                            "helper": null
+                        }
+                    },
+                    {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                            "label": "Text Color",
+                            "helper": "Set the element's text color",
+                            "options": [
+                                {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                },
+                                {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                },
+                                {
+                                    "value": "text-success",
+                                    "content": "success"
+                                },
+                                {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                },
+                                {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                },
+                                {
+                                    "value": "text-info",
+                                    "content": "info"
+                                },
+                                {
+                                    "value": "text-light",
+                                    "content": "light"
+                                },
+                                {
+                                    "value": "text-dark",
+                                    "content": "dark"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                            "label": "Background Color",
+                            "helper": "Set the element's background color",
+                            "options": [
+                                {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                },
+                                {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                },
+                                {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                },
+                                {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                },
+                                {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                },
+                                {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                },
+                                {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                },
+                                {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": {
+                            "props": [
+                                "value",
+                                "helper"
+                            ],
+                            "watch": {
+                                "value": {
+                                    "immediate": true
+                                }
+                            },
+                            "methods": [],
+                            "_scopeId": "data-v-7c18055b",
+                            "computed": {
+                                "effectiveValue": []
+                            },
+                            "_compiled": true,
+                            "components": {
+                                "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": {
+                                        "amdRequire": []
+                                    },
+                                    "extends": {
+                                        "name": "MonacoEditor",
+                                        "model": {
+                                            "event": "change"
+                                        },
+                                        "props": {
+                                            "theme": {
+                                                "default": "vs"
+                                            },
+                                            "value": {
+                                                "required": true
+                                            },
+                                            "options": [],
+                                            "language": [],
+                                            "original": [],
+                                            "amdRequire": [],
+                                            "diffEditor": {
+                                                "default": false
+                                            }
+                                        },
+                                        "watch": {
+                                            "options": {
+                                                "deep": true,
+                                                "user": true
+                                            }
+                                        },
+                                        "methods": []
+                                    },
+                                    "methods": []
+                                }
+                            },
+                            "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                            "label": "Default Value",
+                            "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "FormTextArea",
+                "editor-component": "FormTextArea"
+            },
+            {
+                "label": "Submit Button",
+                "config": {
+                    "icon": "fas fa-share-square",
+                    "name": null,
+                    "event": "submit",
+                    "label": "New Submit",
+                    "variant": "primary",
+                    "fieldValue": null,
+                    "defaultSubmit": true
+                },
+                "component": "FormButton",
+                "inspector": [
+                    {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                            "label": "Label",
+                            "helper": "The label describes the button's text"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                            "name": "Variable Name",
+                            "label": "Variable Name",
+                            "helper": "A variable name is a symbolic name to reference information."
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "event",
+                        "config": {
+                            "label": "Type",
+                            "helper": "Choose whether the button should submit the form",
+                            "options": [
+                                {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                },
+                                {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "fieldValue",
+                        "config": {
+                            "label": "Value",
+                            "helper": "The value being submitted"
+                        }
+                    },
+                    {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                            "label": "Button Variant Style",
+                            "helper": "The variant determines the appearance of the button",
+                            "options": [
+                                {
+                                    "value": "primary",
+                                    "content": "Primary"
+                                },
+                                {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                },
+                                {
+                                    "value": "success",
+                                    "content": "Success"
+                                },
+                                {
+                                    "value": "danger",
+                                    "content": "Danger"
+                                },
+                                {
+                                    "value": "warning",
+                                    "content": "Warning"
+                                },
+                                {
+                                    "value": "info",
+                                    "content": "Info"
+                                },
+                                {
+                                    "value": "light",
+                                    "content": "Light"
+                                },
+                                {
+                                    "value": "dark",
+                                    "content": "Dark"
+                                },
+                                {
+                                    "value": "link",
+                                    "content": "Link"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                            "label": "Visibility Rule",
+                            "helper": "This control is hidden until this expression is true"
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                            "label": "Custom Format String",
+                            "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                            "validation": null
+                        }
+                    },
+                    {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                            "label": "CSS Selector Name",
+                            "helper": "Use this in your custom css rules",
+                            "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                    }
+                ],
+                "editor-control": "FormSubmit",
+                "editor-component": "FormButton"
+            }
+        ]
+    }
+]

--- a/tests/Fixtures/sanitize_single_rich_text_two_pages_screen.json
+++ b/tests/Fixtures/sanitize_single_rich_text_two_pages_screen.json
@@ -1,0 +1,880 @@
+[
+	{
+		"name": "Task 2 Pages A",
+		"items": [
+			{
+				"label": "Textarea",
+				"config": {
+					"icon": "fas fa-paragraph",
+					"name": "form_text_area_2",
+					"rows": 2,
+					"label": "New Textarea",
+					"helper": null,
+					"currency": {
+						"code": "USD",
+						"name": "US Dollar",
+						"format": "#,###.##",
+						"symbol": "$"
+					},
+					"readonly": false,
+					"richtext": true,
+					"validation": [],
+					"placeholder": null
+				},
+				"component": "FormTextArea",
+				"inspector": [
+					{
+						"type": "FormInput",
+						"field": "name",
+						"config": {
+							"name": "Variable Name",
+							"label": "Variable Name",
+							"helper": "A variable name is a symbolic name to reference information.",
+							"validation": "regex:/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "label",
+						"config": {
+							"label": "Label",
+							"helper": "The label describes the field's name"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "placeholder",
+						"config": {
+							"label": "Placeholder Text",
+							"helper": "The placeholder is what is shown in the field when no value is provided yet"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "helper",
+						"config": {
+							"label": "Helper Text",
+							"helper": "Help text is meant to provide additional guidance on the field's value"
+						}
+					},
+					{
+						"type": "FormCheckbox",
+						"field": "richtext",
+						"config": {
+							"label": "Rich Text",
+							"helper": null
+						}
+					},
+					{
+						"type": "ValidationSelect",
+						"field": "validation",
+						"config": {
+							"label": "Validation Rules",
+							"helper": "The validation rules needed for this field"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "rows",
+						"config": {
+							"label": "Rows",
+							"helper": "The number of rows to provide for input",
+							"validation": "integer"
+						}
+					},
+					{
+						"type": "FormCheckbox",
+						"field": "readonly",
+						"config": {
+							"label": "Read Only",
+							"helper": null
+						}
+					},
+					{
+						"type": "ColorSelect",
+						"field": "color",
+						"config": {
+							"label": "Text Color",
+							"helper": "Set the element's text color",
+							"options": [
+								{
+									"value": "text-primary",
+									"content": "primary"
+								},
+								{
+									"value": "text-secondary",
+									"content": "secondary"
+								},
+								{
+									"value": "text-success",
+									"content": "success"
+								},
+								{
+									"value": "text-danger",
+									"content": "danger"
+								},
+								{
+									"value": "text-warning",
+									"content": "warning"
+								},
+								{
+									"value": "text-info",
+									"content": "info"
+								},
+								{
+									"value": "text-light",
+									"content": "light"
+								},
+								{
+									"value": "text-dark",
+									"content": "dark"
+								}
+							]
+						}
+					},
+					{
+						"type": "ColorSelect",
+						"field": "bgcolor",
+						"config": {
+							"label": "Background Color",
+							"helper": "Set the element's background color",
+							"options": [
+								{
+									"value": "alert alert-primary",
+									"content": "primary"
+								},
+								{
+									"value": "alert alert-secondary",
+									"content": "secondary"
+								},
+								{
+									"value": "alert alert-success",
+									"content": "success"
+								},
+								{
+									"value": "alert alert-danger",
+									"content": "danger"
+								},
+								{
+									"value": "alert alert-warning",
+									"content": "warning"
+								},
+								{
+									"value": "alert alert-info",
+									"content": "info"
+								},
+								{
+									"value": "alert alert-light",
+									"content": "light"
+								},
+								{
+									"value": "alert alert-dark",
+									"content": "dark"
+								}
+							]
+						}
+					},
+					{
+						"type": {
+							"props": [
+								"value",
+								"helper"
+							],
+							"watch": {
+								"value": {
+									"immediate": true
+								}
+							},
+							"methods": [],
+							"_scopeId": "data-v-7c18055b",
+							"computed": {
+								"effectiveValue": []
+							},
+							"_compiled": true,
+							"components": {
+								"MonacoEditor": {
+									"name": "monaco-editor",
+									"_Ctor": [],
+									"props": {
+										"amdRequire": []
+									},
+									"extends": {
+										"name": "MonacoEditor",
+										"model": {
+											"event": "change"
+										},
+										"props": {
+											"theme": {
+												"default": "vs"
+											},
+											"value": {
+												"required": true
+											},
+											"options": [],
+											"language": [],
+											"original": [],
+											"amdRequire": [],
+											"diffEditor": {
+												"default": false
+											}
+										},
+										"watch": {
+											"options": {
+												"deep": true,
+												"user": true
+											}
+										},
+										"methods": []
+									},
+									"methods": []
+								}
+							},
+							"staticRenderFns": []
+						},
+						"field": "defaultValue",
+						"config": {
+							"label": "Default Value",
+							"helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "conditionalHide",
+						"config": {
+							"label": "Visibility Rule",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customFormatter",
+						"config": {
+							"label": "Custom Format String",
+							"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+							"validation": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customCssSelector",
+						"config": {
+							"label": "CSS Selector Name",
+							"helper": "Use this in your custom css rules",
+							"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+						}
+					}
+				],
+				"editor-control": "FormTextArea",
+				"editor-component": "FormTextArea"
+			},
+			{
+				"label": "Page Navigation",
+				"config": {
+					"icon": "far fa-compass",
+					"event": "pageNavigate",
+					"label": "Page Navigation",
+					"variant": "secondary",
+					"eventData": "1"
+				},
+				"component": "FormButton",
+				"inspector": [
+					{
+						"type": "PageSelect",
+						"field": "eventData",
+						"config": {
+							"label": "Destination Screen",
+							"helper": "The destination page to navigate to"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "label",
+						"config": {
+							"label": "Button Label",
+							"helper": "The label describes the button's text"
+						}
+					},
+					{
+						"type": "FormMultiselect",
+						"field": "variant",
+						"config": {
+							"label": "Button Variant Style",
+							"helper": "The variant determines the appearance of the button",
+							"options": [
+								{
+									"value": "primary",
+									"content": "Primary"
+								},
+								{
+									"value": "secondary",
+									"content": "Secondary"
+								},
+								{
+									"value": "success",
+									"content": "Success"
+								},
+								{
+									"value": "danger",
+									"content": "Danger"
+								},
+								{
+									"value": "warning",
+									"content": "Warning"
+								},
+								{
+									"value": "info",
+									"content": "Info"
+								},
+								{
+									"value": "light",
+									"content": "Light"
+								},
+								{
+									"value": "dark",
+									"content": "Dark"
+								},
+								{
+									"value": "link",
+									"content": "Link"
+								}
+							]
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "conditionalHide",
+						"config": {
+							"label": "Visibility Rule",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customFormatter",
+						"config": {
+							"label": "Custom Format String",
+							"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+							"validation": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customCssSelector",
+						"config": {
+							"label": "CSS Selector Name",
+							"helper": "Use this in your custom css rules",
+							"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+						}
+					}
+				],
+				"editor-control": "PageNavigation",
+				"editor-component": "FormButton"
+			},
+			{
+				"label": "Submit Button",
+				"config": {
+					"icon": "fas fa-share-square",
+					"name": null,
+					"event": "submit",
+					"label": "New Submit",
+					"variant": "primary",
+					"fieldValue": null,
+					"defaultSubmit": true
+				},
+				"component": "FormButton",
+				"inspector": [
+					{
+						"type": "FormInput",
+						"field": "label",
+						"config": {
+							"label": "Label",
+							"helper": "The label describes the button's text"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "name",
+						"config": {
+							"name": "Variable Name",
+							"label": "Variable Name",
+							"helper": "A variable name is a symbolic name to reference information."
+						}
+					},
+					{
+						"type": "FormMultiselect",
+						"field": "event",
+						"config": {
+							"label": "Type",
+							"helper": "Choose whether the button should submit the form",
+							"options": [
+								{
+									"value": "submit",
+									"content": "Submit Button"
+								},
+								{
+									"value": "script",
+									"content": "Regular Button"
+								}
+							]
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "fieldValue",
+						"config": {
+							"label": "Value",
+							"helper": "The value being submitted"
+						}
+					},
+					{
+						"type": "FormMultiselect",
+						"field": "variant",
+						"config": {
+							"label": "Button Variant Style",
+							"helper": "The variant determines the appearance of the button",
+							"options": [
+								{
+									"value": "primary",
+									"content": "Primary"
+								},
+								{
+									"value": "secondary",
+									"content": "Secondary"
+								},
+								{
+									"value": "success",
+									"content": "Success"
+								},
+								{
+									"value": "danger",
+									"content": "Danger"
+								},
+								{
+									"value": "warning",
+									"content": "Warning"
+								},
+								{
+									"value": "info",
+									"content": "Info"
+								},
+								{
+									"value": "light",
+									"content": "Light"
+								},
+								{
+									"value": "dark",
+									"content": "Dark"
+								},
+								{
+									"value": "link",
+									"content": "Link"
+								}
+							]
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "conditionalHide",
+						"config": {
+							"label": "Visibility Rule",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customFormatter",
+						"config": {
+							"label": "Custom Format String",
+							"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+							"validation": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customCssSelector",
+						"config": {
+							"label": "CSS Selector Name",
+							"helper": "Use this in your custom css rules",
+							"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+						}
+					}
+				],
+				"editor-control": "FormSubmit",
+				"editor-component": "FormButton"
+			}
+		]
+	},
+	{
+		"name": "page 2",
+		"items": [
+			{
+				"label": "Textarea",
+				"config": {
+					"icon": "fas fa-paragraph",
+					"name": "form_text_area_1",
+					"rows": 2,
+					"label": "New Textarea",
+					"helper": null,
+					"currency": {
+						"code": "USD",
+						"name": "US Dollar",
+						"format": "#,###.##",
+						"symbol": "$"
+					},
+					"readonly": false,
+					"richtext": true,
+					"validation": [],
+					"placeholder": null
+				},
+				"component": "FormTextArea",
+				"inspector": [
+					{
+						"type": "FormInput",
+						"field": "name",
+						"config": {
+							"name": "Variable Name",
+							"label": "Variable Name",
+							"helper": "A variable name is a symbolic name to reference information.",
+							"validation": "regex:/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "label",
+						"config": {
+							"label": "Label",
+							"helper": "The label describes the field's name"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "placeholder",
+						"config": {
+							"label": "Placeholder Text",
+							"helper": "The placeholder is what is shown in the field when no value is provided yet"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "helper",
+						"config": {
+							"label": "Helper Text",
+							"helper": "Help text is meant to provide additional guidance on the field's value"
+						}
+					},
+					{
+						"type": "FormCheckbox",
+						"field": "richtext",
+						"config": {
+							"label": "Rich Text",
+							"helper": null
+						}
+					},
+					{
+						"type": "ValidationSelect",
+						"field": "validation",
+						"config": {
+							"label": "Validation Rules",
+							"helper": "The validation rules needed for this field"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "rows",
+						"config": {
+							"label": "Rows",
+							"helper": "The number of rows to provide for input",
+							"validation": "integer"
+						}
+					},
+					{
+						"type": "FormCheckbox",
+						"field": "readonly",
+						"config": {
+							"label": "Read Only",
+							"helper": null
+						}
+					},
+					{
+						"type": "ColorSelect",
+						"field": "color",
+						"config": {
+							"label": "Text Color",
+							"helper": "Set the element's text color",
+							"options": [
+								{
+									"value": "text-primary",
+									"content": "primary"
+								},
+								{
+									"value": "text-secondary",
+									"content": "secondary"
+								},
+								{
+									"value": "text-success",
+									"content": "success"
+								},
+								{
+									"value": "text-danger",
+									"content": "danger"
+								},
+								{
+									"value": "text-warning",
+									"content": "warning"
+								},
+								{
+									"value": "text-info",
+									"content": "info"
+								},
+								{
+									"value": "text-light",
+									"content": "light"
+								},
+								{
+									"value": "text-dark",
+									"content": "dark"
+								}
+							]
+						}
+					},
+					{
+						"type": "ColorSelect",
+						"field": "bgcolor",
+						"config": {
+							"label": "Background Color",
+							"helper": "Set the element's background color",
+							"options": [
+								{
+									"value": "alert alert-primary",
+									"content": "primary"
+								},
+								{
+									"value": "alert alert-secondary",
+									"content": "secondary"
+								},
+								{
+									"value": "alert alert-success",
+									"content": "success"
+								},
+								{
+									"value": "alert alert-danger",
+									"content": "danger"
+								},
+								{
+									"value": "alert alert-warning",
+									"content": "warning"
+								},
+								{
+									"value": "alert alert-info",
+									"content": "info"
+								},
+								{
+									"value": "alert alert-light",
+									"content": "light"
+								},
+								{
+									"value": "alert alert-dark",
+									"content": "dark"
+								}
+							]
+						}
+					},
+					{
+						"type": {
+							"props": [
+								"value",
+								"helper"
+							],
+							"watch": {
+								"value": {
+									"immediate": true
+								}
+							},
+							"methods": [],
+							"_scopeId": "data-v-7c18055b",
+							"computed": {
+								"effectiveValue": []
+							},
+							"_compiled": true,
+							"components": {
+								"MonacoEditor": {
+									"name": "monaco-editor",
+									"_Ctor": [],
+									"props": {
+										"amdRequire": []
+									},
+									"extends": {
+										"name": "MonacoEditor",
+										"model": {
+											"event": "change"
+										},
+										"props": {
+											"theme": {
+												"default": "vs"
+											},
+											"value": {
+												"required": true
+											},
+											"options": [],
+											"language": [],
+											"original": [],
+											"amdRequire": [],
+											"diffEditor": {
+												"default": false
+											}
+										},
+										"watch": {
+											"options": {
+												"deep": true,
+												"user": true
+											}
+										},
+										"methods": []
+									},
+									"methods": []
+								}
+							},
+							"staticRenderFns": []
+						},
+						"field": "defaultValue",
+						"config": {
+							"label": "Default Value",
+							"helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "conditionalHide",
+						"config": {
+							"label": "Visibility Rule",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customFormatter",
+						"config": {
+							"label": "Custom Format String",
+							"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+							"validation": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customCssSelector",
+						"config": {
+							"label": "CSS Selector Name",
+							"helper": "Use this in your custom css rules",
+							"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+						}
+					}
+				],
+				"editor-control": "FormTextArea",
+				"editor-component": "FormTextArea"
+			},
+			{
+				"label": "Page Navigation",
+				"config": {
+					"icon": "far fa-compass",
+					"event": "pageNavigate",
+					"label": "back",
+					"variant": "secondary",
+					"eventData": "0"
+				},
+				"component": "FormButton",
+				"inspector": [
+					{
+						"type": "PageSelect",
+						"field": "eventData",
+						"config": {
+							"label": "Destination Screen",
+							"helper": "The destination page to navigate to"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "label",
+						"config": {
+							"label": "Button Label",
+							"helper": "The label describes the button's text"
+						}
+					},
+					{
+						"type": "FormMultiselect",
+						"field": "variant",
+						"config": {
+							"label": "Button Variant Style",
+							"helper": "The variant determines the appearance of the button",
+							"options": [
+								{
+									"value": "primary",
+									"content": "Primary"
+								},
+								{
+									"value": "secondary",
+									"content": "Secondary"
+								},
+								{
+									"value": "success",
+									"content": "Success"
+								},
+								{
+									"value": "danger",
+									"content": "Danger"
+								},
+								{
+									"value": "warning",
+									"content": "Warning"
+								},
+								{
+									"value": "info",
+									"content": "Info"
+								},
+								{
+									"value": "light",
+									"content": "Light"
+								},
+								{
+									"value": "dark",
+									"content": "Dark"
+								},
+								{
+									"value": "link",
+									"content": "Link"
+								}
+							]
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "conditionalHide",
+						"config": {
+							"label": "Visibility Rule",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customFormatter",
+						"config": {
+							"label": "Custom Format String",
+							"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+							"validation": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customCssSelector",
+						"config": {
+							"label": "CSS Selector Name",
+							"helper": "Use this in your custom css rules",
+							"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+						}
+					}
+				],
+				"editor-control": "PageNavigation",
+				"editor-component": "FormButton"
+			}
+		]
+	}
+]

--- a/tests/Fixtures/sanitize_single_task.bpmn
+++ b/tests/Fixtures/sanitize_single_task.bpmn
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+    <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+        <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false" pm:config="{&#34;web_entry&#34;:null}">
+            <bpmn:outgoing>node_13</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:endEvent id="node_2" name="End Event">
+            <bpmn:incoming>node_5</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:task id="node_3" name="Form Task 3" pm:screenRef="1" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+            <bpmn:incoming>node_8</bpmn:incoming>
+            <bpmn:outgoing>node_5</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="node_5" name="" sourceRef="node_3" targetRef="node_2" />
+        <bpmn:task id="node_6" name="Form Task 2" pm:screenRef="1" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+            <bpmn:incoming>node_11</bpmn:incoming>
+            <bpmn:outgoing>node_8</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="node_8" name="" sourceRef="node_6" targetRef="node_3" />
+        <bpmn:task id="node_9" name="Form Task 1" pm:screenRef="1" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+            <bpmn:incoming>node_13</bpmn:incoming>
+            <bpmn:outgoing>node_11</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_9" targetRef="node_6" />
+        <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_1" targetRef="node_9" />
+        <bpmn:textAnnotation id="node_4">
+            <bpmn:text>Case 1: Two different fixes.</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_7">
+            <bpmn:text>1- Adding _DO_NOT_SANITIZE variable to be available in all screens</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_10">
+            <bpmn:text>2- Passing to sanitize helper all tokens from request and search in all screens every time</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_12">
+            <bpmn:text>form_text_area_1 with rich text option</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_14">
+            <bpmn:text>rich text with content: {{{form_text_area_1}}}</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_15">
+            <bpmn:text>In this step is going to be sanitized because form_text_area_1 is not part of Form Task 2 screen</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_16">
+            <bpmn:text>form_text_area_1 with rich text option</bpmn:text>
+        </bpmn:textAnnotation>
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagramId">
+        <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+            <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+                <dc:Bounds x="200" y="270" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+                <dc:Bounds x="870" y="270" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+                <dc:Bounds x="700" y="250" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+                <di:waypoint x="758" y="288" />
+                <di:waypoint x="888" y="288" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+                <dc:Bounds x="510" y="250" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+                <di:waypoint x="568" y="288" />
+                <di:waypoint x="758" y="288" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+                <dc:Bounds x="330" y="250" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+                <di:waypoint x="388" y="288" />
+                <di:waypoint x="568" y="288" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+                <di:waypoint x="218" y="288" />
+                <di:waypoint x="388" y="288" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+                <dc:Bounds x="240" y="140" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_7_di" bpmnElement="node_7">
+                <dc:Bounds x="430" y="140" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+                <dc:Bounds x="620" y="140" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_12_di" bpmnElement="node_12">
+                <dc:Bounds x="310" y="410" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_14_di" bpmnElement="node_14">
+                <dc:Bounds x="500" y="410" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_15_di" bpmnElement="node_15">
+                <dc:Bounds x="500" y="490" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_16_di" bpmnElement="node_16">
+                <dc:Bounds x="720" y="410" width="150" height="30" />
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Fixtures/sanitize_single_task_loop.bpmn
+++ b/tests/Fixtures/sanitize_single_task_loop.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_2" name="Form Loop Task 1" pm:screenRef="1" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_7</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="node_3" name="Form Loop Task 2" pm:screenRef="150" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_11</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="node_4" name="Form Loop Task 3" pm:screenRef="150" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_11</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="node_5" name="End Event">
+      <bpmn:incoming>node_13</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_7" name="" sourceRef="node_1" targetRef="node_2" />
+    <bpmn:sequenceFlow id="node_9" name="" sourceRef="node_2" targetRef="node_3" />
+    <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_3" targetRef="node_4" />
+    <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_4" targetRef="node_5" />
+    <bpmn:textAnnotation id="node_14">
+      <bpmn:text>Case 4: Text areas inside loop</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="170" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="260" y="190" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="430" y="190" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="600" y="190" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_5_di" bpmnElement="node_5">
+        <dc:Bounds x="760" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="188" y="228" />
+        <di:waypoint x="318" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="318" y="228" />
+        <di:waypoint x="488" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+        <di:waypoint x="488" y="228" />
+        <di:waypoint x="658" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="658" y="228" />
+        <di:waypoint x="778" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_14_di" bpmnElement="node_14">
+        <dc:Bounds x="270" y="100" width="150" height="30" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Fixtures/sanitize_single_task_nested.bpmn
+++ b/tests/Fixtures/sanitize_single_task_nested.bpmn
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+    <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+        <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false" pm:config="{&#34;web_entry&#34;:null}">
+            <bpmn:outgoing>node_5</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:endEvent id="node_2" name="End Event">
+            <bpmn:incoming>node_15</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:task id="node_3" name="Form Task 1 Nested" pm:screenRef="1" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+            <bpmn:incoming>node_5</bpmn:incoming>
+            <bpmn:outgoing>node_11</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="node_5" name="" sourceRef="node_1" targetRef="node_3" />
+        <bpmn:task id="node_8" name="Form Task 2 Nested" pm:screenRef="147" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+            <bpmn:incoming>node_11</bpmn:incoming>
+            <bpmn:outgoing>node_13</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:task id="node_9" name="Form Task 3 Nested" pm:screenRef="146" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+            <bpmn:incoming>node_13</bpmn:incoming>
+            <bpmn:outgoing>node_15</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_3" targetRef="node_8" />
+        <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_8" targetRef="node_9" />
+        <bpmn:sequenceFlow id="node_15" name="" sourceRef="node_9" targetRef="node_2" />
+        <bpmn:textAnnotation id="node_16">
+            <bpmn:text>form_text_area_1 with rich text option inside Nested screen</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_17">
+            <bpmn:text>rich text with content: {{{form_text_area_1}}} inside Nested screen</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_18">
+            <bpmn:text>form_text_area_1 with rich text option inside Nested screen</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_21">
+            <bpmn:text>Case 2:</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:textAnnotation id="node_4">
+            <bpmn:text>Maybe same solution that case 1 but with the difference that we should search also inside nested components on getExceptions methods</bpmn:text>
+        </bpmn:textAnnotation>
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagramId">
+        <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+            <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+                <dc:Bounds x="220" y="160" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+                <dc:Bounds x="840" y="160" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+                <dc:Bounds x="320" y="140" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+                <di:waypoint x="238" y="178" />
+                <di:waypoint x="378" y="178" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="node_8_di" bpmnElement="node_8">
+                <dc:Bounds x="490" y="140" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+                <dc:Bounds x="660" y="140" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+                <di:waypoint x="378" y="178" />
+                <di:waypoint x="548" y="178" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+                <di:waypoint x="548" y="178" />
+                <di:waypoint x="718" y="178" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="node_15_di" bpmnElement="node_15">
+                <di:waypoint x="718" y="178" />
+                <di:waypoint x="858" y="178" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="node_16_di" bpmnElement="node_16">
+                <dc:Bounds x="300" y="280" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_17_di" bpmnElement="node_17">
+                <dc:Bounds x="470" y="280" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_18_di" bpmnElement="node_18">
+                <dc:Bounds x="650" y="280" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_21_di" bpmnElement="node_21">
+                <dc:Bounds x="300" y="0" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+                <dc:Bounds x="480" y="-10" width="150" height="30" />
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Fixtures/sanitize_single_task_nested_loop.bpmn
+++ b/tests/Fixtures/sanitize_single_task_nested_loop.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_2" name="Form Task Nested Loop 1" pm:screenRef="1" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_5</bpmn:incoming>
+      <bpmn:outgoing>node_7</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="node_3" name="Form Task Nested Loop 2" pm:screenRef="152" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_7</bpmn:incoming>
+      <bpmn:outgoing>node_10</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_5" name="" sourceRef="node_1" targetRef="node_2" />
+    <bpmn:sequenceFlow id="node_7" name="" sourceRef="node_2" targetRef="node_3" />
+    <bpmn:task id="node_8" name="Form Task Nested Loop 3" pm:screenRef="153" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_10</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_10" name="" sourceRef="node_3" targetRef="node_8" />
+    <bpmn:endEvent id="node_11" name="End Event">
+      <bpmn:incoming>node_13</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_8" targetRef="node_11" />
+    <bpmn:textAnnotation id="node_14">
+      <bpmn:text>Case 5: Text area inside loop inside nested screen</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="210" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="310" y="190" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="480" y="190" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="228" y="228" />
+        <di:waypoint x="368" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="368" y="228" />
+        <di:waypoint x="538" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_8_di" bpmnElement="node_8">
+        <dc:Bounds x="660" y="190" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_10_di" bpmnElement="node_10">
+        <di:waypoint x="538" y="228" />
+        <di:waypoint x="718" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_11_di" bpmnElement="node_11">
+        <dc:Bounds x="870" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="718" y="228" />
+        <di:waypoint x="888" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_14_di" bpmnElement="node_14">
+        <dc:Bounds x="310" y="90" width="150" height="30" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Fixtures/sanitize_single_task_two_pages.bpmn
+++ b/tests/Fixtures/sanitize_single_task_two_pages.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="node_2" name="End Event">
+      <bpmn:incoming>node_13</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="node_3" name="Form Task 2 Pages 1" pm:screenRef="1" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_6</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="node_4" name="Form Task 2 Pages 2" pm:screenRef="155" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_8</bpmn:incoming>
+      <bpmn:outgoing>node_11</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_6" name="" sourceRef="node_1" targetRef="node_3" />
+    <bpmn:sequenceFlow id="node_8" name="" sourceRef="node_3" targetRef="node_4" />
+    <bpmn:task id="node_9" name="Form Task 2 Pages 3" pm:screenRef="154" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+      <bpmn:incoming>node_11</bpmn:incoming>
+      <bpmn:outgoing>node_13</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_11" name="" sourceRef="node_4" targetRef="node_9" />
+    <bpmn:sequenceFlow id="node_13" name="" sourceRef="node_9" targetRef="node_2" />
+    <bpmn:textAnnotation id="node_5">
+      <bpmn:text>Case 7: Text area inside another page in screen</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="160" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="830" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="260" y="220" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="450" y="220" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="178" y="258" />
+        <di:waypoint x="318" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="318" y="258" />
+        <di:waypoint x="508" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="640" y="220" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_11_di" bpmnElement="node_11">
+        <di:waypoint x="508" y="258" />
+        <di:waypoint x="698" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_13_di" bpmnElement="node_13">
+        <di:waypoint x="698" y="258" />
+        <di:waypoint x="848" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_5_di" bpmnElement="node_5">
+        <dc:Bounds x="260" y="130" width="150" height="30" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Issue & Reproduction Steps
We are using the Text area Rich text on our screen, but the format of HTML is being changed after 2 derivations. 
When you have a rich text area but you are in a screen that does not have that rich text area, all data that is not present on that screen are sanitized. This happens after 2 derivations, or having a rich text area inside a loop or nested screen.

## Solution
- Added a column do_not_sanitize to processRequest table so we can remember and get available all the variables in the entire process. 
- Search inside nested screens and loops before sanitize.

## How to Test
- Create a process with 3 tasks. For the first and last task use a screen with a text area control with the rich text option enabled. In the second task place any control but be sure to not to use the text area in the second task. Run a request and fill the text area with some formatted text, in the last task the formatted text should not be sanitized for text area.
- Same steps as before but use a process with a text area inside a nested screen.
- Same steps as before but use a process with a text area inside a loop.
- Same steps as before but use a process with a text area inside a second page.

Run test cases inside tests/Feature/Api/SanitizeHelperTest

**Working videos**

Case 1 after two tasks

https://user-images.githubusercontent.com/90727999/154064687-618a30e3-d547-4307-90bb-7e68be3b152a.mov


Case 2 inside nested

https://user-images.githubusercontent.com/90727999/154065430-f486308c-15b0-4d19-836f-22e4d1ef792a.mov


Case 3 inside loops

https://user-images.githubusercontent.com/90727999/154065815-d861d510-60ef-4317-8711-92110acc345e.mov


Case 4 different pages

https://user-images.githubusercontent.com/90727999/154066370-0f808701-5156-43b7-b294-162e64048698.mov


Case 5 subprocess

https://user-images.githubusercontent.com/90727999/154066894-0840e69c-3b83-45e2-860a-fd6cbf41c506.mov


## Related Tickets & Packages
- [FOUR-5296](https://processmaker.atlassian.net/browse/FOUR-5296)
- [FOUR-4408](https://processmaker.atlassian.net/browse/FOUR-4408)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
