### PR TITLE
Bugfix/FOUR-7099: TypeError: n.split is not a function: errors appear on the screen with any control, when an error has been generated when creating another control

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -615,6 +615,7 @@ export default {
         this.$refs.menuScreen.sectionRight = false;
       }
       this.mode = mode;
+      this.$store.commit("globalErrorsModule/setMode", this.mode);
       this.previewData = this.previewInputValid ? JSON.parse(this.previewInput) : {};
       this.rendererKey++;
       if (mode == 'preview') {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -212,6 +212,7 @@ import MonacoEditor from "vue-monaco";
 import mockMagicVariables from "./mockMagicVariables";
 import TopMenu from "../../components/Menu";
 import { cloneDeep, debounce , isEqual} from 'lodash';
+import { mapMutations } from 'vuex';
 import i18next from 'i18next';
 
 // Bring in our initial set of controls
@@ -464,6 +465,7 @@ export default {
     this.countElements();
   },
   methods: {
+    ...mapMutations("globalErrorsModule", { setStoreMode: "setMode" }),
     // eslint-disable-next-line func-names
     updateDataInput: debounce(function () {
       if (this.previewInputValid) {
@@ -615,7 +617,7 @@ export default {
         this.$refs.menuScreen.sectionRight = false;
       }
       this.mode = mode;
-      this.$store.commit("globalErrorsModule/setMode", this.mode);
+      this.setStoreMode(this.mode);
       this.previewData = this.previewInputValid ? JSON.parse(this.previewInput) : {};
       this.rendererKey++;
       if (mode == 'preview') {


### PR DESCRIPTION
## Issue & Reproduction Steps
- Log in 
- go to designer
- click on screen
- create a new  screen 
- makes create an error, for example create a signature control with dot in the variable name 
- click on preview
- show  the error 
- click on designer  again 
- delete control signature 
- create  any  control  

Expected behavior: 
In the previous version, 4.2.35, this behavior is not replicated, when removing the control that generates the error, the same error does not appear in the console with other controls. the behavior should be as in version 4.2.35

Actual behavior: 
An error is coming out when creating any control on the screen, after generating an error on the screen such as creating a signature with a dot in the variable name, after even deleting the control, any control created after that, shows the same error on the screen.

## Solution
- Catch the error and show a warning instead an error showing a more friendly console message. 
- Show the message only in preview mode, and not in design mode.
- Show an Invalid variable name console error in preview mode.

**Working video**

https://user-images.githubusercontent.com/90727999/203791112-58b8b4de-c509-4f6d-89d5-be4174a056f8.mov

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-7099](https://processmaker.atlassian.net/browse/FOUR-7099)
- [Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1292)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
