### PR TITLE
Bugfix FOUR 5687 - Validation messages are duplicated according to the number of submit buttons

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -27,6 +27,13 @@
         <b-row class="h-100 m-0" id="preview" v-show="displayPreview">
 
           <b-col class="overflow-auto h-100">
+            <div v-if="$store.getters['globalErrorsModule/isValidScreen'] === false" class="alert alert-danger mt-3">
+              <i class="fas fa-exclamation-circle"/>
+              {{ $store.getters['globalErrorsModule/getErrorMessage'] }}
+              <button type="button" class="close" aria-label="Close" @click="$store.dispatch('globalErrorsModule/close')">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
             <vue-form-renderer
               v-if="renderComponent === 'task-screen'"
               ref="renderer"

--- a/resources/js/tasks/show.js
+++ b/resources/js/tasks/show.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import Vuex from 'vuex';
 import Task from '@processmaker/screen-builder';
 import TaskView from './components/TaskView';
 import AvatarImage from '../components/AvatarImage';
@@ -7,6 +8,7 @@ import debounce from 'lodash/debounce';
 import Timeline from '../components/Timeline';
 import TimelineItem from '../components/TimelineItem';
 
+Vue.use(Vuex);
 Vue.use('task', Task);
 Vue.component('task-view', TaskView);
 Vue.component('avatar-image', AvatarImage);
@@ -14,3 +16,4 @@ Vue.component('monaco-editor', MonacoEditor);
 Vue.component('timeline', Timeline);
 Vue.component('timeline-item', TimelineItem);
 window.debounce = debounce;
+window.Vuex = Vuex;

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -230,8 +230,10 @@
     @endforeach
     <script src="{{mix('js/tasks/show.js')}}"></script>
     <script>
+      const store = new Vuex.Store();
       const main = new Vue({
         mixins:addons,
+        store: store,
         el: "#task",
         data: {
           //Edit data


### PR DESCRIPTION
## Issue & Reproduction Steps
Validation messages are duplicated according to the number of submit buttons.

**Expected behavior**: 
The global error summary (red alert message) should appear once at the top of the viewport, above all DOM elements.
- Can be closed manually via the X on the right side of the banner
- Span the entire width of the form that the user is working on

**Current behavior**: 
An error message is displayed in the validation for the required fields for each submit button.

## How to Test
- It should be possible to visualize the global alert message via in Core.

## Related Tickets & Packages
- [FOUR-5687](https://processmaker.atlassian.net/browse/FOUR-5687)
- [Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1206)