### PR TITLE
FOUR-6509: Problem with Record list and Select List Display

### DIFF
--- a/resources/js/components/common/mixins/accessibility.js
+++ b/resources/js/components/common/mixins/accessibility.js
@@ -49,7 +49,6 @@ export default {
 
       // If there is an element to focus on, then do so
       if (focusableElement instanceof HTMLElement) {
-          console.log('haciendo foco');
           //do not set focus() if it is a vue-multiselect
           const parentVue = this.findHtmlElementParentVueComponent(focusableElement);
           if (parentVue !== null && parentVue.$options.name == 'vue-multiselect') {

--- a/resources/js/components/common/mixins/accessibility.js
+++ b/resources/js/components/common/mixins/accessibility.js
@@ -49,8 +49,25 @@ export default {
 
       // If there is an element to focus on, then do so
       if (focusableElement instanceof HTMLElement) {
+          console.log('haciendo foco');
+          //do not set focus() if it is a vue-multiselect
+          const parentVue = this.findHtmlElementParentVueComponent(focusableElement);
+          if (parentVue !== null && parentVue.$options.name == 'vue-multiselect') {
+              return;
+          }
         focusableElement.focus()
       }
+    },
+    findHtmlElementParentVueComponent(element) {
+        if(element === undefined) {
+            return null; 
+        }
+        if ('__vue__' in element) {
+            return element.__vue__; 
+        }
+        else {
+            return this.findHtmlElementParentVueComponent(element.parentNode);
+        }
     },
     hasCustomFocusErrors() {
       if (this.$root._hasCustomFocusErrors) {


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a screen with a record list
- The sub-screen used for the record list must have a Select List as **its first control** (at the top of the screen)
- Add a record to the record list. 
The issue is that  Select List is displayed expanded when the record list pop up appears.

## Solution
- If the first element is a select list, do not force the focus over it.


## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-6509](https://processmaker.atlassian.net/browse/FOUR-6509)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
