### PR TITLE
Keeps Navbar Profile displayed on small screens

### DIFF
--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -95,23 +95,23 @@
                 <notifications id="navbar-notifications-button" v-bind:is="'notifications'" v-bind:messages="messages">
                 </notifications>
             @endcan
-            <li class="separator d-none d-lg-block"></li>
-            <li class="d-none d-lg-block">
-                @php
-                    $items = [];
-                    foreach ($dropdown_nav->items as $item ) {
-                        $newItem = new stdClass();
-                        $newItem->class = 'fas ' . $item->attr('icon') . ' fa-fw fa-lg';
-                        $newItem->title = $item->title;
-                        $newItem->url = $item->url();
-                        $items[] = $newItem;
-                    }
-                    $items = json_encode($items);
-                    $user = Auth::user();
-                @endphp
-                <navbar-profile :info="{{$user}}" :items="{{$items}}"></navbar-profile>
-            </li>
         </b-navbar-nav>
+        <div class="d-lg-block d-none separator"></div>
+        <div class="navbar-nav d-flex align-items-center">
+            @php
+                $items = [];
+                foreach ($dropdown_nav->items as $item ) {
+                    $newItem = new stdClass();
+                    $newItem->class = 'fas ' . $item->attr('icon') . ' fa-fw fa-lg';
+                    $newItem->title = $item->title;
+                    $newItem->url = $item->url();
+                    $items[] = $newItem;
+                }
+                $items = json_encode($items);
+                $user = Auth::user();
+            @endphp
+            <navbar-profile :info="{{$user}}" :items="{{$items}}"></navbar-profile>
+        </div>
     </b-collapse>
 </b-navbar>
 


### PR DESCRIPTION
In response to bug report https://github.com/ProcessMaker/processmaker/issues/4457

It was impossible to logout on small screen without typing the logout url.

Moved Navbar Profile and its separator outside of d-lg-none block.
Navbar Profile now appears at the bottom of the collapsible mobile menu on small devices.
Navbar Profile behavior is not changed on large screens

Fix:
![fix](https://user-images.githubusercontent.com/73987984/182336818-fe0b83f7-8fb7-44ed-92e4-909e603894b8.PNG)

Before fix:
![open-menu](https://user-images.githubusercontent.com/73987984/182336820-2a0ca6b1-edd0-4725-a630-534fbb5ceca8.PNG)
![page bottom](https://user-images.githubusercontent.com/73987984/182336823-a5b5dcc6-65f7-43fd-a9a4-0c6e803e141a.PNG)

![closed-menu](https://user-images.githubusercontent.com/73987984/182336810-35889f6c-ed24-474c-9e04-9d5da82c5ffb.PNG)
.