### PR TITLE
FOUR-6798 | Selected Filter Options and Screen Reader

### DIFF
--- a/resources/js/components/AdvancedSearch.vue
+++ b/resources/js/components/AdvancedSearch.vue
@@ -8,6 +8,7 @@
                         <multiselect id="process_name_filter" v-model="process"
                                      @search-change="getProcesses"
                                      @input="buildPmql"
+                                     @select="processSelected"
                                      :show-labels="false"
                                      :loading="isLoading.process"
                                      open-direction="bottom"
@@ -15,8 +16,8 @@
                                      :options="processOptions"
                                      :track-by="'id'"
                                      :multiple="true"
-                                     :aria-label="$t('Process')"
-                                     :placeholder="$t('Process')">
+                                     :placeholder="$t('Process')"
+                                     :aria-label="this.process ? this.process.ariaLabel : $t('Process')">
                             <template slot="noResult">
                                 {{ $t('No Results') }}
                             </template>
@@ -31,13 +32,14 @@
                       <multiselect id="process_status_filter" v-model="status"
                                      :show-labels="false"
                                      @input="buildPmql"
+                                     @select="statusSelected"
                                      :loading="isLoading.status"
                                      open-direction="bottom"
                                      label="name"
                                      :options="statusOptions"
                                      track-by="value"
                                      :multiple="true"
-                                     :aria-label="$t('Status')"
+                                     :aria-label="this.status ? this.status.ariaLabel : $t('Status')"
                                      :placeholder="$t('Status')">
                             <template slot="noResult">
                                 {{ $t('No Results') }}
@@ -54,6 +56,7 @@
                                    v-model="requester"
                                      @search-change="getRequesters"
                                      @input="buildPmql"
+                                     @select="requesterSelected"
                                      :show-labels="false"
                                      :loading="isLoading.requester"
                                      open-direction="bottom"
@@ -61,7 +64,7 @@
                                      :options="requesterOptions"
                                      :track-by="'id'"
                                      :multiple="true"
-                                     :aria-label="$t('Requester')"
+                                     :aria-label="$t('Requester') + ' ' + this.requester[0].fullname"
                                      :placeholder="$t('Requester')">
                             <template slot="noResult">
                                 {{ $t('No Results') }}
@@ -83,6 +86,7 @@
                       <multiselect id="process_participant_filter" v-model="participants"
                                      @search-change="getParticipants"
                                      @input="buildPmql"
+                                     @select="participantSelected"
                                      :show-labels="false"
                                      :loading="isLoading.participants"
                                      open-direction="bottom"
@@ -115,6 +119,7 @@
                                   v-model="request"
                                      @search-change="getRequests"
                                      @input="buildPmql"
+                                     @select="requestSelected"
                                      :show-labels="false"
                                      :loading="isLoading.request"
                                      open-direction="bottom"
@@ -139,6 +144,7 @@
                                      v-model="name"
                                      @search-change="getNames"
                                      @input="buildPmql"
+                                     @select="taskSelected"
                                      :show-labels="false"
                                      :loading="isLoading.name"
                                      open-direction="bottom"
@@ -163,6 +169,7 @@
                                       v-model="status"
                                      :show-labels="false"
                                      @input="buildPmql"
+                                     @select="statusOptionsSelected"
                                      :loading="isLoading.status"
                                      open-direction="bottom"
                                      label="name"
@@ -494,15 +501,59 @@ export default {
             this.isLoading.name = false
             setTimeout(3000)
           });
-      }
+      },
+      processSelected(option) {
+        if (this.process) {
+          let name = document.getElementById('process_name_filter');
+          name.ariaLabel = 'Selected' + ' ' + option.name;
+        }
+      },
+      statusSelected(option) {      
+        if (this.status) {
+          let status = document.getElementById('process_status_filter');
+          status.ariaLabel = 'Selected' + ' ' + option.name;
+        }
+      },
+      requesterSelected(option) {
+        if (this.requester) {
+          let requester = document.getElementById('process_requester_filter');
+          requester.ariaLabel = 'Selected' + ' ' + option.fullname;
+        }
+      },
+      participantSelected(option) {
+        if (this.participants) {
+          let participants = document.getElementById('process_participant_filter');
+          participants.ariaLabel = 'Selected' + ' ' + option.fullname;
+        }
+      },
+      requestSelected(option) {
+        if (this.request) {
+          let request = document.getElementById('process_request_filter');
+          request.ariaLabel = 'Selected' + ' ' + option.name;
+        }
+      },
+      taskSelected(option) {
+        if (this.name) {
+          let name = document.getElementById('process_task_filter');
+          name.ariaLabel = 'Selected' + ' ' + option.name;
+        }
+      },
+      statusOptionsSelected(option) {
+        if (this.status) {
+          let status = document.getElementById('process_status_options_filter');
+          status.ariaLabel = 'Selected' + ' ' + option.name;
+        }
+      },
   },
   created() {
     if (this.paramProcess && Array.isArray(this.paramProcess)) {
         this.process = this.paramProcess;
+        this.process.ariaLabel = 'Selected' + ' ' + this.process[0].name;
     }
     
     if (this.paramStatus && Array.isArray(this.paramStatus)) {
         this.status = this.paramStatus;
+        this.status.ariaLabel = 'Selected' + ' ' + this.status[0].name;
     }
     
     if (this.paramRequester && Array.isArray(this.paramRequester)) {

--- a/resources/js/components/AdvancedSearch.vue
+++ b/resources/js/components/AdvancedSearch.vue
@@ -16,8 +16,8 @@
                                      :options="processOptions"
                                      :track-by="'id'"
                                      :multiple="true"
-                                     :placeholder="$t('Process')"
-                                     :aria-label="this.process ? this.process.ariaLabel : $t('Process')">
+                                     :aria-label="this.paramProcess ? this.process.ariaLabel : $t('Process')"
+                                     :placeholder="$t('Process')">
                             <template slot="noResult">
                                 {{ $t('No Results') }}
                             </template>
@@ -39,7 +39,7 @@
                                      :options="statusOptions"
                                      track-by="value"
                                      :multiple="true"
-                                     :aria-label="this.status ? this.status.ariaLabel : $t('Status')"
+                                     :aria-label="this.paramStatus ? this.status.ariaLabel : $t('Status')"
                                      :placeholder="$t('Status')">
                             <template slot="noResult">
                                 {{ $t('No Results') }}
@@ -64,7 +64,7 @@
                                      :options="requesterOptions"
                                      :track-by="'id'"
                                      :multiple="true"
-                                     :aria-label="$t('Requester') + ' ' + this.requester[0].fullname"
+                                     :aria-label="this.paramRequester ? this.requester.ariaLabel : $t('Requester')"
                                      :placeholder="$t('Requester')">
                             <template slot="noResult">
                                 {{ $t('No Results') }}
@@ -94,7 +94,7 @@
                                      :options="participantsOptions"
                                      :track-by="'id'"
                                      :multiple="true"
-                                     :aria-label="$t('Participants')"
+                                     :aria-label="this.paramParticipants ? this.participants.ariaLabel : $t('Participants')"
                                      :placeholder="$t('Participants')">
                             <template slot="noResult">
                                 {{ $t('No Results') }}
@@ -558,10 +558,12 @@ export default {
     
     if (this.paramRequester && Array.isArray(this.paramRequester)) {
         this.requester = this.paramRequester;
+        this.requester.ariaLabel = 'Selected' + ' ' + this.requester[0].fullname;
     }
     
     if (this.paramParticipants && Array.isArray(this.paramParticipants)) {
         this.participants = this.paramParticipants;
+        this.participants.ariaLabel = 'Selected' + ' ' + this.participants[0].fullname;
     }
     
     this.buildPmql();


### PR DESCRIPTION
# Issue
Ticket: [FOUR-6798](https://processmaker.atlassian.net/browse/FOUR-6798)

Filter Options and options that are already selected are not announced for screen reader user.

# Solution
- Add aria-labels to options that are pre-selected when the page loads.
- Add aria-labels to selected options.

# Steps to Reproduce Issue
1. Go to Requests.
2. Open inspector on one of the Advanced Search fields (Process, Status, Requester, Participants).
3. Note that there are no aria-labels for selected options.

# How to Test
1. Update core branch to `feature/FOUR-6798`.
2. Repeat Steps to Reproduce Issue.
4. Aria-labels should appear for pre-selected options and selected options.

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.