### PR TITLE
Bugfix FOUR-6006 - Warnings are displayed when running scripts breaking script execution

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -47,7 +47,7 @@ use Throwable;
  *   schema="processRequestTokenEditable",
  *   @OA\Property(property="user_id", type="string", format="id"),
  *   @OA\Property(property="status", type="string"),
- *   @OA\Property(property="due_at", type="date-time"),
+ *   @OA\Property(property="due_at", type="string", format="date-time"),
  *   @OA\Property(property="initiated_at", type="string", format="date-time"),
  *   @OA\Property(property="riskchanges_at", type="string", format="date-time"),
  *   @OA\Property(property="subprocess_start_event_id", type="string"),
@@ -70,9 +70,9 @@ use Throwable;
  *          @OA\Property(property="initiated_at", type="string", format="date-time"),
  *          @OA\Property(property="advanceStatus", type="string"),
  *          @OA\Property(property="due_notified", type="integer"),
- *          @OA\Property(property="user", @OA\Schema(ref="#/components/schemas/users")),
- *          @OA\Property(property="process", @OA\Schema(ref="#/components/schemas/Process")),
- *          @OA\Property(property="process_request", @OA\Schema(ref="#/components/schemas/processRequest")),
+ *          @OA\Property(property="user", type="object", @OA\Schema(ref="#/components/schemas/users")),
+ *          @OA\Property(property="process", type="object", @OA\Schema(ref="#/components/schemas/Process")),
+ *          @OA\Property(property="process_request", type="object", @OA\Schema(ref="#/components/schemas/processRequest")),
  *       )
  *   }
  * )

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -75,7 +75,7 @@ class User extends Authenticatable implements HasMedia
      *   @OA\Property(property="delegation_user_id", type="string", format="id"),
      *   @OA\Property(property="manager_id", type="string", format="id"),
      *   @OA\Property(property="meta", type="object", additionalProperties=true),
-	 *   @OA\Property(property="force_change_password", type="boolean"),
+	   *   @OA\Property(property="force_change_password", type="boolean"),
      * ),
      * @OA\Schema(
      *   schema="users",


### PR DESCRIPTION
## Issue & Reproduction Steps

Warnings are displayed when running scripts breaking script execution

1. Create a new script
2. Use the following code:

```php
$apiInstance = $api->tasks();
$result = $apiInstance->getTasks();
return $result;
```

3. Run the Script

## Solution
- If the type is not defined it is set to "string"  by default. That causes settyype problems. The solution is to explicitly set the type of the property.

## How to Test
- Rebuild the PHP Executor at `/admin/script-executors`.
- Follow the steps of above.

## Related Tickets & Packages
- [FOUR-6006](https://processmaker.atlassian.net/browse/FOUR-6006)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
