### PR TITLE
Script Executor Refactor - Make SDK optional

### DIFF
--- a/ProcessMaker/Console/Commands/BuildScriptExecutors.php
+++ b/ProcessMaker/Console/Commands/BuildScriptExecutors.php
@@ -16,7 +16,11 @@ class BuildScriptExecutors extends Command
      *
      * @var string
      */
-    protected $signature = 'processmaker:build-script-executor {lang} {user?} {--rebuild} {--sdk}';
+    protected $signature = 'processmaker:build-script-executor
+                            {lang : Script executor language}
+                            {user? : user waiting for the push notification }
+                            {--rebuild : Rebuild the script executor }
+                            {--sdk : Build SDK before to build script executor}';
 
     /**
      * The console command description.

--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -7,6 +7,7 @@ use ProcessMaker\Traits\HasVersioning;
 use Illuminate\Validation\Rule;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use ProcessMaker\Exception\ScriptLanguageNotSupported;
+use ProcessMaker\Facades\Docker;
 
 /**
  * Represents an Eloquent model of a Script Executor
@@ -191,7 +192,7 @@ class ScriptExecutor extends Model
 
     public static function listOfExecutorImages($filterByLanguage = null)
     {
-        exec('docker images | awk \'{r=$1":"$2; print r}\'', $result);
+        exec(Docker::command() . ' images | awk \'{r=$1":"$2; print r}\'', $result);
 
         $instance = config('app.instance');
         return array_values(array_filter($result, function($image) use ($filterByLanguage, $instance) {

--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -68,6 +68,9 @@ class ScriptExecutor extends Model
         }
 
         if ($initialExecutor) {
+            // Reinstalling docker executor should skip default config.
+            unset($params['config']);
+
             $initialExecutor->update($params);
         } else {
             $initialExecutor = self::create($params);


### PR DESCRIPTION
## Improvement
- In order to speed up the installation process, this PR proposes to move the SDK building into the docker executor logic.

## How to Test
Nothing changes, all testing must work exactly the same than the previous version.

## Related Tickets & Packages
N/A

## Documentation changes required
A new option was added to the command: **--sdk**
```
Usage:
  processmaker:build-script-executor [options] [--] <lang> [<user>]

Arguments:
  lang                  Script executor language
  user                  user waiting for the push notification

Options:
      --rebuild         Rebuild the script executor
      --sdk             Build SDK before to build script executor
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --env[=ENV]       The environment the command should run under
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```
## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
