### PR TITLE
Bugfix/FOUR-5490: Tab stops working on nested screen when nested controls have tab order configured

### DIFF
--- a/resources/js/components/Menu.vue
+++ b/resources/js/components/Menu.vue
@@ -10,6 +10,7 @@
               class="text-capitalize"
               :title="button.title"
               :key="indexButton"
+              tabindex="1"
               @click="executeFunction(button.action)"
               v-if="button.hide !== true"
             >


### PR DESCRIPTION
## Issue & Reproduction Steps
- create a screen with controls
- configure the controls with the tab order option
- test the tab order on the same scree
- create a new screen
- add a nested screen
- add in the nested screen the screen created from step 2
- add other controls in the second scren to see the difference
- add a submit
- save the screen
- click preview
- press the TAB key for each control


## Solution
- Added tabindex=“1" to preview button to force jumping to the next element that was configured with some tab order.

**Explanation**
After some research about the behavior, the problem itself is related to the nature of how tabindex works. In the [documentation of tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute we can found the following:

- tabindex=“0” means that the element should be focusable in sequential keyboard navigation, after any positive tabindex values and its order is defined by the document’s source order.
- A positive value means the element should be focusable in sequential keyboard navigation, with its order defined by the value of the number. That is, tabindex=“4" is focused before tabindex=“5” and tabindex=“0", but after tabindex=“3”. If multiple elements share the same positive tabindex value, their order relative to each other follows their position in the document source. The maximum value for tabindex is 32767. If not specified, it takes the default value 0.

If we not define any tabindex, and the component is interactive (button, input, textarea), the default tabindex is 0.

So if we considere the following example,

![Screen Shot 2022-03-10 at 10 34 01](https://user-images.githubusercontent.com/90727999/157679140-82693682-a8cb-4e44-a136-3ecb7aff9009.png)

we should have the next stack of tab index processing:

Tabindex 1
Tabindex 2
Tabindex 3
Tabindex 4
Tabindex 5
Tabindex 6
Tabindex 0 ← When we click preview button the current focus element have a tabindex 0 and will continue with the next following elements in the stack (tabindex 0)
…
Tabindex 0
Tabindex 0

To resume,

- I changed the preview button with a custom tabindex=“1" to force jumping the next element that was configured with some tab order.
- It is necessary to configure all the tabindex elements in the form to avoid unexpected behavior

## How to Test
Follow reproduction steps.

**Working video**

https://user-images.githubusercontent.com/90727999/157679694-74cb57ea-7dd0-4786-9437-e916b87a4574.mov


## Related Tickets & Packages
- [FOUR-5490](https://processmaker.atlassian.net/browse/FOUR-5490)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
