### PR TITLE
PM4EH-61: docker-executor-java SDK compilation bug fix

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -519,7 +519,10 @@ class ProcessController extends Controller
      *         description="If true return only processes that haven't start event definitions",
      *         in="path",
      *         name="without_event_definitions",
-     *         required=false
+     *         required=false,
+     *         @OA\Schema(
+     *           type="boolean",
+     *         )
      *     ),
      *
      *     @OA\Response(


### PR DESCRIPTION
## Issue & Reproduction Steps
When installing processmaker/docker-executor-java, the java SDK build fails which then causes the entire docker image build to fail as well.

To replicate this issue:
1. Run `composer require processmaker/docker-executor-java`
2. Now run `php artisan docker-executor-java:install`

You'll notice compilation errors in the output and an exit code of 1.

## Solution
- Added a open-api-generator anonnation to [Api/ProcessController](https://github.com/ProcessMaker/processmaker/blob/019407013bf78d5af1b0d55d3c4d67a45df5279c/ProcessMaker/Http/Controllers/Api/ProcessController.php#L524).
- Added an additional compiler configuration value for the java sdk compiler.

## How to Test
You should now be able to run the same steps as described above and build the docker-executor-java Docker image without errors and with an exit code of 0.

## Related Tickets & Packages
- [PM4EH-61](https://processmaker.atlassian.net/browse/PM4EH-61)
- Related PR for [processmaker/docker-executor-java](https://github.com/ProcessMaker/docker-executor-java/pull/3)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
