### PR TITLE
Improve DataSummary speed with large data

### DIFF
--- a/resources/js/requests/components/DataSummary.vue
+++ b/resources/js/requests/components/DataSummary.vue
@@ -1,7 +1,24 @@
 <template>
-    <div>
-        <b-table :items="formattedData" :fields="fields"></b-table>
-    </div>
+  <div>
+    <table role="table" class="table b-table">
+      <thead role="rowgroup">
+        <tr role="row">
+          <th role="columnheader" scope="col" aria-colindex="1">
+            <div>{{ $t('Key') }}</div>
+          </th>
+          <th role="columnheader" scope="col" aria-colindex="2">
+            <div>{{ $t('Value') }}</div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in formattedData" :key="row.key">
+          <td aria-colindex="1" role="cell">{{ row.key }}</td>
+          <td aria-colindex="2" role="cell">{{ row.value }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
## Issue & Reproduction Steps
After a process is completed, it goes to the summary screen, in the reported ticket, the amount of data stored in the process is very large causing the summary screen to take a long time to render it. The main problem here is the <b-table> component.

## Solution
- Improve the Request Summary screen with large amount of data.

## How to Test

1. Import de process attached to the ticket
2. Mock a Rest Endpoint that returns a large number of data as required by the Screen of the process
3. Run the process
4. Complete the process

_Test data for the Rest Endpoint:_
[test_data.json.zip](https://github.com/ProcessMaker/processmaker/files/9870212/test_data.json.zip)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6912

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
.