### PR TITLE
Composer Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,9 @@
   "config": {
     "preferred-install": "dist",
     "sort-packages": true,
-    "optimize-autoloader": true
+    "optimize-autoloader": true,
+    "allow-plugins": {
+      "typo3/class-alias-loader": true
+    }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e3838ea268e07e45147f6f4c6367c20",
+    "content-hash": "ab0941ed1f7bb4c2f1ab1f692d5957fb",
     "packages": [
         {
             "name": "babenkoivan/elastic-adapter",
@@ -11980,5 +11980,5 @@
         "php": ">=7.2.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Running `composer install` in Composer v2.3.x generates questions and warning messages.

## Solution
- Allow plugins for typo3/class-alias-loader to remove trust question.
- Update composer.lock hash to remove warning message about outdated composer.lock.