### PR TITLE
FOUR-6660: Process Manager can't reassign requests

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -125,8 +125,10 @@ class RequestController extends Controller
 
         $addons = $this->getPluginAddons('edit', compact(['request']));
 
+        $isProcessManager = $request->process?->manager_id === Auth::user()->id;
+
         return view('requests.show', compact(
-            'request', 'files', 'canCancel', 'canViewComments', 'canManuallyComplete', 'canRetry', 'manager', 'canPrintScreens', 'screenRequested', 'addons'
+            'request', 'files', 'canCancel', 'canViewComments', 'canManuallyComplete', 'canRetry', 'manager', 'canPrintScreens', 'screenRequested', 'addons', 'isProcessManager'
         ));
     }
 

--- a/ProcessMaker/Policies/ProcessRequestTokenPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestTokenPolicy.php
@@ -36,7 +36,9 @@ class ProcessRequestTokenPolicy
      */
     public function view(User $user, ProcessRequestToken $processRequestToken)
     {
-        if ($processRequestToken->user_id == $user->id) {
+        if ($processRequestToken->user_id == $user->id ||
+            $processRequestToken->process()->first()?->manager_id === $user->id
+        ) {
             return true;
         }
         if ($user->canSelfServe($processRequestToken)) {
@@ -55,7 +57,8 @@ class ProcessRequestTokenPolicy
     {
         if (
             $processRequestToken->user_id === $user->id ||
-            $processRequestToken->user_id === app(AnonymousUser::class)->id
+            $processRequestToken->user_id === app(AnonymousUser::class)->id ||
+            $processRequestToken->process()->first()?->manager_id === $user->id
         ) {
             return true;
         }

--- a/ProcessMaker/Policies/ProcessRequestTokenPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestTokenPolicy.php
@@ -37,7 +37,7 @@ class ProcessRequestTokenPolicy
     public function view(User $user, ProcessRequestToken $processRequestToken)
     {
         if ($processRequestToken->user_id == $user->id ||
-            $processRequestToken->process()->first()?->manager_id === $user->id
+            $processRequestToken->process?->manager_id === $user->id
         ) {
             return true;
         }
@@ -58,7 +58,7 @@ class ProcessRequestTokenPolicy
         if (
             $processRequestToken->user_id === $user->id ||
             $processRequestToken->user_id === app(AnonymousUser::class)->id ||
-            $processRequestToken->process()->first()?->manager_id === $user->id
+            $processRequestToken->process?->manager_id === $user->id
         ) {
             return true;
         }

--- a/resources/js/requests/components/RequestDetail.vue
+++ b/resources/js/requests/components/RequestDetail.vue
@@ -44,7 +44,7 @@
 
   export default {
     mixins: [datatableMixin],
-    props: ["processRequestId", "status", "isAdmin"],
+    props: ["processRequestId", "status", "isAdmin", "isProcessManager"],
     data() {
       return {
         orderBy: "due_at",
@@ -100,7 +100,10 @@
           if (this.isAdmin) {
               return true;
           }
-        return String(row.user_id) === String(window.ProcessMaker.user.id) || this.canClaim(row) || row.status === "FAILING";
+        return String(row.user_id) === String(window.ProcessMaker.user.id)
+            || this.canClaim(row)
+            || row.status === "FAILING"
+            || this.isProcessManager;
       },
       onAction(action, rowData, index) {
         switch (action) {

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -110,6 +110,7 @@
 							 :class="{ active: activePending }" id="pending" role="tabpanel"
 							 aria-labelledby="pending-tab">
 							<request-detail ref="pending" :process-request-id="requestId" status="ACTIVE"
+											:is-process-manager="{{$isProcessManager ? 'true' : 'false'}}"
 											:is-admin="{{Auth::user()->is_administrator ? 'true' : 'false'}}">
 							</request-detail>
 						</div>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -223,7 +223,7 @@
     const task = @json($task);
     const userHasAccessToTask = {{ Auth::user()->can('update', $task) ? "true": "false" }};
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
-    const userIsProcessManager = {{ Auth::user()->id === $task->process()->first()?->manager_id ? "true": "false" }};
+    const userIsProcessManager = {{ Auth::user()->id === $task->process?->manager_id ? "true": "false" }};
 
   </script>
     @foreach($manager->getScripts() as $script)

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -113,7 +113,7 @@
                             <h5>{{__('Assigned To')}}</h5>
                             <avatar-image v-if="task.user" size="32" class="d-inline-flex pull-left align-items-center"
                                           :input-data="task.user"></avatar-image>
-                          <div v-if="task.definition.allowReassignment === 'true' || userIsAdmin ">
+                          <div v-if="task.definition.allowReassignment === 'true' || userIsAdmin || userIsProcessManager">
                             <br>
                             <span>
                                 <button v-if="task.advanceStatus === 'open' || task.advanceStatus === 'overdue'" type="button" class="btn btn-outline-secondary btn-block"
@@ -223,6 +223,7 @@
     const task = @json($task);
     const userHasAccessToTask = {{ Auth::user()->can('update', $task) ? "true": "false" }};
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
+    const userIsProcessManager = {{ Auth::user()->id === $task->process()->first()?->manager_id ? "true": "false" }};
 
   </script>
     @foreach($manager->getScripts() as $script)
@@ -259,6 +260,7 @@
           formData: {},
           submitting: false,
           userIsAdmin,
+          userIsProcessManager,
         },
         watch: {
           task: {

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -29,7 +29,7 @@ Broadcast::channel('ProcessMaker.Models.ProcessRequest.{id}', function ($user, $
     $request = ProcessRequest::find($id);
 
     return !empty($request->participants()->where('users.id', $user->getKey())->first())
-        || $request->process()->first()?->manager_id === $user->id;
+        || $request->process?->manager_id === $user->id;
 });
 
 Broadcast::channel('ProcessMaker.Models.ProcessRequestToken.{id}', function ($user, $id) {

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -28,7 +28,8 @@ Broadcast::channel('ProcessMaker.Models.ProcessRequest.{id}', function ($user, $
 
     $request = ProcessRequest::find($id);
 
-    return !empty($request->participants()->where('users.id', $user->getKey())->first());
+    return !empty($request->participants()->where('users.id', $user->getKey())->first())
+        || $request->process()->first()?->manager_id === $user->id;
 });
 
 Broadcast::channel('ProcessMaker.Models.ProcessRequestToken.{id}', function ($user, $id) {


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create 2 users (We’ll call them user1, user2). They should have just the View All Requests permission.
- Create a process with 2 tasks (task1, task2)
- Assign user1 to task1 and task2 and the start event.
- Configure task1 with option “Allow reassignment“.
- Edit the process configuration and set user2 as Process Manager
- Login as user1 and start a request
- Now login as user2, go to All Requests and open the  created request

user 2 even being Process Manager, can’t open the task and see the “Reassign” Button

## Solution
Authorization to update and view tasks were changed to allow Process Managers  to reassign and view tasks.

## How to Test:
The Process Manager user must have additionally the following permissions:
- View All Requests (To access requests that are not his own)
- View Users (To see the user list when reassigning a task)
![image](https://user-images.githubusercontent.com/14875032/200596935-02f33dcc-68b9-4429-997d-b6282bcef31e.png)

As specified in the [PRD ](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/1376452613/Organizational+Hierarchies#VI.-Process-Manager-COMPLETE) the Process Manager can reassign all tasks of a process, even if the task does not have the "Allow Reassignment" setting




## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-6660](https://processmaker.atlassian.net/browse/FOUR-6660)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
