### PR TITLE
 Bugfix FOUR-4789 (develop) - Searches for the date or date time in a collection 

### DIFF
--- a/ProcessMaker/Traits/ExtendedPMQL.php
+++ b/ProcessMaker/Traits/ExtendedPMQL.php
@@ -156,7 +156,6 @@ trait ExtendedPMQL
     private function parseDate($value) {
         try {
             $parsed = Carbon::parse($value, auth()->user()->timezone);
-            $parsed->setTimezone(config('app.timezone'));
             if ($parsed->isMidnight()) {
                 return $parsed->toDateString();
             } else {


### PR DESCRIPTION
## Issue & Reproduction Steps
When using a PMQL query like `(data.form_date_picker_1 ="2021-12-31")` to search a record of a collection, it does not work.

1. Log in
2. Import collection [attached](https://processmaker.atlassian.net/browse/FOUR-4789) 
3. Open the collection
4. Fill following query (data.form_date_picker_1 = "2021-12-31")

## Solution
- The `parseValue` function for dates in `ProcessMaker/Traits/ExtendedPMQL.php` always returned a "date with timestamp", so `2021-12-31 14:00` is different than `2021-12-31` and no records are found.

## How to Test
Please follow the reproduction steps of above to manually tests the search functionality by PMQL date in `/collections/{id}`.

You can also run `vendor/bin/phpunit tests/Feature/ExtendedPMQLTest.php`.

## Related Tickets & Packages
- [FOUR-4789](https://processmaker.atlassian.net/browse/FOUR-4789)
- [Pull Request 4315 (4.29-develop)](https://github.com/ProcessMaker/processmaker/pull/4315)
- [Pull Request 4203](https://github.com/ProcessMaker/processmaker/pull/4203)