### PR TITLE
Customize Service Task queue

### DIFF
--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -22,6 +22,9 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
     public $tokenId;
     public $data;
 
+    public $tries = 3;
+    public $retryAfter = 60;
+
     /**
      * Create a new job instance.
      *

--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -22,6 +22,9 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
     public $tokenId;
     public $data;
 
+    public $tries = 3;
+    public $retryAfter = 60;
+
     /**
      * Create a new job instance.
      *

--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -35,7 +35,11 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
      */
     public function __construct(Definitions $definitions, ProcessRequest $instance, ProcessRequestToken $token, array $data)
     {
-        $pmConfig = json_decode($token->getOwnerElement()->getProperty('config'), true);
+        if ($token->getOwner()) {
+            $pmConfig = json_decode($token->getOwnerElement()->getProperty('config', '{}'), true);
+        } else {
+            $pmConfig = [];
+        }
         $this->onQueue($pmConfig['queue'] ?? 'bpmn');
         $this->definitionsId = $definitions->getKey();
         $this->instanceId = $instance->getKey();

--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -32,7 +32,8 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
      */
     public function __construct(Definitions $definitions, ProcessRequest $instance, ProcessRequestToken $token, array $data)
     {
-        $this->onQueue('bpmn');
+        $pmConfig = json_decode($token->getOwnerElement()->getProperty('config'), true);
+        $this->onQueue($pmConfig['queue'] ?? 'bpmn');
         $this->definitionsId = $definitions->getKey();
         $this->instanceId = $instance->getKey();
         $this->tokenId = $token->getKey();

--- a/ProcessMaker/Managers/WorkflowManager.php
+++ b/ProcessMaker/Managers/WorkflowManager.php
@@ -173,7 +173,7 @@ class WorkflowManager
         Log::info('Dispatch a service task: ' . $serviceTask->getId());
         $instance = $token->processRequest;
         $process = $instance->process;
-        RunServiceTask::dispatch($process, $instance, $token, [])->onQueue('bpmn');
+        RunServiceTask::dispatch($process, $instance, $token, []);
     }
 
     /**

--- a/tests/Feature/Api/ServiceTaskQueueTest.php
+++ b/tests/Feature/Api/ServiceTaskQueueTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Support\Facades\Bus;
+use ProcessMaker\Jobs\RunServiceTask;
+use Tests\Feature\Shared\ProcessTestingTrait;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+/**
+ * Test Service Task Queue
+ *
+ * @group process_tests
+ */
+class ServiceTaskQueueTest extends TestCase
+{
+    use RequestHelper;
+    use ProcessTestingTrait;
+
+    /**
+     * Tests the ServiceTask is dispatched to the custom queue.
+     */
+    public function testCustomQueue()
+    {
+        Bus::fake([
+            RunServiceTask::class,
+        ]);
+
+        // Create a process
+        $process = $this->createProcess(file_get_contents(__DIR__ . '/processes/ServiceTaskCustomQueue.bpmn'));
+        $startEvent = 'node_1';
+
+        // Start a process instance
+        $this->startProcess($process, $startEvent);
+
+        Bus::assertDispatched(RunServiceTask::class, function (RunServiceTask $job) {
+            return $job->queue === "custom-queue";
+        });
+    }
+
+    /**
+     * Tests the ServiceTask is dispatched to the bpmn queue.
+     */
+    public function testDefaultQueue()
+    {
+        Bus::fake([
+            RunServiceTask::class,
+        ]);
+
+        // Create a process
+        $process = $this->createProcess(file_get_contents(__DIR__ . '/processes/ServiceTaskDefaultQueue.bpmn'));
+        $startEvent = 'node_1';
+
+        // Start a process instance
+        $this->startProcess($process, $startEvent);
+
+        Bus::assertDispatched(RunServiceTask::class, function (RunServiceTask $job) {
+            return $job->queue === "bpmn";
+        });
+    }
+}

--- a/tests/Feature/Api/processes/ServiceTaskCustomQueue.bpmn
+++ b/tests/Feature/Api/processes/ServiceTaskCustomQueue.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="node_3" name="Service Task" pm:config='{"queue":"custom-queue"}' implementation="test-implementation">
+      <bpmn:incoming>node_5</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="node_5" sourceRef="node_1" targetRef="node_3" />
+    <bpmn:endEvent id="node_6" name="End Event">
+      <bpmn:incoming>node_8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_8" sourceRef="node_3" targetRef="node_6" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="170" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="290" y="220" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="188" y="258" />
+        <di:waypoint x="348" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+        <dc:Bounds x="480" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="348" y="258" />
+        <di:waypoint x="498" y="258" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/Feature/Api/processes/ServiceTaskDefaultQueue.bpmn
+++ b/tests/Feature/Api/processes/ServiceTaskDefaultQueue.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false">
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="node_3" name="Service Task" implementation="test-implementation">
+      <bpmn:incoming>node_5</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="node_5" sourceRef="node_1" targetRef="node_3" />
+    <bpmn:endEvent id="node_6" name="End Event">
+      <bpmn:incoming>node_8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_8" sourceRef="node_3" targetRef="node_6" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="170" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="290" y="220" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="188" y="258" />
+        <di:waypoint x="348" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+        <dc:Bounds x="480" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="348" y="258" />
+        <di:waypoint x="498" y="258" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Solution
- Add a pm:config property to setup the queue used for a Service Task: `pm:config='{"queue":"custom-queue"}'`

## How to Test
- Add a custom queue to horizon (supervisor-bpmn) e.g. install Ellucian package
- Add the custom property `"queue":"custom-queue"` to the pm:config of your ServiceTask
- Run the process, it should execute the ServiceTask on the defined queue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5388

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
