### PR TITLE
Bugfix/FOUR-6644: Script Message Error, to importing a single screen

### DIFF
--- a/ProcessMaker/Jobs/ImportScreen.php
+++ b/ProcessMaker/Jobs/ImportScreen.php
@@ -56,8 +56,8 @@ class ImportScreen extends ImportProcess
                     foreach ($screen->watchers as $watcher) {
                         $names[] = $watcher->name;
                     }
+                    $this->status['screens']['info'] = __('Please assign a run script user to: ') . implode(', ', $names);
                 }
-                $this->status['screens']['info'] = __('Please assign a run script user to: ') . implode(', ', $names);
             }
         }
         $this->finishStatus('screens');


### PR DESCRIPTION
## Issue & Reproduction Steps
A message "Please assign a run script user to: ." showing also when the screen doesn't have any watcher.

- Have a screen without watchers
- Import the screen

**Current behavior**
Screen that does not have any configuration with script when importing get error messages related to script appears

**Expected behavior**
Script message errors should appears , when the screen use them

## Solution
- Show message info only when watchers exists in the screen.

**Working video**

https://user-images.githubusercontent.com/90727999/193351427-d1830fb4-277b-4ed9-83c2-8b34f7a5ddcc.mov


## How to Test
Follow the steps above.
Test a screen with watchers (should show message)
Test a screen without watchers (should not show message)

## Related Tickets & Packages
- [FOUR-6644](https://processmaker.atlassian.net/browse/FOUR-6644)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
