### PR TITLE
Add BPMN_QUEUE_INTERVAL envvar

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -149,6 +149,7 @@ return [
                 'processes' => 16,
                 'tries' => 1,
                 'timeout' => 3600,
+                'sleep' => intval(env('BPMN_QUEUE_INTERVAL', 3000))*0.001,
             ],
             'supervisor-1' => [
                 'connection' => 'redis',
@@ -168,6 +169,7 @@ return [
                 'processes' => 8,
                 'tries' => 1,
                 'timeout' => 3600,
+                'sleep' => intval(env('BPMN_QUEUE_INTERVAL', 3000))*0.001,
             ],
             'supervisor-1' => [
                 'connection' => 'redis',
@@ -187,6 +189,7 @@ return [
                 'processes' => 8,
                 'tries' => 1,
                 'timeout' => 3600,
+                'sleep' => intval(env('BPMN_QUEUE_INTERVAL', 3000))*0.001,
             ],
             'supervisor-1' => [
                 'connection' => 'redis',

--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -25,6 +25,7 @@ import {
   loopCharacteristicsInspector,
   loopCharacteristicsHandler,
   loopCharacteristicsData,
+  NodeIdentifierInput
 } from '@processmaker/modeler';
 import ModelerScreenSelect from './components/inspector/ScreenSelect';
 import UserSelect from './components/inspector/UserSelect';
@@ -60,6 +61,7 @@ Vue.component('ScriptSelect', ScriptSelect);
 Vue.component('StartPermission', StartPermission);
 Vue.component("Interstitial", Interstitial);
 Vue.component("SelectUserGroup", SelectUserGroup);
+Vue.component("NodeIdentifierInput", NodeIdentifierInput);
 
 let nodeTypes = [
   endEvent,
@@ -90,6 +92,7 @@ ProcessMaker.modelerExtensions = {
   loopCharacteristicsInspector,
   loopCharacteristicsHandler,
   loopCharacteristicsData,
+  NodeIdentifierInput
 };
 
 ProcessMaker.EventBus.$on('modeler-init', registerNodes);
@@ -140,7 +143,7 @@ ProcessMaker.EventBus.$on(
         params: {
           type: 'FORM',
           interactive: true
-        }        
+        }
       }
     });
 

--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -25,7 +25,6 @@ import {
   loopCharacteristicsInspector,
   loopCharacteristicsHandler,
   loopCharacteristicsData,
-  NodeIdentifierInput
 } from '@processmaker/modeler';
 import ModelerScreenSelect from './components/inspector/ScreenSelect';
 import UserSelect from './components/inspector/UserSelect';
@@ -61,7 +60,6 @@ Vue.component('ScriptSelect', ScriptSelect);
 Vue.component('StartPermission', StartPermission);
 Vue.component("Interstitial", Interstitial);
 Vue.component("SelectUserGroup", SelectUserGroup);
-Vue.component("NodeIdentifierInput", NodeIdentifierInput);
 
 let nodeTypes = [
   endEvent,
@@ -92,7 +90,6 @@ ProcessMaker.modelerExtensions = {
   loopCharacteristicsInspector,
   loopCharacteristicsHandler,
   loopCharacteristicsData,
-  NodeIdentifierInput
 };
 
 ProcessMaker.EventBus.$on('modeler-init', registerNodes);
@@ -143,7 +140,7 @@ ProcessMaker.EventBus.$on(
         params: {
           type: 'FORM',
           interactive: true
-        }
+        }        
       }
     });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Jobs execution have a large delay.

## Solution
- Add configurable env variable to setup the internal queue delay when running BPMN Jobs.

## How to Test
Configure the following variables in `.env`:

```
BPMN_ACTIONS_LOCK_CHECK_INTERVAL=30
BPMN_QUEUE_INTERVAL=100
```
Also use the Redis queue.

Test a process with DataSources, note that takes less time to execute each DataSource sequentially.

e.g.
- You have an endpoint that runs in about 1 second
- Create a DataConnector to call that endpoint
- Create a process
- Add the previous data connector to the process, 8 times
- Connect the data connectors sequentially
- Without the changes the process could take about 16 seconds to complete
- With the changes the process should take less than 16 seconds to complete

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5878

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
