### PR TITLE
[FOUR-6856] API docs typo in Security Logs section

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
+++ b/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
@@ -22,7 +22,7 @@ class SecurityLogController extends Controller
      *     path="/security-logs",
      *     summary="Returns all security logs",
      *     operationId="getSecurityLogs",
-     *     tags={"Secuirty Logs"},
+     *     tags={"Security Logs"},
      *     @OA\Parameter(ref="#/components/parameters/filter"),
      *     @OA\Parameter(ref="#/components/parameters/order_by"),
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
@@ -90,7 +90,7 @@ class SecurityLogController extends Controller
      *     path="/security-logs/{securityLog}",
      *     summary="Get single security log by ID",
      *     operationId="getSecurityLog",
-     *     tags={"Secuirty Logs"},
+     *     tags={"Security Logs"},
      *     @OA\Parameter(
      *         description="ID of security log to return",
      *         in="path",


### PR DESCRIPTION
## Issue & Reproduction Steps
Open the api documentation at api/documentation

## Current Behavior
Security is spelled wrong in the header for the Security Logs section.

## Expected Behavior
Security should be spelled correctly.

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
