### PR TITLE
Implement Support for SOAP calls

### DIFF
--- a/ProcessMaker/Contracts/SoapClientInterface.php
+++ b/ProcessMaker/Contracts/SoapClientInterface.php
@@ -14,7 +14,28 @@ interface SoapClientInterface
      */
     public function callMethod(string $method, array $parameters);
 
+    /**
+     * Get a list of service ports available
+     *
+     * @return array
+     */
     public function getServices(): array;
 
+    /**
+     * Get a list of operations available
+     * 
+     * @param string $serviceName If empty, all operations will be returned
+     * 
+     * @return array
+     */
+    public function getOperations(string $serviceName): array;
+
+    /**
+     * Select a service port
+     * 
+     * @param string $portName
+     * 
+     * @return void
+     */
     public function selectServicePort(string $portName);
 }

--- a/ProcessMaker/Contracts/SoapClientInterface.php
+++ b/ProcessMaker/Contracts/SoapClientInterface.php
@@ -28,7 +28,7 @@ interface SoapClientInterface
      * 
      * @return array
      */
-    public function getOperations(string $serviceName): array;
+    public function getOperations(string $serviceName = ''): array;
 
     /**
      * Select a service port

--- a/ProcessMaker/Contracts/WebServiceConfigBuilderInterface.php
+++ b/ProcessMaker/Contracts/WebServiceConfigBuilderInterface.php
@@ -7,9 +7,9 @@ interface WebServiceConfigBuilderInterface
     /**
      * Build the configuration for the WebService
      *
-     * @param array $originalConfig
+     * @param array $serviceTaskConfig
      *
      * @return array
      */
-    public function build(array $originalConfig): array;
+    public function build(array $serviceTaskConfig, array $dataSourceConfig, array $data): array;
 }

--- a/ProcessMaker/Contracts/WebServiceResponseMapperInterface.php
+++ b/ProcessMaker/Contracts/WebServiceResponseMapperInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ProcessMaker\Contracts;
+
+interface WebServiceResponseMapperInterface
+{
+    /**
+     * Map the response from the WebService to request data
+     *
+     * @param mixed $response
+     * @param array $config
+     * @param array $data
+     *
+     * @return array
+     */
+    public function map($response, array $config, array $data): array;
+}

--- a/ProcessMaker/Factories/SoapClientFactory.php
+++ b/ProcessMaker/Factories/SoapClientFactory.php
@@ -3,7 +3,7 @@
 namespace ProcessMaker\Factories;
 
 use ProcessMaker\Contracts\SoapClientInterface;
-use ProcessMaker\Soap\NativeSoapClient;
+use ProcessMaker\WebServices\NativeSoapClient;
 
 class SoapClientFactory
 {

--- a/ProcessMaker/Managers/WebServiceSoapConfigBuilder.php
+++ b/ProcessMaker/Managers/WebServiceSoapConfigBuilder.php
@@ -9,6 +9,8 @@ use ProcessMaker\Models\FormalExpression;
 
 class WebServiceSoapConfigBuilder implements WebServiceConfigBuilderInterface
 {
+    private $mustache = null;
+
     public function build(array $serviceTaskConfig, array $dataSourceConfig, array $data): array
     {
         $config = $serviceTaskConfig;

--- a/ProcessMaker/Managers/WebServiceSoapConfigBuilder.php
+++ b/ProcessMaker/Managers/WebServiceSoapConfigBuilder.php
@@ -2,14 +2,19 @@
 
 namespace ProcessMaker\Managers;
 
-use Illuminate\Support\Facades\Storage;
 use ProcessMaker\Contracts\WebServiceConfigBuilderInterface;
 
 class WebServiceSoapConfigBuilder implements WebServiceConfigBuilderInterface
 {
-    public function build(array $originalConfig): array
+    public function build(array $serviceTaskConfig, array $dataSourceConfig, array $data): array
     {
-        $config = $originalConfig;
+        $config = $serviceTaskConfig;
+        $credentials = $dataSourceConfig['credentials'];
+        $config['wsdl'] = $credentials['wsdl'];
+        $config['username'] = $credentials['username'];
+        $config['password'] = $credentials['password'];
+        $config['authentication_method'] = $credentials['authentication_method'];
+        $config['debug_mode'] = $credentials['debug_mode'];
         return $config;
     }
 }

--- a/ProcessMaker/Managers/WebServiceSoapConfigBuilder.php
+++ b/ProcessMaker/Managers/WebServiceSoapConfigBuilder.php
@@ -2,7 +2,10 @@
 
 namespace ProcessMaker\Managers;
 
+use Exception;
+use Mustache_Engine;
 use ProcessMaker\Contracts\WebServiceConfigBuilderInterface;
+use ProcessMaker\Models\FormalExpression;
 
 class WebServiceSoapConfigBuilder implements WebServiceConfigBuilderInterface
 {
@@ -15,6 +18,83 @@ class WebServiceSoapConfigBuilder implements WebServiceConfigBuilderInterface
         $config['password'] = $credentials['password'];
         $config['authentication_method'] = $credentials['authentication_method'];
         $config['debug_mode'] = $credentials['debug_mode'];
+        $config['location'] = $credentials['location'];
+        // Prepare endpoint params and dataMapping
+        $endpoint = $serviceTaskConfig['endpoint'];
+        $endpointDefinition = $dataSourceConfig['endpoints'][$endpoint];
+        $config['operation'] = $endpointDefinition['operation'];
+        $outboundConfig = $serviceTaskConfig['outboundConfig'];
+        $parameters = [];
+        foreach ($outboundConfig as $map) {
+            if ($map['type'] !== 'PARAM') {
+                continue;
+            }
+            $format = $map['format'];
+            if ($format === 'mustache') {
+                $value = $this->evalMustache($map['value'], $data);
+            } elseif ($format === 'feel') {
+                $value = $this->evalExpression($map['value'], $data);
+            } else {
+                throw new Exception('Invalid format: ' . $format . ' for ' . $map['key']);
+            }
+            $parameters[$map['key']] = $value;
+        }
+        $config['parameters'] = $parameters;
         return $config;
+    }
+
+    /**
+     * Evaluate a BPMN FEEL expression
+     * ex.
+     *      foo             => bar
+     *      _request.id     => 1001
+     *      _user.id        => 101
+     *      10              => 10
+     *      {{ form.age }}  => 21
+     *      "{{ form.lastname }} {{ form.firstname }}" => John Doe
+     *
+     * @return mixed
+     */
+    private function evalExpression($expression, array $data)
+    {
+        try {
+            $formal = new FormalExpression();
+            $formal->setBody($expression);
+            return $formal($data);
+        } catch (Exception $exception) {
+            return "{$expression}: " . $exception->getMessage();
+        }
+    }
+
+    /**
+     * Evaluate a mustache expression
+     * ex.
+     *      foo             => "foo"
+     *      10              => "10"
+     *      {{ user.id }}  => "101"
+     *      {{ form.age }}  => "21"
+     *      {{ form.lastname }} {{ form.firstname }} => "John Doe"
+     * @return string
+     */
+    private function evalMustache($expression, array $data)
+    {
+        try {
+            return $this->getMustache()->render($expression, $data);
+        } catch (Exception $exception) {
+            return "{$expression}: " . $exception->getMessage();
+        }
+    }
+
+    /**
+     * Get mustache engine
+     *
+     * @return \Mustache_Engine
+     */
+    private function getMustache()
+    {
+        if ($this->mustache === null) {
+            $this->mustache = app(Mustache_Engine::class);
+        }
+        return $this->mustache;
     }
 }

--- a/ProcessMaker/Managers/WebServiceSoapRequestBuilder.php
+++ b/ProcessMaker/Managers/WebServiceSoapRequestBuilder.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Managers;
 
 use Exception;
+use Illuminate\Support\Facades\Storage;
 use ProcessMaker\Contracts\WebServiceRequestBuilderInterface;
 
 class WebServiceSoapRequestBuilder implements WebServiceRequestBuilderInterface
@@ -17,12 +18,15 @@ class WebServiceSoapRequestBuilder implements WebServiceRequestBuilderInterface
         switch ($config['authentication_method']) {
             case 'password':
                 $parameters = [
-                    'wsdl' => $config['wsdl'],
+                    'wsdl' => Storage::disk('web_services')->path($config['wsdl']),
                     'options' => array_merge(self::base_options, [
                         'authentication_method' => $config['authentication_method'],
                         'login' => $config['username'],
                         'password' => $config['password'],
+                        'location' => $config['location'],
                     ]),
+                    'operation' => $config['operation'],
+                    'parameters' => $config['parameters'],
                 ];
             break;
             case 'certificate':

--- a/ProcessMaker/Managers/WebServiceSoapResponseBuilder.php
+++ b/ProcessMaker/Managers/WebServiceSoapResponseBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use ProcessMaker\Contracts\WebServiceResponseMapperInterface;
+
+class WebServiceSoapResponseBuilder implements WebServiceResponseMapperInterface
+{
+
+    /**
+     * Map the response from the WebService to request data
+     *
+     * @param mixed $response
+     * @param array $config
+     * @param array $data
+     *
+     * @return array
+     */
+    public function map($response, array $config, array $data): array
+    {
+        $result = [
+            'response' => $response,
+        ];
+
+        return $result;
+    }
+}

--- a/ProcessMaker/Managers/WebServiceSoapServiceCaller.php
+++ b/ProcessMaker/Managers/WebServiceSoapServiceCaller.php
@@ -13,7 +13,7 @@ class WebServiceSoapServiceCaller implements WebServiceCallerInterface
         if (isset($request['service_port'])) {
             $client->selectServicePort($request['service_port']);
         }
-        $response = $client->callMethod($request['method'], $request['parameters']);
+        $response = $client->callMethod($request['operation'], ['body' => $request['parameters']]);
         return $response;
     }
 }

--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -19,6 +19,10 @@ use ProcessMaker\Listeners\BpmnSubscriber;
 use ProcessMaker\Listeners\CommentsSubscriber;
 use ProcessMaker\Managers\ExportManager;
 use ProcessMaker\Managers\TaskSchedulerManager;
+use ProcessMaker\Managers\WebServiceSoapConfigBuilder;
+use ProcessMaker\Managers\WebServiceSoapRequestBuilder;
+use ProcessMaker\Managers\WebServiceSoapResponseBuilder;
+use ProcessMaker\Managers\WebServiceSoapServiceCaller;
 use ProcessMaker\Managers\WorkflowManager;
 use ProcessMaker\Models\FormalExpression;
 use ProcessMaker\Nayra\Bpmn\Models\EventDefinitionBus;
@@ -35,6 +39,7 @@ use ProcessMaker\Nayra\Contracts\Engine\EngineInterface;
 use ProcessMaker\Nayra\Contracts\Storage\BpmnDocumentInterface;
 use ProcessMaker\Repositories\BpmnDocument;
 use ProcessMaker\Repositories\DefinitionsRepository;
+use ProcessMaker\WebServices\WebServiceRequest;
 
 class WorkflowServiceProvider extends ServiceProvider
 {
@@ -201,6 +206,18 @@ class WorkflowServiceProvider extends ServiceProvider
         $this->app->bind(SoapClientInterface::class, function ($app, $request_config) {
             $factory = new SoapClientFactory();
             return $factory->createNativeSoapClient($request_config['wsdl'], $request_config['options']);
+        });
+
+        // @todo Complete the WebServiceRequest Factory
+        $this->app->bind('WebServiceRequest', function ($app, $params) {
+            $dataSource = $params['dataSource'];
+            return new WebServiceRequest(
+                new WebServiceSoapConfigBuilder(),
+                new WebServiceSoapRequestBuilder(),
+                new WebServiceSoapResponseBuilder(),
+                new WebServiceSoapServiceCaller(),
+                $dataSource
+            );
         });
     }
 }

--- a/ProcessMaker/Soap/NativeSoapClient.php
+++ b/ProcessMaker/Soap/NativeSoapClient.php
@@ -84,4 +84,10 @@ class NativeSoapClient implements SoapClientInterface
                 break;
         }
     }
+
+    public function getOperations(string $serviceName = ''): array
+    {
+        $response = $this->soapClient->__getFunctions();
+        return $response;
+    }
 }

--- a/ProcessMaker/WebServices/NativeSoapClient.php
+++ b/ProcessMaker/WebServices/NativeSoapClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ProcessMaker\Soap;
+namespace ProcessMaker\WebServices;
 
 use DOMDocument;
 use DOMXPath;

--- a/ProcessMaker/WebServices/WebServiceRequest.php
+++ b/ProcessMaker/WebServices/WebServiceRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ProcessMaker\WebServices;
+
+use ProcessMaker\Contracts\WebServiceCallerInterface;
+use ProcessMaker\Contracts\WebServiceConfigBuilderInterface;
+use ProcessMaker\Contracts\WebServiceRequestBuilderInterface;
+use ProcessMaker\Contracts\WebServiceResponseMapperInterface;
+
+class WebServiceRequest
+{
+    private $config;
+    private $request;
+    private $responseMapper;
+    private $requestCaller;
+    private $dataSource;
+
+    public function __construct(
+        WebServiceConfigBuilderInterface $config,
+        WebServiceRequestBuilderInterface $request,
+        WebServiceResponseMapperInterface $responseMapper,
+        WebServiceCallerInterface $requestCaller,
+        $dataSource
+    ) {
+        $this->config = $config;
+        $this->request = $request;
+        $this->responseMapper = $responseMapper;
+        $this->requestCaller = $requestCaller;
+        $this->dataSource = $dataSource;
+    }
+
+    public function execute(array $data, array $serviceTaskConfig)
+    {
+        $dataSourceConfig = $this->dataSource->toArray();
+        $dataSourceConfig['credentials'] = json_decode($this->dataSource->credentials);
+        $config = $this->config->build($serviceTaskConfig, $dataSourceConfig, $data);
+        $request = $this->request->build($config, $data);
+        $response = $this->requestCaller->call($request, $config);
+        $result = $this->responseMapper->map($response, $config, $data);
+        return $result;
+    }
+}

--- a/ProcessMaker/WebServices/WebServiceRequest.php
+++ b/ProcessMaker/WebServices/WebServiceRequest.php
@@ -32,7 +32,7 @@ class WebServiceRequest
     public function execute(array $data, array $serviceTaskConfig)
     {
         $dataSourceConfig = $this->dataSource->toArray();
-        $dataSourceConfig['credentials'] = json_decode($this->dataSource->credentials);
+        $dataSourceConfig['credentials'] = $this->dataSource->credentials;
         $config = $this->config->build($serviceTaskConfig, $dataSourceConfig, $data);
         $request = $this->request->build($config, $data);
         $response = $this->requestCaller->call($request, $config);

--- a/tests/Feature/WebServiceRequestTest.php
+++ b/tests/Feature/WebServiceRequestTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\WithFaker;
+use Mockery;
+use ProcessMaker\Contracts\SoapClientInterface;
+use ProcessMaker\Managers\WebServiceSoapServiceCaller;
+use Tests\TestCase;
+
+class WebServiceRequestTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     *
+     * @var WebServiceSoapServiceCaller
+     */
+    private $manager;
+
+    protected function setUpManager(): void
+    {
+        $this->app = $this->createApplication();
+    }
+
+    public function testBuildUserPasswordAuthRequest()
+    {
+        // Mock SoapClientInterface
+        $mock = Mockery::mock(SoapClientInterface::class, function ($mock) {
+            $mock->shouldReceive('callMethod')
+                ->with("Ping", [
+                    "body" => [
+                        "PingRq" => "success"
+                    ]
+                ])
+                ->andReturn((object)[
+                    "PingRs" => (object)[
+                        "_" => "ping"
+                    ]
+                ]);
+        });
+        $this->app->bind(SoapClientInterface::class, function () use ($mock) {
+            return $mock;
+        });
+        $mockDataSource = Mockery::mock(Model::class, function ($mock) {
+            $mock->shouldReceive('getAttribute')->with('credentials')->andReturn([
+                "wsdl"=>"1/TPG_Customer.wsdl",
+                "username"=>"test",
+                "password"=>"password",
+                "location"=>"https://jxtest.processmaker.local/jxchange/2008/ServiceGateway/Customer.svc",
+                "authentication_method"=>"password",
+                "debug_mode"=>false
+            ]);
+            $mock->shouldReceive('toArray')->andReturn([
+                'id' => 1,
+                'endpoints' => [
+                    "Ping" => [
+                        "method"=>"SOAP",
+                        "operation" => "Ping",
+                        "params" => [
+                            [
+                                "key" => "PingRq",
+                                "type" => "string",
+                                "required" => false
+                            ]
+                        ]
+                    ]
+                ],
+            ]);
+        });
+        $serviceTask = app('WebServiceRequest', ['dataSource' => $mockDataSource]);
+        $response = $serviceTask->execute(
+            [
+                'form_input_1' => 'success',
+            ],
+            [
+                "dataSource" => 1,
+                "endpoint" => "Ping",
+                "dataMapping" => [
+                    [
+                        "value" => "",
+                        "key" => "response",
+                        "format" => "dotNotation"
+                    ]
+                ],
+                "outboundConfig" => [
+                    [
+                        "value" => "{{form_input_1}}",
+                        "type" => "PARAM",
+                        "key" => "PingRq",
+                        "format" => "mustache"
+                    ]
+                ],
+                "callback" => false,
+                "callback_url" => "callback_url",
+                "callback_variable" => "callback",
+                "callback_methods" => [
+                    "POST"
+                ],
+                "callback_data_types" => [
+                    "FORM"
+                ],
+                "callback_authentication" => null,
+                "callback_authentication_username" => "",
+                "callback_authentication_password" => "",
+                "callback_whitelist" => []
+            ]
+        );
+        $this->assertEquals([
+            'response' => (object)[
+                "PingRs" => (object)[
+                    "_" => "ping"
+                ]
+            ]
+        ], $response);
+    }
+}

--- a/tests/Feature/WebServiceRequestTest.php
+++ b/tests/Feature/WebServiceRequestTest.php
@@ -36,7 +36,7 @@ class WebServiceRequestTest extends TestCase
                 ])
                 ->andReturn((object)[
                     "PingRs" => (object)[
-                        "_" => "ping"
+                        "_" => "success"
                     ]
                 ]);
         });
@@ -110,7 +110,7 @@ class WebServiceRequestTest extends TestCase
         $this->assertEquals([
             'response' => (object)[
                 "PingRs" => (object)[
-                    "_" => "ping"
+                    "_" => "success"
                 ]
             ]
         ], $response);

--- a/tests/Feature/WebServiceSoapServiceCallerTest.php
+++ b/tests/Feature/WebServiceSoapServiceCallerTest.php
@@ -44,7 +44,7 @@ class WebServiceSoapServiceCallerTest extends TestCase
                 'login' => 'admin',
                 'password' => 'password',
             ],
-            'method' => 'test',
+            'operation' => 'test',
             'parameters' => [
                 'param1' => 'value1',
                 'param2' => 'value2',
@@ -58,7 +58,7 @@ class WebServiceSoapServiceCallerTest extends TestCase
     {
         $mock = $this->partialMock(SoapClientInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('selectServicePort')->with('CustomerServiceSoap');
-            $mock->shouldReceive('callMethod')->once()->andReturn((object)['PingRs' => (object)["_" => 'success']]);
+            $mock->shouldReceive('callMethod')->with('Ping', ['body'=>['PingRq' => 'success']])->once()->andReturn((object)['PingRs' => (object)["_" => 'success']]);
         });
         $this->app->bind(SoapClientInterface::class, function () use ($mock) {
             return $mock;
@@ -74,11 +74,9 @@ class WebServiceSoapServiceCallerTest extends TestCase
                 'password' => 'abcdef1234567890',
             ],
             'service_port' => 'CustomerServiceSoap',
-            'method' => 'Ping',
+            'operation' => 'Ping',
             'parameters' => [
-                'body' => [
-                    'PingRq' => 'success',
-                ],
+                'PingRq' => 'success',
             ],
         ];
         $response = $this->manager->call($request);

--- a/tests/unit/ProcessMaker/Managers/WebServiceSoapConfigBuilderTest.php
+++ b/tests/unit/ProcessMaker/Managers/WebServiceSoapConfigBuilderTest.php
@@ -14,26 +14,101 @@ class WebServiceSoapConfigBuilderTest extends TestCase
      */
     private $manager;
 
-    protected function setUp(): void
+    protected function setUpManager(): void
     {
-        parent::__construct();
         $this->manager = new WebServiceSoapConfigBuilder;
     }
 
     public function testBuildUserPasswordAuthRequest()
     {
-        $originalConfig = [
-            'wsdl' => 'http://test.processmaker.net/soap/globalweather?WSDL',
-            'authentication_method' => 'password',
-            'username' => 'admin',
-            'password' => 'password',
-            'debug_mode' => true,
+        $serviceTaskConfig = [];
+        $dataSourceConfig = [
+            'credentials' => [
+                'wsdl' => 'http://test.processmaker.net/soap/globalweather?WSDL',
+                'authentication_method' => 'password',
+                'username' => 'admin',
+                'password' => 'password',
+                'debug_mode' => true,
+            ],
         ];
-        $config = $this->manager->build($originalConfig);
+        $data = [];
+        $config = $this->manager->build($serviceTaskConfig, $dataSourceConfig, $data);
         $this->assertEquals('http://test.processmaker.net/soap/globalweather?WSDL', $config['wsdl']);
         $this->assertEquals('password', $config['authentication_method']);
         $this->assertEquals('admin', $config['username']);
         $this->assertEquals('password', $config['password']);
         $this->assertEquals(true, $config['debug_mode']);
+    }
+
+    public function testBuildServiceTaskConfig()
+    {
+        $serviceTaskConfig = [
+            "dataSource" => 1,
+            "endpoint" => "list",
+            "dataMapping" => [
+                [
+                    "value" => "PingRs._",
+                    "key" => "response",
+                    "format" => "dotNotation"
+                ]
+            ],
+            "outboundConfig" => [
+                [
+                    "value" => "{{form_input_1}}",
+                    "type" => "PARAM",
+                    "key" => "key1",
+                    "format" => "mustache"
+                ]
+            ],
+            "callback" => false,
+            "callback_url" => "callback_url",
+            "callback_variable" => "callback",
+            "callback_methods" => [
+                "POST"
+            ],
+            "callback_data_types" => [
+                "FORM"
+            ],
+            "callback_authentication" => null,
+            "callback_authentication_username" => "",
+            "callback_authentication_password" => "",
+            "callback_whitelist" => []
+        ];
+        $dataSourceConfig = [
+            'credentials' => [
+                'wsdl' => 'http://test.processmaker.net/soap/globalweather?WSDL',
+                'authentication_method' => 'password',
+                'username' => 'admin',
+                'password' => 'password',
+                'debug_mode' => true,
+            ],
+        ];
+        $data = [];
+        $config = $this->manager->build($serviceTaskConfig, $dataSourceConfig, $data);
+        $this->assertEquals('http://test.processmaker.net/soap/globalweather?WSDL', $config['wsdl']);
+        $this->assertEquals('password', $config['authentication_method']);
+        $this->assertEquals('admin', $config['username']);
+        $this->assertEquals('password', $config['password']);
+        $this->assertEquals('list', $config['endpoint']);
+        $this->assertEquals(true, $config['debug_mode']);
+        $this->assertEquals('PingRs._', $config['dataMapping'][0]['value']);
+        $this->assertEquals('response', $config['dataMapping'][0]['key']);
+        $this->assertEquals('dotNotation', $config['dataMapping'][0]['format']);
+        $this->assertEquals('{{form_input_1}}', $config['outboundConfig'][0]['value']);
+        $this->assertEquals('key1', $config['outboundConfig'][0]['key']);
+        $this->assertEquals('mustache', $config['outboundConfig'][0]['format']);
+        $this->assertEquals(false, $config['callback']);
+        $this->assertEquals('callback_url', $config['callback_url']);
+        $this->assertEquals('callback', $config['callback_variable']);
+        $this->assertEquals([
+            "POST"
+        ], $config['callback_methods']);
+        $this->assertEquals([
+            "FORM"
+        ], $config['callback_data_types']);
+        $this->assertEquals(null, $config['callback_authentication']);
+        $this->assertEquals('', $config['callback_authentication_username']);
+        $this->assertEquals('', $config['callback_authentication_password']);
+        $this->assertEquals([], $config['callback_whitelist']);
     }
 }


### PR DESCRIPTION
## Solution
Implement Support for SOAP calls

## How to Test
Run the test: WebServiceRequestTest. It executes the WebService using a ServiceTask and DataConnector configuration.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6336

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
