### PR TITLE
[FOUR-6407] Link forgot password logo to the main login logo

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -8,8 +8,17 @@
 
 <div align="container">
   <div align="center" class="p-5">
-    <img class="mb-4" src={{asset(env('LOGIN_LOGO_PATH', '/img/processmaker_login.png'))}}>
-     <h3>{{__('Forgot Your Password?')}}</h3>
+    @php
+      $loginLogo = \ProcessMaker\Models\Setting::getLogin();
+      $isDefault = \ProcessMaker\Models\Setting::loginIsDefault();
+      if ($isDefault) {
+        $class = 'login-logo-default';
+      } else {
+        $class = 'login-logo-custom';
+      }
+    @endphp
+    <img class="mb-4" src={{$loginLogo}} alt="{{ config('logo-alt-text', 'ProcessMaker') }}">
+    <h3>{{__('Forgot Your Password?')}}</h3>
     <p>{{__("Enter your email address and we'll send you a reset link.")}}</p>
   </div>
 


### PR DESCRIPTION
## Issue & Reproduction Steps
- Modify the UI so it has a custom login logo
- Go to the login page, notice the new custom logo
- Click the “Forgot Password” button, notice the original ProcessMaker logo
- We need to fix the forgot password page so it reflects the correct logo.

## Solution
- Implement same code as login page. I don’t love the inline PHP but that matches how it’s implemented on the login page. Should refactor in the future.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6407

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
