### PR TITLE
Bugfix FOUR-5377 - Script error using getProcesses API endpoint

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -96,14 +96,12 @@ use Throwable;
  * ),
  * @OA\Schema(
  *     schema="ProcessStartEvents",
- *     @OA\Schema(
- *         @OA\Property(property="eventDefinitions", type="object"),
- *         @OA\Property(property="parallelMultiple", type="boolean"),
- *         @OA\Property(property="outgoing", type="object"),
- *         @OA\Property(property="incoming", type="object"),
- *         @OA\Property(property="id", type="string"),
- *         @OA\Property(property="name", type="string"),
- *     )
+ *     @OA\Property(property="eventDefinitions", type="object"),
+ *     @OA\Property(property="parallelMultiple", type="boolean"),
+ *     @OA\Property(property="outgoing", type="object"),
+ *     @OA\Property(property="incoming", type="object"),
+ *     @OA\Property(property="id", type="string"),
+ *     @OA\Property(property="name", type="string"),
  * ),
  * @OA\Schema(
  *     schema="ProcessWithStartEvents",


### PR DESCRIPTION
## Issue & Reproduction Steps
The next error is generated when we query the `getProcesses()` endpoint in Scripts:

```
(Code: 0) Warning: settype(): Invalid type in /opt/sdk-php/lib/ObjectSerializer.php on line 335 Warning: settype(): Invalid type in /opt/sdk-php/lib/ObjectSerializer.php on line 335
```

## Solution
- The comment annotations for ProcessStartEvents in the `Process.php` file were malformed.

## How to Test
0. Testing in `bugfix/FOUR-5377-4.2` you should go to `admin/script-executors` and click on "PHP Executor -> Rebuild and Save"
1. Create a new PHP script
2. Add the following code and run:

```
$apiInstance = $api->processes();
$result = $apiInstance->getProcesses();
return ['processes' => $result];
```

You should see no errors.

## Related Tickets & Packages
- [FOUR-5377](https://processmaker.atlassian.net/browse/FOUR-5377)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.