### PR TITLE
FOUR-6505

### DIFF
--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -35,6 +35,7 @@ export default {
         //Handler to properly format date/time columns according to configuration of user
         formatDateUser(value, format) {
             let config = '';
+
             if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user && ProcessMaker.user.datetime_format) {
                 if (format === 'datetime') {
                     config = ProcessMaker.user.datetime_format;
@@ -43,10 +44,16 @@ export default {
                     config = ProcessMaker.user.datetime_format.replace(/[\sHh:msaAzZ]/g, '');
                 }
             }
+
             if (value) {
-                return window.moment(value)
+                if (moment(value).isValid()) {
+                    return window.moment(value)
                     .format(config);
+                }
+
+                return value;
             }
+
             return "n/a";
         },
         // Data manager takes new sorting and calls our fetch method

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -141,16 +141,11 @@ export default {
           field.field = column.field;
         }
 
-        let excludedFields = [
-          "initiated_at",
-          "completed_at",
-        ];
-
-        if (column.format === 'datetime' && !excludedFields.includes(column.field)) {
+        if (column.format === 'datetime') {
           field.callback = 'formatDateUser|datetime';
         }
 
-        if (column.format === 'date' && !excludedFields.includes(column.field)) {
+        if (column.format === 'date') {
           field.callback = 'formatDateUser|date';
         }
 
@@ -203,12 +198,14 @@ export default {
           {
             "label": "Started",
             "field": "initiated_at",
+            "format": "datetime",
             "sortable": true,
             "default": true
           },
           {
             "label": "Completed",
             "field": "completed_at",
+            "format": "datetime",
             "sortable": true,
             "default": true
           }
@@ -254,13 +251,6 @@ export default {
       data.meta.to = data.meta.from + data.meta.count;
       data.data = this.jsonRows(data.data);
       for (let record of data.data) {
-        //Format dates
-        record["initiated_at"] = this.formatDate(record["initiated_at"]);
-        if (record["completed_at"]) {
-          record["completed_at"] = this.formatDate(record["completed_at"]);
-        } else {
-          record["completed_at"] = "";
-        }
         //format Status
         record["status"] = this.formatStatus(record["status"]);
       }

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -141,12 +141,17 @@ export default {
           field.field = column.field;
         }
 
-        if (column.format === 'datetime') {
-        field.callback = 'formatDateUser|datetime';
+        let excludedFields = [
+          "initiated_at",
+          "completed_at",
+        ];
+
+        if (column.format === 'datetime' && !excludedFields.includes(column.field)) {
+          field.callback = 'formatDateUser|datetime';
         }
 
-        if (column.format === 'date') {
-        field.callback = 'formatDateUser|date';
+        if (column.format === 'date' && !excludedFields.includes(column.field)) {
+          field.callback = 'formatDateUser|date';
         }
 
         if (column.sortable === true && !field.sortField) {


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Have cases to show in different cases list
2. Make sure that the package-savedsearch was enable
3. Define a format that starts with a **day** like d/m/Y, d.m.Y H:i, d/m/Y h:i A, d/m/Y H:i
4. Review the column **Started** in **Requests** -> My Request, In Progress, Completed, All Request
7. Review the column **Started** in **Requests** -> Started by me, In Progress, Completed, All Request, Saved
![Started-By-Me-ProcessMaker(issue)](https://user-images.githubusercontent.com/42388723/181308715-08fa67d7-e269-4d26-9bf3-b4b048621658.png)
![All-Requests-ProcessMaker(issue)](https://user-images.githubusercontent.com/42388723/181308741-85d72e03-66cf-4467-9905-5cd6928ad32f.png)

## Solution
- The column DateTime was formatted before and we tried to reformat again the moment return an Invalid Date, this occurs when the format starts with **day**
- I check if the isValid() to applied the format
![Started-By-Me-ProcessMaker](https://user-images.githubusercontent.com/42388723/181309831-e7054900-9f0a-4855-a6d4-bebd19d36689.png)
![All-Requests-ProcessMaker](https://user-images.githubusercontent.com/42388723/181309861-43407e81-b045-4767-a8e7-2c15b04c9ea6.png)
![All-Requests-ProcessMaker(savedsearch)](https://user-images.githubusercontent.com/42388723/181309884-c3be6ef9-0f17-4ed8-97db-2336fb956304.png)
![Completed-Requests-ProcessMaker](https://user-images.githubusercontent.com/42388723/181309908-760052a9-a85b-4d45-be40-982abdd6552f.png)
![My-Requests-ProcessMaker](https://user-images.githubusercontent.com/42388723/181310012-6dabc095-1007-4c34-9849-97d52253dd6a.png)

## How to Test
1. Have cases to show in different cases list
6. Enable the package-saved search
7. Review the column **Started**, **Completed** in **Requests** -> My Request, In Progress, Completed, All Request
8. Review the column **Started**, **Completed** in **Requests** -> Started by me, In Progress, Completed, All Request, Saved searches
9. Review the column **Due** in **Tasks** -> To Do

## Related Tickets & Packages
- [FOUR-6505](https://processmaker.atlassian.net/browse/FOUR-6505)
- Requires: https://github.com/ProcessMaker/package-savedsearch/pull/322

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
