### PR TITLE
Bugfix/FOUR-6409: Form Validation Error messaging not displaying correctly

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -27,13 +27,6 @@
         <b-row class="h-100 m-0" id="preview" v-show="displayPreview">
 
           <b-col class="overflow-auto h-100">
-            <div v-if="$store.getters['globalErrorsModule/isValidScreen'] === false" class="alert alert-danger mt-3">
-              <i class="fas fa-exclamation-circle"/>
-              {{ $store.getters['globalErrorsModule/getErrorMessage'] }}
-              <button type="button" class="close" aria-label="Close" @click="$store.dispatch('globalErrorsModule/close')">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
             <vue-form-renderer
               v-if="renderComponent === 'task-screen'"
               ref="renderer"


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:
Please see: https://processmaker.atlassian.net/browse/FOUR-6409

- Create a form with some elements
- Mark some of them as required

Current behavior: When start a new request and start the task or go to preview in screen builder, the validation errors appears before clicking on submit, and not showing as alert

Expected behavior: Validation error message shouldn't appear until the submit button is pressed. Message should appear as the "success" alert when submitting a form

## Solution
- When submit a form, while checking if is valid, if not show ProcessMaker.alert()
- Removed old alert divs

**Working video**

https://user-images.githubusercontent.com/90727999/176259628-06e0ccc5-f2f8-4022-9fbe-dcf215ebb6a4.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-6409](https://processmaker.atlassian.net/browse/FOUR-6409)
- [Screen-builder PR](https://github.com/ProcessMaker/screen-builder/pull/1235)
- ProcessMaker core PR
- [Package-collections PR](https://github.com/ProcessMaker/package-collections/pull/314)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
