### PR TITLE
FOUR-6721 Added ScreenBuilder modules to be initialized on app

### DIFF
--- a/resources/js/processes/screen-builder/main.js
+++ b/resources/js/processes/screen-builder/main.js
@@ -1,9 +1,16 @@
 import Vue from "vue";
 import Vuex from "vuex";
 import ScreenBuilder from "./screen";
+import globalErrorsModule from "@processmaker/screen-builder/src/store/modules/globalErrorsModule";
+import undoRedoModule from "@processmaker/screen-builder/src/store/modules/undoRedoModule";
 
 Vue.use(Vuex);
-const store = new Vuex.Store({ modules: {} });
+const store = new Vuex.Store({
+  modules: {
+    globalErrorsModule,
+    undoRedoModule,
+  },
+});
 
 // Bootstrap our Designer application
 new Vue({


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).
* Errors were happening when opening a screen complaining about Vuex modules not registering from ScreenBuilder and these modules were crucial to sending the errors from Validations

## Solution
- List the changes you've introduced to solve the issue.
* Importing the Vuex modules in core. We did it on the ScreenBuilder side but apparently, we needed to do it on Core side.

## How to Test
Describe how to test that this solution works.
* Check if no errors from Vue / Vuex are being thrown on console when opening a screen.
Usually the errors will happen if there's a problem registering the modules from ScreenBuilder

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
