### PR TITLE
Bugfix/four 6803

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -741,15 +741,6 @@ h1.page-title {
   border-top: 1px solid rgba(255, 255, 255, 0.25);
 }
 
-button.filter-bar {
-  background-color: $primary;
-  border-left: 0;
-  border-right: 0;
-  border-bottom: 0;
-  width: 100%;
-  padding: 0;
-}
-
 .login-logo-default {
   max-width: 292px;
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -741,6 +741,15 @@ h1.page-title {
   border-top: 1px solid rgba(255, 255, 255, 0.25);
 }
 
+button.filter-bar {
+  background-color: $primary;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  width: 100%;
+  padding: 0;
+}
+
 .login-logo-default {
   max-width: 292px;
 }

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -26,32 +26,29 @@
       @endif
     </ul>
   <div class="w-100" v-cloak>
-    <div
-      v-if="expanded"
-      @click="expanded = !expanded"
-      role="button"
-      :aria-label="$t('Collapse sidebar')"
-      class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
-    >
-      <div class="nav-link">
-        <i class="fas fa-angle-double-left nav-icon" v-if="expanded"></i>
-        <i class="fas fa-angle-double-right nav-icon" v-else></i>
-        <span class="nav-text" v-if="expanded" v-cloak >
-          {{ __('Collapse sidebar') }}
-        </span>
-</div>
-    </div>
-    <div
-      v-else
-      @click="expanded = !expanded"
-      role="button"
-      :aria-label="$t('Expand sidebar')"
-      class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
-      v-b-tooltip.hover.right="{ title: $t('Expand sidebar'), animation: false, boundary: 'viewport', delay: { show: 0, hide: 0 } }"
-    >
+    <button
+        v-if="expanded"
+        @click="expanded = !expanded"
+        role="button" :aria-label="$t('Collapse sidebar')"
+        class="nav-item filter-bar justify-content-between py-2 sidebar-expansion">
+        <div class="nav-link">
+            <i class="fas fa-angle-double-left nav-icon" v-if="expanded"></i>
+            <i class="fas fa-angle-double-right nav-icon" v-else></i>
+            <span class="nav-text" v-if="expanded" v-cloak >
+              {{ __('Collapse Sidebar') }}
+            </span>
+        </div>
+    </button>
+    <button
+        v-else @click="expanded = !expanded"
+        role="button"
+        :aria-label="$t('Expand sidebar')"
+        class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
+        v-b-tooltip.hover.right="{ title: $t('Expand Sidebar'), animation: false, boundary: 'viewport', delay: { show: 0, hide: 0 } }"
+        tabindex="0">
       <div class="nav-link">
         <i class="fas fa-angle-double-right nav-icon"></i>
       </div>
-    </div>
+    </button>
   </div>
 </nav>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -26,32 +26,29 @@
       @endif
     </ul>
   <div class="w-100" v-cloak>
-    <div
-      v-if="expanded"
-      @click="expanded = !expanded"
-      role="button"
-      :aria-label="$t('Collapse sidebar')"
-      class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
-    >
-      <div class="nav-link">
-        <i class="fas fa-angle-double-left nav-icon" v-if="expanded"></i>
-        <i class="fas fa-angle-double-right nav-icon" v-else></i>
-        <span class="nav-text" v-if="expanded" v-cloak >
-          {{ __('Collapse sidebar') }}
-        </span>
-</div>
-    </div>
-    <div
-      v-else
-      @click="expanded = !expanded"
-      role="button"
-      :aria-label="$t('Expand sidebar')"
-      class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
-      v-b-tooltip.hover.right="{ title: $t('Expand sidebar'), animation: false, boundary: 'viewport', delay: { show: 0, hide: 0 } }"
-    >
+    <button
+        v-if="expanded"
+        @click="expanded = !expanded"
+        role="button" :aria-label="$t('Collapse sidebar')"
+        class="nav-item filter-bar justify-content-between py-2 sidebar-expansion">
+        <div class="nav-link">
+            <i class="fas fa-angle-double-left nav-icon" v-if="expanded"></i>
+            <i class="fas fa-angle-double-right nav-icon" v-else></i>
+            <span class="nav-text" v-if="expanded" v-cloak >
+              {{ __('Collapse Sidebar') }}
+            </span>
+        </div>
+    </button>
+    <button
+        v-else @click="expanded = !expanded"
+        role="button"
+        :aria-label="$t('Expand sidebar')"
+        class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
+        v-b-tooltip.hover.right="{ title: $t('Expand sidebar'), animation: false, boundary: 'viewport', delay: { show: 0, hide: 0 } }"
+        tabindex="0">
       <div class="nav-link">
         <i class="fas fa-angle-double-right nav-icon"></i>
       </div>
-    </div>
+    </button>
   </div>
 </nav>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -26,29 +26,32 @@
       @endif
     </ul>
   <div class="w-100" v-cloak>
-    <button
-        v-if="expanded"
-        @click="expanded = !expanded"
-        role="button" :aria-label="$t('Collapse sidebar')"
-        class="nav-item filter-bar justify-content-between py-2 sidebar-expansion">
-        <div class="nav-link">
-            <i class="fas fa-angle-double-left nav-icon" v-if="expanded"></i>
-            <i class="fas fa-angle-double-right nav-icon" v-else></i>
-            <span class="nav-text" v-if="expanded" v-cloak >
-              {{ __('Collapse Sidebar') }}
-            </span>
-        </div>
-    </button>
-    <button
-        v-else @click="expanded = !expanded"
-        role="button"
-        :aria-label="$t('Expand sidebar')"
-        class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
-        v-b-tooltip.hover.right="{ title: $t('Expand sidebar'), animation: false, boundary: 'viewport', delay: { show: 0, hide: 0 } }"
-        tabindex="0">
+    <div
+      v-if="expanded"
+      @click="expanded = !expanded"
+      role="button"
+      :aria-label="$t('Collapse sidebar')"
+      class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
+    >
+      <div class="nav-link">
+        <i class="fas fa-angle-double-left nav-icon" v-if="expanded"></i>
+        <i class="fas fa-angle-double-right nav-icon" v-else></i>
+        <span class="nav-text" v-if="expanded" v-cloak >
+          {{ __('Collapse sidebar') }}
+        </span>
+</div>
+    </div>
+    <div
+      v-else
+      @click="expanded = !expanded"
+      role="button"
+      :aria-label="$t('Expand sidebar')"
+      class="nav-item filter-bar justify-content-between py-2 sidebar-expansion"
+      v-b-tooltip.hover.right="{ title: $t('Expand sidebar'), animation: false, boundary: 'viewport', delay: { show: 0, hide: 0 } }"
+    >
       <div class="nav-link">
         <i class="fas fa-angle-double-right nav-icon"></i>
       </div>
-    </button>
+    </div>
   </div>
 </nav>


### PR DESCRIPTION
Ticket [FOUR-6803](https://processmaker.atlassian.net/browse/FOUR-6803)
## Issue & Reproduction Steps
The expand/collapse menu button in the navigation is not announced or is reached by the screen reader.
- Add Screen Reader extension to Chrome
- Go to requests or any page
- Use the tab to navigate the page
- At the moment the expand/collapse menu button is not announced or is reached by the screen reader

## Solution
- Changed div to button elements.

## How to Test
- Add Screen Reader extension to Chrome
- Go to requests or any page
- Use the tab to navigate the page
- Reach the expand/collapse menu button
![Screenshot 2022-11-18 at 6 09 06 PM](https://user-images.githubusercontent.com/5769433/202829468-d9f7a7d4-d194-413c-8af0-621a8b1311dc.png)



## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
