### PR TITLE
Translate login page title

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.minimal')
 @section('title')
-Login
+{{__('Login')}}
 @endsection
 @section('content')
 <div class="d-flex flex-column" style="min-height: 100vh">


### PR DESCRIPTION
## Issue & Reproduction Steps
The title of the login page is a fixed string that must be translated into the current language of the system.

## Solution
The translation function was used.

## How to Test
Change the user language to a language other than English and see the title of the login page in the browser tab.

## Related Tickets & Packages
None

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
