### PR TITLE
Bugfix FOUR-6100 - "Server Error message in Customize UI"

### DIFF
--- a/resources/js/admin/cssOverride/components/SiteDesign.vue
+++ b/resources/js/admin/cssOverride/components/SiteDesign.vue
@@ -141,7 +141,7 @@
       
       <br>
       <div class="d-flex">
-          <b-button variant="outline-danger" @click="onReset">
+          <b-button variant="outline-danger" :disabled="isLoading" @click="onReset">
               <i class="fas fa-undo"></i> {{ $t('Reset') }}
           </b-button>
           
@@ -149,7 +149,7 @@
               {{ $t('Cancel') }}
           </b-button>
           
-          <b-button variant="secondary" class="ml-3" @click="onSubmit">
+          <b-button variant="secondary" class="ml-3" :disabled="isLoading" @click="onSubmit">
               {{ $t('Save') }}
           </b-button>
       </div>
@@ -187,6 +187,7 @@
 export default {
   data() {
     return {
+      isLoading: false,
       altText: '',
       loginFooter: '',
       editorSettings: {
@@ -465,6 +466,7 @@ export default {
       );
     },
     onCreate(data) {
+      this.isLoading = true;
       ProcessMaker.apiClient.post('customize-ui', data)
         .then(response => {
           this.$refs.modalLoading.show();
@@ -477,6 +479,9 @@ export default {
           if (error.response.status && error.response.status === 422) {
             this.errors = error.response.data.errors;
           }
+        })
+        .finally(() => {
+          this.isLoading = false;
         });
     },
     onUpdate(data) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Performing many Save request generates the Server Error: `Call to a member function each() on null at SettingsHelper.php:104`

1. Go to Admin
2. Click on Customize UI
3. Press the SAVE button more than once quickly

## Solution
- Added a loading state to the Save and Reset button, in this way only one request can be made at a time.

## How to Test
- Please follow the reproduction steps above.

## Related Tickets & Packages
- [FOUR-6100](https://processmaker.atlassian.net/browse/FOUR-6100)

Working Video:

https://user-images.githubusercontent.com/90741874/166584688-42899aab-fe48-4ae6-b188-c1a026bfa6fa.mov



## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
