### PR TITLE
FOUR-6727 - Add ExportEncrypted class to core

### DIFF
--- a/ProcessMaker/ImportExport/ExportEncrypted.php
+++ b/ProcessMaker/ImportExport/ExportEncrypted.php
@@ -24,7 +24,7 @@ class ExportEncrypted
      */
     public function call(array $package): array
     {
-        $package['export'] = $this->encrypter->encrypt($package['export']);
+        $package['export'] = $this->encrypter->encrypt(json_encode($package['export']));
         $package['encrypted'] = true;
 
         return $package;

--- a/ProcessMaker/ImportExport/ExportEncrypted.php
+++ b/ProcessMaker/ImportExport/ExportEncrypted.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ProcessMaker\ImportExport;
+
+use Illuminate\Encryption\Encrypter;
+
+class ExportEncrypted
+{
+    public Encrypter $encrypter;
+
+    public function __construct(string $password)
+    {
+        // Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.
+        $cipher = config('app.cipher', 'AES-256-CBC');
+
+        // Should be 32 character long for AES-256-CBC.
+        $password = str_pad($password, 32, 'x', STR_PAD_RIGHT);
+
+        $this->encrypter = new Encrypter($password, $cipher);
+    }
+
+    /**
+     * Encrypt the export key.
+     */
+    public function call(array $package): array
+    {
+        $package['export'] = $this->encrypter->encrypt($package['export']);
+        $package['encrypted'] = true;
+
+        return $package;
+    }
+}

--- a/tests/Feature/Processes/ExportEncryptedTest.php
+++ b/tests/Feature/Processes/ExportEncryptedTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Processes;
+
+use ProcessMaker\ImportExport\ExportEncrypted;
+use Tests\TestCase;
+
+class ExportEncryptedTest extends TestCase
+{
+    public function testExportEncrypted()
+    {
+        $password = '3KctomfPgE';
+        $export = [
+            'type' => 'process_package',
+            'version' => 2,
+            'export' => [
+                'processes' => [],
+                'screens' => [],
+                'scripts' => [],
+            ],
+        ];
+
+        $encrypter = new ExportEncrypted($password);
+        $exportEncrypted = $encrypter->call($export);
+
+        $this->assertArrayHasKey('encrypted', $exportEncrypted);
+        $this->assertIsString($exportEncrypted['export']);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Add a new class ProcessMaker/ExportEncrypted.php.

## Solution
- Added a new class `ProcessMaker/ExportEncrypted.php`.
- It returns an array that run `json_encode` on the export value, encrypts it, and adds "encrypted" => true.
- Added `ExportEncryptedTest.php` test.

## How to Test
- Run `phpunit --filter testExportEncrypted tests/Feature/Processes/ExportEncryptedTest.php`

## Related Tickets & Packages
- [FOUR-6727](https://processmaker.atlassian.net/browse/FOUR-6727)
