### PR TITLE
Add favicon to list of images that can be customized in the Customize UI page

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/CssOverrideController.php
+++ b/ProcessMaker/Http/Controllers/Api/CssOverrideController.php
@@ -74,6 +74,10 @@ class CssOverrideController extends Controller
             $this->uploadFile($setting->refresh(), $request, 'fileIcon', Setting::COLLECTION_CSS_ICON, Setting::DISK_CSS);
             Cache::forget('css-icon');
         }
+        if ($request->has('fileFavicon')) {
+            $this->uploadFile($setting->refresh(), $request, 'fileFavicon', Setting::COLLECTION_CSS_FAVICON, Setting::DISK_CSS);
+            Cache::forget('css-favicon');
+        }
 
         if ($request->has('fileLogin')) {
           $this->uploadFile($setting->refresh(), $request, 'fileLogin', Setting::COLLECTION_CSS_LOGIN, Setting::DISK_CSS);
@@ -150,6 +154,10 @@ class CssOverrideController extends Controller
         if ($request->has('fileIcon') && $request->input('fileIcon')) {
             $this->uploadFile($setting->refresh(), $request, 'fileIcon', Setting::COLLECTION_CSS_ICON, Setting::DISK_CSS);
             Cache::forget('css-icon');
+        }
+        if ($request->has('fileFavicon') && $request->input('fileFavicon')) {
+            $this->uploadFile($setting->refresh(), $request, 'fileFavicon', Setting::COLLECTION_CSS_FAVICON, Setting::DISK_CSS);
+            Cache::forget('css-favicon');
         }
         
         $this->setLoginFooter($request);
@@ -232,6 +240,7 @@ class CssOverrideController extends Controller
             'login' => $request->input('fileLoginName', ''),
             'logo' => $request->input('fileLogoName', ''),
             'icon' => $request->input('fileIconName', ''),
+            'favicon' => $request->input('fileFaviconName', ''),
             'variables' => $request->input('variables', ''),
             'sansSerifFont' => $request->input('sansSerifFont', $this->sansSerifFontDefault()),
         ];

--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -63,6 +63,7 @@ class Setting extends Model implements HasMedia
     public const COLLECTION_CSS_LOGIN = 'login';
     public const COLLECTION_CSS_LOGO = 'logo';
     public const COLLECTION_CSS_ICON = 'icon';
+    public const COLLECTION_CSS_FAVICON = 'favicon';
 
     /**
      * The attributes that aren't mass assignable.
@@ -321,6 +322,22 @@ class Setting extends Model implements HasMedia
             }
         }
 
+        return $url . '?id=' . bin2hex(random_bytes(16));
+    }
+    
+    public static function getFavicon()
+    {
+        //default icon
+        $url = asset(env('FAVICON_PATH', '/favicon.png'));
+        //custom icon
+        $setting = self::byKey('css-override');
+        if ($setting) {
+            $mediaFile = $setting->getMedia(self::COLLECTION_CSS_FAVICON);
+    
+            foreach ($mediaFile as $media) {
+                $url = $media->getFullUrl();
+            }
+        }
         return $url . '?id=' . bin2hex(random_bytes(16));
     }
 }

--- a/resources/js/admin/cssOverride/components/SiteDesign.vue
+++ b/resources/js/admin/cssOverride/components/SiteDesign.vue
@@ -52,6 +52,23 @@
       </b-form-group>
       
       <b-form-group
+          :description="$t('Use a transparent PNG at {{size}} pixels for best results.', { size: '32x32'})"
+          :label="$t('Custom Favicon')"
+          label-for="custom-favicon"
+          class="mb-3"
+          :state="fieldState('fileFavicon')"
+          :invalid-feedback="errorMessage('fileFavicon')"
+      >
+          <b-form-file
+              id="custom-favicon"
+              :placeholder="placeholder(fileFavicon, $t('Choose icon image'))"
+              ref="customFileFavicon"
+              accept="image/x-png,image/gif,image/jpeg"
+              @change.prevent="onFileChangeFavicon"
+          ></b-form-file>
+      </b-form-group>
+      
+      <b-form-group
           :description="$t('Enter the alt text that should accompany the logos and icon.')"
           label="Alternative Text"
           label-for="alt-text"
@@ -196,6 +213,10 @@ export default {
         file: null,
         selectedFile: null,
       },
+      fileFavicon: {
+        file: null,
+        selectedFile: null,
+      },
       colors: null,
       selectedSansSerifFont: {
         'id': "'Open Sans'",
@@ -309,6 +330,7 @@ export default {
         'login': null,
         'logo': null,
         'icon': null,
+        'favicon': null,
         'colors': null,
       }
     }
@@ -328,6 +350,9 @@ export default {
         }
         if (this.config.config.icon != "null") {
           this.fileIcon.selectedFile = this.config.config.icon;
+        }
+        if (this.config.config.favicon != "null") {
+          this.fileFavicon.selectedFile = this.config.config.favicon;
         }
         if (this.config.config.sansSerifFont != "null") {
           this.selectedSansSerifFont = JSON.parse(this.config.config.sansSerifFont);
@@ -402,9 +427,11 @@ export default {
       formData.append('fileLoginName', this.fileLogin.selectedFile);
       formData.append('fileLogoName', this.fileLogo.selectedFile);
       formData.append('fileIconName', this.fileIcon.selectedFile);
+      formData.append('fileFaviconName', this.fileFavicon.selectedFile);
       formData.append('fileLogin', this.fileLogin.file);
       formData.append('fileLogo', this.fileLogo.file);
       formData.append('fileIcon', this.fileIcon.file);
+      formData.append('fileFavicon', this.fileFavicon.file);
       formData.append('variables', JSON.stringify(this.customColors));
       formData.append('sansSerifFont', JSON.stringify(this.selectedSansSerifFont));
       formData.append('loginFooter', this.loginFooter);
@@ -424,8 +451,10 @@ export default {
           formData.append('reset', 'true');
           formData.append('fileLogoName', '');
           formData.append('fileIconName', '');
+          formData.append('fileFaviconName', '');
           formData.append('fileLogo', '');
           formData.append('fileIcon', '');
+          formData.append('fileFavicon', '');
           formData.append('variables', JSON.stringify(this.colorDefault));
           formData.append('sansSerifFont', JSON.stringify({id:"'Open Sans'", value:'Open Sans'}));
           formData.append('loginFooter', '');
@@ -502,6 +531,19 @@ export default {
 
       this.fileIcon.selectedFile = files[0].name;
       this.fileIcon.file = files[0];
+    },
+    browseFavicon() {
+      this.$refs.customFileFavicon.click();
+    },
+    onFileChangeFavicon(e) {
+      let files = e.target.files || e.dataTransfer.files;
+    
+      if (!files.length) {
+        return;
+      }
+    
+      this.fileFavicon.selectedFile = files[0].name;
+      this.fileFavicon.file = files[0];
     },
   }
 };

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -198,6 +198,7 @@
   "Current Local Time": "Current Local Time",
   "Custom Colors": "Custom Colors",
   "Custom CSS": "Custom CSS",
+  "Custom Favicon": "Custom Favicon",
   "Custom Icon": "Custom Icon",
   "Custom Logo": "Custom Logo",
   "Customize UI": "Customize UI",

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -28,7 +28,7 @@
     @endif
 
     <title>@yield('title',__('Welcome')) - {{ __('ProcessMaker') }}</title>
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ \ProcessMaker\Models\Setting::getFavicon() }}">
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     <link href="{{ mix('css/sidebar.css') }}" rel="stylesheet">
     <link href="/css/bpmn-symbols/css/bpmn.css" rel="stylesheet">

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -8,7 +8,7 @@
     <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
     <title>@yield('title',__('Welcome')) - {{ __('ProcessMaker') }}</title>
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ \ProcessMaker\Models\Setting::getFavicon() }}">
 @yield('css')
 </head>
 <body>


### PR DESCRIPTION
## User Story
As an administrator, I want the ability to set the favicon to a custom PNG image, similarly to how I can set the three custom logos currently.

## Solution
To accommodate this, we will simply add a fourth option to the list of icons allowed to be customized via the Customize UI page. We will then reference this custom icon in the primary layout blade template.

## How to Test
1. Visit the Customize UI page
2. Upload a new transparent PNG via the Custom Favicon file upload control
3. Click **Save** to save changes
4. Refresh the page and check to see
    4a. If the source code reflects the new custom favicon after the title tag
    4b. If the favicon has changed in the browser

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5964

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
