### PR TITLE
Bugfix FOUR-6137 - Requests page is displayed when login after lost session

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -32,8 +32,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-
-    protected $redirectTo = '/requests';
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.


### PR DESCRIPTION
## Issue & Reproduction Steps
Users who have a custom dashboard are redirected on login to the `requests` page instead of their dashboard set by the dynamic UI package.

1. Install Dynamic UI package
2. Create a dashboard
3. Assign the created dashboard to any user
4. Log in and log out the above user
5. The problem is related to the cookie `processmaker_intended`. It will expire after 10 minutes. Instead of waiting 10 minutes, you can delete the cookie using browser developer tools or change its value to 1 minute at`LoginController` line 60.
6. Without the above cookie, after a successful login it will redirect to `requests` page because that's how it's set in the `$redirectTo` variable. 

## Solution
- The proposed solution is to redirect always to `Route::get('/', 'HomeController@index')->name('home');` instead of `requests`. This route correctly handles redirects if a custom dashboard exists.
- Another solution could probably be set this cookie no expiration date: `$cookie = cookie("processmaker_intended", redirect()->intended()->getTargetUrl(), 10, '/');`

## How to Test
Please follow the reproduction steps of above in order to reproduce the error and test the solution.

## Related Tickets & Packages
- [FOUR-6137](https://processmaker.atlassian.net/browse/FOUR-6137)

Working video:

https://user-images.githubusercontent.com/90741874/167476424-44479819-13bd-4fff-ba65-f35de6a089c4.mov

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
