### PR TITLE
Fix Data Input Read Only

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -110,7 +110,6 @@
 
                 <b-collapse v-model="showDataPreview" id="showDataPreview" class="mt-2">
                   <monaco-editor
-                    ref="dataPreviewEditor"
                     :options="monacoOptions"
                     class="editor"
                     v-model="previewDataStringyfy"
@@ -478,7 +477,6 @@ export default {
     },
   },
   mounted() {
-    this.$refs.dataPreviewEditor.updateOptions({readOnly: true});
     this.countElements = debounce(this.countElements, 2000);
     this.mountWhenTranslationAvailable();
     this.countElements();

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -110,6 +110,7 @@
 
                 <b-collapse v-model="showDataPreview" id="showDataPreview" class="mt-2">
                   <monaco-editor
+                    ref="dataPreviewEditor"
                     :options="monacoOptions"
                     class="editor"
                     v-model="previewDataStringyfy"
@@ -376,7 +377,6 @@ export default {
         formatOnPaste: true,
         formatOnType: true,
         automaticLayout: true,
-        readOnly: true,
         minimap: { enabled: false },
       },
       mockMagicVariables,
@@ -478,6 +478,7 @@ export default {
     },
   },
   mounted() {
+    this.$refs.dataPreviewEditor.updateOptions({readOnly: true});
     this.countElements = debounce(this.countElements, 2000);
     this.mountWhenTranslationAvailable();
     this.countElements();


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket [FOUR-5893](https://processmaker.atlassian.net/browse/FOUR-5893)

1. Create a screen
2. Add Line Input control
5. click preview
6. In the data input editor try to edit the data

**Expected Behavior**
Should be able to edit the data input on the screen. 

**Current Behavior**
Can not edit the data input on the screen. 


## Solution

The issue was due to the Data Input and Data Preview monaco editors sharing the same options set in the `monacoOptions` variable which had `readOnly` set to `true`. 

Solution is to remove the `readOnly` option from the `monacoOptions`. 


## How to Test
Test the above steps above and ensure the Data Preview editor is read only.

## Related Tickets & Packages
- Original Issue:  https://processmaker.atlassian.net/browse/FOUR-5430

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
