### PR TITLE
Bugfix/FOUR-5958: Fix the issue where comments referencing a username would no longer match

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -84,13 +84,13 @@ class RequestController extends Controller
 
         $userHasCommentsForRequest = Comment::where('commentable_type', ProcessRequest::class)
                 ->where('commentable_id', $request->id)
-                ->where('body','like', '%@' . \Auth::user()->username . '%')
+                ->where('body','like', '%{{' . \Auth::user()->id . '}}%')
                 ->count() > 0;
 
         $requestMedia = $request->media()->get()->pluck('id');
         $userHasCommentsForMedia = Comment::where('commentable_type', \ProcessMaker\Models\Media::class)
                 ->whereIn('commentable_id', $requestMedia)
-                ->where('body','like', '%@' . \Auth::user()->username . '%')
+                ->where('body','like', '%{{' . \Auth::user()->id . '}}%')
                 ->count() > 0;
 
         if (!$userHasCommentsForMedia && !$userHasCommentsForRequest) {

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -44,7 +44,7 @@ class TaskController extends Controller
         $dataManager = new DataManager();
         $userHasComments = Comment::where('commentable_type', ProcessRequestToken::class)
                                     ->where('commentable_id', $task->id)
-                                    ->where('body','like', '%@' . \Auth::user()->username . '%')
+                                    ->where('body','like', '%{{' . \Auth::user()->id . '}}%')
                                     ->count() > 0;
 
         if (!\Auth::user()->can('update', $task) && !$userHasComments) {

--- a/ProcessMaker/Models/Comment.php
+++ b/ProcessMaker/Models/Comment.php
@@ -144,12 +144,9 @@ class Comment extends Model
 
     public function setBodyAttribute($value)
     {
-        $value = preg_replace_callback('/(^|\s)([@][\.a-zA-Z\d\-_]+)/', function ($matches) {
+        // Get al mentions and replace with the user id in mustaches
+        $value = preg_replace_callback('/(^|\s)([@][a-zA-Z-zÀ-ÖØ-öø-ÿ0-9_-]+)/', function ($matches) {
             $username = str_replace([' @','@'], '', $matches[0]);
-
-            // Apply here script algorythm to convert old username format to new one
-            // ...
-
             $user = User::where('username', $username)->first();
             if ($user) {
                 return ' {{' . $user->id . '}}';
@@ -169,11 +166,6 @@ class Comment extends Model
             }
         }, $body);
         return $body;
-
-        // Old format user with special characters
-        // 2 users: myUser_ and myUser     OLD FORMAT
-        // After upgrade to no formate and remove special characters
-        // 2 users myUser and myUser
     }
 
     /**

--- a/ProcessMaker/Models/Comment.php
+++ b/ProcessMaker/Models/Comment.php
@@ -145,7 +145,7 @@ class Comment extends Model
     public function setBodyAttribute($value)
     {
         // Get al mentions and replace with the user id in mustaches
-        $value = preg_replace_callback('/(^|\s)([@][\p{L}\p{N}\-_]++)/', function ($matches) {
+        $value = mb_ereg_replace_callback('(^|\s)([@][\p{L}\p{N}\-_]+)', function ($matches) {
             $username = str_replace([' @','@'], '', $matches[0]);
             $user = User::where('username', $username)->first();
             if ($user) {

--- a/ProcessMaker/Models/Comment.php
+++ b/ProcessMaker/Models/Comment.php
@@ -145,7 +145,7 @@ class Comment extends Model
     public function setBodyAttribute($value)
     {
         // Get al mentions and replace with the user id in mustaches
-        $value = preg_replace_callback('/(^|\s)([@][a-zA-Z-zÀ-ÖØ-öø-ÿ0-9_-]+)/', function ($matches) {
+        $value = preg_replace_callback('/(^|\s)([@][\p{L}\p{N}\-_]++)/', function ($matches) {
             $username = str_replace([' @','@'], '', $matches[0]);
             $user = User::where('username', $username)->first();
             if ($user) {

--- a/tests/Feature/CommentsTest.php
+++ b/tests/Feature/CommentsTest.php
@@ -1,0 +1,206 @@
+<?php
+namespace Tests\Feature;
+use ProcessMaker\Models\Comment;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\ProcessTaskAssignment;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+use Tests\Feature\Shared\RequestHelper;
+
+class CommentsTest extends TestCase
+{
+    use RequestHelper;
+
+    private function createTask(array $data = [])
+    {
+        $data['bpmn'] = file_get_contents(__DIR__ . '/Api/processes/ManualTask.bpmn');
+        $process = factory(Process::class)->create($data);
+        $taskId = 'TaskUID';
+        factory(ProcessTaskAssignment::class)->create([
+            'process_id' => $process->id,
+            'process_task_id' => $taskId,
+            'assignment_id' => $this->user->id,
+            'assignment_type' => User::class,
+        ]);
+
+        $route = route('api.process_events.trigger', [$process->id, 'event' => 'StartEventUID']);
+        $data = [];
+        $response = $this->apiCall('POST', $route, $data);
+
+        // Get task
+        $route = route('api.tasks.index');
+        $response = $this->apiCall('GET', $route);
+        $task = $response->json('data')[0];
+
+        return $task;
+    }
+
+    /**
+     * @return void
+     */
+    public function testCommentMentionAreCorrectlyParsedBetweenUserIdAndUsername()
+    {
+        // Start a process request
+        $task = $this->createTask();
+
+        // Create sample user
+        $testUser = factory(User::class)->create([
+            'username' => 'testuser'
+        ]);
+
+        // Create a comment where the user is tagged
+        $comment = factory(Comment::class)->create([
+            'user_id' => $this->user->id,
+            'body' => 'Should replace the username to user id in mustaches @' . $testUser->username,
+            'commentable_type' => ProcessRequestToken::class,
+            'commentable_id' => $task['id'],
+        ]);
+
+        // Assert that the comment body without the accessor is stored as userid with mustaches
+        $this->assertEquals('Should replace the username to user id in mustaches {{'.$testUser->id.'}}', $comment->getOriginal('body'));
+
+        // Assert that the comment body with the accessor is parsed to username to the ui
+        $this->assertEquals('Should replace the username to user id in mustaches @' . $testUser->username, $comment->body);
+    }
+
+    /**
+     * @return void
+     */
+    public function testChineseCommentMentionAreCorrectlyParsedBetweenUserIdAndUsername()
+    {
+        // Start a process request
+        $task = $this->createTask();
+
+        // Create sample user
+        $testUser = factory(User::class)->create([
+            'username' => '测试用户'
+        ]);
+
+        // Create a comment where the user is tagged
+        $comment = factory(Comment::class)->create([
+            'user_id' => $this->user->id,
+            'body' => 'Should replace the username to user id in mustaches @' . $testUser->username,
+            'commentable_type' => ProcessRequestToken::class,
+            'commentable_id' => $task['id'],
+        ]);
+
+        // Assert that the comment body without the accessor is stored as userid with mustaches
+        $this->assertEquals('Should replace the username to user id in mustaches {{'.$testUser->id.'}}', $comment->getOriginal('body'));
+
+        // Assert that the comment body with the accessor is parsed to username to the ui
+        $this->assertEquals('Should replace the username to user id in mustaches @' . $testUser->username, $comment->body);
+    }
+
+    /**
+     * @return void
+     */
+    public function testArabicCommentMentionAreCorrectlyParsedBetweenUserIdAndUsername()
+    {
+        // Start a process request
+        $task = $this->createTask();
+
+        // Create sample user
+        $testUser = factory(User::class)->create([
+            'username' => 'النسر'
+        ]);
+
+        // Create a comment where the user is tagged
+        $comment = factory(Comment::class)->create([
+            'user_id' => $this->user->id,
+            'body' => 'Should replace the username to user id in mustaches @' . $testUser->username,
+            'commentable_type' => ProcessRequestToken::class,
+            'commentable_id' => $task['id'],
+        ]);
+
+        // Assert that the comment body without the accessor is stored as userid with mustaches
+        $this->assertEquals('Should replace the username to user id in mustaches {{'.$testUser->id.'}}', $comment->getOriginal('body'));
+
+        // Assert that the comment body with the accessor is parsed to username to the ui
+        $this->assertEquals('Should replace the username to user id in mustaches @' . $testUser->username, $comment->body);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGermanCommentMentionAreCorrectlyParsedBetweenUserIdAndUsername()
+    {
+        // Start a process request
+        $task = $this->createTask();
+
+        // Create sample user with german characters
+        $testUser = factory(User::class)->create([
+            'username' => 'ÄÖÜäöü'
+        ]);
+
+        // Create a comment where the user is tagged
+        $comment = factory(Comment::class)->create([
+            'user_id' => $this->user->id,
+            'body' => 'Should replace the username to user id in mustaches @' . $testUser->username,
+            'commentable_type' => ProcessRequestToken::class,
+            'commentable_id' => $task['id'],
+        ]);
+
+        // Assert that the comment body without the accessor is stored as userid with mustaches
+        $this->assertEquals('Should replace the username to user id in mustaches {{'.$testUser->id.'}}', $comment->getOriginal('body'));
+
+        // Assert that the comment body with the accessor is parsed to username to the ui
+        $this->assertEquals('Should replace the username to user id in mustaches @' . $testUser->username, $comment->body);
+    }
+
+    /**
+     * @return void
+     */
+    public function testArmenianCommentMentionAreCorrectlyParsedBetweenUserIdAndUsername()
+    {
+        // Start a process request
+        $task = $this->createTask();
+
+        // Create sample user with swiss characters
+        $testUser = factory(User::class)->create([
+            'username' => 'օգտագործող'
+        ]);
+
+        // Create a comment where the user is tagged
+        $comment = factory(Comment::class)->create([
+            'user_id' => $this->user->id,
+            'body' => 'Should replace the username to user id in mustaches @' . $testUser->username,
+            'commentable_type' => ProcessRequestToken::class,
+            'commentable_id' => $task['id'],
+        ]);
+
+        // Assert that the comment body without the accessor is stored as userid with mustaches
+        $this->assertEquals('Should replace the username to user id in mustaches {{'.$testUser->id.'}}', $comment->getOriginal('body'));
+
+        // Assert that the comment body with the accessor is parsed to username to the ui
+        $this->assertEquals('Should replace the username to user id in mustaches @' . $testUser->username, $comment->body);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBulgarianCommentMentionAreCorrectlyParsedBetweenUserIdAndUsername()
+    {
+        // Start a process request
+        $task = $this->createTask();
+
+        // Create sample user with bulgarian characters
+        $testUser = factory(User::class)->create([
+            'username' => 'Тестов'
+        ]);
+
+        // Create a comment where the user is tagged
+        $comment = factory(Comment::class)->create([
+            'user_id' => $this->user->id,
+            'body' => 'Should replace the username to user id in mustaches @' . $testUser->username,
+            'commentable_type' => ProcessRequestToken::class,
+            'commentable_id' => $task['id'],
+        ]);
+
+        // Assert that the comment body without the accessor is stored as userid with mustaches
+        $this->assertEquals('Should replace the username to user id in mustaches {{'.$testUser->id.'}}', $comment->getOriginal('body'));
+
+        // Assert that the comment body with the accessor is parsed to username to the ui
+        $this->assertEquals('Should replace the username to user id in mustaches @' . $testUser->username, $comment->body);
+    }
+}

--- a/tests/Feature/TasksTest.php
+++ b/tests/Feature/TasksTest.php
@@ -29,10 +29,10 @@ class TasksTest extends TestCase
     }
 
     public function testIndex() {
-        $response = $this->webGet(self::TASKS_URL, []); 
+        $response = $this->webGet(self::TASKS_URL, []);
         $response->assertStatus(200);
-        $response->assertViewIs('tasks.index'); 
-        $response->assertSee('Tasks'); 
+        $response->assertViewIs('tasks.index');
+        $response->assertSee('Tasks');
     }
 
     public function testViewTaskWithComments() {
@@ -48,7 +48,9 @@ class TasksTest extends TestCase
         $task = $response->json('data')[0];
 
         // A user without permissions for the task should generate a 403 error
-        $this->user = factory(User::class)->create();
+        $this->user = factory(User::class)->create([
+            'username' => 'testuser',
+        ]);
         $response = $this->webGet(self::TASKS_URL . '/' . $task['id'] . '/edit', []);
         $response->assertStatus(403);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Fix the issue where comments referencing a username would no longer match. Instead of storing the username itself in the comment text we should store a reference to the user’s ID and parse that into a username at runtime.

Please refer to: [FOUR-5759: The Processes should be order alphabeticallyTRIAGE](https://processmaker.atlassian.net/browse/FOUR-5759).

- Add a comment and tag some user i.e. "This is my comment @myUser"
- Go to your database to the comments table and search the comment. In the body column you will see the comment with the username: "This is my comment @myUser"


## Solution
- Added an accessor and mutator to comment model to parse between username and id and keep the users references in comments.

## How to Test
- Add a comment and tag some user i.e. "This is my comment @myUser"
- Go to your database to the comments table and search the comment. In the body column you will see the comment with the user id in mustaches: "This is my comment {{1}}"
- Go to the ui and you should see in the comment the username parsed "This is my comment @myUser"

Run test cases

**Working video**


https://user-images.githubusercontent.com/90727999/164788943-4739e38f-58cd-49ae-8623-a06e46ffede4.mov



## Related Tickets & Packages
- [FOUR-5958](https://processmaker.atlassian.net/browse/FOUR-5958)
- You should install package comments.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
