### PR TITLE
Bugfix/FOUR-5829: The "Deleted user found" modal is not displayed

### DIFF
--- a/resources/js/admin/users/components/AddUserModal.vue
+++ b/resources/js/admin/users/components/AddUserModal.vue
@@ -74,7 +74,7 @@ export default {
                 let deletedUserExists = false;
                 for (let key of ['username', 'email']) {
                     if (key in this.addError ) {
-                        let message = this.addError[key].find(m => m.startsWith('A user with the'));
+                        let message = this.addError[key].find(m => m.startsWith('The Username has already been taken.'));
                         if (message) {
                             deletedUserExists = message;
                         }


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to Admin tab > Users
- Delete a user
- Click on "+ Add User"
- Try to create a new user with the username of the user you just deleted
- Click on Save

Current Behavior:
It only shows an error message "The Username has already been taken".

Expected Behavior:
A modal should appear asking: Would you like to save and reactivate their account?

## Solution
- Search for the correct string for error message to know if deleted user exist to show reactivate user modal

## How to Test
- Go to Admin tab > Users
- Delete a user
- Click on "+ Add User"
- Try to create a new user with the username of the user you just deleted
- Click on Save, a modal asking for user reactivation should appear
- Click on "Yes" on the modal to reactivate the user, the user should be active now and not showing in deleted users.


**Working video**

https://user-images.githubusercontent.com/90727999/160439743-4dc6f334-ac0c-4178-99ad-beb45b8d290a.mov


## Related Tickets & Packages
- [FOUR-5829](https://processmaker.atlassian.net/browse/FOUR-5829)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
