### PR TITLE
Casting to array in FormalExpression (arrayget) - FOUR-7094

### DIFF
--- a/ProcessMaker/Models/FormalExpression.php
+++ b/ProcessMaker/Models/FormalExpression.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Models;
 
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 use ProcessMaker\Exception\ExpressionFailedException;
 use ProcessMaker\Exception\ScriptLanguageNotSupported;
 use ProcessMaker\Exception\SyntaxErrorException;
@@ -254,6 +255,12 @@ class FormalExpression implements FormalExpressionInterface
             function () {
             },
             function ($arguments, $array, $key, $default) {
+                $array = json_decode(json_encode($array), true);
+                if (is_null($array) && !is_null($array)) {
+                    Log::error('The parameter cannot be converted to an array.', [
+                        'array' => $array
+                    ]);
+                }
                 return Arr::get($array, $key, $default);
             }
         );

--- a/tests/unit/ProcessMaker/Models/FormalExpressionTest.php
+++ b/tests/unit/ProcessMaker/Models/FormalExpressionTest.php
@@ -62,4 +62,30 @@ class FormalExpressionTest extends TestCase
         // Check the expression date('H:i', null, user_tz) == user_schedule_time
         $this->assertTrue($userScheduleTime === $feelDate);
     }
+
+    public function testArrayGet()
+    {
+        $data = [
+            '_parent' => [
+                'request_id' => '123',
+                'config' => [ 'callback' => true ]
+            ],
+            'request' => ['request_id' => '122']
+        ];
+
+        $formalExp = new FormalExpression();
+        $formalExp->setLanguage('FEEL');
+
+        $formalExp->setBody('arrayget(_parent, "config.callback", false)');
+        $callback = $formalExp($data);
+        $this->assertEquals(true, $callback);
+
+        $formalExp->setBody('arrayget(_parent, "request_id", null)');
+        $callback = $formalExp($data);
+        $this->assertEquals('123', $callback);
+
+        $formalExp->setBody('arrayget(request, "request_id", null)');
+        $callback = $formalExp($data);
+        $this->assertEquals('122', $callback);
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
This bug was encountered during the [PM4EH-184](https://processmaker.atlassian.net/browse/PM4EH-184) task. 

It was expected that the process would only move forward after receiving the callback call.

In the process that manages the Data Connector implementation, there is a gateway that checks for a callback. In the "Yes" path, there is a FormalExpression that fails, even though there is a callback in the parent process. This takes the process in the wrong flow, causing the bug.

I suspect it's not a regression issue and that this function has never worked, following the evidence below.

[https://github.com/ProcessMaker/processmaker/commit/83993df2eebe2d62ea97bcec8210f5d9efce450c](https://github.com/ProcessMaker/processmaker/commit/83993df2eebe2d62ea97bcec8210f5d9efce450c)

[https://github.com/ProcessMaker/processmaker/blob/develop/ProcessMaker/Models/FormalExpression.php#L281](https://github.com/ProcessMaker/processmaker/blob/develop/ProcessMaker/Models/FormalExpression.php#L281)

[https://github.com/ProcessMaker/processmaker/commit/367eb3e4bfd6d50a37759a6b0021f5e14fc672da#diff-9b17ccd32dc2f52a975a7da00cf04f6b84b46e5eabf7803efca50cf34e6d9bd1R80](https://github.com/ProcessMaker/processmaker/commit/367eb3e4bfd6d50a37759a6b0021f5e14fc672da#diff-9b17ccd32dc2f52a975a7da00cf04f6b84b46e5eabf7803efca50cf34e6d9bd1R80)

[https://github.com/laravel/framework/blob/6.x/src/Illuminate/Support/Arr.php#L284](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Support/Arr.php#L284)

[https://github.com/laravel/framework/blob/7e82e1a272a72d75b4cd7f35a2267e9af5d642c2/src/Illuminate/Support/Arr.php#L21](https://github.com/laravel/framework/blob/7e82e1a272a72d75b4cd7f35a2267e9af5d642c2/src/Illuminate/Support/Arr.php#L21)

## Solution
Cast to array before calling `Arr::get`.

## How to Test
Run the command:
```
php vendor/phpunit/phpunit/phpunit --colors --stop-on-failure tests/unit/ProcessMaker/Models/FormalExpressionTest.php --filter=testArrayGet
```

Another test can be done by following the "**Steps to Reproduce**" in this ticket [FOUR-7094](https://processmaker.atlassian.net/browse/FOUR-7094).

## Related Tickets & Packages
- [FOUR-7094](https://processmaker.atlassian.net/browse/FOUR-7094)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
