### PR TITLE
FOUR-3239: Described By

### DIFF
--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -33,6 +33,7 @@
                                 :title="$t('Edit')"
                                 v-if="permissions.edit"
                                 v-uni-aria-describedby="props.rowData.id.toString()"
+                                :aria-label="$t('Edit') + ' ' + props.rowData.name.toString()"
                             >
                                 <i class="fas fa-pen-square fa-lg fa-fw"></i>
                             </b-btn>
@@ -43,6 +44,7 @@
                                 :title="$t('Delete')"
                                 v-if="permissions.delete && props.rowData[count] == 0"
                                 v-uni-aria-describedby="props.rowData.id.toString()"
+                                :aria-label="$t('Delete') + ' ' + props.rowData.name.toString()"
                             >
                                 <i class="fas fa-trash-alt fa-lg fa-fw"></i>
                             </b-btn>

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -56,6 +56,7 @@
                       :title="$t('Unpause Start Timer Events')"
                       v-if="props.rowData.has_timer_start_events && props.rowData.pause_timer_start"
                       v-uni-aria-describedby="props.rowData.id.toString()"
+                      :aria-label="$t('Unpause Start Timer Events for') + ' ' + props.rowData.name.toString()"
               >
                 <i class="fas fa-play fa-lg fa-fw"></i>
               </b-btn>
@@ -66,6 +67,7 @@
                       :title="$t('Pause Start Timer Events')"
                       v-if="props.rowData.has_timer_start_events && !props.rowData.pause_timer_start"
                       v-uni-aria-describedby="props.rowData.id.toString()"
+                      :aria-label="$t('Pause Start Timer Events for') + ' ' + props.rowData.name.toString()"
               >
                 <i class="fas fa-pause fa-lg fa-fw"></i>
               </b-btn>
@@ -76,6 +78,7 @@
                       :title="$t('Edit')"
                       v-if="permission.includes('edit-processes') && (props.rowData.status === 'ACTIVE' || props.rowData.status === 'INACTIVE')"
                       v-uni-aria-describedby="props.rowData.id.toString()"
+                      :aria-label="$t('Edit') + ' ' + props.rowData.name.toString()"
               >
                 <i class="fas fa-pen-square fa-lg fa-fw"></i>
               </b-btn>
@@ -86,6 +89,7 @@
                       :title="$t('Configure')"
                       v-if="permission.includes('edit-processes') && (props.rowData.status === 'ACTIVE' || props.rowData.status === 'INACTIVE')"
                       v-uni-aria-describedby="props.rowData.id.toString()"
+                      :aria-label="$t('Configure') + ' ' + props.rowData.name.toString()"
               >
                 <i class="fas fa-cog fa-lg fa-fw"></i>
               </b-btn>
@@ -96,6 +100,7 @@
                       :title="$t('View Documentation')"
                       v-if="permission.includes('view-processes') && isDocumenterInstalled"
                       v-uni-aria-describedby="props.rowData.id.toString()"
+                      :aria-label="$t('View Documentation for') + ' ' + props.rowData.name.toString()"
               >
                 <i class="fas fa-map-signs fa-lg fa-fw"></i>
               </b-btn>
@@ -106,6 +111,7 @@
                       :title="$t('Export')"
                       v-if="permission.includes('export-processes')"
                       v-uni-aria-describedby="props.rowData.id.toString()"
+                      :aria-label="$t('Export') + ' ' + props.rowData.name.toString()"
               >
                 <i class="fas fa-file-export fa-lg fa-fw"></i>
               </b-btn>
@@ -116,6 +122,7 @@
                       :title="$t('Archive')"
                       v-if="permission.includes('archive-processes') && (props.rowData.status === 'ACTIVE' || props.rowData.status === 'INACTIVE')"
                       v-uni-aria-describedby="props.rowData.id.toString()"
+                      :aria-label="$t('Archive') + ' ' + props.rowData.name.toString()"
               >
                 <i class="fas fa-download fa-lg fa-fw"></i>
               </b-btn>
@@ -126,6 +133,7 @@
                       :title="$t('Restore')"
                       v-if="permission.includes('archive-processes') && props.rowData.status === 'ARCHIVED'"
                       v-uni-aria-describedby="props.rowData.id.toString()"
+                      :aria-label="$t('Restore') + ' ' + props.rowData.name.toString()"
               >
                 <i class="fas fa-upload fa-lg fa-fw"></i>
               </b-btn>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-3239](https://processmaker.atlassian.net/browse/FOUR-3239)

The vue-tables and action buttons for Process listing need to be associated using the respective name using aria-describedby 

Direct feedback from accessibility consultant: should use something more like, for example: aria-label="Edit [Process Name]".

# Solution
Add aria-labels to action buttons in the vue-table. Label now includes the action _and_ process name.

# Steps to Reproduce Issue
1. Go to Designer -> Processes
2. Inspect an action button listed to the 

# How to Test
1. Update core branch to `bugfix/FOUR-3239`.

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.