### PR TITLE
FOUR-7110: Improved request retry

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -244,7 +244,7 @@ class ProcessRequestController extends Controller
 
         if ($request->status !== 'ERROR') {
             return response()->json([
-                'message' => 'Only requests with ERROR status can be retried',
+                'message' => __('Only requests with ERROR status can be retried'),
                 'success' => false
             ], 422);
         }
@@ -253,7 +253,7 @@ class ProcessRequestController extends Controller
 
         if (!$retryRequest->hasRetriableTasks() || $retryRequest->hasNonRetriableTasks()) {
             return response()->json([
-                'message' => ['No tasks available to retry'],
+                'message' => [__('No tasks available to retry')],
                 'success' => false,
             ]);
         }

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -243,9 +243,10 @@ class ProcessRequestController extends Controller
         }
 
         if ($request->status !== 'ERROR') {
-            throw ValidationException::withMessages([
-                'status' => __('Only requests with ERROR status can be retried'),
-            ]);
+            return response()->json([
+                'message' => 'Only requests with ERROR status can be retried',
+                'success' => false
+            ], 422);
         }
 
         $retryRequest = RetryProcessRequest::for($request);

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -105,13 +105,7 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
                 $this->instance = $instance;
             });
         } catch (Throwable $exception) {
-            // Change to error status
-            $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
-            $error = $element->getRepository()->createError();
-            $error->setName($exception->getMessage());
-            $token->setProperty('error', $error);
-            Log::error('Script failed: ' . $scriptRef . ' - ' . $exception->getMessage());
-            Log::error($exception->getTraceAsString());
+            $token->logError($exception, $element);
         }
     }
 

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -105,7 +105,17 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
                 $this->instance = $instance;
             });
         } catch (Throwable $exception) {
+
+            $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
+
+            $error = $element->getRepository()->createError();
+            $error->setName($exception->getMessage());
+
+            $token->setProperty('error', $error);
             $token->logError($exception, $element);
+
+            Log::error('Script failed: ' . $scriptRef . ' - ' . $exception->getMessage());
+            Log::error($exception->getTraceAsString());
         }
     }
 

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -649,14 +649,15 @@
           retryRequest() {
 			const apiRequest = () => {
               this.retryDisabled = true
+			  let success = true
 
               ProcessMaker.apiClient.put(`requests/${this.requestId}/retry`).then(response => {
                 if (response.status !== 200) {
                   return;
                 }
 
-                const success = response.data.success || false
                 const message = response.data.message;
+                success = response.data.success || false
 
                 if (success) {
                   if (Array.isArray(message)) {
@@ -664,12 +665,11 @@
                       ProcessMaker.alert(this.$t(line), 'success')
                     }
                   }
-
-                  setTimeout(() => location.reload(), 3000)
                 } else {
                   ProcessMaker.alert(this.$t("Request could not be retried"), 'danger')
+
                 }
-              })
+              }).finally(() => setTimeout(() => location.reload(), success ? 3000 : 1000))
 			}
 
             ProcessMaker.confirmModal(

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -294,6 +294,7 @@
 											type="button"
 											class="btn btn-outline-info btn-block"
 											data-toggle="modal"
+											:disabled="retryDisabled"
 											@click="retryRequest">
 										<i class="fas fa-sync"></i> {{__('Retry')}}
 									</button>
@@ -385,6 +386,7 @@
             userRequested: [],
             errorLogs: @json(['data'=>$request->errors]),
             disabled: false,
+            retryDisabled: false,
             packages: [],
             processId: @json($request->process->id),
             canViewComments: @json($canViewComments),
@@ -646,6 +648,8 @@
           },
           retryRequest() {
 			const apiRequest = () => {
+              this.retryDisabled = true
+
               ProcessMaker.apiClient.put(`requests/${this.requestId}/retry`).then(response => {
                 if (response.status !== 200) {
                   return;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR covers the issue(s) covered in FOUR-7110, namely a 422 error which occurred when the user rapidly used the "Retry" button to trigger the retry request feature. 

## Solution
- Disables the retry button after initial click
- Switches request to "ACTIVE" upon retry
- Switched to better error logging/reporting for when script tasks fail

## How to Test
You should only be able to retry a request once until the page reloads. If the request is in a "In Progress" state, the retry button will not appear (as this is expected). If you refresh again and a script has errored out, it should update the request and you should be able to retry it again.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7110
- https://processmaker.atlassian.net/browse/FOUR-6832

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
