### PR TITLE
Fix Composer PSR-4 autoload warnings

### DIFF
--- a/tests/Feature/Api/SanitizeHelperTest.php
+++ b/tests/Feature/Api/SanitizeHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Api;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;


### PR DESCRIPTION
Part of https://processmaker.atlassian.net/browse/FOUR-5827

Solution:
- Update class names to conform with psr-4
- For packages, remove autoloading tests since it's not needed for phpunit

Other PRs needed:
https://github.com/ProcessMaker/connector-docusign/pull/22
https://github.com/ProcessMaker/package-collections/pull/305
https://github.com/ProcessMaker/package-data-sources/pull/221
https://github.com/ProcessMaker/package-auth/pull/47

**Describe the bug**
See jira link above

**To Reproduce**
Steps to reproduce the behavior:
1. install the packages listed above
2. run composer dump-autoload

**Expected behavior**
No psr-4 warnings

**Additional context**
Add any other context about the problem here.
