### PR TITLE
FOUR-6315: SOAP

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -68,8 +68,8 @@ trait MakeHttpRequests
     /**
      * Prepares data for the http request replacing mustache with pm instance
      *
-     * @param array $data , request data
-     * @param array $config , datasource configuration
+     * @param array $data, request data
+     * @param array $config, datasource configuration
      *
      * @return array
      */
@@ -169,8 +169,8 @@ trait MakeHttpRequests
     /**
      * Prepares data for the http request replacing mustache with pm instance and OutboundConfig
      *
-     * @param array $data , request data
-     * @param array $config , datasource configuration
+     * @param array $data, request data
+     * @param array $config, datasource configuration
      *
      * @return array
      */
@@ -640,6 +640,11 @@ trait MakeHttpRequests
             return;
         }
 
-        Log::channel('data-source')->info($label . str_replace(["\n", "\t", "\r"], '', $log));
+        try {
+            Log::channel('data-source')->info($label . str_replace(["\n", "\t", "\r"], '', $log));
+        }
+        catch(\Throwable $e) {
+            Log::error($e->getMessage());
+        }
     }
 }

--- a/tests/Feature/MakeHttpRequestTest.php
+++ b/tests/Feature/MakeHttpRequestTest.php
@@ -199,6 +199,7 @@ class MakeHttpRequestTest extends TestCase
         $testStub = $this->getObjectForTrait(MakeHttpRequests::class);
         $testStub->endpoints = json_decode('{"create":{"url":"https://fake.server.com/users/{{userIdParam}}","body":"{\n    \"name\":\"{{nameParam}}\",\n    \"age\":\"{{ageParam}}\"\n}","view":false,"method":"PUT","params":[{"id":0,"key":"queryStringParam","value":null,"required":false}],"headers":[{"id":0,"key":"headerParam","value":null,"required":false}],"purpose":"create","updated":"2022-05-30 12:38:48","testData":"{\n    \"nameParam\":\"Dante\",\n    \"ageParam\": 12,\n    \"userIdParam\": 4\n}","body_type":"json","outboundConfig":[]}}', true);
         $testStub->authtype = 'BASIC';
+        $testStub->debug_mode = false;
         $testStub->credentials = ['verify_certificate' => false, 'username' => 'test', 'password' => 'test'];
 
         // This is the configuration that is created when configuring a connector in modeler
@@ -252,6 +253,7 @@ class MakeHttpRequestTest extends TestCase
         $testStub->endpoints = json_decode('{"create":{"url":"https://fake.server.com/users/{{userIdParam}}","body":"{\n    \"name\":\"{{nameParam}}\",\n    \"age\":\"{{ageParam}}\"\n}","view":false,"method":"PUT","params":[{"id":0,"key":"queryStringParam","value":null,"required":false}],"headers":[{"id":0,"key":"headerParam","value":null,"required":false}],"purpose":"create","updated":"2022-05-30 12:38:48","testData":"{\n    \"nameParam\":\"Dante\",\n    \"ageParam\": 12,\n    \"userIdParam\": 4\n}","body_type":"json","outboundConfig":[]}}', true);
         $testStub->authtype = 'BASIC';
         $testStub->credentials = ['verify_certificate' => false, 'username' => 'test', 'password' => 'test'];
+        $testStub->debug_mode = false;
 
         // This is the configuration that is created when configuring a connector in modeler
         $connectorConfig = [
@@ -327,6 +329,7 @@ class MakeHttpRequestTest extends TestCase
         $testStub = $this->getObjectForTrait(MakeHttpRequests::class);
         $testStub->endpoints = json_decode('{"create":{"url":"https://fake.server.com/users/{{userIdParam}}","body":"{\n    \"name\":\"{{nameParam}}\",\n    \"age\":\"{{ageParam}}\"\n}","view":false,"method":"PUT","params":[{"id":0,"key":"queryStringParam","value":null,"required":false}],"headers":[{"id":0,"key":"headerParam","value":null,"required":false}],"purpose":"create","updated":"2022-05-30 12:38:48","testData":"{\n    \"nameParam\":\"Dante\",\n    \"ageParam\": 12,\n    \"userIdParam\": 4\n}","body_type":"json","outboundConfig":[]}}', true);
         $testStub->authtype = 'NONE';
+        $testStub->debug_mode = false;
         // This is the configuration that is created when configuring a connector in modeler
         $endpointConfig = [
             'dataSource' => 1,


### PR DESCRIPTION
Important Note:
One test is failing, but is not related to this PR This test has been fixed in package-data-sources (https://github.com/ProcessMaker/package-data-sources/pull/258). After the package is published the test will run ok.

## Issue & Reproduction Steps
REST connectors didn't have the debug mode enabled.

## Solution
- Added Logging for request calls
- Rest connectors can have debug mode enabled using the UI
![image](https://user-images.githubusercontent.com/14875032/198629717-34d10dfe-3980-47ae-bb0b-61d61adf37db.png)


## How to Test
- Enable log mode for a REST connector
- Use a connector in a process or in test mode
- Verify that the log information is registered in data-sources log files.

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-6954](https://processmaker.atlassian.net/browse/FOUR-6954)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
