### PR TITLE
Bugfix/FOUR-6783: Import screen that doesn't have any watcher fails 

### DIFF
--- a/ProcessMaker/Jobs/ImportScreen.php
+++ b/ProcessMaker/Jobs/ImportScreen.php
@@ -52,8 +52,10 @@ class ImportScreen extends ImportProcess
             //determine if the screen has watchers
             if (property_exists($screen, 'watchers')) {
                 $names = [];
-                foreach ($screen->watchers as $watcher) {
-                    $names[] = $watcher->name;
+                if ($screen->watchers) {
+                    foreach ($screen->watchers as $watcher) {
+                        $names[] = $watcher->name;
+                    }
                 }
                 $this->status['screens']['info'] = __('Please assign a run script user to: ') . implode(', ', $names);
             }

--- a/tests/Feature/Processes/ExportImportScreenTest.php
+++ b/tests/Feature/Processes/ExportImportScreenTest.php
@@ -24,8 +24,6 @@ class ExportImportScreenTest extends TestCase
      */
     public function testExportImportProcess()
     {
-        $this->markTestSkipped('FOUR-6653');
-
         // Create an admin user
         $adminUser = factory(User::class)->create([
             'username' => 'admin',

--- a/tests/Feature/Processes/ScreenConsolidatorTest.php
+++ b/tests/Feature/Processes/ScreenConsolidatorTest.php
@@ -23,8 +23,6 @@ class ScreenConsolidatorTest extends TestCase
      */
     public function testExportImportProcess()
     {
-        $this->markTestSkipped('FOUR-6653');
-
         // Create an admin user
         $adminUser = factory(User::class)->create([
             'username' => 'admin',


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to Screens > import screen
- Select a screen without any watcher or use the file attached
- Click on import

[test_nested_record_list.json.zip](https://github.com/ProcessMaker/processmaker/files/9657594/test_nested_record_list.json.zip)

**Current behavior:**
You can see a 500 server error when trying to import the screen.

**Expected behavior:**
Screen that doesn't have watchers should be imported correctly.

## Solution
- Added condition to check if screen have watchers before trying to do the foreach

**Working video**

https://user-images.githubusercontent.com/90727999/192571703-f793ecf9-0c7f-46c9-a051-66bd2f72e413.mov

Skipped test now passing

<img width="745" alt="Screen Shot 2022-09-27 at 12 33 25" src="https://user-images.githubusercontent.com/90727999/192571736-f0f670ac-ad60-4c72-8374-7cee8075a493.png">


## How to Test
- Test the above steps

## Related Tickets & Packages
- [FOUR-6783](https://processmaker.atlassian.net/browse/FOUR-6783)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
