### PR TITLE
Fix Monaco Editor Freezing with Email Type Screens

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -422,7 +422,7 @@ export default {
   computed: {
     previewDataStringyfy: {
       get() {
-        if (!isEqual(this.previewData, this.previewDataSaved)) {
+        if (this.previewInputValid && !isEqual(this.previewData, this.previewDataSaved)) {
           Object.assign(this.previewDataSaved, this.previewData);
           this.formatMonaco();
         }


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket: [FOUR-6157](https://processmaker.atlassian.net/browse/FOUR-6157)

Inputting data into the Data Input freezes with Email Type Screens. 
An infinite loop is triggered when hitting the `formatMonaco` method with an invalid JSON object in the Data Input.

## Solution
- Check if the Data Input has a valid JSON object before running the `formatMonaco` editor. 

## How to Test

### **Test 1**

1. Go to Designer
2. Create an Email Screen Type
3. Create a Record List
5. Press the Preview button
6. Add "data" in the Data Input section.

**Expected Behavior**
The Preview mode should not freeze after writing text in the Data Input section.

### **Test 2**

Test this [PR](https://github.com/ProcessMaker/processmaker/pull/4298) to ensure no additional regressions.



## Related Tickets & Packages


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
