### PR TITLE
Date format compatibility

### DIFF
--- a/ProcessMaker/Models/ProcessMakerModel.php
+++ b/ProcessMaker/Models/ProcessMakerModel.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use DateTimeInterface;
 
 /**
  * Base class that all models should extend from.
@@ -11,4 +12,15 @@ use Illuminate\Database\Eloquent\Model;
 class ProcessMakerModel extends Model
 {
     use HasFactory;
+
+    /**
+     * Prepare a date for array / JSON serialization.
+     *
+     * @param DateTimeInterface $date
+     * @return string
+     */
+    protected function serializeDate(DateTimeInterface $date)
+    {
+        return $date->format('Y-m-d H:i:s');
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Ethos Sync Process has problems with https://laravel.com/docs/7.x/upgrade#date-serialization
(Check the following error log)

```
Service task failed: package-ellucian-ethos/import-users - SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '2022-10-18T14:28:13.000000Z' for column 'created_at' at row 1 (SQL: insert into `group_members` (`created_at`, `group_id`, `id`, `member_id`, `member_type`, `updated_at`) values (2022-10-18T14:28:13.000000Z, 6, 161, 163, ProcessMaker\Models\User, 2022-10-18T14:28:13.000000Z), (2022-10-18T14:28:13.000000Z, 6, 162, 164, ...
```

## Solution
- Keep the compatibility setting the serialization date format.

## How to Test
- Use ProcessMaker, the date/time fields should keep the previous behavior.
- Ethos Sync Process, should not fail.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6861

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
.
