### PR TITLE
Fix failing test related to MigrateFresh - FOUR-6933

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -95,10 +95,7 @@ if (env('TEST_TOKEN')) {
     Artisan::call('db:wipe', ['--database' => \DB::connection()->getName()]);
     Artisan::call('migrate:fresh', []);
     Artisan::call('db:seed', ['--class' => 'AnonymousUserSeeder']);
-
-    // In \ProcessMaker\Console\Commands\MigrateFresh:35
-    // The migrations table is being manually created to resolve the bug described below.
-    // https://github.com/ProcessMaker/processmaker/pull/4537
+    
     \Illuminate\Foundation\Testing\RefreshDatabaseState::$migrated = true;
 
     ScriptExecutor::firstOrCreate(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -96,6 +96,11 @@ if (env('TEST_TOKEN')) {
     Artisan::call('migrate:fresh', []);
     Artisan::call('db:seed', ['--class' => 'AnonymousUserSeeder']);
 
+    // In \ProcessMaker\Console\Commands\MigrateFresh:35
+    // The migrations table is being manually created to resolve the bug described below.
+    // https://github.com/ProcessMaker/processmaker/pull/4537
+    \Illuminate\Foundation\Testing\RefreshDatabaseState::$migrated = true;
+
     ScriptExecutor::firstOrCreate(
         ['language' => 'php'],
         ['title' => 'Test Executor']


### PR DESCRIPTION
## Issue & Reproduction Steps
In [MigrateFresh:35](https://github.com/ProcessMaker/processmaker/blob/develop/ProcessMaker/Console/Commands/MigrateFresh.php#L35), 
the migrations table is being manually created to resolve the bug described in this [PR]( https://github.com/ProcessMaker/processmaker/pull/4537).

## Solution
Add a configuration so that the migrations table doesn't try to be created.

## How to Test
Run this test:
```
php vendor/phpunit/phpunit/phpunit --colors --stop-on-failure tests/Feature/Api/ChangePasswordTest.php
```

## Related Tickets & Packages
- [FOUR-6933](https://processmaker.atlassian.net/browse/FOUR-6933)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
