### PR TITLE
Retry Script/Service Task on Fatal Error

### DIFF
--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -22,6 +22,9 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
     public $tokenId;
     public $data;
 
+    public $tries = 3;
+    public $retryAfter = 60;
+
     /**
      * Create a new job instance.
      *

--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -22,6 +22,9 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
     public $tokenId;
     public $data;
 
+    public $tries = 3;
+    public $retryAfter = 60;
+
     /**
      * Create a new job instance.
      *


### PR DESCRIPTION
## Issue & Reproduction Steps
When the BPMN jobs queue is saturated, there is the chance a Memory Overflow happens.

## Solution
- Retry the Script/Service Task after 60sec (time to release the request lock). 

## How to Test
Run the sync process several times.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
