### PR TITLE
FOUR-6383: Error to update environment variables

### DIFF
--- a/resources/views/processes/environment-variables/edit.blade.php
+++ b/resources/views/processes/environment-variables/edit.blade.php
@@ -36,8 +36,8 @@
                     </div>
                     <div class="form-group">
                         {!!Form::label('value', __('Value'))!!}
-                        {!!Form::text('value', null,['class'=> 'form-control', 'v-model'=> 'formData.value',
-                        'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.value}'])!!}
+                        {!!Form::textArea('value', null, ['class'=> 'form-control', 'v-model'=> 'formData.value',
+                        'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.description}','rows'=>3, 'required', 'aria-required' => 'true'])!!}
                         <small class="form-text text-muted">{{__('For security purposes, this field will always appear empty') }}</small>
                         <div class="invalid-feedback" role="alert" v-for="value in errors.value">@{{value}}</div>
                     </div>


### PR DESCRIPTION
## Issue & Reproduction Steps
When editing an environment variable, a line input was used to set its value. This controls strips any line break wrote in it, so the edited environment variable lost any typed line break. 

## Solution
- Use a text area instead of a line input for the value of an environment variable.

## How to Test
- Create an environment variable called 'env_var' it must contain  line breaks
- Use an script to get the environment variable. The code for the script should be:
`return return getenv('env_var');`
- Verify that the returned value by the script contains line breaks (\n)
- Edit the environment variable and put another string with line breaks
- Run the script and verify again that the returned value by the script contains line breaks (\n)

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-6383](https://processmaker.atlassian.net/browse/FOUR-6383)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
