### PR TITLE
Bugfix/FOUR-6092: User is not restored

### DIFF
--- a/resources/js/admin/users/components/AddUserModal.vue
+++ b/resources/js/admin/users/components/AddUserModal.vue
@@ -87,7 +87,8 @@ export default {
                         deletedUserExists + ' ' + this.$t('Would you like to save and reactivate their account?')
                     ]);
                     let restoreData = {
-                        email: this.email
+                        email: this.email,
+                        username: this.username
                     };
                     this.showMsgBox(messageVNode, restoreData);
                 }

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -507,6 +507,7 @@ class UsersTest extends TestCase
 
     /**
     * Tests the archiving and restoration of a process
+    * @group agustin
     */
     public function testRestoreSoftDeletedUser()
     {
@@ -549,6 +550,25 @@ class UsersTest extends TestCase
 
         // Restore the user by username
         $response = $this->apiCall('PUT', self::API_TEST_URL .'/restore', [
+            'username' => $user->username
+        ]);
+        $response->assertStatus(200);
+
+        // Assert that the user is listed
+        $response = $this->apiCall('GET', self::API_TEST_URL);
+        $response->assertJsonFragment(['id' => $id]);
+
+        // Soft delete the user
+        $response = $this->apiCall('DELETE', self::API_TEST_URL . '/'. $id);
+        $response->assertStatus(204);
+
+        // Assert that the user is not listed on the main index
+        $response = $this->apiCall('GET', self::API_TEST_URL);
+        $response->assertJsonMissing(['id' => $id]);
+
+        // Restore the user by username and different email
+        $response = $this->apiCall('PUT', self::API_TEST_URL .'/restore', [
+            'email' => 'changed' . $user->email,
             'username' => $user->username
         ]);
         $response->assertStatus(200);


### PR DESCRIPTION
## Issue & Reproduction Steps

- Go to admin
- Create a user
- Delete the user created
- Create a user with the same username that user deleted **but different email**
- Press YES option in reactivated your account 
- The user still in deleted users


## Solution
- Added username to the request to search by username while restoring

**Working video**

https://user-images.githubusercontent.com/90727999/166295651-1f14dfdd-ace5-4c18-b806-6d836760ebb4.mov


## How to Test
-  Go to admin
- Create a user
- Delete the user created
- Create a user with the same username that user deleted **but different email**
- Press YES option in reactivated your account 
- The user still will restored and removed from deleted users tab. You should see it in Users tab.

## Related Tickets & Packages
- [FOUR-6092](https://processmaker.atlassian.net/browse/FOUR-6092)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
