### PR TITLE
Bugfix FOUR 5712 - The second login with saml is redirected to the idp portal

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -55,6 +55,8 @@ class LoginController extends Controller
         $manager = App::make(LoginManager::class);
         $addons = $manager->list();
         $block = $manager->getBlock();
+        // clear cookie to avoid an issue when logout SLO and then try to login with simple PM login form
+        \Cookie::queue(\Cookie::forget('processmaker_session'));
         // cookie required here because SSO redirect resets the session
         $cookie = cookie("processmaker_intended", redirect()->intended()->getTargetUrl(), 10, '/');
         $response = response(view('auth.login', compact('addons', 'block')));


### PR DESCRIPTION
## Issue & Reproduction Steps
When logging out with SAML, we're being redirected to the IDP portal instead of ProcessMaker /login page.

1. Log in with SAML user
2. Log out

## Solution
- Removed `Saml2LogoutEvent` dispatch to avoid re-entering the handle function of the `LogoutListener::class`.

## How to Test
- Please configure the SSO SAML login feature and follow the reproduction steps of above.


**Working video**

https://user-images.githubusercontent.com/90727999/160916727-00a83f82-860b-4357-bc0e-03eabc2be5e9.mov



## Related Tickets & Packages
- [FOUR-5712](https://processmaker.atlassian.net/browse/FOUR-5712)
- [Package-auth PR](https://github.com/ProcessMaker/package-auth/pull/49)
