### PR TITLE
Improve process execution speed

### DIFF
--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -227,7 +227,9 @@ class CallActivity implements CallActivityInterface
      */
     private function syncronizeInstances(ExecutionInstanceInterface $instance, ExecutionInstanceInterface $currentInstance)
     {
-        if ($instance->getProcess()->getOwnerDocument()->getModel()->id !== $currentInstance->getProcess()->getOwnerDocument()->getModel()->id) {
+        $parentProcessId = optional($instance->getProcess()->getOwnerDocument()->getModel())->id;
+        $childProcessId = optional($currentInstance->getProcess()->getOwnerDocument()->getModel())->id;
+        if ($parentProcessId !== $childProcessId) {
             $currentInstance->getProcess()->getEngine()->runToNextState();
         }
     }

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -227,7 +227,7 @@ class CallActivity implements CallActivityInterface
      */
     private function syncronizeInstances(ExecutionInstanceInterface $instance, ExecutionInstanceInterface $currentInstance)
     {
-        if ($instance->process->id !== $currentInstance->process->id) {
+        if ($instance->getProcess()->getOwnerDocument()->getModel()->id !== $currentInstance->getProcess()->getOwnerDocument()->getModel()->id) {
             $currentInstance->getProcess()->getEngine()->runToNextState();
         }
     }

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -46,7 +46,7 @@ class CallActivity implements CallActivityInterface
                     ->getTokenRepository()
                     ->persistCallActivityActivated($token, $instance, $startId);
                 $this->linkProcesses($token, $instance);
-                $this->syncronizeInstances($token->getInstance(), $instance);
+                $this->synchronizeInstances($token->getInstance(), $instance);
             }
         );
     }
@@ -108,7 +108,7 @@ class CallActivity implements CallActivityInterface
 
         // Complete the sub process call
         $this->completeSubprocessBase($token);
-        $this->syncronizeInstances($instance, $token->getInstance());
+        $this->synchronizeInstances($instance, $token->getInstance());
 
         CopyRequestFiles::dispatch($instance, $token->getInstance());
         
@@ -144,7 +144,7 @@ class CallActivity implements CallActivityInterface
         }
         $token->getInstance()->logError(new Exception(implode("\n", $message)), $this);
 
-        $this->syncronizeInstances($instance, $token->getInstance());
+        $this->synchronizeInstances($instance, $token->getInstance());
         return $this;
     }
 
@@ -220,12 +220,12 @@ class CallActivity implements CallActivityInterface
     }
 
     /**
-     * Syncronize two process instances
+     * Synchronize two process instances
      *
      * @param ExecutionInstanceInterface $instance
      * @param ExecutionInstanceInterface $currentInstance
      */
-    private function syncronizeInstances(ExecutionInstanceInterface $instance, ExecutionInstanceInterface $currentInstance)
+    private function synchronizeInstances(ExecutionInstanceInterface $instance, ExecutionInstanceInterface $currentInstance)
     {
         $parentProcessId = optional($instance->getProcess()->getOwnerDocument()->getModel())->id;
         $childProcessId = optional($currentInstance->getProcess()->getOwnerDocument()->getModel())->id;

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -532,7 +532,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
                 $user = null;
         }
         $user = $this->scalateToManagerIfEnabled($user, $activity, $token, $assignmentType);
-        return $this->checkAssignment($token->processRequest, $activity, $assignmentType, $escalateToManager, $user ? User::where('id', $user)->first() : null);
+        return $this->checkAssignment($token->getInstance(), $activity, $assignmentType, $escalateToManager, $user ? User::where('id', $user)->first() : null);
     }
 
     /**

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -788,7 +788,7 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
     public function mergeLatestStoredData()
     {
         $store = $this->getDataStore();
-        $latest = ProcessRequest::find($this->getId());
+        $latest = ProcessRequest::select('data')->find($this->getId());
         $this->data = $store->updateArray($latest->data);
         return $this->data;
     }

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -749,8 +749,8 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
     public function updateCatchEvents()
     {
         $signalEvents = [];
-        foreach ($this->tokens as $token) {
-            $element = $token->getDefinition(true, $this->tokens->toArray());
+        foreach ($this->getTokens() as $token) {
+            $element = $token->getOwnerElement();
             if ($element instanceof IntermediateCatchEventInterface) {
                 foreach ($element->getEventDefinitions() as $eventDefinition) {
                     if ($eventDefinition instanceof SignalEventDefinitionInterface) {
@@ -777,7 +777,6 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
             }
         }
         $this->signal_events = $signalEvents;
-        $this->save();
     }
 
     /**

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -297,6 +297,10 @@ class ProcessRequestToken extends Model implements TokenInterface
      */
     public function getDefinition($asObject = false, $par = null)
     {
+        if ($this->getOwner() && $this->getOwnerElement()) {
+            $element = $this->getOwnerElement();
+            return $asObject ? $element : $element->getProperties();
+        }
         $request = $this->processRequest ?: $this->getInstance();
         $process = $request->processVersion ?: $request->process;
         $definitions = $process->getDefinitions();

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -83,17 +83,18 @@ class TokenRepository implements TokenRepositoryInterface
         if ($isScriptOrServiceTask) {
             $user = null;
         } else {
-            $user = $token->getInstance()->process->getNextUser($activity, $token);
+            $user = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getNextUser($activity, $token);
         }
         $this->addUserToData($token->getInstance(), $user);
         $this->addRequestToData($token->getInstance());
         $token->user_id = $user ? $user->getKey() : null;
+        $token->getInstance()->updateCatchEvents();
         $this->instanceRepository->persistInstanceUpdated($token->getInstance());
         $token->status = ActivityInterface::TOKEN_STATE_ACTIVE;
         $token->element_id = $activity->getId();
         $token->element_type = $this->getActivityType($activity);
         $token->element_name = $activity->getName();
-        $token->process_id = $token->getInstance()->process->getKey();
+        $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
 
         $token->is_self_service = 0;
@@ -115,7 +116,6 @@ class TokenRepository implements TokenRepositoryInterface
         $token->initiated_at = null;
         $token->riskchanges_at = $due ? Carbon::now()->addHours($due * 0.7) : null;
         $token->updateTokenProperties();
-        $token->getInstance()->updateCatchEvents();
         $token->saveOrFail();
         $token->setId($token->getKey());
         $request = $token->getInstance();
@@ -143,7 +143,7 @@ class TokenRepository implements TokenRepositoryInterface
         $token->element_id = $startEvent->getId();
         $token->element_type = $startEvent instanceof StartEventInterface ? 'startEvent' : 'task';
         $token->element_name = $startEvent->getName();
-        $token->process_id = $token->getInstance()->process->getKey();
+        $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
         $token->user_id = empty(Auth::user()) ? null : Auth::user()->id;
 
@@ -182,7 +182,7 @@ class TokenRepository implements TokenRepositoryInterface
         $token->element_id = $activity->getId();
         $token->element_type = $this->getActivityType($activity);
         $token->element_name = $activity->getName();
-        $token->process_id = $token->getInstance()->process_id;
+        $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
         $token->updateTokenProperties();
         $token->save();
@@ -241,7 +241,7 @@ class TokenRepository implements TokenRepositoryInterface
         $token->element_id = $activity->getId();
         $token->element_type = $this->getActivityType($activity);
         $token->element_name = $activity->getName();
-        $token->process_id = $token->getInstance()->process_id;
+        $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
         $token->data = $token->getInstance()->getDataStore()->getData();
         $token->updateTokenProperties();
@@ -255,12 +255,13 @@ class TokenRepository implements TokenRepositoryInterface
         if ($process->isNonPersistent()) {
             return;
         }
+        $token->getInstance()->updateCatchEvents();
         $this->instanceRepository->persistInstanceUpdated($token->getInstance());
         $token->status = $token->getStatus();
         $token->element_id = $intermediateCatchEvent->getId();
         $token->element_type = 'event';
         $token->element_name = $intermediateCatchEvent->getName();
-        $token->process_id = $token->getInstance()->process->getKey();
+        $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
         $token->user_id = null;
         $token->due_at = null;
@@ -269,7 +270,6 @@ class TokenRepository implements TokenRepositoryInterface
         $token->updateTokenProperties();
         $token->saveOrFail();
         $token->setId($token->getKey());
-        $token->getInstance()->updateCatchEvents();
     }
 
     public function persistCatchEventTokenConsumed(CatchEventInterface $intermediateCatchEvent, TokenInterface $token)
@@ -299,7 +299,7 @@ class TokenRepository implements TokenRepositoryInterface
         $token->element_id = $intermediateCatchEvent->getId();
         $token->element_type = 'event';
         $token->element_name = $intermediateCatchEvent->getName();
-        $token->process_id = $token->getInstance()->process->getKey();
+        $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
         $token->user_id = null;
         $token->due_at = null;
@@ -345,7 +345,7 @@ class TokenRepository implements TokenRepositoryInterface
         $token->element_id = $gateway->getId();
         $token->element_type = 'gateway';
         $token->element_name = $gateway->getName();
-        $token->process_id = $token->getInstance()->process->getKey();
+        $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
         $token->user_id = null;
         $token->due_at = null;
@@ -365,7 +365,7 @@ class TokenRepository implements TokenRepositoryInterface
         $this->instanceRepository->persistInstanceUpdated($token->getInstance());
         $token->status = 'CLOSED';
         $token->element_id = $gateway->getId();
-        $token->process_id = $token->getInstance()->process->getKey();
+        $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
         $token->completed_at = Carbon::now();
         $token->updateTokenProperties();
@@ -394,7 +394,7 @@ class TokenRepository implements TokenRepositoryInterface
             $token->element_id = $event->getId();
             $token->element_type = 'end_event';
             $token->element_name = $event->getName();
-            $token->process_id = $token->getInstance()->process->getKey();
+            $token->process_id = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getKey();
             $token->process_request_id = $token->getInstance()->getKey();
             $token->user_id = null;
             $token->due_at = null;

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -79,14 +79,6 @@ class TokenRepository implements TokenRepositoryInterface
         if ($process->isNonPersistent()) {
             return;
         }
-        $this->instanceRepository->persistInstanceUpdated($token->getInstance());
-        $token->status = ActivityInterface::TOKEN_STATE_ACTIVE;
-        $token->element_id = $activity->getId();
-        $token->element_type = $this->getActivityType($activity);
-        $token->element_name = $activity->getName();
-        $token->process_id = $token->getInstance()->process->getKey();
-        $token->process_request_id = $token->getInstance()->getKey();
-        $token->load('processRequest');
         $isScriptOrServiceTask = $activity instanceof ScriptTaskInterface || $activity instanceof ServiceTaskInterface;
         if ($isScriptOrServiceTask) {
             $user = null;
@@ -96,6 +88,14 @@ class TokenRepository implements TokenRepositoryInterface
         $this->addUserToData($token->getInstance(), $user);
         $this->addRequestToData($token->getInstance());
         $token->user_id = $user ? $user->getKey() : null;
+        $this->instanceRepository->persistInstanceUpdated($token->getInstance());
+        $token->status = ActivityInterface::TOKEN_STATE_ACTIVE;
+        $token->element_id = $activity->getId();
+        $token->element_type = $this->getActivityType($activity);
+        $token->element_name = $activity->getName();
+        $token->process_id = $token->getInstance()->process->getKey();
+        $token->process_request_id = $token->getInstance()->getKey();
+        $token->load('processRequest');
 
         $token->is_self_service = 0;
         if ($token->getAssignmentRule() === 'self_service') {
@@ -439,7 +439,6 @@ class TokenRepository implements TokenRepositoryInterface
             unset($userData['remember_token']);
             $instance->getDataStore()->putData('_user', $userData);
         }
-        $this->instanceRepository->persistInstanceUpdated($instance);
     }
 
     /**
@@ -462,7 +461,6 @@ class TokenRepository implements TokenRepositoryInterface
     {
         if (!$instance->getDataStore()->getData('_request')) {
             $instance->getDataStore()->putData('_request', $instance->attributesToArray());
-            $this->instanceRepository->persistInstanceUpdated($instance);
         }
     }
 

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -95,7 +95,6 @@ class TokenRepository implements TokenRepositoryInterface
         $token->element_name = $activity->getName();
         $token->process_id = $token->getInstance()->process->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
-        $token->load('processRequest');
 
         $token->is_self_service = 0;
         if ($token->getAssignmentRule() === 'self_service') {
@@ -108,7 +107,7 @@ class TokenRepository implements TokenRepositoryInterface
             }
         }
 
-        $selfServiceTasks = $token->processRequest->processVersion->self_service_tasks;        
+        $selfServiceTasks = $token->getInstance()->processVersion->self_service_tasks;
         $token->self_service_groups = $selfServiceTasks && isset($selfServiceTasks[$activity->getId()]) ? $selfServiceTasks[$activity->getId()] : [];
         //Default 3 days of due date
         $due = $activity->getProperty('dueIn', '72');

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -87,7 +87,12 @@ class TokenRepository implements TokenRepositoryInterface
         $token->process_id = $token->getInstance()->process->getKey();
         $token->process_request_id = $token->getInstance()->getKey();
         $token->load('processRequest');
-        $user = $token->getInstance()->process->getNextUser($activity, $token);
+        $isScriptOrServiceTask = $activity instanceof ScriptTaskInterface || $activity instanceof ServiceTaskInterface;
+        if ($isScriptOrServiceTask) {
+            $user = null;
+        } else {
+            $user = $token->getInstance()->process->getNextUser($activity, $token);
+        }
         $this->addUserToData($token->getInstance(), $user);
         $this->addRequestToData($token->getInstance());
         $token->user_id = $user ? $user->getKey() : null;


### PR DESCRIPTION
## Issue & Reproduction Steps
- Calculate next user is slow and not required for Service and Script Tasks
- Add _user and _request are slow in Task Activation and should not be done in Repository anymore
- There are places where we are using Eloquent relationships to get Objects (like processRequest, processVersion, processRequestTokens) that were previously loaded this adds a lot of payload when running a process
- `function updateCatchEvents` is used during process execution and it is taking considerable time, needs to be improved.

## Solution
- The user_id in Service and Script tasks are always null, there is no need to calculate its value
- To keep the backward compatibility _user and _request are still being set in Task Activation, but includes some speed improvements
- Reduce the use of eloquent relationships (do not run and additional query to load already loaded objects) to speed up the process
- Reduce the use of eloquent relationships and save the changes only once

## How to Test

- Create a process with DataSources.
- Create a process with User Tasks.
- Create a process with intermediate catch events.
- Run them.
- The processes should work as expected.

[Test Catch Events.zip](https://github.com/ProcessMaker/processmaker/files/8287121/Test.Catch.Events.zip)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5776

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
