### PR TITLE
Fix overflow Redis usage

### DIFF
--- a/ProcessMaker/Helpers/SettingsHelper.php
+++ b/ProcessMaker/Helpers/SettingsHelper.php
@@ -4,6 +4,7 @@ use ProcessMaker\Models\Setting;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 
 if (!function_exists('settings')) {
     /**
@@ -22,7 +23,7 @@ if (!function_exists('settings')) {
             }
         }
 
-        $cache = cache()->tags('setting');
+        $cache = Cache::driver('array')->tags('setting');
 
         // Cache all Setting models
         if (!$cache->has('all')) {
@@ -54,7 +55,7 @@ if (!function_exists('flush_settings')) {
      */
     function flush_settings()
     {
-        cache()->tags('setting')->flush();
+        Cache::driver('array')->tags('setting')->flush();
 
         if (app()->configurationIsCached()) {
             Artisan::call('config:cache');
@@ -82,7 +83,7 @@ if (!function_exists('cache_settings')) {
     {
         try {
             if ((new Setting())->exists()) {
-                $cache = cache()->tags('setting');
+                $cache = Cache::driver('array')->tags('setting');
 
                 // If $force is true, flush the settings cache
                 if ($force) {
@@ -94,7 +95,7 @@ if (!function_exists('cache_settings')) {
                 // are available if they aren't cached yet
                 if (!$cache->has('all')) {
                     $settings = settings();
-                    $cache = cache()->tags('setting');
+                    $cache = Cache::driver('array')->tags('setting');
                 }
 
                 // Iterating through each and calling the byKey()

--- a/ProcessMaker/Helpers/SettingsHelper.php
+++ b/ProcessMaker/Helpers/SettingsHelper.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
 
 if (!function_exists('settings')) {
     /**
@@ -27,6 +28,9 @@ if (!function_exists('settings')) {
 
         // Cache all Setting models
         if (!$cache->has('all')) {
+            if (!Schema::hasTable('settings')) {
+                return [];
+            }
             $cache->put('all', Setting::get(), 60 * 60 * 24 * 7);
         }
 

--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -132,7 +132,7 @@ class Setting extends Model implements HasMedia
      */
     public static function byKey(string $key)
     {
-        $cache = cache()->tags('setting');
+        $cache = Cache::driver('array')->tags('setting');
 
         if ($cache->has($key)) {
             return $cache->get($key);
@@ -325,7 +325,7 @@ class Setting extends Model implements HasMedia
 
         return $url . '?id=' . bin2hex(random_bytes(16));
     }
-    
+
     public static function getFavicon()
     {
         //default icon
@@ -334,7 +334,7 @@ class Setting extends Model implements HasMedia
         $setting = self::byKey('css-override');
         if ($setting) {
             $mediaFile = $setting->getMedia(self::COLLECTION_CSS_FAVICON);
-    
+
             foreach ($mediaFile as $media) {
                 $url = $media->getFullUrl();
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
At Ellucian servers the Redis usage is too high, overflowing the network usage.
This is caused by the use of Redis Cache to store, get, update the settings.

## Solution
- Temporal solution. Use Array Cache to store the settings.

## How to Test
You need a PM4.2 with enterprise packages.

- Configure CACHE_DRIVER to redis (.env)
- Monitor the use of network while using ProcessMaker.
- Before the fix the usage of redis is high reaching 64MB 126MB while running a process and navigating through the menus (Requests, processes, ...)

## Related Tickets & Packages
- https://processmaker.atlassian.net/wiki/spaces/SCO/pages/2858844161/Ellucian+High+Redis+Network+traffic
- - https://processmaker.atlassian.net/browse/FOUR-6578

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
