### PR TITLE
Remove .gitignore file from public directory

### DIFF
--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,2 +1,0 @@
-plugin-processmaker-demo
-


### PR DESCRIPTION
## Issue & Reproduction Steps
The file"processmaker/public/.gitignore" should be removed from the build file.

## Solution
- The `.gitignore` file in the public directory didn't contain updated information. It was simply deleted

## Related Tickets & Packages
- [FOUR-6347](https://processmaker.atlassian.net/browse/FOUR-6347)