### PR TITLE
FOUR-6959 Added @babel/eslint-parser back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
                 "xml-js": "^1.6.7"
             },
             "devDependencies": {
+                "@babel/eslint-parser": "^7.15.8",
                 "accounting": "^0.4.1",
                 "chartjs-plugin-colorschemes": "^0.4.0",
                 "cross-env": "^7.0.3",
@@ -148,6 +149,55 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/eslint-parser": {
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.15.8.tgz",
+            "integrity": "sha512-fYP7QFngCvgxjUuw8O057SVH5jCXsbFFOoE77CFDcvzwBVgTOkMD/L4mIC5Ud1xf8chK/no2fRbSSn1wvNmKuQ==",
+            "dev": true,
+            "dependencies": {
+                "eslint-scope": "^5.1.1",
+                "eslint-visitor-keys": "^2.1.0",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.11.0",
+                "eslint": ">=7.5.0"
+            }
+        },
+        "node_modules/@babel/eslint-parser/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@babel/eslint-parser/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/@babel/generator": {
@@ -16339,6 +16389,41 @@
                 "gensync": "^1.0.0-beta.2",
                 "json5": "^2.2.1",
                 "semver": "^6.3.0"
+            }
+        },
+        "@babel/eslint-parser": {
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.15.8.tgz",
+            "integrity": "sha512-fYP7QFngCvgxjUuw8O057SVH5jCXsbFFOoE77CFDcvzwBVgTOkMD/L4mIC5Ud1xf8chK/no2fRbSSn1wvNmKuQ==",
+            "dev": true,
+            "requires": {
+                "eslint-scope": "^5.1.1",
+                "eslint-visitor-keys": "^2.1.0",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "eslint-scope": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+                    "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                    "dev": true
+                },
+                "estraverse": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+                    "dev": true
+                }
             }
         },
         "@babel/generator": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "e2e:open": "cypress open"
     },
     "devDependencies": {
+        "@babel/eslint-parser": "^7.15.8",
         "accounting": "^0.4.1",
         "chartjs-plugin-colorschemes": "^0.4.0",
         "cross-env": "^7.0.3",


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).
In https://github.com/ProcessMaker/processmaker/commit/53cf828a5434a525797a47c4c794b92e9d2ecc03#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25 we removed `@babel-eslint/parser` by mistake. Which is the parser for eslint, our Javascript linter

## Solution
- Adding it back

## How to Test
Describe how to test that this solution works.
* `npm install`
* Go to a Javascript or Vue file
* Make sure you have enabled in your IDE, the Eslint extension, you should see the errors from Eslint.
* Or run the eslint CLI and you should see the output

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6959

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
