### PR TITLE
FOUR-6616: Add Reset Password CLI Command

### DIFF
--- a/ProcessMaker/Console/Commands/AuthSetPassword.php
+++ b/ProcessMaker/Console/Commands/AuthSetPassword.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Hash;
+use Illuminate\Console\Command;
+use Log;
+use ProcessMaker\Models\User;
+
+class AuthSetPassword extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auth:set-password';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set or reset the password on an account';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $identifier = $this->ask("Enter the user's id or email address");
+
+        if (is_numeric($identifier)) {
+            $user = User::find($identifier);
+        } else {
+            $user = User::where('email', $identifier)->first();
+        }
+
+        if ($user) {
+            if ($user->password) {
+                $verb = 'reset';
+            } else {
+                $verb = 'set';
+            }
+
+            $confirm = $this->confirm("Are you sure you want to {$verb} the password for {$user->fullname}?");
+
+            if ($confirm) {
+                $password = $this->secret('Enter the new password');
+                $confirm = $this->secret('Confirm the new password');
+
+                if ($password === $confirm) {
+                    $user->password = Hash::make($password);
+                    $user->save();
+
+                    Log::notice("Password {$verb} for user {$user->fullname} on command line.");
+                    $this->info("Password {$verb} for user {$user->fullname}.");
+                } else {
+                    return $this->error('Password & confirmation do not match. Please try again.');
+                }
+            } else {
+                return $this->error('Password not reset.');
+            }
+        } else {
+            return $this->error('Unable to find user.');
+        }
+    }
+}


### PR DESCRIPTION
# Issue
Ticket: [FOUR-6616](https://processmaker.atlassian.net/browse/FOUR-6616)

As a CloudOps engineer I want PM4 to have the ability to reset the admin password via CLI in the workspace, so we no longer need to manually do it copying a script.

# Solution
Add AuthSetPassword.php with script for resetting admin password from the CLI.

# How to Test
1. Update core branch to `feature/FOUR-6616`.
2. Run `php artisan auth:set-password` in the terminal.
3. Follow instructions to reset password.
4. Test that password has been reset in the UI.

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.