### PR TITLE
Content Injection - Payload reflected in the page body

### DIFF
--- a/ProcessMaker/Http/Resources/ApiCollection.php
+++ b/ProcessMaker/Http/Resources/ApiCollection.php
@@ -69,7 +69,7 @@ class ApiCollection extends ResourceCollection
         $payload = [
             'data' => $this->collection,
             'meta' => [
-                'filter' => $request->input('filter', ''),
+                'filter' => htmlentities($request->input('filter', '')),
                 'sort_by' => $request->input('order_by', ''),
                 'sort_order' => $request->input('order_direction', ''),
                 /**


### PR DESCRIPTION
## Issue & Reproduction Steps

The query parameter filter that is returned by the ApiCollection shows untrusted or unfiltered data.

1. Go to: /requests/saved-searches/
2. Click on View.
3. Open browser Web Developer Tools
4. Introduce Search < in the Search filter.
5. Go to Network - Response

You may notice that in the Response `meta.filter` will have the value Search `<` instead of Search `&lt`.

Reported endpoints:

```
GET /api/1.0/saved-searches?include=reports%2Cuser_options&page=1&per_page=10&filter=<meta content=was-tnb-leb><div 
style="was-tnb-leb"><a style="was-tnb-leb"><style id="was-tnb-leb"
>&type=request&subset=mine&order_by=title&order_direction=asc HTTP/2

 GET /api/1.0/saved-searches/569/results?page=1&per_page=10&include=process%2Cparticipants%2Cdata&pmql=%28status%20%3D%
20%22In%20Progress%22%20OR%20status%20%3D%20%22Completed%22%20OR%20status%20%3D%20%22Error%22%20OR%20status%20%3D%20%
22Canceled%22%29&filter=<iframe src=was-tnb-leb></iframe>&order_by=id&order_direction=DESC HTTP/2
```

## Solution
- Now the ApiCollection converts all applicable characters to HTML entities, i.e. '<' to '&lt'

## How to Test
- Please follow the reproduction of above.
- As an extra, it would be ideal to know with which tool the Security Scan was made in order to be able to test locally.

## Related Tickets & Packages
- [FOUR-6528](https://processmaker.atlassian.net/browse/FOUR-6528)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
