### PR TITLE
Refreshing the Session Warning countdown - PM4EH-223

### DIFF
--- a/resources/js/components/Session.vue
+++ b/resources/js/components/Session.vue
@@ -63,6 +63,7 @@
                         data: {
                             timeout: ProcessMaker.AccountTimeoutLength,
                             warnSeconds: ProcessMaker.AccountTimeoutWarnSeconds,
+                            enabled: window.ProcessMaker.AccountTimeoutEnabled
                         }
                     });
                     this.onClose();


### PR DESCRIPTION
## Issue & Reproduction Steps
After the user clicked `stay connected`, the `countdown` was not reset, so the popup appeared again and again.

## Solution
- Reset `countdown` after user clicks `stay connected`.

## How to Test
- Put the following settings in the .env file.
```
SESSION_LIFETIME=1
SESSION_EXPIRE_WARNING=30
```
- Wait for 30 seconds and click "Stay connected"

## Related Tickets & Packages
- [PM4EH-223](https://processmaker.atlassian.net/browse/PM4EH-223)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
