### PR TITLE
Modified image code so forgot password pages now reflect custom UI logos

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -8,8 +8,17 @@
 
 <div align="container">
   <div align="center" class="p-5">
-    <img class="mb-4" src={{asset(env('LOGIN_LOGO_PATH', '/img/processmaker_login.png'))}}>
-     <h3>{{__('Forgot Your Password?')}}</h3>
+    @php
+      $loginLogo = \ProcessMaker\Models\Setting::getLogin();
+      $isDefault = \ProcessMaker\Models\Setting::loginIsDefault();
+      if ($isDefault) {
+          $class = 'login-logo-default';
+      } else {
+          $class = 'login-logo-custom';
+      }
+    @endphp
+    <img src={{$loginLogo}} alt="{{ config('logo-alt-text', 'ProcessMaker') }}" class="{{ $class }}">
+    <h3>{{__('Forgot Your Password?')}}</h3>
     <p>{{__("Enter your email address and we'll send you a reset link.")}}</p>
   </div>
 

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -7,7 +7,16 @@
 @section('content')
 <div align="center">
   <div class="formContainer">
-    <img src="/img/processmaker_login.png">
+    @php
+      $loginLogo = \ProcessMaker\Models\Setting::getLogin();
+      $isDefault = \ProcessMaker\Models\Setting::loginIsDefault();
+      if ($isDefault) {
+          $class = 'login-logo-default';
+      } else {
+          $class = 'login-logo-custom';
+      }
+    @endphp
+    <img src={{$loginLogo}} alt="{{ config('logo-alt-text', 'ProcessMaker') }}" class="{{ $class }}">
     <h3>{{__('Reset Your Password')}}</h3>
     <form role="form" class="form" method="POST" action="{{ url('/password/reset') }}">
       {{ csrf_field() }}

--- a/resources/views/auth/passwords/success.blade.php
+++ b/resources/views/auth/passwords/success.blade.php
@@ -3,7 +3,16 @@
 @section('content')
 <div align="center">
   <div class="formContainer">
-    <img src="/img/processmaker_login.png">
+    @php
+      $loginLogo = \ProcessMaker\Models\Setting::getLogin();
+      $isDefault = \ProcessMaker\Models\Setting::loginIsDefault();
+      if ($isDefault) {
+          $class = 'login-logo-default';
+      } else {
+          $class = 'login-logo-custom';
+      }
+    @endphp
+    <img src={{$loginLogo}} alt="{{ config('logo-alt-text', 'ProcessMaker') }}" class="{{ $class }}">
     <div class="form" align="center">
       <div class="form-group">
         <small>


### PR DESCRIPTION
## Issue & Reproduction Steps
When a customer has modified the Custom Login Logo, the server still shows the default ProcessMaker image when going through the Forgot Password flow.

## Solution
Took the image code from the login.blade.php page and applied it to the email.blade, reset.blade, and success.blade php files.

## How to Test
1. Upload a new Custom Login Logo in the `/admin/customize-ui` page
2. Log out, verify the new logo shows
3. Click "Forgot Password?" link and enter your email to start the password reset flow
4. Ensure the forgot password page, the password reset page, and the password reset success page all show the new logo

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6407
- https://processmaker.atlassian.net/wiki/spaces/PM4/pages/2718990337/Dynamic+UI+1.4.0+-+Menu+Enhancements#Forgot-Password-Page-Icon-Update

## Code Review Checklist
- [✅] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [❓] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [❌] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [✅] This solution fixes the bug reported in the original ticket.
- [✅] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [✅] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [✅] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [✅] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [✅] This ticket conforms to the PRD associated with this part of ProcessMaker.
