### PR TITLE
FOUR-6484 & FOUR-6485: patch-1-cartegraph webentry fixes

### DIFF
--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -32,16 +32,13 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \ProcessMaker\Http\Middleware\SessionStarted::class,
-            \Illuminate\Session\Middleware\AuthenticateSession::class,
+            \ProcessMaker\Http\Middleware\AuthenticateSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             //\ProcessMaker\Http\Middleware\VerifyCsrfToken::class,
             \ProcessMaker\Http\Middleware\SetLocale::class,       // This is disabled until all routes are handled by our new engine
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \ProcessMaker\Http\Middleware\GenerateMenus::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
-
-
-
         ],
         'api' => [
             // API Middleware is defined with routeMiddleware below.

--- a/ProcessMaker/Http/Middleware/AuthenticateSession.php
+++ b/ProcessMaker/Http/Middleware/AuthenticateSession.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+use BadMethodCallException;
+use Illuminate\Session\Middleware\AuthenticateSession as BaseAuthenticateSession;
+
+class AuthenticateSession extends BaseAuthenticateSession
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     *
+     * @return mixed
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function handle($request, Closure $next)
+    {
+        if (! $request->hasSession() || ! $request->user()) {
+            return $next($request);
+        }
+
+        // On occasion, the "auth" property is an empty array
+        // and trying to call the viaRemember() method off of
+        // it will throw a fatal error, this is a work around
+        try {
+            if ($this->auth->viaRemember()) {
+                $passwordHash = explode('|', $request->cookies->get($this->auth->getRecallerName()))[2] ?? null;
+
+                if (! $passwordHash || $passwordHash != $request->user()->getAuthPassword()) {
+                    $this->logout($request);
+                }
+            }
+        } catch (BadMethodCallException $exception) {
+            return $next($request);
+        }
+
+        if (! $request->session()->has('password_hash')) {
+            $this->storePasswordHashInSession($request);
+        }
+
+        if ($request->session()->get('password_hash') !== $request->user()->getAuthPassword()) {
+            $this->logout($request);
+        }
+
+        return tap($next($request), function () use ($request) {
+            $this->storePasswordHashInSession($request);
+        });
+    }
+}


### PR DESCRIPTION
## Environment Setup
- Set core to this PR's branch, bugfix/FOUR-6485.
- Set package-webentry to [bugfix/FOUR-6485](https://github.com/ProcessMaker/package-webentry/pull/150).
- Set package-collections to patch-1-cartegraph.
- Set package-savedsearch to patch-1-cartegraph.

## Issue(s) & Reproduction Steps

**Note**: This branch fixes two (2) tickets in Jira.

For [FOUR-6485](https://processmaker.atlassian.net/browse/FOUR-6485):
1. Create a custom webentry URL.
2. Copy the standard webentry URL, then switch it over to a custom URL and save (as well as save the process).
3. Visit the standard webentry URL.
4. Notice the standard URL still works as well as the custom webentry URL.

For [FOUR-6484](https://processmaker.atlassian.net/browse/FOUR-6484):

- Create a custom URL with a segment and one or more URL variables.
- Save the webentry URL and save the processes.
- Attempt to visit the URL without the expected variable(s). 
- You’ll notice you receive a 500 error, which is the HTTP response code for internal server error.

## Solution
- When a standard webentry URL is visited, there is now a check to see if a custom webentry url exists. If one does exists, then it returns a 404 error and exits (since the user should be using the custom url, not the standard).
- The AuthenticateSession middleware was extended from the framework to catch an uncaught exception which was thrown in specific situations using webentry, including when visiting a custom webentry url which expects variables that aren't present.

## How to Test
- When visiting a standard webentry url that has a custom url set, you should now encounter a 404.
- When visiting a custom webentry route that expects variables (but the url you're using doesn't have them), you should npw encounter a 404 instead of a 500.

## Related Tickets & Packages
- Ticket: https://processmaker.atlassian.net/browse/FOUR-6485
- Ticket: https://processmaker.atlassian.net/browse/FOUR-6484
- PR: https://github.com/ProcessMaker/package-webentry/pull/150

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
