### PR TITLE
Build new versions of script executors when install command is run

### DIFF
--- a/ProcessMaker/Console/Commands/BuildScriptExecutors.php
+++ b/ProcessMaker/Console/Commands/BuildScriptExecutors.php
@@ -231,7 +231,7 @@ class BuildScriptExecutors extends Command
                 throw new \Exception('Not a valid image:' . (string) $image);
             }
             $id = intval($match[1]);
-            $existingTag = intval($match[2]);
+            $existingTag = $match[2];
             $existingExecutor = ScriptExecutor::find($id);
             if ($existingExecutor && $existingExecutor->id !== $id) {
                 // Already associated with another script executor

--- a/ProcessMaker/Console/Commands/BuildScriptExecutors.php
+++ b/ProcessMaker/Console/Commands/BuildScriptExecutors.php
@@ -227,13 +227,18 @@ class BuildScriptExecutors extends Command
         $images = ScriptExecutor::listOfExecutorImages($executor->language);
         $instance = config('app.instance');
         foreach ($images as $image) {
-            if (!preg_match('/executor-' . $instance . '-.+-(\d+):/', $image, $match)) {
+            if (!preg_match('/executor-' . $instance . '-.+-(\d+):(v[0-9.]+)/', $image, $match)) {
                 throw new \Exception('Not a valid image:' . (string) $image);
             }
             $id = intval($match[1]);
+            $existingTag = intval($match[2]);
             $existingExecutor = ScriptExecutor::find($id);
             if ($existingExecutor && $existingExecutor->id !== $id) {
                 // Already associated with another script executor
+                continue;
+            }
+            if ($existingTag !== $executor->imageTag()) {
+                // A newer version is required
                 continue;
             }
             // Rename unassociated image with this executor's id

--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\Rule;
 use ProcessMaker\Exception\ScriptLanguageNotSupported;
 use ProcessMaker\Traits\Exportable;
@@ -169,12 +170,11 @@ class ScriptExecutor extends ProcessMakerModel
     public function imageTag()
     {
         $config = self::config($this->language);
-        $tag = 'v';
-        if (isset($config['package_version'])) {
-            $tag .= $config['package_version'];
-        }
+        $composerPath = $config['package_path'];
+        $composer = json_decode(file_get_contents($composerPath . '/composer.json'), true);
+        $version = Arr::get($composer, 'version', '0');
 
-        return $tag;
+        return 'v' . $version;
     }
 
     public function scripts()


### PR DESCRIPTION
## Issue & Reproduction Steps
The logic that checks if a docker image exists for an executor is not checking the tag version of the image. This means when we have a new version we need to run php artisan processmaker:build-script-executor xxxxx --rebuild.

Building the new version of the image should be handled by the install command.
.

## Solution
- Check the version when seeing if we can re-use an existing docker image
- Get the version from compser.json instead of the package provider

## How to Test
- Bump the version of a script executor, for example docker-executor-node-ssr, in its composer.json file
- Run the installer, for example `php artisan docker-executor-node-ssr:install`
- Docker image should rebuild, not just retag the old image

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6889

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
