### PR TITLE
Feature/FOUR-6178: Web Entry Custom URLS

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -917,7 +917,7 @@ class ProcessController extends Controller
                     $id = $element->getAttributeNode('id')->value;
                     foreach ($xmlAssignable as $assign) {
                         if ($assign['type'] === 'webentryCustomRoute' && $assign['id'] == $id) {
-                            $this->checkForExistingRoute($assign['value']);
+                            $this->checkForExistingRoute($process->id, $assign['value']);
                             $this->updateRoute($element, $assign['value']);
                         } elseif ($assign['id'] == $id && array_key_exists('value', $assign) && array_key_exists('id', $assign['value'])) {
                             $value = $assign['value']['id'];
@@ -1158,9 +1158,9 @@ class ProcessController extends Controller
         return $isDecoded && $validType && $validVersion;
     }
 
-    private function checkForExistingRoute($route) 
+    private function checkForExistingRoute($processId, $route) 
     {   
-        $existingRoute = WebentryRoute::where('first_segment', $route)->first();
+        $existingRoute = WebentryRoute::where('first_segment', $route)->where('process_id','!=', $processId)->first();
         if ($existingRoute) {
             throw new \Exception('Segment should be unique. Used in process ' . $existingRoute->process_id . 'node ID: "' . $existingRoute->node_id . '"');
         }

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -26,6 +26,8 @@ use ProcessMaker\Nayra\Storage\BpmnDocument;
 use ProcessMaker\Nayra\Exceptions\ElementNotFoundException;
 use ProcessMaker\Nayra\Storage\BpmnElement;
 use ProcessMaker\Rules\BPMNValidation;
+use ProcessMaker\Providers\WorkflowServiceProvider;
+use ProcessMaker\Package\WebEntry\Models\WebentryRoute;
 use Throwable;
 
 class ProcessController extends Controller
@@ -914,7 +916,10 @@ class ProcessController extends Controller
                 foreach ($elements as $element) {
                     $id = $element->getAttributeNode('id')->value;
                     foreach ($xmlAssignable as $assign) {
-                        if ($assign['id'] == $id && array_key_exists('value', $assign) && array_key_exists('id', $assign['value'])) {
+                        if ($assign['type'] === 'webentryCustomRoute' && $assign['id'] == $id) {
+                            $this->checkForExistingRoute($assign['value']);
+                            $this->updateRoute($element, $assign['value']);
+                        } elseif ($assign['id'] == $id && array_key_exists('value', $assign) && array_key_exists('id', $assign['value'])) {
                             $value = $assign['value']['id'];
                             if (is_int($value)) {
                                 $element->setAttribute('pm:assignment', 'user_group');
@@ -1151,5 +1156,27 @@ class ProcessController extends Controller
         $hasVersion = $isDecoded && isset($decoded->version) && is_string($decoded->version);
         $validVersion = $hasVersion && method_exists(ImportProcess::class, "parseFileV{$decoded->version}");
         return $isDecoded && $validType && $validVersion;
+    }
+
+    private function checkForExistingRoute($route) 
+    {
+        if (WebentryRoute::where('first_segment', $route)->first()) {
+            return response('', 422);
+        }
+    }
+
+    private function updateRoute($node, $route) 
+    {
+        $config = json_decode($node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config'), true);
+        if ($config['web_entry']['webentryRouteConfig']['firstUrlSegment'] !== $route) {
+            // update firstUrlSegment to new route
+            $config['web_entry']['webentryRouteConfig']['firstUrlSegment'] = $route;
+            
+            // update entryUrl to new route
+            $path = parse_url($config['web_entry']['webentryRouteConfig']['entryUrl'], PHP_URL_PATH);
+            $newEntryUrl = str_replace($config['web_entry']['webentryRouteConfig']['firstUrlSegment'], $route, $path);
+            $config['web_entry']['webentryRouteConfig']['entryUrl'] = $newEntryUrl;
+            $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config', json_encode($config));
+        }
     }
 }

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -1159,9 +1159,10 @@ class ProcessController extends Controller
     }
 
     private function checkForExistingRoute($route) 
-    {
-        if (WebentryRoute::where('first_segment', $route)->first()) {
-            return response('', 422);
+    {   
+        $existingRoute = WebentryRoute::where('first_segment', $route)->first();
+        if ($existingRoute) {
+            throw new \Exception('Segment should be unique. Used in process ' . $existingRoute->process_id . 'node ID: "' . $existingRoute->node_id . '"');
         }
     }
 

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use ProcessMaker\Models\AnonymousUser;
 use ProcessMaker\Notifications\ImportReady;
+use ProcessMaker\Package\WebEntry\Models\WebentryRoute;
 
 class ImportProcess implements ShouldQueue
 {
@@ -289,7 +290,8 @@ class ImportProcess implements ShouldQueue
                     $error = null;
                     $existingRoute = WebentryRoute::where('first_segment', $webEntryRouteConfig['firstUrlSegment'])->first();
                     if ($existingRoute) {
-                        $error = __('Route Already Exists, please update this Route.');
+                        $existingProcess = Process::select('name')->where('id', $existingRoute->process_id)->first();
+                        $error = __('Route should be unique. Used in process: :process_name in node ID: :node_id', ['process_name' => $existingProcess->name, 'node_id' => $existingRoute->node_id]);
                     }
 
                     $this->assignable->push((object) [

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -927,7 +927,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
     public function manageCustomRoutes()
     {
         foreach ($this->start_events as $startEvent) {
-            $webEntryProperties = (isset(json_decode($startEvent['config'])->web_entry) ? json_decode($startEvent['config'])->web_entry : null);
+            $webEntryProperties = (isset($startEvent['config']) && isset(json_decode($startEvent['config'])->web_entry) ? json_decode($startEvent['config'])->web_entry : null);
             
             if ($webEntryProperties && isset($webEntryProperties->webentryRouteConfig)) {
                 switch ($webEntryProperties->webentryRouteConfig->urlType) {

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1384,12 +1384,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
 
     private function deleteUnusedCustomRoutes($url, $processId, $nodeId) {
         // Delete unused custom routes
-        $customRoute = null;
-        if (!$url) {
-            $customRoute = webentryRoute::where('process_id', $processId)->where('node_id', $nodeId)->first();
-        } else {
-            $customRoute = WebentryRoute::where('first_segment', $url)->where('process_id', $processId)->where('node_id', $nodeId)->first();
-        }
+        $customRoute = webentryRoute::where('process_id', $processId)->where('node_id', $nodeId)->first();
         if ($customRoute) {
             $customRoute->delete();
         }

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1383,6 +1383,8 @@ class Process extends Model implements HasMedia, ProcessModelInterface
     private function deleteUnusedCustomRoutes($url, $processId, $nodeId) {
         // Delete unused custom routes
         $customRoute = WebentryRoute::where('first_segment', $url)->where('process_id', $processId)->where('node_id', $nodeId)->first();
-        $customRoute->delete();
+        if ($customRoute) {
+            $customRoute->delete();
+        }
     }
 }

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -931,9 +931,10 @@ class Process extends Model implements HasMedia, ProcessModelInterface
 
             if ($webEntryProperties && isset($webEntryProperties->webentryRouteConfig) && $webEntryProperties->webentryRouteConfig->firstUrlSegment != '') {
                 $webentryRouteConfig = $webEntryProperties->webentryRouteConfig;
-                WebentryRoute::updateOrCreate(
+                try {
+                    WebentryRoute::updateOrCreate(
                     [
-                        'process_id' => $webentryRouteConfig->processId,
+                        'process_id' => $this->id,
                         'node_id' => $webentryRouteConfig->nodeId,
                     ],
                     [
@@ -941,6 +942,10 @@ class Process extends Model implements HasMedia, ProcessModelInterface
                         'params' => $webentryRouteConfig->parameters,
                     ]
                 );
+                } catch (\Exception $e) {
+                    \Log::info('*** Error: '. $e->getMessage());
+                }
+
             }
         }
     }

--- a/ProcessMaker/Observers/ProcessObserver.php
+++ b/ProcessMaker/Observers/ProcessObserver.php
@@ -45,32 +45,6 @@ class ProcessObserver
      * @param Process $process
      */
     public function saved(Process $process) {
-        $this->deleteUnusedCustomRoutes();
         $process->manageCustomRoutes();
-    }
-
-    private function deleteUnusedCustomRoutes() {
-        $processes = Process::all();
-        $customRoutes = WebentryRoute::all();
-
-        foreach ($customRoutes as $route) {
-            $deleteRoute = true;
-            $process = $processes->firstWhere('id', $route->process_id);
-            if (!$process) {
-                return;
-            }
-            $startEvents = $process->start_events;
-
-            foreach ($startEvents as $startEvent) {
-                if (!isset($startEvent['config']) || (!isset(json_decode($startEvent['config'])->web_entry))) {
-                    continue;
-                } else if ($route->node_id == $startEvent['id']) {
-                    $deleteRoute = false;
-                }
-            }
-            if ($deleteRoute) {
-                $route->delete();
-            }
-        }
     }
 }

--- a/ProcessMaker/Observers/ProcessObserver.php
+++ b/ProcessMaker/Observers/ProcessObserver.php
@@ -56,6 +56,9 @@ class ProcessObserver
         foreach ($customRoutes as $route) {
             $deleteRoute = true;
             $process = $processes->firstWhere('id', $route->process_id);
+            if (!$process) {
+                return;
+            }
             $startEvents = $process->start_events;
 
             foreach ($startEvents as $startEvent) {

--- a/ProcessMaker/Observers/ProcessObserver.php
+++ b/ProcessMaker/Observers/ProcessObserver.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Observers;
 use ProcessMaker\Exception\ReferentialIntegrityException;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Package\WebEntry\Models\WebentryRoute;
 
 class ProcessObserver
 {
@@ -36,5 +37,37 @@ class ProcessObserver
         $process->signal_events = $process->getUpdatedStartEventsSignalEvents();
         $process->conditional_events = $process->getUpdatedConditionalStartEvents();
         $process->validateBpmnDefinition(true);
+    }
+
+    /**
+     * Handle the Process "saved" event.
+     *
+     * @param Process $process
+     */
+    public function saved(Process $process) {
+        $this->deleteUnusedCustomRoutes();
+        $process->manageCustomRoutes();
+    }
+
+    private function deleteUnusedCustomRoutes() {
+        $processes = Process::all();
+        $customRoutes = WebentryRoute::all();
+
+        foreach ($customRoutes as $route) {
+            $deleteRoute = true;
+            $process = $processes->firstWhere('id', $route->process_id);
+            $startEvents = $process->start_events;
+
+            foreach ($startEvents as $startEvent) {
+                if (!isset($startEvent['config']) || (!isset(json_decode($startEvent['config'])->web_entry))) {
+                    continue;
+                } else if ($route->node_id == $startEvent['id']) {
+                    $deleteRoute = false;
+                }
+            }
+            if ($deleteRoute) {
+                $route->delete();
+            }
+        }
     }
 }

--- a/database/migrations/2022_05_24_122028_create_webentry_routes_table.php
+++ b/database/migrations/2022_05_24_122028_create_webentry_routes_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateWebentryRoutesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('webentry_routes', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('first_segment')->unique();
+            $table->json('params')->nullable();
+            $table->unsignedInteger('process_id');
+            $table->string('node_id');
+            $table->boolean('is_task_webentry')->default(0);
+            $table->timestamps();
+
+            // Indexes
+            $table->index('first_segment');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('webentry_routes');
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            // Remove index by: user_id, status, due_at, due_notified
+            $table->dropIndex(['user_id', 'status', 'due_at', 'due_notified']);
+        });
+    }
+}

--- a/resources/js/components/shared/Column.vue
+++ b/resources/js/components/shared/Column.vue
@@ -4,8 +4,8 @@
           <div class="d-flex flex-row justify-content-between ">
               <div>
                   <div class="handle pl-1 pr-2" :class="{'without-format': withoutFormat}">
-                      <i class="fas fa-grip-vertical handle-bars"></i>
-                      <div v-show="!withoutFormat">{{ $t(format) }}</div>
+                      <i class="fas fa-grip-vertical handle-bars"></i> 
+                      <span v-show="!withoutFormat">{{ $t(format) }}</span>
                   </div>
                   <span class="column-label" :class="{'without-format': withoutFormat}">{{ item.label }}</span>
               </div>

--- a/resources/js/components/shared/Column.vue
+++ b/resources/js/components/shared/Column.vue
@@ -3,12 +3,13 @@
       <div :key="item.field" class="column-card card card-body p-2 my-3 w-100">
           <div class="d-flex flex-row justify-content-between ">
               <div>
-                  <div class="handle pl-1 pr-2">
-                      <i class="fa fa-fw fa-bars handle-bars"></i> {{ $t(format) }}
+                  <div class="handle pl-1 pr-2" :class="{'without-format': withoutFormat}">
+                      <i class="fa fa-fw fa-bars handle-bars"></i>
+                      <div v-show="!withoutFormat">{{ $t(format) }}</div>
                   </div>
-                  <span class="column-label">{{ item.label }}</span>
+                  <span class="column-label" :class="{'without-format': withoutFormat}">{{ item.label }}</span>
               </div>
-              <div>        
+              <div>
                 <a v-show="!withoutConfig" class="text-primary column-button" v-b-modal.column-modal v-if="! item.default" @click="onConfig"><i class="fa fa-cog fa-fw"></i></a>
                 <a v-show="!withoutRemove" class="text-primary column-button" @click="onRemove"><i class="fa fa-times fa-fw"></i></a>
               </div>
@@ -21,7 +22,7 @@
 import DataFormats from '../../data-formats';
 
 export default {
-  props: ["column","withoutConfig","withoutRemove"],
+  props: ["column","withoutConfig","withoutRemove","withoutFormat"],
   data() {
     return {
       item: this.column
@@ -56,7 +57,7 @@ export default {
   .column-card {
     cursor: grab;
   }
-  
+
   .handle {
     background: #dfdfdf;
     color: #555;
@@ -68,13 +69,21 @@ export default {
     top: 0;
     width: 175px;
   }
-  
+
+  .handle.without-format {
+    width: auto;
+  }
+
   .handle-bars {
     color: #999;
     margin-left: 8px;
     margin-right: 6px;
   }
-  
+
+  .column-label.without-format {
+    padding-left: 51px
+  }
+
   .column-label {
     padding-left: 181px;
   }
@@ -82,12 +91,12 @@ export default {
   .column-card a {
     cursor: pointer;
   }
-  
+
   .column-card:active,
   .column-card:focus {
     cursor: grabbing;
   }
-  
+
   .column-add,
   .column-add:active,
   .column-add:focus {

--- a/resources/js/components/shared/Column.vue
+++ b/resources/js/components/shared/Column.vue
@@ -4,7 +4,7 @@
           <div class="d-flex flex-row justify-content-between ">
               <div>
                   <div class="handle pl-1 pr-2" :class="{'without-format': withoutFormat}">
-                      <i class="fa fa-fw fa-bars handle-bars"></i>
+                      <i class="fas fa-grip-vertical handle-bars"></i>
                       <div v-show="!withoutFormat">{{ $t(format) }}</div>
                   </div>
                   <span class="column-label" :class="{'without-format': withoutFormat}">{{ item.label }}</span>

--- a/resources/views/processes/import.blade.php
+++ b/resources/views/processes/import.blade.php
@@ -607,6 +607,11 @@
             ProcessMaker.alert(message, variant);
           },
           checkForExistingRoute(item) {
+            if (!item.value) {
+              item.error = 'Segment is required';
+              return
+            } 
+            
             ProcessMaker.apiClient.get(`/webentry/custom_route/check/${item.value}`)
               .then(response => {
                 item.error = null;

--- a/resources/views/processes/import.blade.php
+++ b/resources/views/processes/import.blade.php
@@ -72,7 +72,11 @@
                                                 @{{ $t(item.prefix) }} <strong>@{{item.name }}</strong> @{{ $t(item.suffix) }}
                                                 <i class="assignable-arrow fas fa-long-arrow-alt-right"></i>
                                             </td>
-                                            <td class="assignable-entity">
+                                            <td v-if="item.type === 'webentryCustomRoute'" class="assinable-entity">
+                                              <b-form-input v-model="item.value" :state="item.error ? false : true"></b-form-input>
+                                              <div class="invalid-feedback" v-if="item.error" role="alert">@{{item.error}}</div>
+                                            </td>
+                                            <td v-else class="assignable-entity">
                                                 <label for="search-task-text" class="d-none">{{__('Type to search task')}}</label>
                                                 <multiselect id="search-task-text"
                                                              v-model="item.value"

--- a/resources/views/processes/import.blade.php
+++ b/resources/views/processes/import.blade.php
@@ -73,8 +73,8 @@
                                                 <i class="assignable-arrow fas fa-long-arrow-alt-right"></i>
                                             </td>
                                             <td v-if="item.type === 'webentryCustomRoute'" class="assinable-entity">
-                                              <b-form-input v-model="item.value" :state="item.error ? false : true"></b-form-input>
-                                              <div class="invalid-feedback" v-if="item.error" role="alert">@{{item.error}}</div>
+                                              <b-input v-model="item.value" @change="checkForExistingRoute(item)" :class="{'is-invalid': item.error }"></b-input>
+                                              <div class="invalid-feedback" v-if="item.error" role="alert"><div v-html="item.error"></div></div>
                                             </td>
                                             <td v-else class="assignable-entity">
                                                 <label for="search-task-text" class="d-none">{{__('Type to search task')}}</label>
@@ -531,6 +531,7 @@
                 this.onCancel();
               })
               .catch(error => {
+                console.log("error", error);
                 ProcessMaker.alert(this.$t('Unable cannot save the assignments.'), 'danger');
               });
           },
@@ -605,6 +606,15 @@
             }
             ProcessMaker.alert(message, variant);
           },
+          checkForExistingRoute(item) {
+            ProcessMaker.apiClient.get(`/webentry/custom_route/check/${item.value}`)
+              .then(response => {
+                item.error = null;
+              })
+              .catch(error => {
+                item.error = error.response.data.error;
+              });
+          }
         },
         mounted() {
           let received = false;

--- a/resources/views/processes/import.blade.php
+++ b/resources/views/processes/import.blade.php
@@ -610,8 +610,9 @@
             if (!item.value) {
               item.error = 'Segment is required';
               return
-            } 
-            
+            }
+            item.value = item.value.replace(/\s+/g, '-').toLowerCase();
+
             ProcessMaker.apiClient.get(`/webentry/custom_route/check/${item.value}`)
               .then(response => {
                 item.error = null;


### PR DESCRIPTION
Please read the PRD [FOUR-6178](https://processmaker.atlassian.net/browse/FOUR-6178)

> **_NOTE:_** Custom URL for web entries are only available for start event web entries

## How to Test
- Create some processes with web entry start events.
- Click the new **Options** button under web entry URL
- A modal should open with all the configuration fields for custom webentries URL
- Test first segment is unique
- Add some parameters like state, city
- Copy the url, in the parameters section you should have something like /{state}/{city}
- Paste the URL in the web browser and replaze the variables {state} and {city} for some param like /nevada/las-vegas
- The form for the web entry should show.
- Complete the form and go to requests
- Check in the request data tab, you should see 2 new attributes in the data object "state" and "city", with the values entered in the URL input of the browser.

Also test web entry is working without custom params

**Working video**

**With custom params**

https://user-images.githubusercontent.com/90727999/170558698-286a10f7-e8b5-478d-af26-193a54646bb2.mov

**Without custom params**

https://user-images.githubusercontent.com/90727999/170558845-5528d520-e527-471c-8a54-d4d53b7ddaa1.mov


## Related Tickets & Packages
- [FOUR-6178](https://processmaker.atlassian.net/browse/FOUR-6178)
- PR [package-webentries](https://github.com/ProcessMaker/package-webentry/pull/146)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
