### PR TITLE
Bugfix/FOUR-6598: Remove Log Line from Conditional Start Events

### DIFF
--- a/ProcessMaker/Bpmn/Process.php
+++ b/ProcessMaker/Bpmn/Process.php
@@ -41,7 +41,6 @@ class Process extends ModelsProcess
             $key = '_process_' . $this->getOwnerDocument()->getModel()->getKey();
             $properties = Cache::store('global_variables')->get($key, []);
             $properties[$name] = $value;
-            \Log::info(['global_variables', $key, $properties]);
             try {
                 Cache::store('global_variables')->forever($key, $properties);
             } catch (\Throwable $e) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently, when the "Condition" field of a Conditional Start Event is empty it always evaluates to true. A workspace would constantly have script tasks running non stop and this would create huge log files: ~10GB per day.

In order to avoid huge log files, please remove the following line at ProcessMaker/Bpmn/Process.php line 44

## Solution
- Removed line 44 at ProcessMaker/Bpmn/Process.php

## Related Tickets & Packages
- [FOUR-6598](https://processmaker.atlassian.net/browse/FOUR-6598)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
