### PR TITLE
Bugfix FOUR-6181 - error "Array to string conversion" with imported process

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -246,7 +246,7 @@ class ProcessRequestToken extends Model implements TokenInterface
                 break;
             case 'manager':
                 $process = $this->process()->first();
-                return collect([$process->properties['manager_id'] ?? null]);
+                return collect([optional($process)->manager_id]);
                 break;
             default:
                 return collect([]);

--- a/ProcessMaker/Traits/ProcessTrait.php
+++ b/ProcessMaker/Traits/ProcessTrait.php
@@ -93,7 +93,9 @@ trait ProcessTrait
      */
     public function getManagerIdAttribute()
     {
-        return $this->getProperty('manager_id');
+        $property = $this->getProperty('manager_id');
+
+        return collect($property)->get('id', $property);
     }
 
     /**

--- a/resources/views/processes/import.blade.php
+++ b/resources/views/processes/import.blade.php
@@ -510,13 +510,16 @@
             });
             return response;
           },
+          formatValueScreen(item) {
+            return (item && item.id) ? item.id : null
+          },
           onAssignmentSave() {
             ProcessMaker.apiClient.post('/processes/' + this.processId + '/import/assignments',
               {
                 "assignable": this.assignable,
                 'cancel_request': this.formatAssignee(this.cancelRequest),
                 'edit_data': this.formatAssignee(this.processEditData),
-                'manager_id': this.manager,
+                'manager_id': this.formatValueScreen(this.manager),
                 'status': this.status,
               })
               .then(response => {
@@ -583,7 +586,7 @@
             }
             this.assignable = response.data.assignable;
             this.processId = response.data.process.id;
-            
+
             if (_.get(response, 'data.process.properties.manager_can_cancel_request', false)) {
               this.cancelRequest.push(this.managerOption);
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
When Importing a process and setting the Manager, it's saved in the database as a full Object instead of just an id. 

1. Import the attached process (notification-task.json). 
2. Assign a Process Manager.
![image](https://user-images.githubusercontent.com/90741874/167920969-1d5af8fc-4250-4d49-b1a7-294db3bfcfbe.png)
3. Save
4. Run request and submit
5. At this point you will be able to replicate the problem, because the `manager_id` property was saved as an Object instead of an int.

## Solution
- Added the same function as the edit view to make sure that the ID is sent to the back-end instead of an object.

## How to Test
- Follow the reproduction steps of above. 
- When importing the process and assigning a Process Manager it will store the manager_id correctly on DB. 

## Related Tickets & Packages
- [FOUR-6181](https://processmaker.atlassian.net/browse/FOUR-6181)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
