### PR TITLE
Bugfix 6101-B: Error validations are not marked with the color selected in Customize UI

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -138,11 +138,11 @@ button:focus.navbar-toggler {
   // font-size: 14px;
 }
 
-.is-invalid .multiselect__tags {
+.has-errors .multiselect__tags {
   border-color: $danger !important;
 }
 
-.multiselect.is-invalid ~ .invalid-feedback {
+.multiselect.has-errors ~ .invalid-feedback {
   display: block;
 }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Select List still mark in red the validation of the required field

1. Go to admin
2. Open Customize UI
3. Select a color different to red in "Danger" option
4. Save the changes
5. Create a Screen
6. Add controls like(line input, textarea, select list, signature)
7. Add Required validation in each control
8. Press preview button

## Solution
- Another class is used for errors, since other packages like saved search overwrite using inline css and the !important property.

## How to Test
- Compile assets, please run `npm link` for screen builder and vue-form-elements.

## Related Tickets & Packages
- [FOUR-6101](https://processmaker.atlassian.net/browse/FOUR-6101)