### PR TITLE
Bugfix FOUR-6287 - Getting processes via SDK doesn't work

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -76,7 +76,7 @@ use Throwable;
  *   @OA\Property(property="warnings", type="string"),
  *   @OA\Property(property="self_service_tasks", type="object"),
  *   @OA\Property(property="signal_events", type="array", @OA\Items(type="object")),
- *   @OA\Property(property="category", @OA\Schema(ref="#/components/schemas/ProcessCategory")),
+ *   @OA\Property(property="category", type="object", @OA\Schema(ref="#/components/schemas/ProcessCategory")),
  *   @OA\Property(property="manager_id", type="integer", format="id"),
  * ),
  * @OA\Schema(

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -235,7 +235,7 @@ class Process extends Model implements HasMedia, ProcessModelInterface
      */
     public function category()
     {
-        return $this->belongsTo(ProcessCategory::class, 'process_category_id');
+        return $this->belongsTo(ProcessCategory::class, 'process_category_id')->withDefault();
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
An error is generated when we query the `getProcesses()` endpoint in Scripts and we `include=category`. Also note, this only happen when a Process **has more than 1 category assigned**.

`(Code: 0) Warning: settype(): Invalid type in /opt/sdk-php/lib/ObjectSerializer.php on line 335 Warning: settype(): Invalid type in /opt/sdk-php/lib/ObjectSerializer.php on line 335`.

## Solution
- It seems that by default when no type is defined, the property is set to `string`. The proposed solution is to define the property as an object.

## How to Test
1. Create process with 2 or more categories.
2. Create a new PHP script
3. Add the next code and run:

```
$filter = '';
$order_by = 'id';
$order_direction = 'asc'; 
$per_page = 5; 
$status = 'ACTIVE';
$include = 'category'; // string | Include data from related models in payload. Comma separated list.

$apiInstance = $api->processes();
$result = $apiInstance->getProcesses($filter, $order_by, $order_direction, $per_page, $status, $include);

return ['processes' => $result];
```


## Related Tickets & Packages
- [FOUR-6287](https://processmaker.atlassian.net/browse/FOUR-6287)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
