### PR TITLE
FOUR-6466: Web entry timeout redirect in Cartegraph instances (cartegraph)

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -254,6 +254,7 @@ if (userID) {
     let timeoutScript = document.head.querySelector("meta[name=\"timeout-worker\"]").content;
     window.ProcessMaker.AccountTimeoutLength = parseInt(eval(document.head.querySelector("meta[name=\"timeout-length\"]").content));
     window.ProcessMaker.AccountTimeoutWarnSeconds = parseInt(document.head.querySelector("meta[name=\"timeout-warn-seconds\"]").content);
+    window.ProcessMaker.AccountTimeoutEnabled = document.head.querySelector("meta[name=\"timeout-enabled\"]") ? parseInt(document.head.querySelector("meta[name=\"timeout-enabled\"]").content) : 1;
     window.ProcessMaker.AccountTimeoutWorker = new Worker(timeoutScript);
     window.ProcessMaker.AccountTimeoutWorker.addEventListener('message', function (e) {
         if (e.data.method === 'countdown') {
@@ -273,7 +274,8 @@ if (userID) {
         method: 'start',
         data: {
             timeout: window.ProcessMaker.AccountTimeoutLength,
-            warnSeconds: window.ProcessMaker.AccountTimeoutWarnSeconds
+            warnSeconds: window.ProcessMaker.AccountTimeoutWarnSeconds,
+            enabled: window.ProcessMaker.AccountTimeoutEnabled
         }
     });
 }

--- a/resources/js/timeout.js
+++ b/resources/js/timeout.js
@@ -12,9 +12,13 @@ self.addEventListener('message', function (e) {
 });
 
 self.start = function (data) {
+  // Exit if timeout control is not enabled
+  if (!data.enabled) {
+    return;
+  }
   var timestampAtStart = Math.floor(Date.now() / 1000);
   var timeoutAt = timestampAtStart + (data.timeout * 60);
-  
+
   clearInterval(self.interval);
   self.interval = setInterval(function () {
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Create an Anonymous Web Entry. Wait until the session timeout time happens.

## Solution
-  A new property that determines if a webentry is anonymous or not has been added to the model
-  To set the time out this property isAnonymous sets a header to enable/disable the time out control


## How to Test
Create an Anonymous Web Entry. Wait until the session timeout time happens and verify that the pages is not redirected to the login page. 
To speed up the test, change the default session time out in .env or editing config/session.php to something like  
'lifetime' => env('SESSION_LIFETIME', 10) 
that is 10 minutes by default.

Test with embedded and not embedded web entries and with  web entries in start events and tasks.

The attached zip file has a process with the 4 combinations. Put the html files in processmaber/public  to open them directly in the browser (e.g. http://server/embedded_auth_start.html)

[webentry.zip](https://github.com/ProcessMaker/processmaker/files/9085477/webentry.zip)


## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-6466](https://processmaker.atlassian.net/browse/FOUR-6466)
PR for webentry: [https://github.com/ProcessMaker/package-webentry/pull/153](https://github.com/ProcessMaker/package-webentry/pull/153)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.