### PR TITLE
Move hash generation inside UserFactory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,17 +4,19 @@ use Faker\Generator as Faker;
 use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\User;
 
-$onePassword = Hash::make('oneOnlyPassword');
-
 /**
  * Model factory for a User
  */
-$factory->define(User::class, function (Faker $faker) use($onePassword) {
+$factory->define(User::class, function (Faker $faker) {
+
+    if (!isset($GLOBALS['testPassword'])) {
+        $GLOBALS['testPassword'] = Hash::make('oneOnlyPassword');
+    }
 
     return [
         'username' => $faker->unique()->userName,
         'email' => $faker->unique()->email,
-        'password' => $onePassword,
+        'password' => $GLOBALS['testPassword'],
 
         'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This line of code was adding extra payload to every ProcessMaker endpoint

![image](https://user-images.githubusercontent.com/8028650/163881256-88fb5b98-d485-4ff1-8e7c-99b8df38cc36.png)

## Solution
- Move the hash generation inside the factory.

## How to Test
- As a developer the add a log, dump or die to make sure `Hash::make('oneOnlyPassword');` is not executed on every endpoint.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5977

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
