### PR TITLE
Fixes for SOAP: FOUR-6315

### DIFF
--- a/ProcessMaker/Helpers/StringHelper.php
+++ b/ProcessMaker/Helpers/StringHelper.php
@@ -14,6 +14,11 @@ class StringHelper
         return $string;
     }
 
+    public static function friendlyFileName($string)
+    {
+        return preg_replace('/[^\w\.!@#$^+=-]/','_', $string);
+    }
+
     public static function unSnakeSlug($string)
     {
         return trim(preg_replace('/[_-]/', ' ', $string));

--- a/ProcessMaker/Helpers/StringHelper.php
+++ b/ProcessMaker/Helpers/StringHelper.php
@@ -16,7 +16,7 @@ class StringHelper
 
     public static function friendlyFileName($string)
     {
-        return preg_replace('/[^\w\.!@#$^+=-]/','_', $string);
+        return strtolower(preg_replace('/[^\w\.!@#$^+=-]/','_', $string));
     }
 
     public static function unSnakeSlug($string)

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Log;
 use Mustache_Engine;
 use ProcessMaker\Exception\HttpInvalidArgumentException;
 use ProcessMaker\Exception\HttpResponseException;
+use ProcessMaker\Helpers\StringHelper;
 use ProcessMaker\Models\FormalExpression;
 use Psr\Http\Message\ResponseInterface;
 
@@ -640,11 +641,20 @@ trait MakeHttpRequests
             return;
         }
 
+        if (empty($this->name)) {
+            return;
+        }
+
         try {
-            Log::channel('data-source')->info($label . str_replace(["\n", "\t", "\r"], '', $log));
+            $connectorName = StringHelper::friendlyFileName($this->name) . '_(' . $this->id . ')';
+            Log::build([
+                'driver' => 'daily',
+                'path' => storage_path("logs/data-connectors/$connectorName.log"),
+            ])->info($label . str_replace(["\n", "\t", "\r"], '', $log));
         }
         catch(\Throwable $e) {
             Log::error($e->getMessage());
         }
     }
+
 }

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -660,7 +660,8 @@ trait MakeHttpRequests
             $connectorName = StringHelper::friendlyFileName($this->name) . '_(' . $this->id . ')';
             Log::build([
                 'driver' => 'daily',
-                'path' => storage_path("logs/data-connectors/$connectorName.log"),
+                'path' => storage_path("logs/data-sources/$connectorName.log"),
+                'days' => env('DATA_SOURCE_CLEAR_LOG', 21),
             ])->info($label . str_replace(["\n", "\t", "\r"], '', $cleanedLog));
         }
         catch(\Throwable $e) {

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -644,13 +644,14 @@ trait MakeHttpRequests
         if (empty($this->name)) {
             return;
         }
-
+        $cleanedLog = preg_replace('/(Authorization.+Bearer\s+)(.+)([\'"])/mi', "$1*******$3", $log);
+        $cleanedLog = preg_replace('/(Authorization.+Basic\s+)(.+)([\'"])/mi', "$1*******$3", $log);
         try {
             $connectorName = StringHelper::friendlyFileName($this->name) . '_(' . $this->id . ')';
             Log::build([
                 'driver' => 'daily',
                 'path' => storage_path("logs/data-connectors/$connectorName.log"),
-            ])->info($label . str_replace(["\n", "\t", "\r"], '', $log));
+            ])->info($label . str_replace(["\n", "\t", "\r"], '', $cleanedLog));
         }
         catch(\Throwable $e) {
             Log::error($e->getMessage());

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -644,8 +644,18 @@ trait MakeHttpRequests
         if (empty($this->name)) {
             return;
         }
-        $cleanedLog = preg_replace('/(Authorization.+Bearer\s+)(.+)([\'"])/mi', "$1*******$3", $log);
-        $cleanedLog = preg_replace('/(Authorization.+Basic\s+)(.+)([\'"])/mi', "$1*******$3", $log);
+        $cleanedLog = preg_replace('/(Authorization.+Bearer\s+)(.+?)([\'"])/mi', "$1*******$3", $log);
+        $cleanedLog = preg_replace('/(Authorization.+Basic\s+)(.+?)([\'"])/mi', "$1*******$3", $cleanedLog);
+
+        //oauth password sends security information in the body. As this request is our own,
+        //it is the only case in which we can obfuscate parts of the body as we know its structure
+        if ($this->authtype === 'OAUTH2_PASSWORD') {
+            $cleanedLog = preg_replace('/(body.+?)(username[\'"]\s*:\s*[\'"])(.+?)([\'"])/mi', "$1$2*******$4", $cleanedLog);
+            $cleanedLog = preg_replace('/(body.+?)(password[\'"]\s*:\s*[\'"])(.+?)([\'"])/mi', "$1$2*******$4", $cleanedLog);
+            $cleanedLog = preg_replace('/(body.+?)(client_id[\'"]\s*:\s*[\'"])(.+?)([\'"])/mi', "$1$2*******$4", $cleanedLog);
+            $cleanedLog = preg_replace('/(body.+?)(client_secret[\'"]\s*:\s*[\'"])(.+?)([\'"])/mi', "$1$2*******$4", $cleanedLog);
+        }
+
         try {
             $connectorName = StringHelper::friendlyFileName($this->name) . '_(' . $this->id . ')';
             Log::build([

--- a/ProcessMaker/WebServices/NativeSoapClient.php
+++ b/ProcessMaker/WebServices/NativeSoapClient.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\WebServices;
 use DOMDocument;
 use DOMXPath;
 use Illuminate\Support\Facades\Log;
+use ProcessMaker\Helpers\StringHelper;
 use ProcessMaker\WebServices\Contracts\SoapClientInterface;
 use SimpleXMLElement;
 use SoapClient;
@@ -18,6 +19,8 @@ class NativeSoapClient implements SoapClientInterface
     private $services = [];
 
     private $debug = false;
+
+    private $options;
 
     public function __construct(string $wsdl, array $options)
     {
@@ -41,6 +44,7 @@ class NativeSoapClient implements SoapClientInterface
             ];
         }
         $this->debug = $options['debug_mode'] ?? false;
+        $this->options = $options;
         // Add Soap Auth Headers
         $this->addSoapAuthHeaders($options);
     }
@@ -98,7 +102,12 @@ class NativeSoapClient implements SoapClientInterface
                 }
             }
 
-            Log::channel('data-source')->info($label . $doc->saveXML());
+            //Log::channel('data-source')->info($label . $doc->saveXML());
+            $connectorName = StringHelper::friendlyFileName($this->options['datasource_name']) . '_(' . $this->options['datasource_id'] . ')';
+            Log::build([
+                'driver' => 'daily',
+                'path' => storage_path("logs/data-connectors/$connectorName.log"),
+            ])->info($label . $doc->saveXML());
         } catch (\Throwable $th) {
             if ($label === 'Request Headers: ') {
                 $newLog = '';

--- a/ProcessMaker/WebServices/NativeSoapClient.php
+++ b/ProcessMaker/WebServices/NativeSoapClient.php
@@ -102,7 +102,6 @@ class NativeSoapClient implements SoapClientInterface
                 }
             }
 
-            //Log::channel('data-source')->info($label . $doc->saveXML());
             $connectorName = StringHelper::friendlyFileName($this->options['datasource_name']) . '_(' . $this->options['datasource_id'] . ')';
             Log::build([
                 'driver' => 'daily',

--- a/ProcessMaker/WebServices/NativeSoapClient.php
+++ b/ProcessMaker/WebServices/NativeSoapClient.php
@@ -105,7 +105,8 @@ class NativeSoapClient implements SoapClientInterface
             $connectorName = StringHelper::friendlyFileName($this->options['datasource_name']) . '_(' . $this->options['datasource_id'] . ')';
             Log::build([
                 'driver' => 'daily',
-                'path' => storage_path("logs/data-connectors/$connectorName.log"),
+                'path' => storage_path("logs/data-sources/$connectorName.log"),
+                'days' => env('DATA_SOURCE_CLEAR_LOG', 21),
             ])->info($label . $doc->saveXML());
         } catch (\Throwable $th) {
             if ($label === 'Request Headers: ') {

--- a/ProcessMaker/WebServices/SoapConfigBuilder.php
+++ b/ProcessMaker/WebServices/SoapConfigBuilder.php
@@ -43,8 +43,8 @@ class SoapConfigBuilder implements WebServiceConfigBuilderInterface
         $config['service_url'] = $credentials['service_url'] ?? '';
         $config['passphrase'] = $credentials['passphrase'] ?? '';
         $config['password_type'] = $credentials['password_type'] ?? 'None';
-        $config['datasource_name'] = $dataSourceConfig['name'];
-        $config['datasource_id'] = $dataSourceConfig['id'];
+        $config['datasource_name'] = $dataSourceConfig['name'] ?? '';
+        $config['datasource_id'] = $dataSourceConfig['id'] ?? '';
         // Prepare endpoint params and dataMapping
         if (!empty($serviceTaskConfig['endpoint'])) {
             $endpoint = $serviceTaskConfig['endpoint'];

--- a/ProcessMaker/WebServices/SoapConfigBuilder.php
+++ b/ProcessMaker/WebServices/SoapConfigBuilder.php
@@ -43,6 +43,8 @@ class SoapConfigBuilder implements WebServiceConfigBuilderInterface
         $config['service_url'] = $credentials['service_url'] ?? '';
         $config['passphrase'] = $credentials['passphrase'] ?? '';
         $config['password_type'] = $credentials['password_type'] ?? 'None';
+        $config['datasource_name'] = $dataSourceConfig['name'];
+        $config['datasource_id'] = $dataSourceConfig['id'];
         // Prepare endpoint params and dataMapping
         if (!empty($serviceTaskConfig['endpoint'])) {
             $endpoint = $serviceTaskConfig['endpoint'];

--- a/ProcessMaker/WebServices/SoapRequestBuilder.php
+++ b/ProcessMaker/WebServices/SoapRequestBuilder.php
@@ -26,6 +26,8 @@ class SoapRequestBuilder implements WebServiceRequestBuilderInterface
                         'location' => null,
                         'debug_mode' => $config['debug_mode'],
                         'password_type' => $config['password_type'],
+                        'datasource_name' => $config['datasource_name'],
+                        'datasource_id' => $config['datasource_id'],
                     ]),
                     'operation' => $config['operation'],
                     'parameters' => $config['parameters'],
@@ -40,6 +42,8 @@ class SoapRequestBuilder implements WebServiceRequestBuilderInterface
                         'password' => $config['password'],
                         'location' => $config['location'],
                         'debug_mode' => $config['debug_mode'],
+                        'datasource_name' => $config['datasource_name'],
+                        'datasource_id' => $config['datasource_id'],
                     ]),
                     'operation' => $config['operation'],
                     'parameters' => $config['parameters'],
@@ -57,6 +61,9 @@ class SoapRequestBuilder implements WebServiceRequestBuilderInterface
                         'passphrase'    => $config['passphrase'],
                         'cache_wsdl'    => WSDL_CACHE_NONE,
                         'exceptions'    => true,
+                        'debug_mode' => $config['debug_mode'],
+                        'datasource_name' => $config['datasource_name'],
+                        'datasource_id' => $config['datasource_id'],
                         'stream_context' => stream_context_create([
                             'ssl' => [
                                 'verify_peer' => false,


### PR DESCRIPTION
## Issue & Reproduction Steps
This ticket resolves:

https://processmaker.atlassian.net/browse/FOUR-7153
https://processmaker.atlassian.net/browse/FOUR-7152
https://processmaker.atlassian.net/browse/FOUR-7151
https://processmaker.atlassian.net/browse/FOUR-7145
https://processmaker.atlassian.net/browse/FOUR-6954

## Solution
- Logging file name has been changed
- Obfuscating Oauth and simple user password information

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
