### PR TITLE
Certain queries return an error when searching for Translations

### DIFF
--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -78,7 +78,7 @@ export default {
         },
         // Some controllers return each row as a json object to preserve integer keys (ie saved search)
         jsonRows(rows) {
-            if (rows.length === 0 || !('_json' in rows[0])) {
+            if (rows.length === 0 || !(_.has(_.head(rows), '_json'))) {
                 return rows;
             }
             return rows.map(row => JSON.parse(row._json));


### PR DESCRIPTION
## Issue & Reproduction Steps

### Steps to Reproduce
1. Visit the /admin/translations page.
2. Type the word `test` into the search field.

### Current Behavior
An error message is returned.

### Expected Behavior
Any results matching the query should be returned.

## Solution
Discovered that the issue was caused because the `jsonRows` method in the datatable mixin was causing an error. This was due to the fact that it expected the first array key to be `0` which can never be guaranteed. To work around this, we use the Lodash `head` method to obtain the first element in the array and then use the Lodash `has` method to determine whether the `_json` property exists.

## How to Test
Follow the reproduction steps above with and without the relevant branches checked out.

## Required PRs
- https://github.com/ProcessMaker/processmaker/pull/4338

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5953

## Before
https://user-images.githubusercontent.com/867714/163346870-d9d05236-00cc-4a5a-96fd-afc3407ea997.mov

## After
https://user-images.githubusercontent.com/867714/163346887-66023704-2480-4e4a-9483-18274c80650b.mov

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.