### PR TITLE
Validate Id parameters to be integer type

### DIFF
--- a/ProcessMaker/Providers/RouteServiceProvider.php
+++ b/ProcessMaker/Providers/RouteServiceProvider.php
@@ -27,6 +27,28 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Route::pattern('user', '[0-9]+');
+        Route::pattern('group', '[0-9]+');
+        Route::pattern('group_member', '[0-9]+');
+        Route::pattern('environment_variable', '[0-9]+');
+        Route::pattern('screen', '[0-9]+');
+        Route::pattern('screen_category', '[0-9]+');
+        Route::pattern('script', '[0-9]+');
+        Route::pattern('script_id', '[0-9]+');
+        Route::pattern('script_category', '[0-9]+');
+        Route::pattern('process', '[0-9]+');
+        Route::pattern('processId', '[0-9]+');
+        Route::pattern('process_category', '[0-9]+');
+        Route::pattern('task', '[0-9]+');
+        Route::pattern('request', '[0-9]+');
+        Route::pattern('file', '[0-9]+');
+        Route::pattern('notification', '[0-9]+');
+        Route::pattern('task_assignment', '[0-9]+');
+        Route::pattern('comment', '[0-9]+');
+        Route::pattern('script_executor', '[0-9]+');
+        Route::pattern('securityLog', '[0-9]+');
+        Route::pattern('setting', '[0-9]+');
+
         parent::boot();
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -193,7 +193,7 @@ Route::group(
     Route::get('settings/groups', 'SettingController@groups')->name('settings.groups')->middleware('can:view-settings');
     Route::post('settings/import', 'SettingController@import')->name('settings.import')->middleware('can:update-settings');
     Route::put('settings/{setting}', 'SettingController@update')->name('settings.update')->middleware('can:update-settings');
-    Route::get('settings/group/{group}/buttons', 'SettingController@buttons')->name('settings.buttons')->middleware('can:view-settings');
+    Route::get('settings/group/{group}/buttons', 'SettingController@buttons')->name('settings.buttons')->middleware('can:view-settings')->where('group', '[A-Za-z0-9 -_]+');
     Route::post('settings/upload-file', 'SettingController@upload')->name('settings.upload-file')->middleware('can:update-settings');
 
     // debugging javascript errors


### PR DESCRIPTION
## Issue & Reproduction Steps
In endpoints type `users/{user} ` the parameter `{user}` must be an integer.
`users/1` but if you enter `users/1something` it also returns the correct answer.


https://user-images.githubusercontent.com/1747025/171860364-aed630fe-0bc7-493f-b4c7-af7b62aed902.mp4



## Solution
- Added validation with global constraints for these parameters.

## How to Test
Review endpoints of this type and enter wrong parameters.

## Related Tickets & Packages
- Ticket [FOUR-6346](https://processmaker.atlassian.net/browse/FOUR-6346)

Also please check this PR
[connector-docusign](https://github.com/ProcessMaker/connector-docusign/pull/26)
[package-auth](https://github.com/ProcessMaker/package-auth/pull/59)
[package-collections](https://github.com/ProcessMaker/package-collections/pull/311)
[package-comments](https://github.com/ProcessMaker/package-comments/pull/78)
[package-data-sources](https://github.com/ProcessMaker/package-data-sources/pull/228)
[package-dynamic-ui](https://github.com/ProcessMaker/package-dynamic-ui/pull/58)
[package-files](https://github.com/ProcessMaker/package-files/pull/82)
[package-savedsearch](https://github.com/ProcessMaker/package-savedsearch/pull/314)
[package-versions](https://github.com/ProcessMaker/package-versions/pull/52)
[package-vocabularies](https://github.com/ProcessMaker/package-vocabularies/pull/61)
[package-webentry](https://github.com/ProcessMaker/package-webentry/pull/147)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
