### PR TITLE
FOUR-5957: Create an upgrade migration to sanitize usernames 

### DIFF
--- a/ProcessMaker/Jobs/SanitizeUsernames.php
+++ b/ProcessMaker/Jobs/SanitizeUsernames.php
@@ -92,7 +92,7 @@ class SanitizeUsernames implements ShouldQueue
 
         foreach ($comments_with_username as $comment) {
             DB::table('comments')->where('id', $comment->id)->update([
-                'body' => str_replace("@{$previous_username}", "@$new_username", $comment->body)
+                'body' => str_replace("@{$previous_username} ", "@$new_username ", $comment->body)
             ]);
         }
     }
@@ -111,7 +111,7 @@ class SanitizeUsernames implements ShouldQueue
         $i = 0;
 
         $generator = static function () use ($username, &$i): string {
-            if (blank($username = mb_ereg_match("[^\p{L}\p{N}\-_\s]", $username))) {
+            if (blank($username = mb_ereg_replace('[^\p{L}\p{N}\-_\s]', '', $username))) {
                 $username = 'user_'.random_bytes(4);
             }
 

--- a/ProcessMaker/Jobs/SanitizeUsernames.php
+++ b/ProcessMaker/Jobs/SanitizeUsernames.php
@@ -3,8 +3,10 @@
 namespace ProcessMaker\Jobs;
 
 use Illuminate\Bus\Queueable;
+use ProcessMaker\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -88,15 +90,6 @@ class SanitizeUsernames implements ShouldQueue
         if($unique_username_query->exists()) {
             goto build_username_query;
         }
-
-        // Grab the User model rules
-        //        $rules = (object) User::rules($username);
-
-        // Make sure the new, filtered username is valid
-        // with the User-model provided rules
-        //        Validator::make($rules->username,
-        //            ['username' => $username]
-        //        )->validate();
 
         // Once we know it's a unique, valid
         // username, send it back

--- a/ProcessMaker/Jobs/SanitizeUsernames.php
+++ b/ProcessMaker/Jobs/SanitizeUsernames.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SanitizeUsernames implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $users;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Collection $users)
+    {
+        $this->users = $users;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        foreach ($this->users as $index => $user) {
+
+            // Store the pre-update username for comparison
+            $pre_update_username = $user->username;
+            $updated_username = static::filterAndValidateUsername($user->username, $user->id);
+
+            // If it's the same, then it was already valid
+            if ($pre_update_username === $updated_username) {
+                continue;
+            }
+
+            // Set the valid username to the user
+            $update = DB::table('users')->where('id', $user->id)->update([
+                'username' => $updated_username
+            ]);
+
+            // Log the result and continue
+            if ($update) {
+                logger()->info("Username Updated From ({$pre_update_username}) to ({$user->username})", [
+                    'user_id' => $user->id,
+                    'updated_from_username' => $pre_update_username,
+                    'updated_to_username' => $user->username
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Provide the user id or User model and receive a validated username string
+     *
+     * @param  string  $username
+     * @param  int  $id
+     *
+     * @return string
+     */
+    public static function filterAndValidateUsername(string $username, int $id): string
+    {
+        $i = 0;
+
+        $generator = static function () use ($username, &$i): string {
+            preg_match_all('/[^a-zA-Z\d\s_-]/m', $username, $invalid_chars, PREG_SET_ORDER, 0);
+            $invalid_chars = collect($invalid_chars)->flatten()->unique()->values();
+            $username = ! blank($invalid_chars) ? str_replace($invalid_chars->all(), '', $username) : $username;
+            return $i++ !== 0 ? $username.$i : $username;
+        };
+
+        // Ensure uniqueness for the username
+        build_username_query:
+        $unique_username_query = DB::table('users')->where('username', $username = $generator())
+                                   ->where('id', '!=', $id)
+                                   ->orderBy('id');
+
+        if($unique_username_query->exists()) {
+            goto build_username_query;
+        }
+
+        // Grab the User model rules
+        //        $rules = (object) User::rules($username);
+
+        // Make sure the new, filtered username is valid
+        // with the User-model provided rules
+        //        Validator::make($rules->username,
+        //            ['username' => $username]
+        //        )->validate();
+
+        // Once we know it's a unique, valid
+        // username, send it back
+        return $username;
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Arr;
 use Faker\Generator as Faker;
 use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\User;
@@ -10,33 +9,10 @@ $onePassword = Hash::make('oneOnlyPassword');
 /**
  * Model factory for a User
  */
-$factory->define(User::class, function (Faker $faker) use ($onePassword) {
-
-    $username = static function ($generated = '') use ($faker) {
-        try {
-            $username_generator = static function () use ($faker, &$generated) {
-                $generated = \random_int(1, 100) > \random_int(1, 50)
-                    ? $faker->unique()->userName.Arr::random(
-                        ['\'','"','~','`','-','_','/','','$','|','@','!','%','=','*',')','(','+','#', '.']
-                    ) : str_replace('.', '', $faker->unique()->userName);
-            };
-
-            $username_generator();
-
-            while (User::where('username', '=', $generated)->exists()) {
-                $username_generator();
-            }
-
-            return $generated;
-        } catch (Exception $exception) {
-            dump($exception);
-
-            return $faker->unique()->userName;
-        }
-    };
+$factory->define(User::class, function (Faker $faker) use($onePassword) {
 
     return [
-        'username' => $username(),
+        'username' => $faker->unique()->userName,
         'email' => $faker->unique()->email,
         'password' => $onePassword,
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Arr;
 use Faker\Generator as Faker;
 use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\User;
@@ -9,10 +10,33 @@ $onePassword = Hash::make('oneOnlyPassword');
 /**
  * Model factory for a User
  */
-$factory->define(User::class, function (Faker $faker) use($onePassword) {
+$factory->define(User::class, function (Faker $faker) use ($onePassword) {
+
+    $username = static function ($generated = '') use ($faker) {
+        try {
+            $username_generator = static function () use ($faker, &$generated) {
+                $generated = \random_int(1, 100) > \random_int(1, 50)
+                    ? $faker->unique()->userName.Arr::random(
+                        ['\'','"','~','`','-','_','/','','$','|','@','!','%','=','*',')','(','+','#', '.']
+                    ) : str_replace('.', '', $faker->unique()->userName);
+            };
+
+            $username_generator();
+
+            while (User::where('username', '=', $generated)->exists()) {
+                $username_generator();
+            }
+
+            return $generated;
+        } catch (Exception $exception) {
+            dump($exception);
+
+            return $faker->unique()->userName;
+        }
+    };
 
     return [
-        'username' => $faker->unique()->userName,
+        'username' => $username(),
         'email' => $faker->unique()->email,
         'password' => $onePassword,
 

--- a/upgrades/2022_04_19_164837_sanitize_usernames.php
+++ b/upgrades/2022_04_19_164837_sanitize_usernames.php
@@ -1,19 +1,11 @@
 <?php
 
-use ProcessMaker\Models\User;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Validator;
+use ProcessMaker\Jobs\SanitizeUsernames as SanitizeUsernamesJob;
 use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
 
 class SanitizeUsernames extends Upgrade
 {
-    /**
-     * The version of ProcessMaker being upgraded *to*
-     *
-     * @var string example: 4.2.28
-     */
-    public $to = '4.2.30-RC1';
-
     /**
      * Run any validations/pre-run checks to ensure the environment, settings,
      * packages installed, etc. are right correct to run this upgrade.
@@ -45,32 +37,11 @@ class SanitizeUsernames extends Upgrade
      */
     public function up()
     {
-        $users = DB::table('users')->select(['id','username'])
-                                   ->orderBy('id')
-                                   ->get();
-
-        foreach ($users as $user) {
-
-            // Store the pre-update username for comparison
-            $pre_update_username = $user->username;
-            $updated_username = static::filterAndValidateUsername($user->username, $user->id);
-
-            // If it's the same, then it was already valid
-            if ($pre_update_username === $updated_username) {
-                continue;
+        DB::table('users')->select(['id','username'])->orderBy('id')->chunk(1000,
+            static function ($users) {
+                dispatch(new SanitizeUsernamesJob($users))->onQueue('high');
             }
-
-            // Set the valid username to the user
-            DB::table('users')->where('id', '=', $user->id)
-                                     ->update(['username' => $updated_username]);
-
-            // Log the result and continue
-            logger()->info("Username Updated From ({$pre_update_username}) to ({$user->username})", [
-                'user_id' => $user->id,
-                'updated_from_username' => $pre_update_username,
-                'updated_to_username' => $user->username
-            ]);
-        }
+        );
     }
 
 
@@ -82,55 +53,6 @@ class SanitizeUsernames extends Upgrade
     public function down()
     {
         //
-    }
-
-    /**
-     * Provide the user id or User model and receive a validated username string
-     *
-     * @param  string  $username
-     * @param  int  $id
-     *
-     * @return string
-     */
-    public static function filterAndValidateUsername(string $username, int $id): string
-    {
-        $generator = static function (int $i = null) use (&$username) {
-            preg_match_all('/[^a-zA-Z\d\s_-]/m', $username, $invalid_chars, PREG_SET_ORDER, 0);
-
-            $invalid_chars = collect($invalid_chars)->flatten()->unique()->values();
-            $username = ! blank($invalid_chars) ? str_replace($invalid_chars->all(), '', $username) : $username;
-
-            if (is_int($i) && $i !== 0) {
-                $username .= $i;
-            }
-        };
-
-        // Will validate/filter the username
-        // and set $valid_username
-        $generator($i = 0);
-
-        // Ensure uniqueness for the username
-        $unique_username_query =  DB::table('users')->where('username', '=', $username)
-                                                    ->where('id', '!=', $id)
-                                                    ->orderBy('id');
-
-        // if it's not unique, append an index number to it
-        while ($unique_username_query->exists()) {
-            $generator(++$i);
-        }
-
-        // Grab the User model rules
-//        $rules = (object) User::rules($username);
-
-        // Make sure the new, filtered username is valid
-        // with the User-model provided rules
-//        Validator::make($rules->username,
-//            ['username' => $username]
-//        )->validate();
-
-        // Once we know it's a unique, valid
-        // username, send it back
-        return $username;
     }
 }
 

--- a/upgrades/2022_04_19_164837_sanitize_usernames.php
+++ b/upgrades/2022_04_19_164837_sanitize_usernames.php
@@ -1,5 +1,8 @@
 <?php
 
+use ProcessMaker\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
 use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
 
 class SanitizeUsernames extends Upgrade
@@ -10,13 +13,6 @@ class SanitizeUsernames extends Upgrade
      * @var string example: 4.2.28
      */
     public $to = '4.2.30-RC1';
-
-    /**
-     * Upgrade migration cannot be skipped if the pre-upgrade checks fail
-     *
-     * @var bool
-     */
-    public $required = true;
 
     /**
      * Run any validations/pre-run checks to ensure the environment, settings,
@@ -49,8 +45,34 @@ class SanitizeUsernames extends Upgrade
      */
     public function up()
     {
-        //
+        $users = DB::table('users')->select(['id','username'])
+                                   ->orderBy('id')
+                                   ->get();
+
+        foreach ($users as $user) {
+
+            // Store the pre-update username for comparison
+            $pre_update_username = $user->username;
+            $updated_username = static::filterAndValidateUsername($user->username, $user->id);
+
+            // If it's the same, then it was already valid
+            if ($pre_update_username === $updated_username) {
+                continue;
+            }
+
+            // Set the valid username to the user
+            DB::table('users')->where('id', '=', $user->id)
+                                     ->update(['username' => $updated_username]);
+
+            // Log the result and continue
+            logger()->info("Username Updated From ({$pre_update_username}) to ({$user->username})", [
+                'user_id' => $user->id,
+                'updated_from_username' => $pre_update_username,
+                'updated_to_username' => $user->username
+            ]);
+        }
     }
+
 
     /**
      * Reverse the upgrade migrations.
@@ -60,6 +82,55 @@ class SanitizeUsernames extends Upgrade
     public function down()
     {
         //
+    }
+
+    /**
+     * Provide the user id or User model and receive a validated username string
+     *
+     * @param  string  $username
+     * @param  int  $id
+     *
+     * @return string
+     */
+    public static function filterAndValidateUsername(string $username, int $id): string
+    {
+        $generator = static function (int $i = null) use (&$username) {
+            preg_match_all('/[^a-zA-Z\d\s_-]/m', $username, $invalid_chars, PREG_SET_ORDER, 0);
+
+            $invalid_chars = collect($invalid_chars)->flatten()->unique()->values();
+            $username = ! blank($invalid_chars) ? str_replace($invalid_chars->all(), '', $username) : $username;
+
+            if (is_int($i) && $i !== 0) {
+                $username .= $i;
+            }
+        };
+
+        // Will validate/filter the username
+        // and set $valid_username
+        $generator($i = 0);
+
+        // Ensure uniqueness for the username
+        $unique_username_query =  DB::table('users')->where('username', '=', $username)
+                                                    ->where('id', '!=', $id)
+                                                    ->orderBy('id');
+
+        // if it's not unique, append an index number to it
+        while ($unique_username_query->exists()) {
+            $generator(++$i);
+        }
+
+        // Grab the User model rules
+//        $rules = (object) User::rules($username);
+
+        // Make sure the new, filtered username is valid
+        // with the User-model provided rules
+//        Validator::make($rules->username,
+//            ['username' => $username]
+//        )->validate();
+
+        // Once we know it's a unique, valid
+        // username, send it back
+        return $username;
     }
 }
 

--- a/upgrades/2022_04_19_164837_sanitize_usernames.php
+++ b/upgrades/2022_04_19_164837_sanitize_usernames.php
@@ -6,6 +6,8 @@ use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
 
 class SanitizeUsernames extends Upgrade
 {
+    public $to = '4.2.30-RC';
+
     /**
      * Run any validations/pre-run checks to ensure the environment, settings,
      * packages installed, etc. are right correct to run this upgrade.

--- a/upgrades/2022_04_19_164837_sanitize_usernames.php
+++ b/upgrades/2022_04_19_164837_sanitize_usernames.php
@@ -6,7 +6,7 @@ use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
 
 class SanitizeUsernames extends Upgrade
 {
-    public $to = '4.2.30-RC';
+    public $to = '4.2.30-RC1';
 
     /**
      * Run any validations/pre-run checks to ensure the environment, settings,

--- a/upgrades/2022_04_19_164837_sanitize_usernames.php
+++ b/upgrades/2022_04_19_164837_sanitize_usernames.php
@@ -1,0 +1,65 @@
+<?php
+
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class SanitizeUsernames extends Upgrade
+{
+    /**
+     * The version of ProcessMaker being upgraded *to*
+     *
+     * @var string example: 4.2.28
+     */
+    public $to = '4.2.30-RC1';
+
+    /**
+     * Upgrade migration cannot be skipped if the pre-upgrade checks fail
+     *
+     * @var bool
+     */
+    public $required = true;
+
+    /**
+     * Run any validations/pre-run checks to ensure the environment, settings,
+     * packages installed, etc. are right correct to run this upgrade.
+     *
+     * There is no need to check against the version(s) as the upgrade
+     * migrator will do this automatically and fail if the correct
+     * version(s) are not present.
+     *
+     * Throw a \RuntimeException if the conditions are *NOT* correct for this
+     * upgrade migration to run. If this is not a required upgrade, then it
+     * will be skipped. Otherwise the exception thrown will be caught, noted,
+     * and will prevent the remaining migrations from continuing to run.
+     *
+     * Returning void or null denotes the checks were successful.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function preflightChecks()
+    {
+        //
+    }
+
+    /**
+     * Run the upgrade migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the upgrade migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}
+

--- a/upgrades/2022_04_19_164837_sanitize_usernames.php
+++ b/upgrades/2022_04_19_164837_sanitize_usernames.php
@@ -37,7 +37,7 @@ class SanitizeUsernames extends Upgrade
      */
     public function up()
     {
-        DB::table('users')->select(['id','username'])->orderBy('id')->chunk(1000,
+        DB::table('users')->select(['id','username'])->orderBy('id')->chunk(250,
             static function ($users) {
                 dispatch(new SanitizeUsernamesJob($users))->onQueue('high');
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
In prior versions of processmaker/processmaker, the username field allowed numerous characters which are now disallowed. The only allowed characters in a username are alphanumeric, the underscore character "_", and the hyphen character "-". 

## Solution
- An upgrade migration is included in this PR which when run, spawns a UsernameSanitization job per 250 users. It spreads out the workload so the PHP process won't run out of memory in the event there are 25,000+ usernames.
- The UsernameSanitization job removes all disallowed characters and checks to make sure the sanitized username is unique. If it is not unique, it will append a number start with 0 to the end of the username and check for uniqueness again and will loop this behavior until the username is unique. It will then save the username and continue to the next.
- The UsernameSanitization job will also search through existing comments (if package-comments is installed) and replace the unsanitized username with the updated, sanitized version.

## How to Test
1. Create a bunch of dummy users with usernames containing disallowed characters e.g. !@#$%^&*(). You may have to go directly into the database to save this.
2. Run `php artisan upgrade` and check to make sure the jobs are spawned in the queue and have run properly.
3. After the jobs have completed, check the users in the admin dashboard. The usernames should now only contain the allowed characters.

## Related Tickets & Packages
- JIRA [ticket FOUR-5957](https://processmaker.atlassian.net/browse/FOUR-5957)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
