### PR TITLE
Bugfix/FOUR-5538: [27478] System Signals able to be deleted, edited, cause processes to not work

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SignalController.php
+++ b/ProcessMaker/Http/Controllers/Api/SignalController.php
@@ -173,6 +173,18 @@ class SignalController extends Controller
         );
 
         $oldSignal = SignalManager::findSignal($signalId);
+        $oldSignalProcesses = SignalManager::getSignalProcesses($signalId, true);
+
+        $editable = true;
+        foreach ($oldSignalProcesses as $process) {
+            if (count($process['catches']) && $process['is_system']) {
+                $editable = false;
+            }
+        }
+
+        if (!$editable) {
+            return abort(403, __('System signals cannot be modified.'));
+        }
 
         $errorValidations = SignalManager::validateSignal($newSignal, $oldSignal);
         if (count($errorValidations) > 0) {

--- a/ProcessMaker/Managers/SignalManager.php
+++ b/ProcessMaker/Managers/SignalManager.php
@@ -38,6 +38,7 @@ class SignalManager
                                     ? [
                                         'id' => $process->id,
                                         'name' => $process->name,
+                                        'is_system' => $process->category->is_system,
                                         'catches' => self::getSignalCatchEvents($node->getAttribute('id'), $process->getDomDocument())->toArray()
                                     ]
                                     : null

--- a/ProcessMaker/Managers/SignalManager.php
+++ b/ProcessMaker/Managers/SignalManager.php
@@ -163,6 +163,20 @@ class SignalManager
     }
 
     /**
+     * @param $signalId
+     * @param $includeSystemProcesses
+     *
+     * @return array
+     */
+    public static function getSignalProcesses($signalId, $includeSystemProcesses = false)
+    {
+        $assocSignal =  SignalManager::getAllSignals($includeSystemProcesses)
+                            ->firstWhere('id', $signalId);
+
+        return $assocSignal && $assocSignal['processes'] ? $assocSignal['processes'] : [];
+    }
+
+    /**
      * @param SignalData $newSignal
      * @param SignalData | null $oldSignal In case of an insert, this variable is null
      *

--- a/resources/js/processes/signals/components/SignalListing.vue
+++ b/resources/js/processes/signals/components/SignalListing.vue
@@ -26,28 +26,30 @@
         <template slot="actions" slot-scope="props">
           <div class="actions">
             <div class="popout">
-              <b-btn
-                variant="link"
-                @click="onEdit(props.rowData, props.rowIndex)"
-                v-b-tooltip.hover
-                :title="$t('Edit')"
-                :disabled="!isEditable(props.rowData)"
-                v-if="permission.includes('edit-processes')"
-                v-uni-aria-describedby="props.rowData.id.toString()"
-              >
-                <i class="fas fa-pen-square fa-lg fa-fw"></i>
-              </b-btn>
-              <b-btn
-                variant="link"
-                @click="onReview(props.rowData, props.rowIndex)"
-                v-b-tooltip.hover
-                :title="isCollection(props.rowData) ? $t('View Collection') : $t('Delete')"
-                :disabled="(!isDeletable(props.rowData) || !permission.includes('edit-processes')) && !isCollection(props.rowData)"
-                v-uni-aria-describedby="props.rowData.id.toString()"
-              >
-                <i v-if="isCollection(props.rowData)" class="fas fa-external-link-alt fa-lg fa-fw"></i>
-                <i v-else class="fas fa-trash-alt fa-lg fa-fw"></i>
-              </b-btn>
+              <span v-b-tooltip.hover
+                    :title="isEditable(props.rowData) ? $t('Edit') : $t('Cannot edit system signals.')">
+                <b-btn
+                    variant="link"
+                    @click="onEdit(props.rowData, props.rowIndex)"
+                    :disabled="!isEditable(props.rowData)"
+                    v-if="permission.includes('edit-processes')"
+                    v-uni-aria-describedby="props.rowData.id.toString()"
+                >
+                    <i class="fas fa-pen-square fa-lg fa-fw"></i>
+                </b-btn>
+              </span>
+              <span v-b-tooltip.hover
+                :title="getDeleteButtonTitle(props.rowData)">
+                <b-btn
+                    variant="link"
+                    @click="onReview(props.rowData, props.rowIndex)"
+                    :disabled="(!isDeletable(props.rowData) || !permission.includes('edit-processes')) && !isCollection(props.rowData)"
+                    v-uni-aria-describedby="props.rowData.id.toString()"
+                >
+                    <i v-if="isCollection(props.rowData)" class="fas fa-external-link-alt fa-lg fa-fw"></i>
+                    <i v-else class="fas fa-trash-alt fa-lg fa-fw"></i>
+                </b-btn>
+              </span>
             </div>
           </div>
         </template>
@@ -116,6 +118,21 @@ export default {
         }
       });
       return editable;
+    },
+    getDeleteButtonTitle(rowData) {
+        if (this.isCollection(rowData)) {
+            return this.$t('View Collection');
+        }
+        if (!this.isDeletable(rowData) && this.isEditable(rowData)) {
+            return this.$t('Cannot delete signals present in a process.');
+        }
+        if (!this.isDeletable(rowData) && !this.isEditable(rowData)) {
+            return this.$t('Cannot delete system signals.');
+        }
+        if (!this.permission.includes('edit-processes')) {
+            return this.$t('You do not have permission to delete signals');
+        }
+        return this.$t('Delete');
     },
     onEdit(data, index) {
       window.location = "/designer/signals/" + data.id + "/edit";

--- a/resources/js/processes/signals/components/SignalListing.vue
+++ b/resources/js/processes/signals/components/SignalListing.vue
@@ -31,6 +31,7 @@
                 @click="onEdit(props.rowData, props.rowIndex)"
                 v-b-tooltip.hover
                 :title="$t('Edit')"
+                :disabled="!isEditable(props.rowData)"
                 v-if="permission.includes('edit-processes')"
                 v-uni-aria-describedby="props.rowData.id.toString()"
               >
@@ -106,6 +107,15 @@ export default {
     isDeletable(data) {
       let catches = data.processes.reduce((carry, process) => carry + process.catches.length, 0);
       return catches === 0;
+    },
+    isEditable(data) {
+      let editable = true;
+      data.processes.forEach(process => {
+        if (process.catches.length && process.is_system) {
+          editable = false;
+        }
+      });
+      return editable;
     },
     onEdit(data, index) {
       window.location = "/designer/signals/" + data.id + "/edit";

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1558,6 +1558,9 @@
   "Signal Payload": "Signal Payload",
   "Signals present in processes and system processes cannot be deleted.": "Signals present in processes and system processes cannot be deleted.",
   "System signals cannot be modified.": "System signals cannot be modified.",
+  "Cannot edit system signals.": "Cannot edit system signals.",
+  "Cannot delete System signals.": "Cannot delete System signals.",
+  "Cannot delete signals present in a process.": "Cannot delete signals present in a process.",
   "Display contents of docker file that will be prepended to your customizations below.": "Display contents of docker file that will be prepended to your customizations below.",
   "Downloading files is not available.": "Downloading files is not available."
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1557,6 +1557,7 @@
   "Data Sources Package not installed.": "Data Sources Package not installed.",
   "Signal Payload": "Signal Payload",
   "Signals present in processes and system processes cannot be deleted.": "Signals present in processes and system processes cannot be deleted.",
+  "System signals cannot be modified.": "System signals cannot be modified.",
   "Display contents of docker file that will be prepended to your customizations below.": "Display contents of docker file that will be prepended to your customizations below.",
   "Downloading files is not available.": "Downloading files is not available."
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1556,6 +1556,7 @@
   "Assignee Manager Escalation": "Assignee Manager Escalation",
   "Data Sources Package not installed.": "Data Sources Package not installed.",
   "Signal Payload": "Signal Payload",
+  "Signals present in processes and system processes cannot be deleted.": "Signals present in processes and system processes cannot be deleted.",
   "Display contents of docker file that will be prepended to your customizations below.": "Display contents of docker file that will be prepended to your customizations below.",
   "Downloading files is not available.": "Downloading files is not available."
 }

--- a/tests/Feature/Api/processes/SignalSimple.bpmn
+++ b/tests/Feature/Api/processes/SignalSimple.bpmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+    <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+        <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+            <bpmn:outgoing>node_10</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:endEvent id="node_2" name="End Event">
+            <bpmn:incoming>node_7</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:task id="node_3" name="Form Task" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false">
+            <bpmn:incoming>node_12</bpmn:incoming>
+            <bpmn:outgoing>node_7</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="node_7" sourceRef="node_3" targetRef="node_2" />
+        <bpmn:intermediateThrowEvent id="node_13" name="Intermediate Signal Throw Event">
+            <bpmn:incoming>node_10</bpmn:incoming>
+            <bpmn:outgoing>node_12</bpmn:outgoing>
+            <bpmn:signalEventDefinition signalRef="MySignalID" pm:config="{&#34;payload&#34;:[{&#34;id&#34;:&#34;ALL_REQUEST_DATA&#34;,&#34;variable&#34;:&#34;&#34;,&#34;expression&#34;:&#34;&#34;}]}" />
+        </bpmn:intermediateThrowEvent>
+        <bpmn:sequenceFlow id="node_10" sourceRef="node_1" targetRef="node_13" />
+        <bpmn:sequenceFlow id="node_12" sourceRef="node_13" targetRef="node_3" />
+    </bpmn:process>
+    <bpmn:signal id="MySignalID" name="MySignal" />
+    <bpmndi:BPMNDiagram id="BPMNDiagramId">
+        <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+            <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+                <dc:Bounds x="130" y="190" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+                <dc:Bounds x="520" y="190" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+                <dc:Bounds x="300" y="170" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+                <di:waypoint x="358" y="208" />
+                <di:waypoint x="538" y="208" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="node_13_di" bpmnElement="node_13">
+                <dc:Bounds x="210" y="110" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_10_di" bpmnElement="node_10">
+                <di:waypoint x="148" y="208" />
+                <di:waypoint x="228" y="128" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="node_12_di" bpmnElement="node_12">
+                <di:waypoint x="228" y="128" />
+                <di:waypoint x="358" y="208" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Issue & Reproduction Steps
Signals that are present in processes or in system processes should not be deleted.

- Have an instance with PM 4.2.x
- Go to Designer, Signals
- Find the signals that belong to the package-advanced-user-manager package, see the image attached
- Delete those signals
- Try a request with any existing process, you will the error attached: Element "sync_assignment" was not found


## Solution
- In the **index** method in signals controller, changed the parameter **includeSystemProcesses** to true to retrieve signals with system processes, to disable the delete button in frontend.
- In the **destroy** method in signals controller, check if signals are present in some process or system process and abort the deleting operation.

## How to Test

**Case 1**
- Go to designer / signals and create a signal
- After create the signal the icon to delete the signal should be VISIBLE
- Click the delete button, the signal should be deleted

**Case 2**
- Go to designer / signals and create a signal
- Go to designer / processes and create a process
- Add a signal event in the process and configure the signal previously created. Save the process
- Go to designer / signals again, the signal you created previously should have the delete button disabled
- Try to delete the previous signal via postman. You should receive an error message "Signals present in processes and system processes cannot be deleted."

**Case 3**
- Install advance-user-manager package
- Go to designer / signals and notice that should be present 3 new system signals ("sync_assignment",	"escalate_task", "delegate_task")
- That system signals should have the delete button disabled
- Try to delete some of that system signals via postman. You should receive an error message "Signals present in processes and system processes cannot be deleted."

Run test cases under tests/Feature/Api/SignalTest.php

**Working video**
P.S.: Ignore the word "bya" in the video (is via)

https://user-images.githubusercontent.com/90727999/157320329-3f0f8392-5e0e-45cc-a54d-a1ac02e3d028.mov


## Related Tickets & Packages
- [FOUR-5538](https://processmaker.atlassian.net/browse/FOUR-5538)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
