### PR TITLE
Translate button label in confirm box

### DIFF
--- a/resources/js/components/Confirm.vue
+++ b/resources/js/components/Confirm.vue
@@ -2,8 +2,8 @@
     <b-modal dialog-class="top-20" v-model="showModal" @hide="onClose" :title="title">
         <div class="my-3" :class="classMessage" v-html="message"></div>
         <template #modal-footer>
-            <b-button class="m-0" variant="outline-secondary" @click="onDeny">Cancel</b-button>
-            <b-button class="m-0" @click="onConfirm">Confirm</b-button>
+            <b-button class="m-0" variant="outline-secondary" @click="onDeny">{{$t('Cancel')}}</b-button>
+            <b-button class="m-0" @click="onConfirm">{{$t('Confirm')}}</b-button>
         </template>
     </b-modal>
 </template>


### PR DESCRIPTION
## Issue & Reproduction Steps
The label of the confirmation box buttons has not been translated.

## Solution
The translation function was used.

## How to Test
Change the local language of the system and watch the confirmation modal.

## Related Tickets & Packages
None

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
