### PR TITLE
Bugfix/FOUR-5566: Modeler - When 2 nodes have the same id, modeler starts to unresponsive

### DIFF
--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -25,6 +25,7 @@ import {
   loopCharacteristicsInspector,
   loopCharacteristicsHandler,
   loopCharacteristicsData,
+  NodeIdentifierInput
 } from '@processmaker/modeler';
 import ModelerScreenSelect from './components/inspector/ScreenSelect';
 import UserSelect from './components/inspector/UserSelect';
@@ -60,6 +61,7 @@ Vue.component('ScriptSelect', ScriptSelect);
 Vue.component('StartPermission', StartPermission);
 Vue.component("Interstitial", Interstitial);
 Vue.component("SelectUserGroup", SelectUserGroup);
+Vue.component("NodeIdentifierInput", NodeIdentifierInput);
 
 let nodeTypes = [
   endEvent,
@@ -90,6 +92,7 @@ ProcessMaker.modelerExtensions = {
   loopCharacteristicsInspector,
   loopCharacteristicsHandler,
   loopCharacteristicsData,
+  NodeIdentifierInput
 };
 
 ProcessMaker.EventBus.$on('modeler-init', registerNodes);
@@ -140,7 +143,7 @@ ProcessMaker.EventBus.$on(
         params: {
           type: 'FORM',
           interactive: true
-        }        
+        }
       }
     });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:
- Create a new Process or edit an existing one. 
- Add two tasks to the process
- From the Advanced settings panel, edit the Node Identifier option and provide a non-unique identifier.

Current Behavior:
Modeler starts to get unresponsive
No warning that something is wrong is displayed

## Solution
- Added a custom component for Node identifier input, to validate if new value of current node id is unique in store.state.nodes list
- If new id value exists, do not set the new Node identifier value, to avoid unresponsive behavior.
- Show a validation error when Node ID is not unique

## How to Test
Test the steps above

**IMPORTANT:** 
- Please test it with all modeler elements (start event, end event, intermediate event, task, gateways, and also with all elements for each enterprise package)
- Test also changing another properties in the inspector for the elements (as name, node identifier, etc) and check if values are correctly modified.

Run in Modeler.spec.js **Check node ID is unique**  test

**Working video**


https://user-images.githubusercontent.com/90727999/163193266-3ec9e3f0-0451-472a-94a3-a2d6e22a9f08.mov


## Related Tickets & Packages
- [FOUR-5566](https://processmaker.atlassian.net/browse/FOUR-5566)
- [Connector docusign PR](https://github.com/ProcessMaker/connector-docusign/pull/23)
- [Connector send email PR](https://github.com/ProcessMaker/connector-send-email/pull/202)
- [Package data sources PR]https://github.com/ProcessMaker/package-data-sources/pull/224)
- [ProcessMaker PR] (https://github.com/ProcessMaker/processmaker/pull/4336)
- [Modeler PR] (https://github.com/ProcessMaker/modeler/pull/1436)
## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
