### PR TITLE
FOUR-6970: error TypeError: this.input.join is not a function, when saving the selected groups for synchronization

### DIFF
--- a/resources/js/admin/settings/components/SettingCheckboxes.vue
+++ b/resources/js/admin/settings/components/SettingCheckboxes.vue
@@ -57,7 +57,7 @@ export default {
       options: [],
       selected: null,
       showModal: false,
-      transformed: null,
+      transformed: [],
     };
   },
   computed: {
@@ -137,7 +137,7 @@ export default {
   },
   mounted() {
     if (this.value === null) {
-      this.input = '';
+      this.input = [];
     } else {
       this.input = this.value;
     }


### PR DESCRIPTION
## Issue & Reproduction Steps

* Log in 
* click on ADmin
* click on settings 
* click on LDAP
* configure  LDAP 
* click on Groups to Import 
* select groups
* click on SAVE  

## Solution
- The model variable used  for b-form-checkbox-group was initialized as null or an empty string. This worked with old versions of vue-boostrap. The issue was resolved initializing the variable as an emty array [] 

Documentation: ([b-form-checkbox-group](https://bootstrap-vue.org/docs/components/form-checkbox))

## How to Test
* Use the reproduction steps
* Verify that the console error  this.input.join... etc is no longer present.

To facilitate the test, the next LDAP configuration can be used:

services.ldap.type => openldap
services.ldap.server.address => ldap.forumsys.com
services.ldap.server.port => 389
services.ldap.server.tls => 0
services.ldap.base_dn => "dc=example,dc=com"
services.ldap.authentication.username => "cn=read-only-admin,dc=example,dc=com"
services.ldap.authentication.password => password

## Related Tickets & Packages
This PR resolves the next issues:

[https://processmaker.atlassian.net/browse/FOUR-6970](https://processmaker.atlassian.net/browse/FOUR-6970)
[https://processmaker.atlassian.net/browse/FOUR-6969](https://processmaker.atlassian.net/browse/FOUR-6969)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
