### PR TITLE
FOUR-1267 Importing a screen with scripts (watchers) does not assign a user to the script

### DIFF
--- a/ProcessMaker/Jobs/ImportScreen.php
+++ b/ProcessMaker/Jobs/ImportScreen.php
@@ -47,6 +47,14 @@ class ImportScreen extends ImportProcess
         $this->prepareStatus('screens', count($this->file->screens));
         foreach ($this->file->screens as $screen) {
             $new[Screen::class][$screen->id] = $this->saveScreen($screen);
+            //determine if the screen has watchers
+            if (property_exists($screen, "watchers")) {
+                $names = [];
+                foreach ($screen->watchers as $watcher) {
+                    $names[] = $watcher->name;
+                }
+                $this->status['screens']['info'] = __('Please assign a run script user to: ') . implode(', ', $names);
+            }
         }
         $this->finishStatus('screens');
 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -576,6 +576,7 @@
   "Phone": "Phone",
   "Placeholder Text": "Placeholder Text",
   "Placeholder": "Placeholder",
+  "Please assign a run script user to: ": "Please assign a run script user to: ",
   "Please change your account password": "Please change your account password",
   "Please contact your administrator to get started.": "Please contact your administrator to get started.",
   "Please log in to continue your work on this page.": "Please log in to continue your work on this page.",

--- a/resources/views/processes/screens/import.blade.php
+++ b/resources/views/processes/screens/import.blade.php
@@ -48,7 +48,8 @@
             <ul v-show="options" class="list-unstyled">
                 <li v-for="item in options">
                     <i :class="item.success ? 'fas fa-check text-success' : 'fas fa-times text-danger'"></i>
-                    @{{item.label}} - @{{item.message}}
+                    @{{item.label}} - @{{item.message}} 
+                    <span v-if="item.info" :class="'text-danger d-block'"> @{{item.info}}.</span>
                 </li>
             </ul>
             <div slot="modal-footer" class="w-100" align="right">


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Have a screen that has a watcher configured and working correctly
2. import the screen
3. Open the imported screen
4. Click the preview option
5. Fill the field that triggers the watcher
6. A message error is displayed

## Solution
- Display a warning message when a screen is imported, and the same has watchers assigned, so the process architect will be informed that the script related needs to assign a user to run correctly.

## How to Test
After importing the screen, if it has watchers assigned in the import summary panel, a warning message is displayed. Before the changes, the message displayed indicates that no errors/warnings were detected in the importation. This is not true because it is required to have the architect's intervention to complete the setup.

![Import Screen Summary Panel](https://user-images.githubusercontent.com/1739152/180827599-fde85550-7e26-450c-8743-218777956ec5.png)

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-1267](https://processmaker.atlassian.net/browse/FOUR-1267)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the Potentila Fix recommended in the ticket.
