### PR TITLE
Script error using getProcesses API endpoint

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -74,7 +74,7 @@ use Throwable;
  *   @OA\Property(property="package_key", type="string"),
  *   @OA\Property(property="start_events", type="array", @OA\Items(ref="#/components/schemas/ProcessStartEvents")),
  *   @OA\Property(property="warnings", type="string"),
- *   @OA\Property(property="self_service_tasks", type="array", @OA\Items(type="object")),
+ *   @OA\Property(property="self_service_tasks", type="object"),
  *   @OA\Property(property="signal_events", type="array", @OA\Items(type="object")),
  *   @OA\Property(property="category", @OA\Schema(ref="#/components/schemas/ProcessCategory")),
  *   @OA\Property(property="manager_id", type="integer", format="id"),

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -18,12 +18,1850 @@
         }
     ],
     "paths": {
+        "/collections": {
+            "get": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Returns all collections that the user has access to",
+                "description": "Get a list of Collections.",
+                "operationId": "getCollections",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_by"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/include"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of collections",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/collections"
+                                            }
+                                        },
+                                        "meta": {
+                                            "$ref": "#/components/schemas/metadata"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Save a new collections",
+                "description": "Create a new Collection.",
+                "operationId": "createCollection",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/collectionsEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/collections"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/collections/{collection_id}": {
+            "get": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Get single collections by ID",
+                "description": "Get a single Collection.",
+                "operationId": "getCollectionById",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of collection to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully found the collections",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/collections"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Update a collection",
+                "description": "Update a Collection.",
+                "operationId": "updateCollection",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of collection to update",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/collectionsEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Delete a collection",
+                "description": "Delete a Collection.",
+                "operationId": "deleteCollection",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of collection to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            }
+        },
+        "/collections/{collection_id}/export": {
+            "post": {
+                "tags": [
+                    "Screens"
+                ],
+                "summary": "Trigger export collections job",
+                "description": "Export the specified collection.",
+                "operationId": "exportCollection",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of the collection to export",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "success"
+                    }
+                }
+            }
+        },
+        "/collections/import": {
+            "post": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Import a new collection",
+                "description": "Import the specified collection.",
+                "operationId": "importCollection",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "required": [
+                                    "file"
+                                ],
+                                "properties": {
+                                    "file": {
+                                        "description": "file to upload",
+                                        "type": "file",
+                                        "format": "file"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/collections"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "success"
+                    }
+                }
+            }
+        },
+        "/collections/{collection_id}/truncate": {
+            "delete": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Deletes all records in a collection",
+                "description": "Truncate a Collection.",
+                "operationId": "truncateCollection",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of collection to truncate",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            }
+        },
+        "/collections/{collection_id}/records": {
+            "get": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Returns all records",
+                "description": "Get the list of records of a collection.",
+                "operationId": "getRecords",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of collection to get records for",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "pmql",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_by"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/include"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of records of a collection",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/records"
+                                            }
+                                        },
+                                        "meta": {
+                                            "$ref": "#/components/schemas/metadata"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Save a new record in a collection",
+                "description": "Create a new record in a Collection.",
+                "operationId": "createRecord",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of the collection",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/recordsEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/records"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/collections/{collection_id}/records/{record_id}": {
+            "get": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Get single record of a collection",
+                "description": "Get a single record of a Collection.",
+                "operationId": "getRecordById",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of the collection",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "record_id",
+                        "in": "path",
+                        "description": "ID of the record to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully found the record",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/records"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Update a record",
+                "description": "Update a record in a Collection.",
+                "operationId": "updateRecord",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of collection",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "record_id",
+                        "in": "path",
+                        "description": "ID of the record ",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/recordsEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Delete a collection record",
+                "description": "Delete a record of a Collection.",
+                "operationId": "deleteRecord",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of collection",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "record_id",
+                        "in": "path",
+                        "description": "ID of record in collection",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "Collections"
+                ],
+                "summary": "Partial update of a record",
+                "description": "Implements a partial update of a record in a Collection.",
+                "operationId": "patchRecord",
+                "parameters": [
+                    {
+                        "name": "collection_id",
+                        "in": "path",
+                        "description": "ID of collection ",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "record_id",
+                        "in": "path",
+                        "description": "ID of the record ",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/collectionsEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "success"
+                    }
+                }
+            }
+        },
+        "/data_source_categories": {
+            "get": {
+                "tags": [
+                    "DataSourcesCategories"
+                ],
+                "summary": "Returns all Data Connectors categories that the user has access to",
+                "description": "Display a listing of the Data Connector Categories.",
+                "operationId": "getDataSourceCategories",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_by"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of Data Connectors categories",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/DataSourceCategory"
+                                            }
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/components/schemas/metadata"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "DataSourcesCategories"
+                ],
+                "summary": "Save a new Data Connector Category",
+                "description": "Store a newly created Data Connector Category in storage",
+                "operationId": "createDataSourceCategory",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/dataSourceCategoryEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DataSourceCategory"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/data_source_categories/{data_source_category_id}": {
+            "get": {
+                "tags": [
+                    "DataSourcesCategories"
+                ],
+                "summary": "Get single Data Connector category by ID",
+                "description": "Display the specified data Source category.",
+                "operationId": "getDatasourceCategoryById",
+                "parameters": [
+                    {
+                        "name": "data_source_category_id",
+                        "in": "path",
+                        "description": "ID of Data Connector category to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully found the Data Connector",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DataSourceCategory"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "DataSourcesCategories"
+                ],
+                "summary": "Update a Data Connector Category",
+                "description": "Updates the current element",
+                "operationId": "updateDatasourceCategory",
+                "parameters": [
+                    {
+                        "name": "data_source_category_id",
+                        "in": "path",
+                        "description": "ID of Data Connector category to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/dataSourceCategoryEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DataSourceCategory"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "DataSourcesCategories"
+                ],
+                "summary": "Delete a Data Connector category",
+                "description": "Remove the specified resource from storage.",
+                "operationId": "deleteDataSourceCategory",
+                "parameters": [
+                    {
+                        "name": "data_source_category_id",
+                        "in": "path",
+                        "description": "ID of Data Connector category to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            }
+        },
+        "/data_sources": {
+            "get": {
+                "tags": [
+                    "DataSources"
+                ],
+                "summary": "Returns all Data Connectors that the user has access to",
+                "description": "Get the list of records of a Data Connector",
+                "operationId": "getDataSources",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_by"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/include"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of Data Connectors",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/dataSource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/components/schemas/metadata"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "DataSources"
+                ],
+                "summary": "Save a new Data Connector",
+                "description": "Create a new Data Connector.",
+                "operationId": "createDataSource",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/dataSourceEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dataSource"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/data_sources/data_source_id": {
+            "get": {
+                "tags": [
+                    "DataSources"
+                ],
+                "summary": "Get single Data Connector by ID",
+                "description": "Get a single Data Connector.",
+                "operationId": "getDataSourceById",
+                "parameters": [
+                    {
+                        "name": "data_source_id",
+                        "in": "path",
+                        "description": "ID of Data Connector to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully found the Data Connector",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dataSource"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "DataSources"
+                ],
+                "summary": "Update a Data Connector",
+                "description": "Update a Data Connector.",
+                "operationId": "updateDataSource",
+                "parameters": [
+                    {
+                        "name": "data_source_id",
+                        "in": "path",
+                        "description": "ID of Data Connector to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/dataSourceEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dataSource"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "DataSources"
+                ],
+                "summary": "Delete a Data Connector",
+                "description": "Delete a Data Connector.",
+                "operationId": "deleteDataSource",
+                "parameters": [
+                    {
+                        "name": "data_source_id",
+                        "in": "path",
+                        "description": "ID of Data Connector to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dataSource"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/data_sources/data_source_id/test": {
+            "post": {
+                "tags": [
+                    "DataSources"
+                ],
+                "summary": "Send a Data Connector request",
+                "description": "Send a Data Connector request.",
+                "operationId": "sendDataSource",
+                "parameters": [
+                    {
+                        "name": "data_source_id",
+                        "in": "path",
+                        "description": "ID of Data Connector to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/dataSourceEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dataSource"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/requests/{request_id}/data_sources/{data_source_id}": {
+            "post": {
+                "tags": [
+                    "DataSources"
+                ],
+                "summary": "execute Data Source",
+                "description": "Execute a data Source endpoint",
+                "operationId": "executeDataSourceForRequest",
+                "parameters": [
+                    {
+                        "name": "request_id",
+                        "in": "path",
+                        "description": "ID of the request in whose context the datasource will be executed",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "data_source_id",
+                        "in": "path",
+                        "description": "ID of DataSource to be run",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "config": {
+                                        "$ref": "#/components/schemas/DataSourceCallParameters"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DataSourceResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/requests/data_sources/{data_source_id}": {
+            "post": {
+                "tags": [
+                    "DataSources"
+                ],
+                "summary": "execute Data Source",
+                "operationId": "executeDataSource",
+                "parameters": [
+                    {
+                        "name": "data_source_id",
+                        "in": "path",
+                        "description": "ID of DataSource to be run",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "config": {
+                                        "$ref": "#/components/schemas/DataSourceCallParameters"
+                                    },
+                                    "data": {
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DataSourceResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/{saved_search_id}/charts": {
+            "get": {
+                "tags": [
+                    "SavedSearchCharts"
+                ],
+                "summary": "Returns all saved search charts that the user has access to",
+                "description": "Get a list of SavedSearchCharts.",
+                "operationId": "getSavedSearchCharts",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Only return saved searches by type",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "request",
+                                "task",
+                                "collection"
+                            ]
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_by"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/include"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of saved search charts",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SavedSearchChart"
+                                            }
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/components/schemas/metadata"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "SavedSearchCharts"
+                ],
+                "summary": "Update several saved search charts at once",
+                "description": "Batch update several SavedSearchCharts.",
+                "operationId": "batchUpdateSavedSearchCharts",
+                "parameters": [
+                    {
+                        "name": "saved_search_id",
+                        "in": "path",
+                        "description": "ID of saved search to which these charts will be saved",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/SavedSearchChart"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "SavedSearchCharts"
+                ],
+                "summary": "Save a new saved search chart",
+                "description": "Create a new SavedSearchChart.",
+                "operationId": "createSavedSearchChart",
+                "parameters": [
+                    {
+                        "name": "saved_search_id",
+                        "in": "path",
+                        "description": "ID of saved search to which this chart will be saved",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SavedSearchChartEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SavedSearchChart"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/charts/{chart_id}": {
+            "get": {
+                "tags": [
+                    "SavedSearchCharts"
+                ],
+                "summary": "Get single saved search chart by ID",
+                "description": "Get a single SavedSearchChart.",
+                "operationId": "getSavedSearchChartById",
+                "parameters": [
+                    {
+                        "name": "chart_id",
+                        "in": "path",
+                        "description": "ID of chart to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully found the saved search chart",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SavedSearchChart"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "SavedSearchCharts"
+                ],
+                "summary": "Update a saved search chart",
+                "description": "Update a SavedSearchChart.",
+                "operationId": "updateSavedSearchChart",
+                "parameters": [
+                    {
+                        "name": "chart_id",
+                        "in": "path",
+                        "description": "ID of chart to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SavedSearchChartEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SavedSearchChart"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "SavedSearchCharts"
+                ],
+                "summary": "Delete a saved search chart",
+                "description": "Delete a SavedSearchChart.",
+                "operationId": "deleteSavedSearchChart",
+                "parameters": [
+                    {
+                        "name": "chart_id",
+                        "in": "path",
+                        "description": "ID of chart to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            }
+        },
+        "/saved-searches/charts/{chart_id}/fields": {
+            "get": {
+                "tags": [
+                    "SavedSearchCharts"
+                ],
+                "summary": "Get available chart fields for a Saved Search by ID",
+                "description": "Get available chart fields for a Saved Search.",
+                "operationId": "getSavedSearchFieldsById",
+                "parameters": [
+                    {
+                        "name": "chart_id",
+                        "in": "path",
+                        "description": "ID of Saved Search to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully found the saved search",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SavedSearch"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/reports": {
+            "post": {
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Save a new report",
+                "operationId": "createReport",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ReportEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Report"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/reports/{reportId}": {
+            "put": {
+                "tags": [
+                    "SavedSearches"
+                ],
+                "summary": "Update a saved search",
+                "description": "Update a Report",
+                "operationId": "updateReport",
+                "parameters": [
+                    {
+                        "name": "reportId",
+                        "in": "path",
+                        "description": "ID of report",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SavedSearchEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SavedSearch"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches": {
+            "get": {
+                "tags": [
+                    "SavedSearches"
+                ],
+                "summary": "Returns all saved searches that the user has access to",
+                "description": "Get a list of SavedSearches.",
+                "operationId": "getSavedSearches",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Only return saved searches by type",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "request",
+                                "task",
+                                "collection"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "subset",
+                        "in": "query",
+                        "description": "Only return saved searches that are yours or those that have been shared with you",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "mine",
+                                "shared"
+                            ]
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_by"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/include"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of saved searches",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SavedSearch"
+                                            }
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/components/schemas/metadata"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "SavedSearches"
+                ],
+                "summary": "Save a new saved search",
+                "description": "Create a new SavedSearch.",
+                "operationId": "createSavedSearch",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SavedSearchEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SavedSearch"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/{savedSearchId}": {
+            "get": {
+                "tags": [
+                    "SavedSearches"
+                ],
+                "summary": "Get single saved searches by ID",
+                "description": "Get a single SavedSearch.",
+                "operationId": "getSavedSearchById",
+                "parameters": [
+                    {
+                        "name": "savedSearchId",
+                        "in": "path",
+                        "description": "ID of saved search to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully found the saved search",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SavedSearch"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "SavedSearches"
+                ],
+                "summary": "Update a saved search",
+                "description": "Update a SavedSearch.",
+                "operationId": "updateSavedSearch",
+                "parameters": [
+                    {
+                        "name": "savedSearchId",
+                        "in": "path",
+                        "description": "ID of saved search to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SavedSearchEditable"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SavedSearch"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/{savedSearchId}/columns": {
+            "get": {
+                "tags": [
+                    "SavedSearches"
+                ],
+                "summary": "Returns all columns associated with a Saved Search",
+                "description": "Display a listing of columns.",
+                "operationId": "getSavedSearchColumns",
+                "parameters": [
+                    {
+                        "name": "savedSearchId",
+                        "in": "path",
+                        "description": "ID of saved search to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "description": "Include specific categories. Comma separated list.",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "current",
+                                    "default",
+                                    "available",
+                                    "data"
+                                ]
+                            },
+                            "uniqueItems": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Categorized list of columns",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "current": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/columns"
+                                            }
+                                        },
+                                        "default": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/columns"
+                                            }
+                                        },
+                                        "available": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/columns"
+                                            }
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/columns"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/{savedSearchId}/users": {
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Returns all users",
+                "description": "Display a listing of the resource.",
+                "operationId": "getSavedSearchUsers",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_by"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/include"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of users",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/users"
+                                            }
+                                        },
+                                        "meta": {
+                                            "$ref": "#/components/schemas/metadata"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/{savedSearchId}/groups": {
+            "get": {
+                "tags": [
+                    "Groups"
+                ],
+                "summary": "Returns all groups that the user has access to",
+                "description": "Display a listing of the resource.",
+                "operationId": "getSavedSearchGroups",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/order_by"
+                    },
+                    {
+                        "$ref": "#/components/parameters/order_direction"
+                    },
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/include"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of groups",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/groups"
+                                            }
+                                        },
+                                        "meta": {
+                                            "$ref": "#/components/schemas/metadata"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/saved-searches/{saved_search_id}": {
+            "delete": {
+                "tags": [
+                    "SavedSearches"
+                ],
+                "summary": "Delete a saved search",
+                "description": "Delete a SavedSearch.",
+                "operationId": "deleteSavedSearch",
+                "parameters": [
+                    {
+                        "name": "saved_search_id",
+                        "in": "path",
+                        "description": "ID of saved search to return",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "success"
+                    }
+                }
+            }
+        },
+        "/saved-searches/icons": {
+            "get": {
+                "tags": [
+                    "SavedSearches"
+                ],
+                "summary": "Returns all icons for saved searches",
+                "description": "Get a list of icons available for SavedSearches.",
+                "operationId": "getSavedSearchesIcons",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/per_page"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "list of icons for saved searches",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SavedSearchIcon"
+                                            }
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/components/schemas/metadata"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/customize-ui": {
             "post": {
                 "tags": [
                     "CssSettings"
                 ],
                 "summary": "Create or update a new setting",
+                "description": "Create a new Settings css-override",
                 "operationId": "updateCssSetting",
                 "requestBody": {
                     "required": true,
@@ -32,11 +1870,9 @@
                             "schema": {
                                 "properties": {
                                     "variables": {
-                                        "description": "Create a new Settings css-override",
                                         "type": "string"
                                     },
                                     "sansSerifFont": {
-                                        "description": "Create a new Settings css-override",
                                         "type": "string"
                                     }
                                 },
@@ -65,6 +1901,7 @@
                     "Environment Variables"
                 ],
                 "summary": "Returns all environmentVariables that the user has access to. For security, values are not included.",
+                "description": "Fetch a collection of variables based on paged request and filter if provided",
                 "operationId": "getEnvironmentVariables",
                 "parameters": [
                     {
@@ -91,14 +1928,12 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Fetch a collection of variables based on paged request and filter if provided",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/EnvironmentVariable"
                                             }
                                         },
                                         "meta": {
-                                            "description": "Fetch a collection of variables based on paged request and filter if provided",
                                             "type": "object"
                                         }
                                     },
@@ -114,6 +1949,7 @@
                     "Environment Variables"
                 ],
                 "summary": "Create a new environment variable",
+                "description": "Creates a new global Environment Variable in the system",
                 "operationId": "createEnvironmentVariable",
                 "requestBody": {
                     "required": true,
@@ -145,6 +1981,7 @@
                     "Environment Variables"
                 ],
                 "summary": "Get an environment variable by id. For security, the value is not included.",
+                "description": "Return an environment variable instance\nUsing implicit model binding, will automatically return 404 if variable now found",
                 "operationId": "getEnvironmentVariableById",
                 "parameters": [
                     {
@@ -175,6 +2012,7 @@
                     "Environment Variables"
                 ],
                 "summary": "Update an environment variable",
+                "description": "Update an environment variable",
                 "operationId": "updateEnvironmentVariable",
                 "parameters": [
                     {
@@ -240,6 +2078,7 @@
                     "Files"
                 ],
                 "summary": "Returns the list of files",
+                "description": "Display a listing of the resource.",
                 "operationId": "getFiles",
                 "parameters": [
                     {
@@ -263,7 +2102,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/media"
@@ -285,6 +2123,7 @@
                     "Files"
                 ],
                 "summary": "Save a new media file. Note: To upload files to a request, use createRequestFile in the RequestFile API",
+                "description": "Store a newly created resource in storage.",
                 "operationId": "createFile",
                 "parameters": [
                     {
@@ -349,19 +2188,15 @@
                                 "schema": {
                                     "properties": {
                                         "id": {
-                                            "description": "Store a newly created resource in storage.",
                                             "type": "string"
                                         },
                                         "model_id": {
-                                            "description": "Store a newly created resource in storage.",
                                             "type": "string"
                                         },
                                         "file_name": {
-                                            "description": "Store a newly created resource in storage.",
                                             "type": "string"
                                         },
                                         "mime_type": {
-                                            "description": "Store a newly created resource in storage.",
                                             "type": "string"
                                         }
                                     },
@@ -379,6 +2214,7 @@
                     "Files"
                 ],
                 "summary": "Get the metadata of a file. To actually fetch the file see Get File Contents",
+                "description": "Get a single media file.",
                 "operationId": "getFileById",
                 "parameters": [
                     {
@@ -412,6 +2248,7 @@
                     "Files"
                 ],
                 "summary": "Delete a media file",
+                "description": "Remove the specified resource from storage.",
                 "operationId": "deleteFile",
                 "parameters": [
                     {
@@ -440,6 +2277,7 @@
                     "Files"
                 ],
                 "summary": "Get the contents of a file",
+                "description": "Display the specified resource.",
                 "operationId": "getFileContentsById",
                 "parameters": [
                     {
@@ -476,6 +2314,7 @@
                     "Groups"
                 ],
                 "summary": "Returns all groups that the user has access to",
+                "description": "Display a listing of the resource.",
                 "operationId": "getGroups",
                 "parameters": [
                     {
@@ -505,7 +2344,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/groups"
@@ -527,6 +2365,7 @@
                     "Groups"
                 ],
                 "summary": "Save a new group",
+                "description": "Store a newly created resource in storage.",
                 "operationId": "createGroup",
                 "requestBody": {
                     "required": true,
@@ -561,6 +2400,7 @@
                     "Groups"
                 ],
                 "summary": "Get single group by ID",
+                "description": "Display the specified resource.",
                 "operationId": "getGroupById",
                 "parameters": [
                     {
@@ -594,6 +2434,7 @@
                     "Groups"
                 ],
                 "summary": "Update a group",
+                "description": "Update a user",
                 "operationId": "updateGroup",
                 "parameters": [
                     {
@@ -630,6 +2471,7 @@
                     "Groups"
                 ],
                 "summary": "Delete a group",
+                "description": "Delete a user",
                 "operationId": "deleteGroup",
                 "parameters": [
                     {
@@ -658,6 +2500,7 @@
                     "Groups"
                 ],
                 "summary": "Returns all users of a group",
+                "description": "Display the list of users in a group",
                 "operationId": "getGroupUsers",
                 "parameters": [
                     {
@@ -687,7 +2530,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display the list of users in a group",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/users"
@@ -711,6 +2553,7 @@
                     "Groups"
                 ],
                 "summary": "Returns all users of a group",
+                "description": "Display the list of groups in a group",
                 "operationId": "getGroupGroupss",
                 "parameters": [
                     {
@@ -740,7 +2583,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display the list of groups in a group",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/groups"
@@ -764,6 +2606,7 @@
                     "Group Members"
                 ],
                 "summary": "Returns all groups for a given member",
+                "description": "Display a listing of the resource.",
                 "operationId": "getGroupMembers",
                 "parameters": [
                     {
@@ -787,7 +2630,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/groupMembers"
@@ -809,6 +2651,7 @@
                     "Group Members"
                 ],
                 "summary": "Save a new group member",
+                "description": "Store a newly created resource in storage.",
                 "operationId": "createGroupMember",
                 "requestBody": {
                     "required": true,
@@ -840,6 +2683,7 @@
                     "Group Members"
                 ],
                 "summary": "Get single group member by ID",
+                "description": "Display the specified resource.",
                 "operationId": "getGroupMemberById",
                 "parameters": [
                     {
@@ -870,6 +2714,7 @@
                     "Group Members"
                 ],
                 "summary": "Delete a group member",
+                "description": "Delete a group membership",
                 "operationId": "deleteGroupMember",
                 "parameters": [
                     {
@@ -895,6 +2740,7 @@
                     "Group Members"
                 ],
                 "summary": "Returns all groups available for a given member",
+                "description": "Display a listing of groups available",
                 "operationId": "getGroupMembersAvailable",
                 "parameters": [
                     {
@@ -936,7 +2782,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of groups available",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/availableGroupMembers"
@@ -960,6 +2805,7 @@
                     "Group Members"
                 ],
                 "summary": "Returns all users available for a given group",
+                "description": "Display a listing of users available",
                 "operationId": "getUserMembersAvailable",
                 "parameters": [
                     {
@@ -997,7 +2843,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of users available",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/users"
@@ -1021,6 +2866,7 @@
                     "Notifications"
                 ],
                 "summary": "Returns all notifications that the user has access to",
+                "description": "Display a listing of the resource.",
                 "operationId": "getNotifications",
                 "parameters": [
                     {
@@ -1056,15 +2902,12 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/Notification"
                                             }
                                         },
-                                        "meta": {
-                                            "description": "Display a listing of the resource."
-                                        }
+                                        "meta": {}
                                     },
                                     "type": "object"
                                 }
@@ -1078,6 +2921,7 @@
                     "Notifications"
                 ],
                 "summary": "Save a new notifications",
+                "description": "Store a newly created resource in storage.",
                 "operationId": "createNotification",
                 "requestBody": {
                     "required": true,
@@ -1109,6 +2953,7 @@
                     "Notifications"
                 ],
                 "summary": "Get single notification by ID",
+                "description": "Display the specified resource.",
                 "operationId": "getNotificationById",
                 "parameters": [
                     {
@@ -1139,6 +2984,7 @@
                     "Notifications"
                 ],
                 "summary": "Update a notification",
+                "description": "Update a user",
                 "operationId": "updateNotification",
                 "parameters": [
                     {
@@ -1172,6 +3018,7 @@
                     "Notifications"
                 ],
                 "summary": "Delete a notification",
+                "description": "Delete a notification",
                 "operationId": "deleteNotification",
                 "parameters": [
                     {
@@ -1197,6 +3044,7 @@
                     "Notifications"
                 ],
                 "summary": "Mark notifications as read by the user",
+                "description": "Update notification as read",
                 "operationId": "markNotificationAsRead",
                 "requestBody": {
                     "required": true,
@@ -1237,6 +3085,7 @@
                     "Notifications"
                 ],
                 "summary": "Mark notifications as unread by the user",
+                "description": "Update notifications as unread",
                 "operationId": "markNotificationAsUnread",
                 "requestBody": {
                     "required": true,
@@ -1277,6 +3126,7 @@
                     "Notifications"
                 ],
                 "summary": "Mark notifications as read by id and type",
+                "description": "Update all notification as read.",
                 "operationId": "markAllAsRead",
                 "requestBody": {
                     "required": true,
@@ -1286,17 +3136,11 @@
                                 "properties": {
                                     "id": {
                                         "description": "Polymorphic relation id",
-                                        "type": "integer",
-                                        "items": {
-                                            "type": "integer"
-                                        }
+                                        "type": "integer"
                                     },
                                     "type": {
                                         "description": "Polymorphic relation type",
-                                        "type": "string",
-                                        "items": {
-                                            "type": "string"
-                                        }
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object"
@@ -1316,8 +3160,9 @@
                 "tags": [
                     "Permissions"
                 ],
-                "summary": "Update the permissions of an user",
-                "operationId": "ProcessMaker\\Http\\Controllers\\Api\\PermissionController::update",
+                "summary": "Update the permissions of a user",
+                "description": "Update permissions",
+                "operationId": "51b3555fb753f44324bf5c3880e01454",
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -1325,15 +3170,19 @@
                             "schema": {
                                 "properties": {
                                     "user_id": {
-                                        "description": "Id of the user whose permissions are configured",
+                                        "description": "ID of the user whose permissions are configured",
                                         "type": "integer"
                                     },
                                     "group_id": {
-                                        "description": "Id of the group whose permissions are configured",
+                                        "description": "ID of the group whose permissions are configured",
                                         "type": "integer"
                                     },
+                                    "is_administrator": {
+                                        "description": "Whether the user should have Super Admin privileges",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
                                     "permission_names": {
-                                        "description": "Update permissions",
                                         "type": "array",
                                         "items": {
                                             "type": "string"
@@ -1358,6 +3207,7 @@
                     "Process Categories"
                 ],
                 "summary": "Returns all processes categories that the user has access to",
+                "description": "Display a listing of the Process Categories.",
                 "operationId": "getProcessCategories",
                 "parameters": [
                     {
@@ -1386,14 +3236,12 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the Process Categories.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/ProcessCategory"
                                             }
                                         },
                                         "meta": {
-                                            "description": "Display a listing of the Process Categories.",
                                             "type": "object"
                                         }
                                     },
@@ -1409,6 +3257,7 @@
                     "Process Categories"
                 ],
                 "summary": "Save a new process Category",
+                "description": "Store a newly created Process Category in storage",
                 "operationId": "createProcessCategory",
                 "requestBody": {
                     "required": true,
@@ -1440,6 +3289,7 @@
                     "Process Categories"
                 ],
                 "summary": "Get single process category by ID",
+                "description": "Display the specified Process category.",
                 "operationId": "getProcessCategoryById",
                 "parameters": [
                     {
@@ -1470,6 +3320,7 @@
                     "Process Categories"
                 ],
                 "summary": "Update a process Category",
+                "description": "Updates the current element",
                 "operationId": "updateProcessCategory",
                 "parameters": [
                     {
@@ -1510,6 +3361,7 @@
                     "Process Categories"
                 ],
                 "summary": "Delete a process category",
+                "description": "Remove the specified resource from storage.",
                 "operationId": "deleteProcessCategory",
                 "parameters": [
                     {
@@ -1542,6 +3394,7 @@
                     "Processes"
                 ],
                 "summary": "Returns all processes that the user has access to",
+                "description": "Get list Process",
                 "operationId": "getProcesses",
                 "parameters": [
                     {
@@ -1571,7 +3424,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Get list Process",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/Process"
@@ -1593,6 +3445,7 @@
                     "Processes"
                 ],
                 "summary": "Save a new process",
+                "description": "Store a newly created resource in storage.",
                 "operationId": "createProcess",
                 "requestBody": {
                     "required": true,
@@ -1624,6 +3477,7 @@
                     "Processes"
                 ],
                 "summary": "Get single process by ID",
+                "description": "Display the specified resource.",
                 "operationId": "getProcessById",
                 "parameters": [
                     {
@@ -1657,6 +3511,7 @@
                     "Processes"
                 ],
                 "summary": "Update a process",
+                "description": "Updates the current element",
                 "operationId": "updateProcess",
                 "parameters": [
                     {
@@ -1697,6 +3552,7 @@
                     "Processes"
                 ],
                 "summary": "Delete a process",
+                "description": "Remove the specified resource from storage.",
                 "operationId": "deleteProcess",
                 "parameters": [
                     {
@@ -1722,6 +3578,7 @@
                     "Processes"
                 ],
                 "summary": "Returns the list of processes that the user can start",
+                "description": "Returns the list of processes that the user can start.",
                 "operationId": "startProcesses",
                 "parameters": [
                     {
@@ -1738,6 +3595,12 @@
                     },
                     {
                         "$ref": "#/components/parameters/include"
+                    },
+                    {
+                        "name": "without_event_definitions",
+                        "in": "path",
+                        "description": "If true return only processes that haven't start event definitions",
+                        "required": false
                     }
                 ],
                 "responses": {
@@ -1748,7 +3611,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Returns the list of processes that the user can start.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/ProcessWithStartEvents"
@@ -1772,6 +3634,7 @@
                     "Processes"
                 ],
                 "summary": "Restore an inactive process",
+                "description": "Reverses the soft delete of the element",
                 "operationId": "restoreProcess",
                 "parameters": [
                     {
@@ -1804,6 +3667,7 @@
                     "Processes"
                 ],
                 "summary": "Export a single process by ID and return a URL to download it",
+                "description": "Export the specified process.",
                 "operationId": "exportProcess",
                 "parameters": [
                     {
@@ -1824,7 +3688,6 @@
                                 "schema": {
                                     "properties": {
                                         "url": {
-                                            "description": "Export the specified process.",
                                             "type": "string"
                                         }
                                     },
@@ -1842,6 +3705,7 @@
                     "Processes"
                 ],
                 "summary": "Import a new process",
+                "description": "Import the specified process.",
                 "operationId": "importProcess",
                 "requestBody": {
                     "required": true,
@@ -1880,7 +3744,8 @@
                     "Processes"
                 ],
                 "summary": "Check if the import is ready",
-                "operationId": "ProcessMaker\\Http\\Controllers\\Api\\ProcessController::import_ready",
+                "description": "Check if the import is ready",
+                "operationId": "6a131993b7c879ddcd3d3a291dd8380f",
                 "parameters": [
                     {
                         "name": "code",
@@ -1900,7 +3765,6 @@
                                 "schema": {
                                     "properties": {
                                         "ready": {
-                                            "description": "Check if the import is ready",
                                             "type": "boolean"
                                         }
                                     },
@@ -1918,6 +3782,7 @@
                     "Processes"
                 ],
                 "summary": "Update assignments after import",
+                "description": "Import Assignments of process.",
                 "operationId": "assignmentProcess",
                 "parameters": [
                     {
@@ -1953,6 +3818,7 @@
                     "Processes"
                 ],
                 "summary": "Start a new process",
+                "description": "Trigger an start event within a process.",
                 "operationId": "triggerStartEvent",
                 "parameters": [
                     {
@@ -2005,6 +3871,7 @@
                     "Process Requests"
                 ],
                 "summary": "Returns all process Requests that the user has access to",
+                "description": "Display a listing of the resource.",
                 "operationId": "getProcessesRequests",
                 "parameters": [
                     {
@@ -2046,7 +3913,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/processRequest"
@@ -2070,6 +3936,7 @@
                     "Process Requests"
                 ],
                 "summary": "Get single process request by ID",
+                "description": "Display the specified resource.",
                 "operationId": "getProcessRequestById",
                 "parameters": [
                     {
@@ -2106,6 +3973,7 @@
                     "Process Requests"
                 ],
                 "summary": "Update a process request",
+                "description": "Update a request",
                 "operationId": "updateProcessRequest",
                 "parameters": [
                     {
@@ -2142,6 +4010,7 @@
                     "Process Requests"
                 ],
                 "summary": "Delete a process request",
+                "description": "Delete a request",
                 "operationId": "deleteProcessRequest",
                 "parameters": [
                     {
@@ -2177,6 +4046,7 @@
                     "Process Requests"
                 ],
                 "summary": "Update a process request event",
+                "description": "Trigger a intermediate catch event",
                 "operationId": "updateProcessRequestEvent",
                 "parameters": [
                     {
@@ -2211,6 +4081,7 @@
                     "Request Files"
                 ],
                 "summary": "Returns the list of files associated with a request",
+                "description": "Display a listing of the resource.",
                 "operationId": "getRequestFiles",
                 "parameters": [
                     {
@@ -2243,14 +4114,12 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/media"
                                             }
                                         },
                                         "meta": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "object",
                                             "allOf": [
                                                 {
@@ -2271,6 +4140,7 @@
                     "Request Files"
                 ],
                 "summary": "Save a new media file to a request",
+                "description": "Store a newly created resource in storage.",
                 "operationId": "createRequestFile",
                 "parameters": [
                     {
@@ -2317,11 +4187,9 @@
                                 "schema": {
                                     "properties": {
                                         "message": {
-                                            "description": "Store a newly created resource in storage.",
                                             "type": "string"
                                         },
                                         "fileUploadId": {
-                                            "description": "Store a newly created resource in storage.",
                                             "type": "integer"
                                         }
                                     },
@@ -2339,6 +4207,7 @@
                     "Request Files"
                 ],
                 "summary": "Get a file uploaded to a request",
+                "description": "Display the specified resource.",
                 "operationId": "getRequestFilesById",
                 "parameters": [
                     {
@@ -2382,6 +4251,7 @@
                     "Request Files"
                 ],
                 "summary": "Delete all media associated with a request",
+                "description": "Remove the specified resource from storage.",
                 "operationId": "deleteRequestFile",
                 "parameters": [
                     {
@@ -2419,6 +4289,7 @@
                     "Screen Categories"
                 ],
                 "summary": "Returns all screens categories that the user has access to",
+                "description": "Display a listing of the Screen Categories.",
                 "operationId": "getScreenCategories",
                 "parameters": [
                     {
@@ -2447,14 +4318,12 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the Screen Categories.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/ScreenCategory"
                                             }
                                         },
                                         "meta": {
-                                            "description": "Display a listing of the Screen Categories.",
                                             "type": "object"
                                         }
                                     },
@@ -2470,6 +4339,7 @@
                     "Screen Categories"
                 ],
                 "summary": "Save a new Screen Category",
+                "description": "Store a newly created Screen Category in storage",
                 "operationId": "createScreenCategory",
                 "requestBody": {
                     "required": true,
@@ -2501,6 +4371,7 @@
                     "Screen Categories"
                 ],
                 "summary": "Get single screen category by ID",
+                "description": "Display the specified screen category.",
                 "operationId": "getScreenCategoryById",
                 "parameters": [
                     {
@@ -2531,6 +4402,7 @@
                     "Screen Categories"
                 ],
                 "summary": "Update a screen Category",
+                "description": "Updates the current element",
                 "operationId": "updateScreenCategory",
                 "parameters": [
                     {
@@ -2571,6 +4443,7 @@
                     "Screen Categories"
                 ],
                 "summary": "Delete a screen category",
+                "description": "Remove the specified resource from storage.",
                 "operationId": "deleteScreenCategory",
                 "parameters": [
                     {
@@ -2596,6 +4469,7 @@
                     "Screens"
                 ],
                 "summary": "Returns all screens that the user has access to",
+                "description": "Get a list of Screens.",
                 "operationId": "getScreens",
                 "parameters": [
                     {
@@ -2631,14 +4505,12 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Get a list of Screens.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/screens"
                                             }
                                         },
                                         "meta": {
-                                            "description": "Get a list of Screens.",
                                             "type": "object"
                                         }
                                     },
@@ -2654,6 +4526,7 @@
                     "Screens"
                 ],
                 "summary": "Save a new screens",
+                "description": "Create a new Screen.",
                 "operationId": "createScreen",
                 "requestBody": {
                     "required": true,
@@ -2685,6 +4558,7 @@
                     "Screens"
                 ],
                 "summary": "Get single screens by ID",
+                "description": "Get a single Screen.",
                 "operationId": "getScreensById",
                 "parameters": [
                     {
@@ -2715,6 +4589,7 @@
                     "Screens"
                 ],
                 "summary": "Update a screen",
+                "description": "Update a Screen.",
                 "operationId": "updateScreen",
                 "parameters": [
                     {
@@ -2748,6 +4623,7 @@
                     "Screens"
                 ],
                 "summary": "Delete a screen",
+                "description": "Delete a Screen.",
                 "operationId": "deleteScreen",
                 "parameters": [
                     {
@@ -2773,6 +4649,7 @@
                     "Screens"
                 ],
                 "summary": "duplicate a screen",
+                "description": "duplicate a Screen.",
                 "operationId": "duplicateScreen",
                 "parameters": [
                     {
@@ -2815,6 +4692,7 @@
                     "Screens"
                 ],
                 "summary": "Export a single screen by ID",
+                "description": "Export the specified screen.",
                 "operationId": "exportScreen",
                 "parameters": [
                     {
@@ -2847,6 +4725,7 @@
                     "Screens"
                 ],
                 "summary": "Import a new screen",
+                "description": "Import the specified screen.",
                 "operationId": "importScreen",
                 "requestBody": {
                     "required": true,
@@ -2873,7 +4752,6 @@
                                 "schema": {
                                     "properties": {
                                         "status": {
-                                            "description": "Import the specified screen.",
                                             "type": "object"
                                         }
                                     },
@@ -2891,6 +4769,7 @@
                     "Screens"
                 ],
                 "summary": "Preview a screen",
+                "description": "Get preview a screen",
                 "operationId": "preview",
                 "requestBody": {
                     "required": true,
@@ -2899,19 +4778,15 @@
                             "schema": {
                                 "properties": {
                                     "config": {
-                                        "description": "Get preview a screen",
                                         "type": "object"
                                     },
                                     "watchers": {
-                                        "description": "Get preview a screen",
                                         "type": "object"
                                     },
                                     "computed": {
-                                        "description": "Get preview a screen",
                                         "type": "object"
                                     },
                                     "custom_css": {
-                                        "description": "Get preview a screen",
                                         "type": "string"
                                     }
                                 },
@@ -2940,6 +4815,7 @@
                     "Script Categories"
                 ],
                 "summary": "Returns all scripts categories that the user has access to",
+                "description": "Display a listing of the Script Categories.",
                 "operationId": "getScriptCategories",
                 "parameters": [
                     {
@@ -2968,14 +4844,12 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the Script Categories.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/ScriptCategory"
                                             }
                                         },
                                         "meta": {
-                                            "description": "Display a listing of the Script Categories.",
                                             "type": "object"
                                         }
                                     },
@@ -2991,6 +4865,7 @@
                     "Script Categories"
                 ],
                 "summary": "Save a new Script Category",
+                "description": "Store a newly created Script Category in storage",
                 "operationId": "createScriptCategory",
                 "requestBody": {
                     "required": true,
@@ -3022,6 +4897,7 @@
                     "Script Categories"
                 ],
                 "summary": "Get single script category by ID",
+                "description": "Display the specified script category.",
                 "operationId": "getScriptCategoryById",
                 "parameters": [
                     {
@@ -3052,6 +4928,7 @@
                     "Script Categories"
                 ],
                 "summary": "Update a script Category",
+                "description": "Updates the current element",
                 "operationId": "updateScriptCategory",
                 "parameters": [
                     {
@@ -3092,6 +4969,7 @@
                     "Script Categories"
                 ],
                 "summary": "Delete a script category",
+                "description": "Remove the specified resource from storage.",
                 "operationId": "deleteScriptCategory",
                 "parameters": [
                     {
@@ -3117,6 +4995,7 @@
                     "Scripts"
                 ],
                 "summary": "Returns all scripts that the user has access to",
+                "description": "Get a list of scripts in a process.",
                 "operationId": "getScripts",
                 "parameters": [
                     {
@@ -3143,14 +5022,12 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Get a list of scripts in a process.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/scripts"
                                             }
                                         },
                                         "meta": {
-                                            "description": "Get a list of scripts in a process.",
                                             "type": "object"
                                         }
                                     },
@@ -3166,6 +5043,7 @@
                     "Scripts"
                 ],
                 "summary": "Save a new script",
+                "description": "Create a new script in a process.",
                 "operationId": "createScript",
                 "requestBody": {
                     "required": true,
@@ -3197,6 +5075,7 @@
                     "Scripts"
                 ],
                 "summary": "Test script code without saving it",
+                "description": "Previews executing a script, with sample data/config data",
                 "operationId": "previewScript",
                 "parameters": [
                     {
@@ -3214,25 +5093,21 @@
                             "schema": {
                                 "properties": {
                                     "data": {
-                                        "description": "Previews executing a script, with sample data/config data",
                                         "type": "array",
                                         "items": {
                                             "type": "object"
                                         }
                                     },
                                     "config": {
-                                        "description": "Previews executing a script, with sample data/config data",
                                         "type": "array",
                                         "items": {
                                             "type": "object"
                                         }
                                     },
                                     "code": {
-                                        "description": "Previews executing a script, with sample data/config data",
                                         "type": "string"
                                     },
                                     "nonce": {
-                                        "description": "Previews executing a script, with sample data/config data",
                                         "type": "string"
                                     }
                                 },
@@ -3254,6 +5129,7 @@
                     "Scripts"
                 ],
                 "summary": "Execute script",
+                "description": "Executes a script, with sample data/config data",
                 "operationId": "executeScript",
                 "parameters": [
                     {
@@ -3271,14 +5147,12 @@
                             "schema": {
                                 "properties": {
                                     "data": {
-                                        "description": "Executes a script, with sample data/config data",
                                         "type": "array",
                                         "items": {
                                             "type": "object"
                                         }
                                     },
                                     "config": {
-                                        "description": "Executes a script, with sample data/config data",
                                         "type": "array",
                                         "items": {
                                             "type": "object"
@@ -3310,6 +5184,7 @@
                     "Scripts"
                 ],
                 "summary": "Get the response of a script execution by execution key",
+                "description": "Get the response of a script execution",
                 "operationId": "getScriptExecutionResponse",
                 "parameters": [
                     {
@@ -3339,6 +5214,7 @@
                     "Scripts"
                 ],
                 "summary": "Get single script by ID",
+                "description": "Get a single script in a process.",
                 "operationId": "getScriptsById",
                 "parameters": [
                     {
@@ -3369,6 +5245,7 @@
                     "Scripts"
                 ],
                 "summary": "Update a script",
+                "description": "Update a script in a process.",
                 "operationId": "updateScript",
                 "parameters": [
                     {
@@ -3402,6 +5279,7 @@
                     "Scripts"
                 ],
                 "summary": "Delete a script",
+                "description": "Delete a script in a process.",
                 "operationId": "deleteScript",
                 "parameters": [
                     {
@@ -3427,6 +5305,7 @@
                     "Scripts"
                 ],
                 "summary": "duplicate a script",
+                "description": "duplicate a Script.",
                 "operationId": "duplicateScript",
                 "parameters": [
                     {
@@ -3469,6 +5348,7 @@
                     "Settings"
                 ],
                 "summary": "Returns all settings",
+                "description": "Display a listing of the resource.",
                 "operationId": "getSettings",
                 "parameters": [
                     {
@@ -3495,7 +5375,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/settings"
@@ -3519,6 +5398,7 @@
                     "Settings"
                 ],
                 "summary": "Update a setting",
+                "description": "Update a setting",
                 "operationId": "updateSetting",
                 "parameters": [
                     {
@@ -3560,6 +5440,7 @@
                     "Tasks"
                 ],
                 "summary": "Returns all tasks that the user has access to",
+                "description": "Display a listing of the resource.",
                 "operationId": "getTasks",
                 "parameters": [
                     {
@@ -3592,7 +5473,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/processRequestToken"
@@ -3616,6 +5496,7 @@
                     "Tasks"
                 ],
                 "summary": "Get a single task by ID",
+                "description": "Display the specified resource.",
                 "operationId": "getTasksById",
                 "parameters": [
                     {
@@ -3649,6 +5530,7 @@
                     "Tasks"
                 ],
                 "summary": "Update a task",
+                "description": "Updates the current element",
                 "operationId": "updateTask",
                 "parameters": [
                     {
@@ -3672,12 +5554,10 @@
                                 ],
                                 "properties": {
                                     "status": {
-                                        "description": "Updates the current element",
                                         "type": "string",
                                         "example": "COMPLETED"
                                     },
                                     "data": {
-                                        "description": "Updates the current element",
                                         "type": "object"
                                     }
                                 },
@@ -3712,6 +5592,7 @@
                     "Users"
                 ],
                 "summary": "Returns all users",
+                "description": "Display a listing of the resource.",
                 "operationId": "getUsers",
                 "parameters": [
                     {
@@ -3750,7 +5631,6 @@
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Display a listing of the resource.",
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/components/schemas/users"
@@ -3772,6 +5652,7 @@
                     "Users"
                 ],
                 "summary": "Save a new users",
+                "description": "Store a newly created resource in storage.",
                 "operationId": "createUser",
                 "requestBody": {
                     "required": true,
@@ -3806,6 +5687,7 @@
                     "Users"
                 ],
                 "summary": "Get single user by ID",
+                "description": "Display the specified resource.",
                 "operationId": "getUserById",
                 "parameters": [
                     {
@@ -3839,6 +5721,7 @@
                     "Users"
                 ],
                 "summary": "Update a user",
+                "description": "Update a user",
                 "operationId": "updateUser",
                 "parameters": [
                     {
@@ -3878,6 +5761,7 @@
                     "Users"
                 ],
                 "summary": "Delete a user",
+                "description": "Delete a user",
                 "operationId": "deleteUser",
                 "parameters": [
                     {
@@ -3970,10 +5854,440 @@
                 },
                 "type": "object"
             },
+            "collectionsEditable": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "custom_title": {
+                        "type": "string"
+                    },
+                    "create_screen_id": {
+                        "type": "string",
+                        "format": "id"
+                    },
+                    "read_screen_id": {
+                        "type": "string",
+                        "format": "id"
+                    },
+                    "update_screen_id": {
+                        "type": "string",
+                        "format": "id"
+                    },
+                    "signal_create": {
+                        "type": "boolean"
+                    },
+                    "signal_update": {
+                        "type": "boolean"
+                    },
+                    "signal_delete": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "collections": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/collectionsEditable"
+                    },
+                    {
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "created_by_id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "updated_by_id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "columns": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "recordsEditable": {
+                "properties": {
+                    "data": {
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "records": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/recordsEditable"
+                    },
+                    {
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "collection_id": {
+                                "type": "string",
+                                "format": "id"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "DataSourceCallParameters": {
+                "properties": {
+                    "endpoint": {
+                        "type": "string"
+                    },
+                    "dataMapping": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "key": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "outboundConfig": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "key": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "DataSourceResponse": {
+                "properties": {
+                    "status": {
+                        "type": "integer"
+                    },
+                    "response": {
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "dataSourceEditable": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "id"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "endpoints": {
+                        "type": "string"
+                    },
+                    "mappings": {
+                        "type": "string"
+                    },
+                    "authtype": {
+                        "type": "string"
+                    },
+                    "credentials": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "data_source_category_id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "dataSource": {
+                "description": "Class DataSource",
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/dataSourceEditable"
+                    },
+                    {
+                        "properties": {
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        }
+                    }
+                ]
+            },
+            "dataSourceCategoryEditable": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "ACTIVE",
+                            "INACTIVE"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "DataSourceCategory": {
+                "description": "Represents a business data Source category definition.",
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/dataSourceCategoryEditable"
+                    },
+                    {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        }
+                    }
+                ]
+            },
+            "SavedSearchEditable": {
+                "properties": {
+                    "meta": {
+                        "type": "object",
+                        "additionalProperties": "true"
+                    },
+                    "pmql": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "task",
+                            "request"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "SavedSearch": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "user_id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SavedSearchEditable"
+                    }
+                ]
+            },
+            "SavedSearchIcon": {
+                "description": "Represents an Eloquent model of a Saved Search.",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "SavedSearchChartEditable": {
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "bar",
+                            "bar-vertical",
+                            "line",
+                            "pie",
+                            "doughnut"
+                        ]
+                    },
+                    "config": {
+                        "type": "object",
+                        "additionalProperties": "true"
+                    },
+                    "sort": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "SavedSearchChart": {
+                "description": "Represents an Eloquent model of a Saved Search Chart.",
+                "allOf": [
+                    {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "saved_search_id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "user_id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "deleted_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SavedSearchChartEditable"
+                    }
+                ]
+            },
+            "ReportEditable": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "adhoc",
+                            "scheduled"
+                        ]
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": [
+                            "csv",
+                            "xlsx"
+                        ]
+                    },
+                    "saved_search_id": {
+                        "type": "integer"
+                    },
+                    "config": {
+                        "type": "object",
+                        "additionalProperties": "true"
+                    },
+                    "to": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subject": {
+                        "type": "string"
+                    },
+                    "body": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "Report": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "user_id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SavedSearchEditable"
+                    }
+                ]
+            },
             "updateUserGroups": {
+                "description": "Update a user's groups",
                 "properties": {
                     "groups": {
-                        "description": "Update a user's groups",
                         "type": "array",
                         "items": {
                             "type": "integer",
@@ -3984,6 +6298,7 @@
                 "type": "object"
             },
             "restoreUser": {
+                "description": "Reverses the soft delete of a user",
                 "properties": {
                     "username": {
                         "description": "Username to restore",
@@ -4118,46 +6433,36 @@
             "commentsEditable": {
                 "properties": {
                     "id": {
-                        "description": "Represents a business process definition.",
                         "type": "string",
                         "format": "id"
                     },
                     "user_id": {
-                        "description": "Represents a business process definition.",
                         "type": "string",
                         "format": "id"
                     },
                     "commentable_id": {
-                        "description": "Represents a business process definition.",
                         "type": "string",
                         "format": "id"
                     },
                     "commentable_type": {
-                        "description": "Represents a business process definition.",
                         "type": "string"
                     },
                     "up": {
-                        "description": "Represents a business process definition.",
                         "type": "integer"
                     },
                     "down": {
-                        "description": "Represents a business process definition.",
                         "type": "integer"
                     },
                     "subject": {
-                        "description": "Represents a business process definition.",
                         "type": "string"
                     },
                     "body": {
-                        "description": "Represents a business process definition.",
                         "type": "string"
                     },
                     "hidden": {
-                        "description": "Represents a business process definition.",
                         "type": "boolean"
                     },
                     "type": {
-                        "description": "Represents a business process definition.",
                         "type": "string",
                         "enum": [
                             "LOG",
@@ -4168,22 +6473,23 @@
                 "type": "object"
             },
             "comments": {
-                "properties": {
-                    "created_at": {
-                        "description": "Represents a business process definition.",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updated_at": {
-                        "description": "Represents a business process definition.",
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                },
+                "description": "Represents a business process definition.",
                 "type": "object",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/commentsEditable"
+                    },
+                    {
+                        "properties": {
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        }
                     }
                 ]
             },
@@ -4228,15 +6534,16 @@
             "groupsEditable": {
                 "properties": {
                     "name": {
-                        "description": "Represents a group definition.",
                         "type": "string"
                     },
                     "description": {
-                        "description": "Represents a group definition.",
                         "type": "string"
                     },
+                    "manager_id": {
+                        "type": "int",
+                        "format": "id"
+                    },
                     "status": {
-                        "description": "Represents a group definition.",
                         "type": "string",
                         "enum": [
                             "ACTIVE",
@@ -4247,6 +6554,7 @@
                 "type": "object"
             },
             "groups": {
+                "description": "Represents a group definition.",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/groupsEditable"
@@ -4254,17 +6562,14 @@
                     {
                         "properties": {
                             "created_at": {
-                                "description": "Represents a group definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a group definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "id": {
-                                "description": "Represents a group definition.",
                                 "type": "string",
                                 "format": "id"
                             }
@@ -4276,21 +6581,17 @@
             "groupMembersEditable": {
                 "properties": {
                     "group_id": {
-                        "description": "Represents a group Members definition.",
                         "type": "string",
                         "format": "id"
                     },
                     "member_id": {
-                        "description": "Represents a group Members definition.",
                         "type": "string",
                         "format": "id"
                     },
                     "member_type": {
-                        "description": "Represents a group Members definition.",
                         "type": "string"
                     },
                     "description": {
-                        "description": "Represents a group Members definition.",
                         "type": "string"
                     }
                 },
@@ -4304,17 +6605,14 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -4331,25 +6629,20 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "group": {
-                                "description": "Represents a group Members definition.",
                                 "type": "object"
                             },
                             "member": {
-                                "description": "Represents a group Members definition.",
                                 "type": "object"
                             },
                             "created_at": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -4363,31 +6656,25 @@
                     {
                         "properties": {
                             "group_id": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "member_id": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "member_type": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string"
                             },
                             "id": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -4397,24 +6684,21 @@
                 ]
             },
             "availableGroupMembers": {
+                "description": "Represents a group Members definition.",
                 "allOf": [
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "description": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string"
                             },
                             "name": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string"
                             },
                             "status": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "enum": [
                                     "ACTIVE",
@@ -4422,12 +6706,10 @@
                                 ]
                             },
                             "created_at": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a group Members definition.",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -4439,87 +6721,74 @@
             "mediaEditable": {
                 "properties": {
                     "id": {
-                        "description": "Represents media files stored in the database",
                         "type": "integer",
                         "format": "id"
                     },
                     "model_id": {
-                        "description": "Represents media files stored in the database",
                         "type": "integer",
                         "format": "id"
                     },
                     "model_type": {
-                        "description": "Represents media files stored in the database",
                         "type": "string",
                         "format": "id"
                     },
                     "collection_name": {
-                        "description": "Represents media files stored in the database",
                         "type": "string"
                     },
                     "name": {
-                        "description": "Represents media files stored in the database",
                         "type": "string"
                     },
                     "file_name": {
-                        "description": "Represents media files stored in the database",
                         "type": "string"
                     },
                     "mime_type": {
-                        "description": "Represents media files stored in the database",
                         "type": "string"
                     },
                     "disk": {
-                        "description": "Represents media files stored in the database",
                         "type": "string"
                     },
                     "size": {
-                        "description": "Represents media files stored in the database",
                         "type": "integer"
                     },
                     "manipulations": {
-                        "description": "Represents media files stored in the database",
                         "type": "object"
                     },
                     "custom_properties": {
-                        "description": "Represents media files stored in the database",
                         "type": "object"
                     },
                     "responsive_images": {
-                        "description": "Represents media files stored in the database",
                         "type": "object"
                     },
                     "order_column": {
-                        "description": "Represents media files stored in the database",
                         "type": "integer"
                     }
                 },
                 "type": "object"
             },
             "media": {
-                "properties": {
-                    "created_at": {
-                        "description": "Represents media files stored in the database",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updated_at": {
-                        "description": "Represents media files stored in the database",
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                },
                 "type": "object",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/mediaEditable"
+                    },
+                    {
+                        "properties": {
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        }
                     }
                 ]
             },
             "mediaExported": {
+                "description": "Represents media files stored in the database",
                 "properties": {
                     "url": {
-                        "description": "Represents media files stored in the database",
                         "type": "string"
                     }
                 },
@@ -4528,45 +6797,37 @@
             "NotificationEditable": {
                 "properties": {
                     "type": {
-                        "description": "Represents a notification definition.",
                         "type": "string"
                     },
                     "notifiable_type": {
-                        "description": "Represents a notification definition.",
                         "type": "string"
                     },
                     "notifiable_id": {
-                        "description": "Represents a notification definition.",
                         "type": "integer"
                     },
                     "data": {
-                        "description": "Represents a notification definition.",
                         "type": "string"
                     },
                     "name": {
-                        "description": "Represents a notification definition.",
                         "type": "string"
                     },
                     "message": {
-                        "description": "Represents a notification definition.",
                         "type": "string"
                     },
                     "processName": {
-                        "description": "Represents a notification definition.",
                         "type": "string"
                     },
                     "userName": {
-                        "description": "Represents a notification definition.",
                         "type": "string"
                     },
                     "request_id": {
-                        "description": "Represents a notification definition.",
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
             "Notification": {
+                "description": "Represents a notification definition.",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/NotificationEditable"
@@ -4574,21 +6835,17 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents a notification definition.",
                                 "type": "string"
                             },
                             "read_at": {
-                                "description": "Represents a notification definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "created_at": {
-                                "description": "Represents a notification definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a notification definition.",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -4600,78 +6857,64 @@
             "ProcessEditable": {
                 "properties": {
                     "process_category_id": {
-                        "description": "Represents a business process definition.",
                         "type": "integer",
                         "format": "id"
                     },
                     "name": {
-                        "description": "Represents a business process definition.",
                         "type": "string"
                     },
                     "description": {
-                        "description": "Represents a business process definition.",
                         "type": "string"
                     },
                     "status": {
-                        "description": "Represents a business process definition.",
                         "type": "string",
                         "enum": [
                             "ACTIVE",
-                            "INACTIVE"
+                            "INACTIVE",
+                            "ARCHIVED"
                         ]
                     },
                     "pause_timer_start": {
-                        "description": "Represents a business process definition.",
                         "type": "integer"
                     },
                     "cancel_screen_id": {
-                        "description": "Represents a business process definition.",
                         "type": "integer"
                     },
                     "has_timer_start_events": {
-                        "description": "Represents a business process definition.",
                         "type": "boolean"
                     },
                     "request_detail_screen_id": {
-                        "description": "Represents a business process definition.",
                         "type": "integer",
                         "format": "id"
                     },
                     "is_valid": {
-                        "description": "Represents a business process definition.",
                         "type": "integer"
                     },
                     "package_key": {
-                        "description": "Represents a business process definition.",
                         "type": "string"
                     },
                     "start_events": {
-                        "description": "Represents a business process definition.",
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/ProcessStartEvents"
                         }
                     },
                     "warnings": {
-                        "description": "Represents a business process definition.",
                         "type": "string"
                     },
                     "self_service_tasks": {
-                        "description": "Represents a business process definition.",
-                        "type": "array",
-                        "items": {
-                            "type": "object"
-                        }
+                        "type": "object"
                     },
                     "signal_events": {
-                        "description": "Represents a business process definition.",
                         "type": "array",
                         "items": {
                             "type": "object"
                         }
                     },
-                    "category": {
-                        "description": "Represents a business process definition."
+                    "category": {},
+                    "manager_id": {
+                        "type": "integer",
+                        "format": "id"
                     }
                 },
                 "type": "object"
@@ -4684,36 +6927,29 @@
                     {
                         "properties": {
                             "user_id": {
-                                "description": "Represents a business process definition.",
                                 "type": "integer",
                                 "format": "id"
                             },
                             "id": {
-                                "description": "Represents a business process definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "deleted_at": {
-                                "description": "Represents a business process definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "created_at": {
-                                "description": "Represents a business process definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a business process definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "notifications": {
-                                "description": "Represents a business process definition.",
                                 "type": "object"
                             },
                             "task_notifications": {
-                                "description": "Represents a business process definition.",
                                 "type": "object"
                             }
                         },
@@ -4721,7 +6957,29 @@
                     }
                 ]
             },
-            "ProcessStartEvents": {},
+            "ProcessStartEvents": {
+                "properties": {
+                    "eventDefinitions": {
+                        "type": "object"
+                    },
+                    "parallelMultiple": {
+                        "type": "boolean"
+                    },
+                    "outgoing": {
+                        "type": "object"
+                    },
+                    "incoming": {
+                        "type": "object"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "ProcessWithStartEvents": {
                 "allOf": [
                     {
@@ -4730,7 +6988,6 @@
                     {
                         "properties": {
                             "events": {
-                                "description": "Represents a business process definition.",
                                 "type": "array",
                                 "items": {
                                     "$ref": "#/components/schemas/ProcessStartEvents"
@@ -4749,42 +7006,36 @@
                     {
                         "properties": {
                             "status": {
-                                "description": "Represents a business process definition.",
                                 "type": "array",
                                 "items": {
                                     "type": "object"
                                 }
                             },
                             "assignable": {
-                                "description": "Represents a business process definition.",
                                 "type": "array",
                                 "items": {
                                     "type": "object"
                                 }
                             },
-                            "process": {
-                                "description": "Represents a business process definition."
-                            }
+                            "process": {}
                         },
                         "type": "object"
                     }
                 ]
             },
             "ProcessAssignments": {
+                "description": "Represents a business process definition.",
                 "properties": {
                     "assignable": {
-                        "description": "Represents a business process definition.",
                         "type": "array",
                         "items": {
                             "type": "object"
                         }
                     },
                     "cancel_request": {
-                        "description": "Represents a business process definition.",
                         "type": "object"
                     },
                     "edit_data": {
-                        "description": "Represents a business process definition.",
                         "type": "object"
                     }
                 },
@@ -4793,11 +7044,9 @@
             "ProcessCategoryEditable": {
                 "properties": {
                     "name": {
-                        "description": "Represents a business process category definition.",
                         "type": "string"
                     },
                     "status": {
-                        "description": "Represents a business process category definition.",
                         "type": "string",
                         "enum": [
                             "ACTIVE",
@@ -4808,6 +7057,7 @@
                 "type": "object"
             },
             "ProcessCategory": {
+                "description": "Represents a business process category definition.",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/ProcessCategoryEditable"
@@ -4815,17 +7065,14 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents a business process category definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Represents a business process category definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a business process category definition.",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -4837,70 +7084,62 @@
             "processPermissionsEditable": {
                 "properties": {
                     "id": {
-                        "description": "Represents a Process permission.",
                         "type": "integer",
                         "format": "id"
                     },
                     "process_id": {
-                        "description": "Represents a Process permission.",
                         "type": "integer",
                         "format": "id"
                     },
                     "permission_id": {
-                        "description": "Represents a Process permission.",
                         "type": "integer",
                         "format": "id"
                     },
                     "assignable_id": {
-                        "description": "Represents a Process permission.",
                         "type": "integer",
                         "format": "id"
                     },
                     "assignable_type": {
-                        "description": "Represents a Process permission.",
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
             "processPermissions": {
-                "properties": {
-                    "created_at": {
-                        "description": "Represents a Process permission.",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updated_at": {
-                        "description": "Represents a Process permission.",
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                },
+                "description": "Represents a Process permission.",
                 "type": "object",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/processPermissionsEditable"
+                    },
+                    {
+                        "properties": {
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        }
                     }
                 ]
             },
             "processRequestEditable": {
                 "properties": {
                     "user_id": {
-                        "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                         "type": "string",
                         "format": "id"
                     },
                     "callable_id": {
-                        "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                         "type": "string",
                         "format": "id"
                     },
                     "data": {
-                        "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                         "type": "object"
                     },
                     "status": {
-                        "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                         "type": "string",
                         "enum": [
                             "ACTIVE",
@@ -4910,21 +7149,19 @@
                         ]
                     },
                     "name": {
-                        "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                         "type": "string"
                     },
                     "process_id": {
-                        "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                         "type": "integer"
                     },
                     "process": {
-                        "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                         "type": "object"
                     }
                 },
                 "type": "object"
             },
             "processRequest": {
+                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/processRequestEditable"
@@ -4932,45 +7169,35 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "process_id": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "process_collaboration_id": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "participant_id": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "process_category_id": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "user": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process."
-                            },
+                            "user": {},
                             "participants": {
-                                "description": "Represents an Eloquent model of a Request which is an instance of a Process.",
                                 "type": "array",
                                 "items": {
                                     "$ref": "#/components/schemas/users"
@@ -4984,40 +7211,34 @@
             "processRequestTokenEditable": {
                 "properties": {
                     "user_id": {
-                        "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                         "type": "string",
                         "format": "id"
                     },
                     "status": {
-                        "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                         "type": "string"
                     },
                     "due_at": {
-                        "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                         "type": "date-time"
                     },
                     "initiated_at": {
-                        "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                         "type": "string",
                         "format": "date-time"
                     },
                     "riskchanges_at": {
-                        "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                         "type": "string",
                         "format": "date-time"
                     },
                     "subprocess_start_event_id": {
-                        "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                         "type": "string"
                     },
                     "data": {
-                        "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                         "type": "object"
                     }
                 },
                 "type": "object"
             },
             "processRequestToken": {
+                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/processRequestTokenEditable"
@@ -5025,70 +7246,52 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string",
                                 "format": "id"
                             },
                             "process_id": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string",
                                 "format": "id"
                             },
                             "process_request_id": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string",
                                 "format": "id"
                             },
                             "element_id": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string",
                                 "format": "id"
                             },
                             "element_type": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string",
                                 "format": "id"
                             },
                             "element_index": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string"
                             },
                             "element_name": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string"
                             },
                             "created_at": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "initiated_at": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "advanceStatus": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "string"
                             },
                             "due_notified": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine",
                                 "type": "integer"
                             },
-                            "user": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine"
-                            },
-                            "process": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine"
-                            },
-                            "process_request": {
-                                "description": "ProcessRequestToken is used to store the state of a token of the\nNayra engine"
-                            }
+                            "user": {},
+                            "process": {},
+                            "process_request": {}
                         },
                         "type": "object"
                     }
@@ -5097,22 +7300,18 @@
             "taskAssignmentsEditable": {
                 "properties": {
                     "process_id": {
-                        "description": "Represents a business process task assignment definition.",
                         "type": "string",
                         "format": "id"
                     },
                     "process_task_id": {
-                        "description": "Represents a business process task assignment definition.",
                         "type": "string",
                         "format": "id"
                     },
                     "assignment_id": {
-                        "description": "Represents a business process task assignment definition.",
                         "type": "string",
                         "format": "id"
                     },
                     "assignment_type": {
-                        "description": "Represents a business process task assignment definition.",
                         "type": "string",
                         "enum": [
                             "ProcessMaker\\Models\\User",
@@ -5123,71 +7322,63 @@
                 "type": "object"
             },
             "taskAssignments": {
-                "properties": {
-                    "id": {
-                        "description": "Represents a business process task assignment definition.",
-                        "type": "string",
-                        "format": "id"
-                    },
-                    "created_at": {
-                        "description": "Represents a business process task assignment definition.",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updated_at": {
-                        "description": "Represents a business process task assignment definition.",
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                },
+                "description": "Represents a business process task assignment definition.",
                 "type": "object",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/taskAssignmentsEditable"
+                    },
+                    {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "id"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        }
                     }
                 ]
             },
             "screensEditable": {
                 "properties": {
                     "title": {
-                        "description": "Class Screen",
                         "type": "string"
                     },
                     "type": {
-                        "description": "Class Screen",
                         "type": "string"
                     },
                     "description": {
-                        "description": "Class Screen",
                         "type": "string"
                     },
                     "config": {
-                        "description": "Class Screen",
                         "type": "array",
                         "items": {
                             "type": "object"
                         }
                     },
                     "computed": {
-                        "description": "Class Screen",
                         "type": "array",
                         "items": {
                             "type": "object"
                         }
                     },
                     "watchers": {
-                        "description": "Class Screen",
                         "type": "array",
                         "items": {
                             "type": "object"
                         }
                     },
                     "custom_css": {
-                        "description": "Class Screen",
                         "type": "string"
                     },
                     "screen_category_id": {
-                        "description": "Class Screen",
                         "type": "string"
                     }
                 },
@@ -5201,17 +7392,14 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Class Screen",
                                 "type": "string",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Class Screen",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Class Screen",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -5221,9 +7409,9 @@
                 ]
             },
             "screenExported": {
+                "description": "Class Screen",
                 "properties": {
                     "url": {
-                        "description": "Class Screen",
                         "type": "string"
                     }
                 },
@@ -5232,11 +7420,9 @@
             "ScreenCategoryEditable": {
                 "properties": {
                     "name": {
-                        "description": "Represents a business screen category definition.",
                         "type": "string"
                     },
                     "status": {
-                        "description": "Represents a business screen category definition.",
                         "type": "string",
                         "enum": [
                             "ACTIVE",
@@ -5247,6 +7433,7 @@
                 "type": "object"
             },
             "ScreenCategory": {
+                "description": "Represents a business screen category definition.",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/ScreenCategoryEditable"
@@ -5254,17 +7441,14 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents a business screen category definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Represents a business screen category definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a business screen category definition.",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -5276,13 +7460,13 @@
             "ScreenTypeEditable": {
                 "properties": {
                     "name": {
-                        "description": "Represents a business screen Type definition.",
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
             "ScreenType": {
+                "description": "Represents a business screen Type definition.",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/ScreenTypeEditable"
@@ -5290,7 +7474,6 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents a business screen Type definition.",
                                 "type": "string",
                                 "format": "id"
                             }
@@ -5302,35 +7485,27 @@
             "scriptsEditable": {
                 "properties": {
                     "title": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "string"
                     },
                     "description": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "string"
                     },
                     "language": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "string"
                     },
                     "code": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "string"
                     },
                     "timeout": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "integer"
                     },
                     "run_as_user_id": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "integer"
                     },
                     "key": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "string"
                     },
                     "script_category_id": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "integer"
                     }
                 },
@@ -5344,17 +7519,14 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents an Eloquent model of a Script",
                                 "type": "integer",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Represents an Eloquent model of a Script",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents an Eloquent model of a Script",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -5364,13 +7536,12 @@
                 ]
             },
             "scriptsPreview": {
+                "description": "Represents an Eloquent model of a Script",
                 "properties": {
                     "status": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "string"
                     },
                     "key": {
-                        "description": "Represents an Eloquent model of a Script",
                         "type": "string"
                     }
                 },
@@ -5379,11 +7550,9 @@
             "ScriptCategoryEditable": {
                 "properties": {
                     "name": {
-                        "description": "Represents a business script category definition.",
                         "type": "string"
                     },
                     "status": {
-                        "description": "Represents a business script category definition.",
                         "type": "string",
                         "enum": [
                             "ACTIVE",
@@ -5394,6 +7563,7 @@
                 "type": "object"
             },
             "ScriptCategory": {
+                "description": "Represents a business script category definition.",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/ScriptCategoryEditable"
@@ -5401,17 +7571,14 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Represents a business script category definition.",
                                 "type": "string",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Represents a business script category definition.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Represents a business script category definition.",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -5423,52 +7590,43 @@
             "settingsEditable": {
                 "properties": {
                     "key": {
-                        "description": "Class Settings",
                         "type": "string"
                     },
                     "config": {
-                        "description": "Class Settings",
                         "type": "array",
                         "items": {
                             "type": "object"
                         }
                     },
                     "name": {
-                        "description": "Class Settings",
                         "type": "string"
                     },
                     "helper": {
-                        "description": "Class Settings",
                         "type": "string"
                     },
                     "group": {
-                        "description": "Class Settings",
                         "type": "string"
                     },
                     "format": {
-                        "description": "Class Settings",
                         "type": "string"
                     },
                     "hidden": {
-                        "description": "Class Settings",
                         "type": "boolean"
                     },
                     "readonly": {
-                        "description": "Class Settings",
                         "type": "boolean"
                     },
                     "variables": {
-                        "description": "Class Settings",
                         "type": "string"
                     },
                     "sansSerifFont": {
-                        "description": "Class Settings",
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
             "settings": {
+                "description": "Class Settings",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/settingsEditable"
@@ -5476,17 +7634,14 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "Class Settings",
                                 "type": "string",
                                 "format": "id"
                             },
                             "created_at": {
-                                "description": "Class Settings",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "Class Settings",
                                 "type": "string",
                                 "format": "date-time"
                             }
@@ -5498,92 +7653,70 @@
             "usersEditable": {
                 "properties": {
                     "email": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string",
                         "format": "email"
                     },
                     "firstname": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "lastname": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "username": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "password": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "address": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "city": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "state": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "postal": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "country": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "phone": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "fax": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "cell": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "title": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "timezone": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "datetime_format": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "language": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "is_administrator": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "boolean"
                     },
                     "expires_at": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "loggedin_at": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "remember_token": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "status": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string",
                         "enum": [
                             "ACTIVE",
@@ -5593,44 +7726,41 @@
                         ]
                     },
                     "fullname": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "avatar": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string"
                     },
                     "media": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/media"
                         }
                     },
                     "birthdate": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string",
                         "format": "date"
                     },
                     "delegation_user_id": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string",
                         "format": "id"
                     },
                     "manager_id": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "string",
                         "format": "id"
                     },
                     "meta": {
-                        "description": "The attributes that are mass assignable.",
                         "type": "object",
                         "additionalProperties": true
+                    },
+                    "force_change_password": {
+                        "type": "boolean"
                     }
                 },
                 "type": "object"
             },
             "users": {
+                "description": "The attributes that are mass assignable.",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/usersEditable"
@@ -5638,21 +7768,17 @@
                     {
                         "properties": {
                             "id": {
-                                "description": "The attributes that are mass assignable.",
                                 "type": "integer"
                             },
                             "created_at": {
-                                "description": "The attributes that are mass assignable.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "updated_at": {
-                                "description": "The attributes that are mass assignable.",
                                 "type": "string",
                                 "format": "date-time"
                             },
                             "deleted_at": {
-                                "description": "The attributes that are mass assignable.",
                                 "type": "string",
                                 "format": "date-time"
                             }


### PR DESCRIPTION
## Issue & Reproduction Steps
The following error is generated when we query the getProcesses() endpoint in Scripts:

`(Code: 0) Warning: settype(): Invalid type in /opt/sdk-php/lib/ObjectSerializer.php on line 335 Warning: settype(): Invalid type in /opt/sdk-php/lib/ObjectSerializer.php on line 335`

## Solution
- Change response field self_service_tasks of array to object

## How to Test
1. Create process with assigment self-service
2. Create a new PHP script
3. the scrAdd the following code and run:

`$apiInstance = $api->processes();
$result = $apiInstance->getProcesses();
return ['processes' => $result];`

## Related Tickets & Packages
[FOUR-5377](https://processmaker.atlassian.net/browse/FOUR-5377)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
