### PR TITLE
FOUR-5432: Fix for branch 4.2.31

### DIFF
--- a/ProcessMaker/Jobs/SanitizeUsernames.php
+++ b/ProcessMaker/Jobs/SanitizeUsernames.php
@@ -111,7 +111,7 @@ class SanitizeUsernames implements ShouldQueue
         $i = 0;
 
         $generator = static function () use ($username, &$i): string {
-            if (blank($username = mb_ereg_replace('[^\p{L}\p{N}\-_\s]', '', $username))) {
+            if (blank($username = mb_ereg_replace('[^\p{L}\p{N}\-_\.\@\+\s]', '', $username))) {
                 $username = 'user_'.random_bytes(4);
             }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Keeps @ + . - _  characters in user names when the migration that fixes user names is run

## Solution
- Added the allowed characters in the regular expressions

## How to Test
Add users that use  not allowed characters and allowed characters, for example
user1.lastname1
user2@lastname2
user3_lastname3
user4-lastname4
user5+lastname5
user6~lastname6
user7 lastname7
user8*lastname8
user9^lastname9

After the upgrade the user names should be modified to (not allowed characters must be removed):
user1.lastname1
user2@lastname2
user3_lastname3
user4-lastname4
user5+lastname5
user6lastname6
user7lastname7
user8lastname8
user9lastname9





## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-6432](https://processmaker.atlassian.net/browse/FOUR-6432)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
