### PR TITLE
FOUR-6607: Border-radius on multiselect__tags field needed

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -120,7 +120,7 @@ button:focus.navbar-toggler {
 
 .multiselect .multiselect__tags {
   border-color: $form-control-border-color;
-  border-radius: $form-control-border-radius;
+  border-radius: 0.125em;
 }
 
 .multiselect__tags {
@@ -209,7 +209,7 @@ button:focus.navbar-toggler {
       .multiselect__tags {
         border-top-color: #ddd;
         border-bottom-width: 0;
-        border-radius: 0;
+        border-radius: 0.125em;
         height: 40px;
         max-height: 40px;
       }
@@ -255,7 +255,7 @@ button:focus.navbar-toggler {
       .multiselect__tags {
         border-left-color: #ddd;
         border-right-width: 0;
-        border-radius: 0;
+        border-radius: 0.125em;
         height: 40px;
         max-height: 40px;
       }


### PR DESCRIPTION
# Issue
Ticket: [FOUR-6607](https://processmaker.atlassian.net/browse/FOUR-6607)

There are currently no border-radius attributes on the multiselect field. It needs a border-radius of .125em to make it consistent with other screen elements, like the .card class used for our table.

# Solution
Updated border radius of `multiselect__tags` to 0.125em

# Current UI
<img width="1034" alt="Current UI" src="https://user-images.githubusercontent.com/73713665/186257549-1db856f1-a851-4e4a-b1fe-1be217901d61.png">

# Updated UI
<img width="1037" alt="Updated UI" src="https://user-images.githubusercontent.com/73713665/186257511-7c492f57-20e8-4c08-b60b-2846758b6a2b.png">

# How to Test
1. Update core branch to `bugfix/FOUR-6607`
2. Open local environment, go to Requests
3. Inspect the Process, Status, Requester, or Participants drop-down. The `multiselect__tags` field border-radius should be 0.125em.
4. You can inspect other multiselect dropdowns throughout the application. Packages such as package-savedsearch and package-data-sources use `multiselect__tags` fields in their configurations. The border-radius for those fields should be 0.125em as well.

# Related Tickets & Packages
- [FOUR-5110](https://processmaker.atlassian.net/browse/FOUR-5110) | Design Bugs

# Code Review Checklist
- [x]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x]  This solution fixes the bug reported in the original ticket.
- [x]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x]  This ticket conforms to the PRD associated with this part of ProcessMaker.