### PR TITLE
Starting counter manually due network latency - FOUR-6985

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -274,6 +274,16 @@ if (userID) {
     }
   });
 
+  //in some cases it's necessary to start manually
+  window.ProcessMaker.AccountTimeoutWorker.postMessage({
+    method: 'start',
+    data: {
+      timeout: window.ProcessMaker.AccountTimeoutLength,
+      warnSeconds: window.ProcessMaker.AccountTimeoutWarnSeconds,
+      enabled: window.ProcessMaker.AccountTimeoutEnabled
+    }
+  });
+
   const isSameDevice = (e) => {
     const localDeviceId = Vue.$cookies.get(e.device_variable);
     const remoteDeviceId = e.device_id;


### PR DESCRIPTION
## Issue & Reproduction Steps
In development the loading of js assets is fast. So right after login, we normally receive the `.SessionStarted` event coming from the websocket service (Laravel Echo).

In a cloud environment, after login, it takes some time to load the javascript, and when it loads, the `.SessionStarted` event has already been fired.

![Captura de tela de 2022-12-06 17-52-47](https://user-images.githubusercontent.com/16992680/206029884-2250ba2f-ec94-48a1-85eb-4a037c0027ae.png)


## Solution
- Start the counter manually.

## How to Test
In a cloud environment, open an incognito tab, disable caching, log in and don't click on anything. The modal should open normally.

Locally, lower your network speed and do the test above.
The network speed can be 10mbits/s for download and upload and 50ms latency, close to 4g speed.

## Related Tickets & Packages
- [FOUR-6985](https://processmaker.atlassian.net/browse/FOUR-6985)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
