### PR TITLE
FOUR-6875 - Fixing command processmaker:install failing

### DIFF
--- a/ProcessMaker/Console/Commands/MigrateFresh.php
+++ b/ProcessMaker/Console/Commands/MigrateFresh.php
@@ -31,6 +31,9 @@ class MigrateFresh extends FreshCommand
             }
         }
 
+        $this->info('Creating migrations table...');
+        $this->call('migrate:install');
+
         $this->info('Dropped all tables successfully.');
 
         $this->call('migrate', array_filter([


### PR DESCRIPTION
## Issue & Reproduction Steps
This bug happens when we have an old database named `processmaker` and we try to do a new installation in another database, `processmaker_test` for example.

## Solution
The solution is to create the migrations table before calling the migrate:install command.

The `ProcessMaker\Console\Commands\MigrateFresh` class seems to be no longer needed, and if confirmed it should be deleted in another PR.

## How to Test
- Do a normal install on a `processmaker` database.
- Create another database, like `processmaker_test` 
- Delete the `.env` file and run  `php artisan processmaker:install` 

## Related Tickets & Packages
- [FOUR-6875](https://processmaker.atlassian.net/browse/FOUR-6875)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
