### PR TITLE
Fix swagger docs generation

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
+++ b/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
@@ -10,7 +10,7 @@ use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
 
 class SecurityLogController extends Controller
-{ 
+{
     /**
      * Get a list of Security Logs.
      *
@@ -27,7 +27,7 @@ class SecurityLogController extends Controller
      *     @OA\Parameter(ref="#/components/parameters/order_by"),
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
      *     @OA\Parameter(ref="#/components/parameters/per_page"),
-     *     
+     *
      *     @OA\Response(
      *         response=200,
      *         description="list of security logs",
@@ -50,7 +50,7 @@ class SecurityLogController extends Controller
     public function index(Request $request)
     {
         $query = SecurityLog::query();
-        
+
         if ($filter = $request->input('filter')) {
             $filter = '%' . mb_strtolower($filter) . '%';
             $query->where('event', 'like', $filter)
@@ -58,25 +58,25 @@ class SecurityLogController extends Controller
                   ->orWhere(DB::raw("LOWER(meta->>'$.browser.name')"), 'like', $filter)
                   ->orWhere(DB::raw("LOWER(meta->>'$.os.name')"), 'like', $filter);
         }
-        
+
         if ($orderBy = $request->input('order_by')) {
             $orderBy = DB::raw(preg_replace('/\.(.+)/', "->>'\$.$1'", $orderBy, 1));
-            
+
             $orderDirection = $request->input('order_direction');
-            
+
             if (! $orderDirection) {
                 $orderDirection = 'asc';
             }
-            
+
             $query->orderBy($orderBy, $orderDirection);
         }
 
         if ($pmql = $request->input('pmql')) {
             $query->pmql($pmql);
         }
-        
+
         $response = $query->get();
-        
+
         return new ApiCollection($response);
     }
 
@@ -89,7 +89,7 @@ class SecurityLogController extends Controller
      * @OA\Get(
      *     path="/security-logs/{securityLog}",
      *     summary="Get single security log by ID",
-     *     operationId="getSecurityLogs",
+     *     operationId="getSecurityLog",
      *     tags={"Secuirty Logs"},
      *     @OA\Parameter(
      *         description="ID of security log to return",
@@ -100,7 +100,7 @@ class SecurityLogController extends Controller
      *           type="string",
      *         )
      *     ),
-     *     
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Successfully found the security log",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -3820,7 +3820,7 @@
                 ],
                 "summary": "Get single security log by ID",
                 "description": "Display the specified resource.",
-                "operationId": "getSecurityLogs",
+                "operationId": "getSecurityLog",
                 "parameters": [
                     {
                         "name": "securityLog",


### PR DESCRIPTION
## Issue & Reproduction Steps
When running the processmaker install artisan command, the swagger docs generator fails due to a duplicate property being found in the API SecurityLogsController file. This causes the command to exit (with code 1) and prevents the remainder of the installation.

To reproduce, run the `php artisan processmaker:install` command and you'll encounter an exception being thrown.

## Solution
- Rename the duplicate operationId in the SecurityLogsController.

## How to Test
You should be able to run `php artisan processmaker:install` without any exceptions being thrown.

## Related Tickets & Packages
- [FOUR-6265](https://processmaker.atlassian.net/browse/FOUR-6265)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
