### PR TITLE
Bugfix/four 6589

### DIFF
--- a/ProcessMaker/SanitizeHelper.php
+++ b/ProcessMaker/SanitizeHelper.php
@@ -37,7 +37,7 @@ class SanitizeHelper {
     {
         if (is_string($value) && $strip_tags) {
             // Remove most injectable code
-            $value = strip_tags($value);
+            $value = self::strip_tags($value);
 
             // Return the sanitized string
             return $value;
@@ -52,6 +52,26 @@ class SanitizeHelper {
 
         // Return the original value.
         return $value;
+    }
+
+    /**
+     * Strip php and html tags
+     * 
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function strip_tags($string)
+    {
+        // strip server side tags
+        $string = preg_replace('/(<\?((?!\?>)[\w\W])+\?>)/', '', $string);
+        // strip html comments
+        $string = preg_replace('/(<!--((?!-->)[\w\W])+-->)/', '', $string);
+        // strip html tags
+        $string = preg_replace('/<[a-zA-Z0-9]+[^>]*>/', '', $string);
+        $string = preg_replace('/<\/[a-zA-Z0-9]+[^>]*>/', '', $string);
+        $string = preg_replace('/<[a-zA-Z0-9]+[^>]*\/>/', '', $string);
+        return $string;
     }
 
     /**

--- a/tests/unit/ProcessMaker/SanitizeHelperTest.php
+++ b/tests/unit/ProcessMaker/SanitizeHelperTest.php
@@ -46,5 +46,6 @@ class SanitizeHelperTest extends TestCase
         $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <?
             echo \'\\\'\'
         ?> STUFF'));
+        $this->assertEquals('Next is a php code with closing tag  > <', SanitizeHelper::strip_tags('Next is a php code with closing tag <test of < character ' . "\n" . '<?php' . "\n" . ' class SanitizeHelper { > } ?>' . "\n" . ' < > > <'));
     }
 }

--- a/tests/unit/ProcessMaker/SanitizeHelperTest.php
+++ b/tests/unit/ProcessMaker/SanitizeHelperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ProcessMaker;
+
+use Tests\TestCase;
+
+class SanitizeHelperTest extends TestCase
+{
+    public function testSanitize()
+    {
+        $this->assertEquals('test', SanitizeHelper::strip_tags('<p>test</p>'));
+        $this->assertEquals('image:;', SanitizeHelper::strip_tags('image:<img src="https://example.com/image" />;'));
+        $this->assertEquals('br:;', SanitizeHelper::strip_tags('br:<br />;'));
+        $this->assertEquals('br:;', SanitizeHelper::strip_tags('br:<br/>;'));
+        $this->assertEquals('br:;', SanitizeHelper::strip_tags('br:<br>;'));
+        // This is not a valid html tag
+        $this->assertEquals('Monitor <90in', SanitizeHelper::strip_tags('Monitor <90in'));
+        // ADOA example
+        $equipment = <<<EQUIPMENT
+        Computer                         Serial # DE1013356        
+        Monitor (s)                     CNK51105LD      <AF3412-23
+        Keyboard (s)                    CNK51105LD      <FF0012-23
+        EQUIPMENT;
+        $this->assertEquals($equipment, SanitizeHelper::strip_tags($equipment));
+        // strip_tags tests
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <? cool < blah ?> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <? cool > blah ?> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <!-- cool < blah --> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <!-- cool > blah --> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <? echo \"\\\"\"?> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <? echo \'\\\'\'?> STUFF'));
+        $this->assertEquals('TESTS ?!!?!?!!!?!!', SanitizeHelper::strip_tags('TESTS ?!!?!?!!!?!!'));
+        // test including car returns
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <? cool 
+        < blah ?> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <? cool 
+        > blah ?> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <!-- cool 
+        < blah --> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <!--
+            cool > blah
+        --> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <?
+            echo \"\\\"\"
+        ?> STUFF'));
+        $this->assertEquals('NEAT  STUFF', SanitizeHelper::strip_tags('NEAT <?
+            echo \'\\\'\'
+        ?> STUFF'));
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
data_enconded is a computed property that contains an object encoded as JSON string. When a property of this object contains a < symbol, the form data is sanitized the json variable is truncated. The following is and example of the content of data_encoded that has the problem:

```
{
    "REQUEST_ID": 183681,
    "STATUS": "IN_PROGRESS",
    "USER_ID": 48252,
    "ADOA_RWA_REMOTE_AGREEMENT_VALID": "N",
    "ADOA_RWA_AGENCY_NAME": "DEPT OF ECONOMIC SECURITY",
    "ADOA_RWA_EMPLOYEE_NAME": "BEGAY, MARIE",
    "ADOA_RWA_EIN": "211913",
    "ADOA_RWA_POSITION": "SDE000022620",
    "ADOA_RWA_JOB_TITLE": "PROG SVC EVALR 2",
    "ADOA_RWA_FLSA": "Non-Exempt",
    "ADOA_RWA_TYPE_REQUEST": "NEW",
    "ADOA_RWA_STREET_ADDRESS": "5205 W Thunderbird W Rd. # 2054",
    "ADOA_RWA_CITY": "914",
    "ADOA_RWA_CITY_OTHER": null,
    "ADOA_RWA_STATE": "3",
    "ADOA_RWA_ZIP_CODE": "85306",
    "ADOA_RWA_FIXED_SCHEDULE": {
        "value": "FIXED",
        "content": "Fixed Schedule (indicate scheduled remote work days):"
    },
    "ADOA_RWA_FIXED_WEEK_1": [
        "MON",
        "TUE",
        "WED",
        "THU",
        "FRI"
    ],
    "ADOA_RWA_FIXED_WEEK_2": [],
    "ADOA_RWA_VAR_SCHEDULE_COMMENT": null,
    "ADOA_RWA_APPROVED": "am not",
    "ADOA_RWA_PHONE": null,
    "ADOA_RWA_EQUIPMENT": "Computer                      Serial # <DE1013356",
    "ADOA_RWA_PROVIDED": "The employee",
    "ADOA_RWA_NOT_APPLICABLE": true,
    "ADOA_RWA_NOT_APPLICABLE_TEXT": null,
    "ADOA_RWA_EMPLOYEE_SIGNATURE": "",
    "ADOA_RWA_EMPLOYEE_SIGNATURE_TEXT": "",
    "ADOA_RWA_EMPLOYEE_SIGNATURE_DATE": "",
    "ADOA_RWA_EMPLOYEE_EMAIL": "",
    "REQUEST_OLD": "",
    "EMPLOYEE_LAST_NAME": "BEGAY",
    "EMPLOYEE_FIRST_NAME": "MARIE",
    "EMPLOYEE_SUPERVISOR_POSITION": "SDE000001971",
    "EMA_EMPLOYEE_EIN": "211913",
    "EMA_EMPLOYEE_FIRST_NAME": "MARIE",
    "EMA_EMPLOYEE_LAST_NAME": "BEGAY"
}
```

## Solution
- Improve the strip_tags function used to sanitize the inputs. As same as the strip_tags php function it must remove `<html>` `<?php ?>` and `<!-- comment -->` tags.

## How to Test

1. Import the attached process
2. Run the process
3. In the ADOA_RWA_EQUIPMENT text area include a description that contains a < e.g. Computer                      Serial # <DE1013356
4. Submit the form
5. Note that the data_encoded value was truncated

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6589

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
