### PR TITLE
FOUR-5585 - Console error when adding Script Task

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
+++ b/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
@@ -43,7 +43,7 @@
         watch: {
             value: {
                 handler() {
-                    this.code = this.value;
+                    this.code = this.value ? this.value : '';
                 },
                 immediate: true,
             },


### PR DESCRIPTION
## Issue & Reproduction Steps
When adding a Script Task in Modeler an error appears in the console.

1. Open/create a process
2. Open the browser dev tools, console page
3. Add a task to the modeler
4. Change the task to Script Task

## Solution
- The vue-monaco component requires a prop "value" as a string. Currently it was passed undefined.
- The solution is, to make sure "value" prop is set to a string.

## How to Test
Please follow the Reproduction Steps of above. You should not see any console errors.

## Related Tickets & Packages
- [FOUR-5585](https://processmaker.atlassian.net/browse/FOUR-5585)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.