### PR TITLE
Fix error when validating API docs during executor builds

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
+++ b/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
@@ -21,7 +21,7 @@ class SecurityLogController extends Controller
      * @OA\Get(
      *     path="/security-logs",
      *     summary="Returns all security logs",
-     *     operationId="getSecurityLogs",
+     *     operationId="listSecurityLogs",
      *     tags={"Secuirty Logs"},
      *     @OA\Parameter(ref="#/components/parameters/filter"),
      *     @OA\Parameter(ref="#/components/parameters/order_by"),

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -3773,7 +3773,7 @@
                 ],
                 "summary": "Returns all security logs",
                 "description": "Get a list of Security Logs.",
-                "operationId": "getSecurityLogs",
+                "operationId": "listSecurityLogs",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/filter"


### PR DESCRIPTION
## Issue & Reproduction Steps
**Reproduction Steps**
- Truncate your script_executors table
- Run `art docker-executor-node:install`

**Current Behavior**
- Build of docker executors fails when validating API docs with message `attribute paths.'/security-logs/{securityLog}'(get).operationId is repeated`.

**Expected Behavior**
- Build of docker executors should continue

## Solution
Remove the duplicate operation ID from the code added in https://github.com/ProcessMaker/processmaker/pull/4361.

## How to Test
- Truncate your script_executors table
- Run `art docker-executor-node:install` and ensure it does not fail

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6266

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
