### PR TITLE
Bugfix FOUR-6398 "Setup User" and "User Setup Signal Throw" are displayed under All Requests

### DIFF
--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -52,7 +52,7 @@ trait HideSystemResources
         } elseif (static::class == ProcessRequest::class) {
             // ProcessRequests must be filtered this way since
             // they could be in a separate database
-            $systemProcessIds = Process::system()->pluck('id');
+            $systemProcessIds = Process::withTrashed()->system()->pluck('id');
             $query->whereNotIn('process_id', $systemProcessIds);
         } elseif (static::class == User::class) {
             return $query->where('is_system', false);


### PR DESCRIPTION
## Issue & Reproduction Steps
The "Setup User" and "User Setup Signal Throw" requests from previously executed runs of Ethos User Sync are now viewable under All Requests.

1. Create or locate a System Process.
2. Generate a request from that Process.
3. Delete the Process from step 1.

## Solution
- The scope `withTrashed` was added, to take into account soft-deleted processes so we can correctly filter system requests.

## How to Test
Follow the reproduction steps of above. You should not see system requests at `/requests` page.

## Related Tickets & Packages
- [FOUR-6398](https://processmaker.atlassian.net/browse/FOUR-6398)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

test with 'single' quotes