### PR TITLE
Bugfix/FOUR-6869: Console error shows in request view

### DIFF
--- a/resources/js/requests/components/RequestErrors.vue
+++ b/resources/js/requests/components/RequestErrors.vue
@@ -53,6 +53,8 @@
         methods: {
             formatDate(date) {
                 return moment(date).fromNow();
+            },
+            fetch() {
             }
         }
     };


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to Reproduce:**
- Create any process with a task
- Run a request for the process
- Go to the request view ( request/{id} url )
- Open the browser inspector in console tab

**Current Behavior:**
An error shows in the console:

```
vendor.js?id=91fb2ab774296935e4b121c4796b09b1:111958 [Vue warn]: Error in created hook: "TypeError: this.fetch is not a function"

found in

---> <RequestErrors> at resources/js/requests/components/RequestErrors.vue
       <Root>
```
 
**Expected Behavior:**

No errors should show in the console


## Solution
- Added fetch function to avoid console error

**Working video**

https://user-images.githubusercontent.com/90727999/196979260-a636a01e-85c1-4e2c-a824-fbcfb52a659a.mov


## How to Test
-  Follow above steps

## Related Tickets & Packages
- [FOUR-6869](https://processmaker.atlassian.net/browse/FOUR-6869)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
