### PR TITLE
Add validation when value pmql is array

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -671,6 +671,8 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                 $operator = $expression->operator;
                 if (is_string($value)) {
                     $value = '"' . $value . '"';
+                } else if (is_array($value)) {
+                    $value = json_encode($value);
                 }
 
                 $pmql = "$field $operator $value";


### PR DESCRIPTION
## Issue & Reproduction Steps
Perform a PMQL search query with (IN or NOT IN)

**Current behavior**
when the search is done not return results and returns a server error.

**Expected behavior**
The search with PMQL (IN, NOT IN) should work fine and not returns a server error.

## Solution
- Add validation when the value in PMQL is an array

## How to Test
perform PMQL queries on the section to fetch (Request and Tasks)

## Related Tickets & Packages
- [FOUR-6782](https://processmaker.atlassian.net/browse/FOUR-6782)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
