### PR TITLE
Bugfix/four 5659

### DIFF
--- a/ProcessMaker/Console/Commands/MissingFilesUploadId.php
+++ b/ProcessMaker/Console/Commands/MissingFilesUploadId.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Support\Arr;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use ProcessMaker\Models\ProcessRequest;
+
+class MissingFilesUploadId extends Command
+{
+    private $MAX_SCRIPT_TIMEOUT = 3600;
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = "processmaker:fix-missing-file-upload-id";
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix broken file IDs in requests';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->writeln("Searching for request with calls to sub-process\n", 'info', true);
+
+        foreach (ProcessRequest::where('process_collaboration_id', '!=', null)->orderBy('id', 'asc')->get() as $request) {
+            $data = $request->data;
+            $modify = false;
+            foreach ($request->getMedia() as $file) {
+                if (Arr::has($data, $file->getCustomProperty('data_name'))) {
+                    $modify = true;
+                    Arr::set($data, $file->getCustomProperty('data_name'), $file->id);
+                }
+            }
+            if ($modify) {
+                $this->writeln("Process Request: {$request->id} modified", 'info', true);
+                $request->data = $data;
+                $request->save();
+            }
+        }
+    }
+
+
+    private function writeln($message, $type, $toLog = false)
+    {
+        $this->{$type}($message);
+        if ($toLog) {
+            Log::Info("Garbage Collector: " . $message);
+        }
+    }
+}

--- a/ProcessMaker/Jobs/CopyRequestFiles.php
+++ b/ProcessMaker/Jobs/CopyRequestFiles.php
@@ -2,12 +2,13 @@
 
 namespace ProcessMaker\Jobs;
 
+use Illuminate\Support\Arr;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Models\ProcessRequest;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use ProcessMaker\Models\ProcessRequest;
 
 class CopyRequestFiles implements ShouldQueue
 {
@@ -47,6 +48,13 @@ class CopyRequestFiles implements ShouldQueue
             $newFile = $fileToCopy->copy($this->to);
             $newFile->setCustomProperty('createdBy', $originalCreatedBy);
             $newFile->save();
+
+            //update the file with new ID
+            $processRequest = ProcessRequest::find($newFile->model_id);
+            $data = $processRequest->data;
+            Arr::set($data, $fileToCopy->getCustomProperty('data_name'), $newFile->id);
+            $processRequest->data = $data;
+            $processRequest->save();
         }
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
when you have a sub-process and files are uploaded, a copy of the file is made changing the original id, but the file id is not updated in the process data.

## Solution
- Update file ID's

## How to Test
[sub process.json.txt](https://github.com/ProcessMaker/processmaker/files/8454962/sub.process.json.txt)
[Process files.json.txt](https://github.com/ProcessMaker/processmaker/files/8454963/Process.files.json.txt)

load the sub-process and the process runs a case, the files must be visible and can be downloaded in the last task

## Related Tickets & Packages
- [FOUR-5659](https://processmaker.atlassian.net/browse/FOUR-5659)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
