### PR TITLE
FOUR-6777: Improve performance of request detail screen when using self service

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -82,8 +82,6 @@ class Task extends ApiResource
                                                 || count($array['assignable_users']) < 1;
         if (in_array('assignableUsers', $include) && $needToRecalculateAssignableUsers) {
             $nivel = array_search('request', array_column(debug_backtrace(), 'function'));
-            \Illuminate\Support\Facades\Log::Critical(str_repeat("        ", $nivel) . __LINE__ ."  => Entrando a Assignable");
-
             $definition = $this->getDefinition();
             if (isset($definition['assignment']) && $definition['assignment'] == 'self_service') {
                 $users = [];

--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -78,7 +78,12 @@ class Task extends ApiResource
          */
 
         // Used to retrieve the assignable users for self service tasks
-        if (in_array('assignableUsers', $include)) {
+        $needToRecalculateAssignableUsers = !array_key_exists('assignable_users', $array)
+                                                || count($array['assignable_users']) < 1;
+        if (in_array('assignableUsers', $include) && $needToRecalculateAssignableUsers) {
+            $nivel = array_search('request', array_column(debug_backtrace(), 'function'));
+            \Illuminate\Support\Facades\Log::Critical(str_repeat("        ", $nivel) . __LINE__ ."  => Entrando a Assignable");
+
             $definition = $this->getDefinition();
             if (isset($definition['assignment']) && $definition['assignment'] == 'self_service') {
                 $users = [];

--- a/resources/js/requests/components/RequestDetail.vue
+++ b/resources/js/requests/components/RequestDetail.vue
@@ -146,7 +146,7 @@
           .get(
             "tasks?page=" +
             this.page +
-            "&include=user,assignableUsers" +
+            "&include=user" +
             "&process_request_id=" +
             this.processRequestId +
             "&status=" +


### PR DESCRIPTION
## Issue & Reproduction Steps
Create a table with +100000 requests that are part of a self service task
Open one of those requets (url  /requests/nnn, where nnn = request id)
It will take 5 or more seconds to render the task list

## Solution
 Avoid duplicated assignable users logic when returning a request detail

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-6777

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
