### PR TITLE
FOUR-6112: Adding --force flag to artisan upgrade command

### DIFF
--- a/ProcessMaker/Upgrades/Commands/UpgradeCommand.php
+++ b/ProcessMaker/Upgrades/Commands/UpgradeCommand.php
@@ -16,6 +16,7 @@ class UpgradeCommand extends BaseCommand
      */
     protected $signature = 'upgrade
                             {--pretend : Dry run the pending upgrade migrations}
+                            {--force : Force the upgrades to run even in production}
                             {--step : Force the upgrade migrations to be run so they can be rolled back individually}';
 
     /**
@@ -60,6 +61,7 @@ class UpgradeCommand extends BaseCommand
         $this->prepareDatabase();
 
         $this->migrator->run($this->getMigrationPaths(), [
+            'force' => $this->option('force'),
             'pretend' => $this->option('pretend'),
             'step' => $this->option('step'),
         ]);


### PR DESCRIPTION
## Issue & Reproduction Steps
CloudOps is requesting a `--force` flag for the `php artisan upgrade` command to skip the "Do you want to run the upgrade migrations in production?" console prompt. 

## Solution
- Added the `--force` flag option to the [UpgradeCommand file](https://github.com/ProcessMaker/processmaker/blob/ba6c5bd41a38b74b3bfa20e7811bf5144c74d84b/ProcessMaker/Upgrades/Commands/UpgradeCommand.php).

## How to Test
1. Make sure you environment is set to production in the .env file: `APP_ENV=production` and debugging is turned off: `APP_DEBUG=FALSE`.
2. Without having previously run the upgrade command, run `php artisan upgrade`. This should prompt you to answer "y" or "n", type "n" and hit enter.
3. Now run `php artisan upgrade --force`. The upgrade migrations should run without prompting you for input.

## Related Tickets & Packages
- [JIRA ticket FOUR-6112](https://processmaker.atlassian.net/browse/FOUR-6112)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
