### PR TITLE
FOUR-5693: Remove requests with a big data on the creditaccess DEV server

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -658,7 +658,9 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
         $user = User::where('username', $value)->get()->first();
 
         if ($user) {
-            $requests = ProcessRequest::where('user_id', $expression->operator, $user->id)->get();
+            $requests = ProcessRequest::select('id')
+                ->where('user_id', $expression->operator, $user->id)
+                ->get();
             return function ($query) use ($requests) {
                 $query->whereIn('id', $requests->pluck('id'));
             };
@@ -679,7 +681,11 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
         $user = User::where('username', $value)->get()->first();
 
         if ($user) {
-            $tokens = ProcessRequestToken::where('user_id', $expression->operator, $user->id)->get();
+            $tokens = ProcessRequestToken::select('process_request_id')
+                ->where('user_id', $expression->operator, $user->id)
+                ->whereIn('element_type', ['task', 'userTask', 'startEvent'])
+                ->distinct()
+                ->get();
 
             return function ($query) use ($tokens) {
                 $query->whereIn('id', $tokens->pluck('process_request_id'));


### PR DESCRIPTION
## Issue & Reproduction Steps
- Have many requests with large data (data > 300KB and number of requests > 1000). 
- Create a saved search based on the requests list.

An error 500 is displayed when going to the created saved search

## Solution
Modified the Laravel query that retrieves the requests list to avoid parsing the "data" column of a request. This implies modifying code in PM 4 core. This improvement is available currently in 4.28 only.

## How to Test
- Have many requests with large data (data > 300KB and number of requests > 1000). 
- Create a saved search based on the requests list.
Verify that the saved search returns the expected result.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-5693

QA Notes: The ticket is similar to this one  already merged in 4.2
https://processmaker.atlassian.net/browse/FOUR-5118

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
