### PR TITLE
FOUR-5868: Upgrade migration to clean-up and remove package-advancedforms

### DIFF
--- a/upgrades/2022_04_13_085018_clean_up_and_remove_package_advanced_forms.php
+++ b/upgrades/2022_04_13_085018_clean_up_and_remove_package_advanced_forms.php
@@ -1,0 +1,150 @@
+<?php
+
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\ScreenVersion;
+use ProcessMaker\Models\ScreenType;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+use Illuminate\Support\Facades\File;
+
+class CleanUpAndRemovePackageAdvancedForms extends Upgrade
+{
+    /**
+     * The version of ProcessMaker being upgraded *to*
+     *
+     * @var string example: 4.2.28
+     */
+    public $to = '4.2.30-RC1';
+
+    /**
+     * Upgrade migration cannot be skipped if the pre-upgrade checks fail
+     *
+     * @var bool
+     */
+    public $required = false;
+
+    /**
+     * Run any validations/pre-run checks to ensure the environment, settings,
+     * packages installed, etc. are right correct to run this upgrade.
+     *
+     * There is no need to check against the version(s) as the upgrade
+     * migrator will do this automatically and fail if the correct
+     * version(s) are not present.
+     *
+     * Throw a \RuntimeException if the conditions are *NOT* correct for this
+     * upgrade migration to run. If this is not a required upgrade, then it
+     * will be skipped. Otherwise the exception thrown will be caught, noted,
+     * and will prevent the remaining migrations from continuing to run.
+     *
+     * Returning void or null denotes the checks were successful.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function preflightChecks()
+    {
+        if (!$this->packageAdvancedFormsInstalled()) {
+            throw new RuntimeException('This upgrade migration requires package-advancedforms to be installed.');
+        }
+
+        if ($this->advancedTypeScreensExist()) {
+            throw new RuntimeException('There are screens found with the type "ADVANCED". Please update or remove these screens and re-run this upgrade migration.');
+        }
+    }
+
+    /**
+     * Run the upgrade migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->composerRemovePackageAdvancedForms();
+
+        $this->removeAdvancedScreenType();
+
+        $this->removePublishedAssets();
+    }
+
+    /**
+     * Reverse the upgrade migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->installPackageAdvancedForms();
+    }
+
+    /**
+     * Install package-advancedforms with composer then run the package install command
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected function installPackageAdvancedForms(): void
+    {
+        if (!is_string(system($command = 'composer require processmaker/package-advancedforms --no-interaction > /dev/null 2>&1'))) {
+            throw new RuntimeException("Unknown error while running: {$command}");
+        }
+
+        if (!is_string(system($command = PHP_BINARY.' '. base_path('artisan') .' package-advancedforms:install > /dev/null 2>&1'))) {
+            throw new RuntimeException("Unknown error while running: {$command}");
+        }
+    }
+
+    /**
+     * Remove package-advancedforms using composer
+     *
+     * @return void
+     */
+    protected function composerRemovePackageAdvancedForms(): void
+    {
+        system('composer remove processmaker/package-advancedforms --no-interaction');
+    }
+
+    /**
+     * Remove the ScreenType: "ADVANCED"
+     *
+     * @return void
+     */
+    protected function removeAdvancedScreenType(): void
+    {
+        ScreenType::query()->where('name', 'ADVANCED')->delete();
+    }
+
+    /**
+     * Removes the published front-end assets for package-advancedforms
+     *
+     * @return void
+     */
+    protected function removePublishedAssets(): void
+    {
+        if (File::exists($path = public_path('vendor/processmaker/packages/package-advancedforms'))) {
+            File::deleteDirectory($path);
+        }
+    }
+
+    /**
+     * Are there Screens with the type "ADVANCED"?
+     *
+     * @return bool
+     */
+    protected function advancedTypeScreensExist(): bool
+    {
+        return ScreenVersion::query()->where('type', 'ADVANCED')->exists()
+            || Screen::query()->where('type', 'ADVANCED')->exists();
+    }
+
+    /**
+     * Is package-advancedforms installed
+     *
+     * @return bool
+     */
+    protected function packageAdvancedFormsInstalled(): bool
+    {
+        return File::exists(base_path('vendor/processmaker/package-advancedforms'));
+    }
+}
+


### PR DESCRIPTION
## Issue & Reproduction Steps
If the deprecated package "[package-advancedforms](https://github.com/ProcessMaker/package-advancedforms)" is installed after upgrading to 4.2.30+, we need automatically clean up and remove it.

## Solution
- Included is an upgrade migration file which will check for package-advancedforms when run.
- If the package exists and there are no screens with the ScreenType "ADVANCED", then the upgrade migration will remove the package with composer, remove the ScreenType "ADVANCED" from the table "screen_types", and will remove any package-specific published assets.
- If this upgrade migration is rolled back, it will attempt to re-install package-advancedforms.

## How to Test
- Make sure you're running processmaker/processmaker version 4.2.30-RC1 (at least) and make sure processmaker/package-advancedforms is installed. 
- Run `php artisan upgrade` and you'll see the progress, success, and/or failure of the upgrade migration in the console output. Verify this by checking the "screen_types" table for the row "ADVANCED". You can also check the public/ and vendor/ directories for the package-specific directories to ensure they're deleted.
- Run `php artisan upgrade:rollback` to attempt the rollback of the upgrade migration. 

## Related Tickets & Packages
- JIRA [ticket FOUR-5868](https://processmaker.atlassian.net/browse/FOUR-5868)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
