### PR TITLE
Allow customization of app title via language files

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,4 +1,5 @@
 {
+  "ProcessMaker": "ProcessMaker",
   "Skip to Content": "Skip to Content",
   " pending": " pending",
   ":user has completed the task :task_name": ":user has completed the task :task_name",

--- a/resources/views/auth/oauth2/authorize.blade.php
+++ b/resources/views/auth/oauth2/authorize.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ProcessMaker Oauth2 Server</title>
+    <title>{{ __('ProcessMaker') }} Oauth2 Server</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- Style sheets -->

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -27,7 +27,7 @@
       <meta name="alertMessage" content="{{$message}}">
     @endif
 
-    <title>@yield('title',__('Welcome')) - ProcessMaker</title>
+    <title>@yield('title',__('Welcome')) - {{ __('ProcessMaker') }}</title>
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon.png">
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     <link href="{{ mix('css/sidebar.css') }}" rel="stylesheet">

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
-    <title>@yield('title',__('Welcome')) - ProcessMaker</title>
+    <title>@yield('title',__('Welcome')) - {{ __('ProcessMaker') }}</title>
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon.png">
 @yield('css')


### PR DESCRIPTION
## Issue & Reproduction Steps

### Story
As a solutions engineer, I want to be able to customize the name displayed in the title bar of the application. This will allow us to more easily build out white-label solutions that obscure the name of ProcessMaker in favor of the name of the client.

## Solution
In order to accommodate this, we will simply change the title in our primary layouts to a translated string so that said string can be updated by administrators with the Translations package installed, or by open source users utilizing the language files.

## How to Test
With the Translations package installed, visit `/admin/translations` and search for the string `ProcessMaker`. Then change that string to a different string. After a refresh, that string should now appear in the page title of your web browser.

## Required PRs
- https://github.com/ProcessMaker/package-translations/pull/44

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5956

## Example
https://user-images.githubusercontent.com/867714/163350204-d1096288-9a48-4b27-a089-ae1a289d87b0.mov

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
