### PR TITLE
FOUR-6642: The .text-muted class for helper text is a non-accessible color

### DIFF
--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -130,7 +130,7 @@ $custom-range-track-bg: #d9dee2;
 $footer-text: white;
 
 //text
-$text-muted: #788793;
+$text-muted: #6c757d;
 
 //This z-index for the alert popup
 $alertZIndex: 1051;


### PR DESCRIPTION
# Issue
Ticket: [FOUR-6642](https://processmaker.atlassian.net/browse/FOUR-6642)

There are some instances in ProcessMaker where the .text-muted class has its color set to `#788793`. This shade of grey does not meet web accessibility contrast standards.

# Solution
The color of the .text-muted class has been reset to the Bootstrap default of `#6c757d`.

# Current UI
![CurrentUI](https://user-images.githubusercontent.com/73713665/186723636-58e8669d-a99f-4bc6-ab94-107e8e0666bf.jpg)

# Updated UI
<img width="1437" alt="UpdatedUI" src="https://user-images.githubusercontent.com/73713665/186723728-e2b243e6-b01e-4b1c-a33e-cc0cc1f2eb76.png">

# How to Test
1. Update core branch to `bugfix/FOUR-6642`
2. Open local environment, go to a Process.
3. In the Configuration menu, inspect the helper text under the Node Identifier field. The .text-muted color should be `#6c757d`.

# Related Tickets & Packages
- [FOUR-5110](https://processmaker.atlassian.net/browse/FOUR-5110) | Design Bugs

# Code Review Checklist

- [x]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x]  This solution fixes the bug reported in the original ticket.
- [x]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x]  This ticket conforms to the PRD associated with this part of ProcessMaker.