### PR TITLE
Refresh nested screen

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -623,10 +623,13 @@ export default {
       this.previewData = this.previewInputValid ? JSON.parse(this.previewInput) : {};
       this.rendererKey++;
       if (mode == 'preview') {
+        this.$dataProvider.flushScreenCache();
         this.preview.config = cloneDeep(this.config);
         this.preview.computed = cloneDeep(this.computed);
         this.preview.customCSS = cloneDeep(this.customCSS);
         this.preview.watchers = cloneDeep(this.watchers);
+      } else {
+        this.$refs.builder.refreshContent();
       }
     },
     onUpdate(data) {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -402,7 +402,6 @@ export default {
       this.previewData = {};
     },
     previewInput() {
-      console.log('previewInput');
       if (this.previewInputValid) {
         // Copy data over
         this.previewData = JSON.parse(this.previewInput);

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -209,7 +209,7 @@ import "@processmaker/vue-form-elements/dist/vue-form-elements.css";
 import MonacoEditor from "vue-monaco";
 import mockMagicVariables from "./mockMagicVariables";
 import TopMenu from "../../components/Menu";
-import { cloneDeep, debounce } from 'lodash';
+import { cloneDeep, debounce , isEqual} from 'lodash';
 import i18next from 'i18next';
 
 // Bring in our initial set of controls
@@ -416,7 +416,7 @@ export default {
   computed: {
     previewDataStringyfy: {
       get() {
-        if (JSON.stringify(this.previewData) !== JSON.stringify(this.previewDataSaved)) {
+        if (!isEqual(this.previewData, this.previewDataSaved)) {
           Object.assign(this.previewDataSaved, this.previewData);
           this.formatMonaco();
         }

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -402,6 +402,7 @@ export default {
       this.previewData = {};
     },
     previewInput() {
+      console.log('previewInput');
       if (this.previewInputValid) {
         // Copy data over
         this.previewData = JSON.parse(this.previewInput);
@@ -417,6 +418,7 @@ export default {
     previewDataStringyfy: {
       get() {
         if (JSON.stringify(this.previewData) !== JSON.stringify(this.previewDataSaved)) {
+          Object.assign(this.previewDataSaved, this.previewData);
           this.formatMonaco();
         }
         return JSON.stringify(this.previewData);


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a nested screen with a couple of fields
- Create a form screen
- Add the nested screen
- On a new tab edit the nested screen
- Change the nested screen
- Go the tab of the parent screen

## Solution
- Reset the cache for the modified nested screen when change from Design <--> Preview

## How to Test
See the video:

https://user-images.githubusercontent.com/8028650/163227831-dea8a931-d573-4678-a094-2e5c8ddd4200.mp4

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5933
- REQUIRES: https://github.com/ProcessMaker/processmaker/pull/4332
- REQUIRES: https://github.com/ProcessMaker/screen-builder/pull/1203

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
