### PR TITLE
Four-6337 Configure user password

### DIFF
--- a/ProcessMaker/Contracts/SoapClientInterface.php
+++ b/ProcessMaker/Contracts/SoapClientInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ProcessMaker\Contracts;
+
+interface SoapClientInterface
+{
+    /**
+     * Execute a Soap Method
+     *
+     * @param array $method
+     * @param array $parameters
+     *
+     * @return array
+     */
+    public function callMethod(string $method, array $parameters): array;
+}

--- a/ProcessMaker/Contracts/WebServiceCallerInterface.php
+++ b/ProcessMaker/Contracts/WebServiceCallerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ProcessMaker\Contracts;
+
+interface WebServiceCallerInterface
+{
+    /**
+     * Execute the Soap Request
+     *
+     * @param array $request
+     *
+     * @return mixed
+     */
+    public function call(array $request): array;
+}

--- a/ProcessMaker/Contracts/WebServiceConfigBuilderInterface.php
+++ b/ProcessMaker/Contracts/WebServiceConfigBuilderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ProcessMaker\Contracts;
+
+interface WebServiceConfigBuilderInterface
+{
+    /**
+     * Build the configuration for the WebService
+     *
+     * @param array $originalConfig
+     *
+     * @return array
+     */
+    public function build(array $originalConfig): array;
+}

--- a/ProcessMaker/Contracts/WebServiceRequestBuilderInterface.php
+++ b/ProcessMaker/Contracts/WebServiceRequestBuilderInterface.php
@@ -10,7 +10,7 @@ interface WebServiceRequestBuilderInterface
      * @param array $config
      * @param array $data
      *
-     * @return mixed
+     * @return array
      */
-    public function build(array $config, array $data);
+    public function build(array $config, array $data): array;
 }

--- a/ProcessMaker/Contracts/WebServiceRequestBuilderInterface.php
+++ b/ProcessMaker/Contracts/WebServiceRequestBuilderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ProcessMaker\Contracts;
+
+interface WebServiceRequestBuilderInterface
+{
+    /**
+     * Build the WebService request
+     *
+     * @param array $config
+     * @param array $data
+     *
+     * @return mixed
+     */
+    public function build(array $config, array $data);
+}

--- a/ProcessMaker/Managers/WebServiceSoapConfigBuilder.php
+++ b/ProcessMaker/Managers/WebServiceSoapConfigBuilder.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use Illuminate\Support\Facades\Storage;
+use ProcessMaker\Contracts\WebServiceConfigBuilderInterface;
+
+class WebServiceSoapConfigBuilder implements WebServiceConfigBuilderInterface
+{
+    public function build(array $originalConfig): array
+    {
+        $config = $originalConfig;
+        return $config;
+    }
+}

--- a/ProcessMaker/Managers/WebServiceSoapRequestBuilder.php
+++ b/ProcessMaker/Managers/WebServiceSoapRequestBuilder.php
@@ -12,7 +12,7 @@ class WebServiceSoapRequestBuilder implements WebServiceRequestBuilderInterface
         'trace' => true,
     ];
 
-    public function build(array $config, array $data)
+    public function build(array $config, array $data): array
     {
         switch ($config['authentication_method']) {
             case 'password':

--- a/ProcessMaker/Managers/WebServiceSoapRequestBuilder.php
+++ b/ProcessMaker/Managers/WebServiceSoapRequestBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use Exception;
+use ProcessMaker\Contracts\WebServiceRequestBuilderInterface;
+
+class WebServiceSoapRequestBuilder implements WebServiceRequestBuilderInterface
+{
+    const base_options = [
+        'exceptions' => true,
+        'trace' => true,
+    ];
+
+    public function build(array $config, array $data)
+    {
+        switch ($config['authentication_method']) {
+            case 'password':
+                $parameters = [
+                    'wsdl' => $config['wsdl'],
+                    'options' => array_merge(self::base_options, [
+                        'login' => $config['username'],
+                        'password' => $config['password'],
+                    ]),
+                ];
+            break;
+            case 'certificate':
+            break;
+            default:
+                throw new Exception('Invalid authentication method: ' . $config['authentication_method']);
+        }
+        return $parameters;
+    }
+}

--- a/ProcessMaker/Managers/WebServiceSoapServiceCaller.php
+++ b/ProcessMaker/Managers/WebServiceSoapServiceCaller.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use ProcessMaker\Contracts\SoapClientInterface;
+use ProcessMaker\Contracts\WebServiceCallerInterface;
+
+class WebServiceSoapServiceCaller implements WebServiceCallerInterface
+{
+    public function call(array $request): array
+    {
+        $client = app(SoapClientInterface::class, $request);
+        $response = $client->callMethod($request['method'], $request['parameters']);
+        return $response;
+    }
+}

--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -11,6 +11,7 @@ use ProcessMaker\Assets\ScriptsInProcess;
 use ProcessMaker\Assets\ScriptsInScreen;
 use ProcessMaker\Bpmn\MustacheOptions;
 use ProcessMaker\BpmnEngine;
+use ProcessMaker\Contracts\SoapClientInterface;
 use ProcessMaker\Contracts\TimerExpressionInterface;
 use ProcessMaker\Facades\WorkflowManager as WorkflowManagerFacade;
 use ProcessMaker\Listeners\BpmnSubscriber;
@@ -195,5 +196,8 @@ class WorkflowServiceProvider extends ServiceProvider
         $this->app->bind('workflow.FormalExpression', function ($app) {
             return new FormalExpression();
         });
+
+        // @todo: SoapClientImpl::class
+        $this->app->bind(SoapClientInterface::class, SoapClientImpl::class);
     }
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -88,13 +88,14 @@ return [
             'url' => env('APP_URL').'/storage/setting',
             'visibility' => 'public',
         ],
-        'soap_certificates' => [
-            'driver' => 'local',
-            'root' => storage_path('app/private/soap_certificates'),
-        ],
         'private_settings' => [
             'driver' => 'local',
             'root' => storage_path('app/private/settings'),
+            'visibility' => 'private',
+        ],
+        'web_services' => [
+            'driver' => 'local',
+            'root' => storage_path('app/private/web_services'),
             'visibility' => 'private',
         ],
         'tmp' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -88,6 +88,10 @@ return [
             'url' => env('APP_URL').'/storage/setting',
             'visibility' => 'public',
         ],
+        'soap_certificates' => [
+            'driver' => 'local',
+            'root' => storage_path('app/private/soap_certificates'),
+        ],
         'private_settings' => [
             'driver' => 'local',
             'root' => storage_path('app/private/settings'),

--- a/tests/Feature/WebServiceSoapServiceCallerTest.php
+++ b/tests/Feature/WebServiceSoapServiceCallerTest.php
@@ -18,9 +18,8 @@ class WebServiceSoapServiceCallerTest extends TestCase
      */
     private $manager;
 
-    protected function setUp(): void
+    protected function setUpManager(): void
     {
-        parent::setUp();
         $this->manager = new WebServiceSoapServiceCaller;
         $this->app = app();
     }

--- a/tests/Feature/WebServiceSoapServiceCallerTest.php
+++ b/tests/Feature/WebServiceSoapServiceCallerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Mockery;
+use ProcessMaker\Contracts\SoapClientInterface;
+use ProcessMaker\Managers\WebServiceSoapServiceCaller;
+use Tests\TestCase;
+
+class WebServiceSoapServiceCallerTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     *
+     * @var WebServiceSoapServiceCaller
+     */
+    private $manager;
+
+    protected function setUp(): void
+    {
+        parent::__construct();
+        $this->manager = new WebServiceSoapServiceCaller;
+        $this->app = app();
+    }
+
+    public function testBuildUserPasswordAuthRequest()
+    {
+        // Mock SoapClientInterface
+        $mock = Mockery::mock(SoapClientInterface::class, function ($mock) {
+            $mock->shouldReceive('callMethod')->andReturn(['response' => 'success']);
+        });
+        $this->app->bind(SoapClientInterface::class, function () use ($mock) {
+            return $mock;
+        });
+        $request = [
+            'wsdl' => 'http://test.processmaker.net/soap/globalweather?WSDL',
+            'options' => [
+                'exceptions' => true,
+                'trace' => true,
+                'login' => 'admin',
+                'password' => 'password',
+            ],
+            'method' => 'test',
+            'parameters' => [
+                'param1' => 'value1',
+                'param2' => 'value2',
+            ],
+        ];
+        $response = $this->manager->call($request);
+        $this->assertEquals('success', $response['response']);
+    }
+}

--- a/tests/Feature/WebServiceSoapServiceCallerTest.php
+++ b/tests/Feature/WebServiceSoapServiceCallerTest.php
@@ -20,7 +20,7 @@ class WebServiceSoapServiceCallerTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::__construct();
+        parent::setUp();
         $this->manager = new WebServiceSoapServiceCaller;
         $this->app = app();
     }

--- a/tests/unit/ProcessMaker/Managers/WebServiceSoapConfigBuilderTest.php
+++ b/tests/unit/ProcessMaker/Managers/WebServiceSoapConfigBuilderTest.php
@@ -16,7 +16,7 @@ class WebServiceSoapConfigBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::__construct();
+        parent::setUp();
         $this->manager = new WebServiceSoapConfigBuilder;
     }
 

--- a/tests/unit/ProcessMaker/Managers/WebServiceSoapConfigBuilderTest.php
+++ b/tests/unit/ProcessMaker/Managers/WebServiceSoapConfigBuilderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class WebServiceSoapConfigBuilderTest extends TestCase
+{
+
+    /**
+     *
+     * @var WebServiceSoapConfigBuilder
+     */
+    private $manager;
+
+    protected function setUp(): void
+    {
+        parent::__construct();
+        $this->manager = new WebServiceSoapConfigBuilder;
+    }
+
+    public function testBuildUserPasswordAuthRequest()
+    {
+        $originalConfig = [
+            'wsdl' => 'http://test.processmaker.net/soap/globalweather?WSDL',
+            'authentication_method' => 'password',
+            'username' => 'admin',
+            'password' => 'password',
+            'debug_mode' => true,
+        ];
+        $config = $this->manager->build($originalConfig);
+        $this->assertEquals('http://test.processmaker.net/soap/globalweather?WSDL', $config['wsdl']);
+        $this->assertEquals('password', $config['authentication_method']);
+        $this->assertEquals('admin', $config['username']);
+        $this->assertEquals('password', $config['password']);
+        $this->assertEquals(true, $config['debug_mode']);
+    }
+}

--- a/tests/unit/ProcessMaker/Managers/WebServiceSoapRequestBuilderTest.php
+++ b/tests/unit/ProcessMaker/Managers/WebServiceSoapRequestBuilderTest.php
@@ -15,7 +15,7 @@ class WebServiceSoapRequestBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::__construct();
+        parent::setUp();
         $this->manager = new WebServiceSoapRequestBuilder;
     }
 

--- a/tests/unit/ProcessMaker/Managers/WebServiceSoapRequestBuilderTest.php
+++ b/tests/unit/ProcessMaker/Managers/WebServiceSoapRequestBuilderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use Tests\TestCase;
+
+class WebServiceSoapRequestBuilderTest extends TestCase
+{
+
+    /**
+     *
+     * @var WebServiceSoapRequestBuilder
+     */
+    private $manager;
+
+    protected function setUp(): void
+    {
+        parent::__construct();
+        $this->manager = new WebServiceSoapRequestBuilder;
+    }
+
+    public function testBuildUserPasswordAuthRequest()
+    {
+        $config = [
+            'wsdl' => 'http://test.processmaker.net/soap/globalweather?WSDL',
+            'authentication_method' => 'password',
+            'username' => 'admin',
+            'password' => 'password',
+        ];
+        $data = [];
+        $config = $this->manager->build($config, $data);
+        $this->assertEquals('http://test.processmaker.net/soap/globalweather?WSDL', $config['wsdl']);
+        $this->assertEquals('admin', $config['options']['login']);
+        $this->assertEquals('password', $config['options']['password']);
+    }
+}


### PR DESCRIPTION
## Contains:
Implement Soap base contract and classes to configure a User Password authentication

![image](https://user-images.githubusercontent.com/8028650/171299574-92edd4c1-6e19-45f2-a350-debe3c3df462.png)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6337

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
