### PR TITLE
Fix: Api 'Delete' method with Request Files

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -343,7 +343,7 @@ class ProcessRequestFileController extends Controller
      */
     public function destroy(Request $laravel_request, ProcessRequest $request, Media $file)
     {
-        $request->getMedia()->firstWhere('id', $file->id)->destroy();
+        $request->getMedia()->firstWhere('id', $file->id)->delete();
         return response([], 204);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket: [FOUR-5697](https://processmaker.atlassian.net/browse/FOUR-5697)

Error is returned when using the API to delete a request file.

**Steps to Reproduce:**

1. Start a request that contains at least one uploaded file.
2. Delete the uploaded file using the following API: /requests/{request_id}/files/{file_id} Delete all media associate a request.


## Solution
- 'To few arguments' errors were being returned with the `destroy()` method, update the query to use the `delete()` method instead

## How to Test
Test the steps above

**Video**

https://user-images.githubusercontent.com/52755494/173419700-030087e5-e8ca-484d-909a-d05f07f19c01.mov



## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
