### PR TITLE
Add fields parameter to screens index

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -81,6 +81,13 @@ class ScreenController extends Controller
 
         $include = $request->input('include', '');
 
+        // sparse fields
+        $fields = $request->input('fields', '');
+        if ($fields) {
+            $fields = explode(',', $fields);
+            $query->select($fields);
+        }
+
         if ($include) {
             $include = explode(',', $include);
             $count = array_search('categoryCount', $include);


### PR DESCRIPTION
## Issue & Reproduction Steps
The screen select list is slow.

## Solution
- Add a parameter to reduce the data loaded to list the screens

## How to Test

1. Create about 500 screens
2. Create a new screen
3. Go to preview
4. Go to design
5. Add a nested screen
6. Choose a screen
7. Go back to preview
8. Go back to design
9. Add a new nested screen or select one already added
10. Choose a screen

Repeat steps 7 to 10 note the screen is getting very very slow

## Related Tickets & Packages
- REQUIRES: https://processmaker.atlassian.net/browse/FOUR-5890
- Requires: https://github.com/ProcessMaker/screen-builder/pull/1201
- TICKET: https://processmaker.atlassian.net/browse/FOUR-5890

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
