### PR TITLE
Fix Infinite loop when deleting data in the Data Input editor

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -492,15 +492,12 @@ export default {
   methods: {
     monacoMounted(editor) {
       this.editor = editor;
+      this.editor.updateOptions({ readOnly:  true });
     },
     formatMonaco() {
       if (!this.editor) {
         return;
       }
-      this.editor.updateOptions({ readOnly:  false });
-      this.editor.getAction('editor.action.formatDocument').run().then(() => {
-        this.editor.updateOptions({ readOnly: true });
-      });
     },
     countElements() {
       if (!this.$refs.renderer) {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -424,7 +424,6 @@ export default {
       get() {
         if (this.previewInputValid && !isEqual(this.previewData, this.previewDataSaved)) {
           Object.assign(this.previewDataSaved, this.previewData);
-          this.formatMonaco();
         }
         return JSON.stringify(this.previewData);
       },
@@ -493,11 +492,6 @@ export default {
     monacoMounted(editor) {
       this.editor = editor;
       this.editor.updateOptions({ readOnly:  true });
-    },
-    formatMonaco() {
-      if (!this.editor) {
-        return;
-      }
     },
     countElements() {
       if (!this.$refs.renderer) {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -424,6 +424,7 @@ export default {
       get() {
         if (this.previewInputValid && !isEqual(this.previewData, this.previewDataSaved)) {
           Object.assign(this.previewDataSaved, this.previewData);
+          this.formatMonaco();
         }
         return JSON.stringify(this.previewData);
       },
@@ -492,6 +493,17 @@ export default {
     monacoMounted(editor) {
       this.editor = editor;
       this.editor.updateOptions({ readOnly:  true });
+    },
+    formatMonaco() {
+      if (!this.editor) {
+        return;
+      }
+      this.editor.updateOptions({ readOnly:  false });
+      setTimeout(() => {
+        this.editor.getAction('editor.action.formatDocument').run().then(() => {
+          this.editor.updateOptions({ readOnly:  true });
+        });
+      }, 300);
     },
     countElements() {
       if (!this.$refs.renderer) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket:  [FOUR-6157](https://processmaker.atlassian.net/browse/FOUR-6157)
[Reopened Comment](https://processmaker.atlassian.net/browse/FOUR-6157)

When the Data Preview editor options were being updated to  `readOnly` an infinite loop was triggered freezing the screen.

**NOTE:**
Was ONLY able to replicate this issue on the RT server. Was not able to replicate it locally. 

**Steps to Reproduce**

1. Create an Email type screen
2. Add a RecordList and input a variable name
3. Preview the screen and input `"foo": "foobar"` into the Data Input editor
4. Delete the data

**Expected Behavior**
The screen does not freeze when deleting data from the data input editor.

## Solution
 - Configure the Data Preview editor to be readonly when the editor is mounted instead of when data is being formatted. 


## How to Test
Follow the steps above

## Related Tickets & Packages


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
