### PR TITLE
Always use the `processmaker` connection

### DIFF
--- a/ProcessMaker/Upgrades/Commands/BaseCommand.php
+++ b/ProcessMaker/Upgrades/Commands/BaseCommand.php
@@ -29,20 +29,6 @@ class BaseCommand extends Command
     }
 
     /**
-     * Get the database name the upgrades will use
-     *
-     * @return string
-     */
-    protected function getDatabase()
-    {
-        if ($this->hasOption('database') && $database = $this->option('database')) {
-            return $database;
-        }
-
-        return (string) config('database.connections.processmaker.database');
-    }
-
-    /**
      * Get the path to the migration directory.
      *
      * @return string

--- a/ProcessMaker/Upgrades/Commands/UpgradeCommand.php
+++ b/ProcessMaker/Upgrades/Commands/UpgradeCommand.php
@@ -72,8 +72,7 @@ class UpgradeCommand extends BaseCommand
      */
     protected function prepareDatabase()
     {
-        $this->migrator->setOutput($this->output)
-                       ->setConnection($this->getDatabase());
+        $this->migrator->setOutput($this->output);
 
         if (!$this->migrator->repositoryExists()) {
             $this->call('upgrade:install');

--- a/ProcessMaker/Upgrades/Commands/UpgradeInstallCommand.php
+++ b/ProcessMaker/Upgrades/Commands/UpgradeInstallCommand.php
@@ -48,8 +48,6 @@ class UpgradeInstallCommand extends BaseCommand
      */
     public function handle()
     {
-        $this->repository->setSource($this->getDatabase());
-
         if ($this->repository->repositoryExists()) {
             return $this->warn('Upgrade migration table already exists.');
         }

--- a/ProcessMaker/Upgrades/Commands/UpgradeResetCommand.php
+++ b/ProcessMaker/Upgrades/Commands/UpgradeResetCommand.php
@@ -55,8 +55,6 @@ class UpgradeResetCommand extends BaseCommand
             return;
         }
 
-        $this->migrator->setConnection($this->getDatabase());
-
         // First, we'll make sure that the migration table actually exists before we
         // start trying to rollback and re-run all of the migrations. If it's not
         // present we'll just bail out with an info message for the developers.

--- a/ProcessMaker/Upgrades/Commands/UpgradeRollbackCommand.php
+++ b/ProcessMaker/Upgrades/Commands/UpgradeRollbackCommand.php
@@ -73,8 +73,7 @@ class UpgradeRollbackCommand extends BaseCommand
      */
     protected function prepareDatabase()
     {
-        $this->migrator->setOutput($this->output)
-                       ->setConnection($this->getDatabase());
+        $this->migrator->setOutput($this->output);
 
         if (!$this->migrator->repositoryExists()) {
             $this->call('upgrade:install');

--- a/ProcessMaker/Upgrades/Commands/UpgradeStatusCommand.php
+++ b/ProcessMaker/Upgrades/Commands/UpgradeStatusCommand.php
@@ -42,8 +42,6 @@ class UpgradeStatusCommand extends BaseCommand
      */
     public function handle()
     {
-        $this->migrator->setConnection($this->getDatabase());
-
         if (!$this->migrator->repositoryExists()) {
             $this->error('No upgrade migrations found.');
 

--- a/ProcessMaker/Upgrades/UpgradeMigrationRepository.php
+++ b/ProcessMaker/Upgrades/UpgradeMigrationRepository.php
@@ -26,7 +26,7 @@ class UpgradeMigrationRepository extends DMR implements MigrationRepositoryInter
      *
      * @var string
      */
-    protected $connection;
+    protected $connection = 'processmaker';
 
     /**
      * Get the ran migrations.
@@ -185,14 +185,4 @@ class UpgradeMigrationRepository extends DMR implements MigrationRepositoryInter
         return $this->resolver->connection($this->connection);
     }
 
-    /**
-     * Set the information source to gather data.
-     *
-     * @param  string  $name
-     * @return void
-     */
-    public function setSource($name)
-    {
-        $this->connection = $name;
-    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-6124

## Solution
- We were confusing the connection name with the database name. Solution is to hard-code database connection name to `processmaker`

## How to Test
run artisan upgrade

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6124

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
