### PR TITLE
Bugfix/FOUR-6042: Task tab is still shown on completed requests

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -32,7 +32,7 @@
                                        aria-controls="errors" aria-selected="false">{{__('Errors')}}</a>
                                 </li>
                             @endif
-                            <li class="nav-item" v-if="status !== 'COMPLETED' || status !== 'PENDING'">
+                            <li class="nav-item" v-if="showTasks">
                                 <a class="nav-link" :class="{ active: activePending }" id="pending-tab"
                                    data-toggle="tab" @click="switchTab('pending')" href="#pending" role="tab"
                                    aria-controls="pending" aria-selected="true">{{__('Tasks')}}</a>
@@ -103,7 +103,7 @@
                             <request-errors :errors="errorLogs"></request-errors>
                         </div>
                         <div class="tab-pane fade show card card-body border-top-0 p-0" :class="{ active: activePending }" id="pending" role="tabpanel"
-                             aria-labelledby="pending-tab" v-if="status !== 'COMPLETED' || status !== 'PENDING'">
+                             aria-labelledby="pending-tab">
                             <request-detail ref="pending" :process-request-id="requestId" status="ACTIVE" :is-admin="{{Auth::user()->is_administrator ? 'true' : 'false'}}">
                             </request-detail>
                         </div>
@@ -389,6 +389,13 @@
            */
           showSummary() {
             return this.request.status === 'ACTIVE' || this.request.status === 'COMPLETED' || this.request.status === 'CANCELED';
+          },
+          /**
+           * Show tasks if request status is not completed or pending
+           *
+           */
+          showTasks() {
+            return this.request.status !== 'COMPLETED' && this.request.status !== 'PENDING';
           },
           /**
            * If the screen summary is configured.


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create process
- Add a task
- Create a Request
- Complete the request

**Current Behavior** 
Task tab is still shown on completed requests, Giving the feeling that there are even more tasks 

**Expected Behavior**
Task tab should not showing on completed requests. As in PM 4.1.27 

## Solution
- Hide tasks in request if no pending task or process completed.

**Working video**

https://user-images.githubusercontent.com/90727999/166745121-3785cddd-eb03-49c2-807b-f22fe4ad4fce.mov



## How to Test
- Create process
- Add a task
- Create a Request
- Complete the request
- You should not see **Tasks** tab

## Related Tickets & Packages
- [FOUR-6042](https://processmaker.atlassian.net/browse/FOUR-6042)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
