### PR TITLE
4.2.- Screen freeze with several triggers in watcher with dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
         "vue-croppie": "1.3.12",
         "vue-deepset": "^0.6.3",
         "vue-events": "^3.1.0",
-        "vue-json-pretty": "^1.7.1",
         "vue-monaco": "^1.2.1",
         "vue-password": "^1.2.0",
         "vue-resource": "^1.5.1",

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -376,6 +376,7 @@ export default {
         formatOnPaste: true,
         formatOnType: true,
         automaticLayout: true,
+        readOnly: true,
         minimap: { enabled: false },
       },
       mockMagicVariables,

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -413,11 +413,14 @@ export default {
     },
   },
   computed: {
-    previewDataStringyfy() {
-      if (JSON.stringify(this.previewData) !== JSON.stringify(this.previewDataSaved)) {
-        this.formatMonaco();
-      }
-      return JSON.stringify(this.previewData);
+    previewDataStringyfy: {
+      get() {
+        if (JSON.stringify(this.previewData) !== JSON.stringify(this.previewDataSaved)) {
+          this.formatMonaco();
+        }
+        return JSON.stringify(this.previewData);
+      },
+      set() {}
     },
     previewInputValid() {
       try {


### PR DESCRIPTION
## Issue & Reproduction Steps
The designer of screen-builder freezes with thousands of options in the selection list.

## Solution
- Change of componente in preview data 

## How to Test
 - Create Screen
 - Add select list with data connector
 - Add watcher to have dependency with others select list
 - Press preview button
 - Enable the watcher several times

https://user-images.githubusercontent.com/1747025/157733155-5ed48b91-c648-4144-859f-3d5115182883.mp4



## Related Tickets & Packages
- [FOUR-5430](https://processmaker.atlassian.net/browse/FOUR-5430)
## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
