### PR TITLE
Fix bug where composer install will fail if no database connection is available

### DIFF
--- a/ProcessMaker/Repositories/ConfigRepository.php
+++ b/ProcessMaker/Repositories/ConfigRepository.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Support\Arr;
 use ProcessMaker\Models\Setting;
+use RuntimeException;
 
 class ConfigRepository implements ArrayAccess, ConfigContract
 {
@@ -56,8 +57,13 @@ class ConfigRepository implements ArrayAccess, ConfigContract
         // Query only what we need from the database and
         // bind the key/config value to the global
         // app config for each
-        foreach (Setting::select('id', 'key', 'config', 'format')->get() as $setting) {
-            $this->set($setting->key, $setting->config);
+        try {
+            foreach (Setting::select('id', 'key', 'config', 'format')->get() as $setting) {
+                $this->set($setting->key, $setting->config);
+            }
+        } catch (RuntimeException $exception) {
+            // Catch an exception being thrown when no
+            // database connection is available
         }
 
         return $this;


### PR DESCRIPTION
## Issue & Reproduction Steps

1. On a freshly cloned instance of processmaker/processmaker, attempt to run `composer install`.
2. Notice an exception is thrown and the install fails.

This happens because a the database connection isn't available during the install process and the `ConfigRepository` attempts to query the database, which throws the exception.

## Solution
A `try {} catch {}` block was added around the Eloquent model query in the `ConfigRepository` to ensure if a database connection isn't available, it will catch the exception and allow the install to continue.

## How to Test
You should be able to run `composer install` without any exceptions being thrown.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
