### PR TITLE
FOUR-7092 Updating Node to 16.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you are new to ProcessMaker 4 and would like to load the software locally, we
 ## System Requirements
 
 * [Composer 2](https://getcomposer.org/)
-* [Node.js 16.15](https://nodejs.org/en/)
+* [Node.js 16.18.1](https://nodejs.org/en/)
 * [NPM 8.9](https://www.npmjs.com/package/npm)
 * [PHP 8.1](https://php.net)
 * [PHP-FPM](https://www.php.net/manual/en/install.fpm.php)
@@ -153,7 +153,7 @@ You can develop ProcessMaker as well as ProcessMaker packages locally. In order 
 * [PHP 8.1](https://php.net) or above
   * Windows users can install [XAMPP](https://www.apachefriends.org/index.html)
 * [Composer 2](https://getcomposer.org/)
-* [Node.js 16.15](https://nodejs.org/en/) or above
+* [Node.js 16.18.1](https://nodejs.org/en/) or above
 
 **Steps for Development Installation**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,8 +87,8 @@
                 "vue-loader": "^15.10.0"
             },
             "engines": {
-                "node": "~16.15",
-                "npm": "~8.9"
+                "node": "~16.18",
+                "npm": "~8.19"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "coverageDirectory": "<rootDir>/tests/js/coverage"
     },
     "engines": {
-        "npm": "~8.9",
-        "node": "~16.15"
+        "npm": "~8.19",
+        "node": "~16.18"
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).
Node and NPM in Core weren't up to date with the latest LTS and there was a security issue with the pipeline and SecOps reported an issue with it

## Solution
- The pipeline shouldn't have any errors or warnings regarding security issues
- Upgrading Node and NPM to almost the latest LTS

## How to Test
Installing locally node version 16.18.1 which comes with npm version 8.19
Running `npm install` in core
No errors should happen

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7092

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
