### PR TITLE
Bugfix/FOUR-5313: The URL does not show the request with authenticated web entry

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -9,6 +9,7 @@ use ProcessMaker\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use ProcessMaker\Traits\HasControllerAddons;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cookie;
 
 class LoginController extends Controller
 {
@@ -62,7 +63,7 @@ class LoginController extends Controller
     }
 
     public function loginWithIntendedCheck(Request $request) {
-        $intended = redirect()->intended()->getTargetUrl();
+        $intended = Cookie::get('processmaker_intended');
         if ($intended) {
             // Check if the route is a fallback, meaning it's invalid (like favicon.ico)
             $route = app('router')->getRoutes() ->match(
@@ -75,7 +76,7 @@ class LoginController extends Controller
             // Getting intended deletes it, so put in back
             $request->session()->put('url.intended', $intended);
         }
-        
+
         // Check the status of the user
         $user = User::where('username', $request->input('username'))->first();
         if (!$user || $user->status === 'INACTIVE') {

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -63,12 +63,12 @@ class AuthTest extends TestCase
             'password' => Hash::make('abc123'),
             'status' => 'ACTIVE',
         ]);
-        
+
         $response = $this->post('login', [
             'username' => 'foobar',
             'password' => 'abc123',
         ]);
-        $response->assertRedirect('/');
+        $response->assertRedirect('/requests');
         $response->assertSessionHasNoErrors();
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

- Log in 
- Create a process 
- Configure start event  with  web entry Authenticated
- Copy URL
- Open new  browser (incognito)
- Paste URL
- Login  

After login in web entry is redirecting to requests instead to the webentry task

## Solution
- Retrieve the correct redirect URL from cookie **processmaker_intended**.

## How to Test
Same as steps to reproduce. After login in web entry should redirect the webentry task.

**Working video**

https://user-images.githubusercontent.com/90727999/158172578-26045b0b-021c-4c5e-8a4c-ce0d991b3e07.mov


## Related Tickets & Packages
- [FOUR-5313](https://processmaker.atlassian.net/browse/FOUR-5313)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
