### PR TITLE
Content Security Policy issue on PM 4.2.34

### DIFF
--- a/ProcessMaker/Http/Controllers/TestStatusController.php
+++ b/ProcessMaker/Http/Controllers/TestStatusController.php
@@ -32,4 +32,9 @@ class TestStatusController extends Controller
 
         return 'Email received.<script>setTimeout("window.close()", 2000);</script>';
     }
+
+    public function csp()
+    {
+        return view('test.csp-meta-tags');
+    }
 }

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -4,7 +4,6 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'none';"> 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="app-url" content="{{ config('app.url') }}">
@@ -27,6 +26,7 @@
       <meta name="alertVariant" content="{{$type}}">
       <meta name="alertMessage" content="{{$message}}">
     @endif
+    @include('shared.csp-meta-tags')
 
     <title>@yield('title',__('Welcome')) - {{ __('ProcessMaker') }}</title>
     <link rel="icon" type="image/png" sizes="16x16" href="{{ \ProcessMaker\Models\Setting::getFavicon() }}">

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -3,10 +3,10 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'none';"> 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
+    @include('shared.csp-meta-tags')
     <title>@yield('title',__('Welcome')) - {{ __('ProcessMaker') }}</title>
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ \ProcessMaker\Models\Setting::getFavicon() }}">

--- a/resources/views/shared/csp-meta-tags.blade.php
+++ b/resources/views/shared/csp-meta-tags.blade.php
@@ -1,0 +1,1 @@
+<meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'self' blob: data:;">

--- a/resources/views/test/csp-meta-tags.blade.php
+++ b/resources/views/test/csp-meta-tags.blade.php
@@ -1,0 +1,4 @@
+@extends('layouts.minimal')
+@section('content')
+  <embed type="image/jpg" src="img/logo.png">
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,6 @@
 use ProcessMaker\Http\Controllers\Api\Requests\RequestsController;
 
 Route::group(['middleware' => ['auth', 'sanitize', 'external.connection', 'force_change_password']], function () {
-
     // Routes related to Authentication (password reset, etc)
     // Auth::routes();
     Route::namespace('Admin')->prefix('admin')->group(function () {
@@ -98,6 +97,7 @@ Route::group(['middleware' => ['auth', 'sanitize', 'external.connection', 'force
 
     Route::get('/test_status', 'TestStatusController@test')->name('test.status');
     Route::get('/test_email', 'TestStatusController@email')->name('test.email');
+    Route::get('/test_csp', 'TestStatusController@csp')->name('test.csp');
 });
 
 // Add our broadcasting routes

--- a/tests/Feature/Csp/AddCspHeadersTest.php
+++ b/tests/Feature/Csp/AddCspHeadersTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ProcessMaker;
+
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class AddCspHeadersTest extends TestCase
+{
+    use RequestHelper;
+
+    public function testWillOutputCspHeadersWithDefaultConfig()
+    {
+        $defaultPolicy = "script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'self' blob: data:;";
+        $string = $this->metaTagString('Content-Security-Policy', $defaultPolicy);
+
+        $response = $this->webCall('GET', route('test.csp'));
+
+        $this->assertStringContainsString($string, $response->getContent());
+    }
+
+    private function metaTagString(string $headerName = 'Content-Security-Policy', $content = '.*')
+    {
+        return "<meta http-equiv=\"{$headerName}\" content=\"{$content}\">";
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps

The `customer-adoa` package uses the `<embed>` tag which is not allowed by the Content Security Policy for the `object-src` directive. See `customer-adoa/resources/js/checkRequestsCoachingNotes.js`.

## Solution

- For this problem, I consider that we only need to enable the `object-src` directive to allow `<object>` and `<embed>` tags.
- The proposed `gap:` source seems to be an invalid source, see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources
  - We'll use these sources: `'self' blob: data:;`.

## How to Test

Visit the `/test_csp` route. With the PR changes, you will be able to view the content of the `<embed>` tag.

## Related Tickets & Packages
- [PM4EH-187](https://processmaker.atlassian.net/browse/PM4EH-187)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
