### PR TITLE
[FOUR-6593] Ethos Package is breaking Core CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,9 @@
         },
         "processmaker": {
             "build": "6f008378",
+            "custom": {
+                "package-ellucian-ethos": "1.6.0"
+            },
             "enterprise": {
                 "connector-docusign": "1.0.0",
                 "connector-pdf-print": "1.8.0",
@@ -103,7 +106,6 @@
                 "package-conversational-forms": "1.2.0",
                 "package-data-sources": "1.10.1",
                 "package-dynamic-ui": "1.4.0",
-                "package-ellucian-ethos": "1.6.0",
                 "package-files": "1.4.1",
                 "package-googleplaces": "1.2.0",
                 "package-process-documenter": "1.1.0",


### PR DESCRIPTION
## Issue & Reproduction Steps
CICD was broken due to a custom package being listed in the enterprise package property of composer.json. It was listed there to provide Cloud Ops with a way of programmatically installing the correct version of said package.

## Solution
Move the custom package to its own section. Could be used in the future by other custom packages without impacting CICD.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6593

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
