### PR TITLE
Bugfix FOUR-6344 Modify swagger documentation for Users API filter

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -36,7 +36,12 @@ class UserController extends Controller
      *     operationId="getUsers",
      *     tags={"Users"},
      *     @OA\Parameter(ref="#/components/parameters/status"),
-     *     @OA\Parameter(ref="#/components/parameters/filter"),
+     *     @OA\Parameter(
+     *         name="filter",
+     *         in="query",
+     *         description="Filter results by string. Searches First Name, Last Name, Email and Username.",
+     *         @OA\Schema(type="string"),
+     *     ),
      *     @OA\Parameter(ref="#/components/parameters/order_by"),
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
      *     @OA\Parameter(ref="#/components/parameters/per_page"),
@@ -80,7 +85,7 @@ class UserController extends Controller
         if (!empty($filter)) {
             $filter = '%' . $filter . '%';
             $query->where(function ($query) use ($filter) {
-                $query->Where('username', 'like', $filter)
+                $query->where('username', 'like', $filter)
                     ->orWhere('firstname', 'like', $filter)
                     ->orWhere('lastname', 'like', $filter)
                     ->orWhere('email', 'like', $filter);


### PR DESCRIPTION
## Issue & Reproduction Steps

The Swagger documentation for the User API needs to be updated to reflect that only these keys are searched.

- First Name
- Last Name
- Username
- Email

## Solution
- Updated description for Users API filter parameter.

## How to Test
- Run `php artisan l5-swagger:generate`.
- Go to `/api/documentation`.
- Test the getUsers endpoint.

## Related Tickets & Packages
- [FOUR-6344](https://processmaker.atlassian.net/browse/FOUR-6344)
- [Saved Search Pull Request](https://github.com/ProcessMaker/package-savedsearch/pull/316)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.