### PR TITLE
FOUR-7210: Fix memory leak when running migration to add UUID column to failed_jobs table

### DIFF
--- a/database/migrations/2022_08_24_000000_add_uuid_to_failed_jobs_table.php
+++ b/database/migrations/2022_08_24_000000_add_uuid_to_failed_jobs_table.php
@@ -15,7 +15,7 @@ class AddUuidToFailedJobsTable extends Migration
      */
     public function up()
     {
-        if (!Schema::table('failed_jobs')->hasColumn('uuid')) {
+        if (!Schema::hasColumn('failed_jobs', 'uuid')) {
             Schema::table('failed_jobs', function (Blueprint $table) {
                 $table->string('uuid')->after('id')->nullable()->unique();
             });


### PR DESCRIPTION
## Issue
A new UUID column was introduced to the failed_jobs table in Laravel 8. To account for this a new migration was created to create that column and to populate the UUID for all existing failed jobs. This migration will fail if there is more data in the failed_jobs table than the memory limit set for PHP since the migration will attempt to load all data before updating the existing rows.

### Reproduction Steps
1. Make sure the failed_jobs table contains enough data to trigger the memory leak (usually 1 GB or more in size)
2. Check that the migration has not been run yet (named 2022_08_24_000000_add_uuid_to_failed_jobs_table)
3. Run the command php artisan migrate
4. Notice the exception thrown (PHP ran out of memory)

## Solution
Refactored the migration to use a chunking in the query. This way it will only load a given number of rows in memory at a time during the update preventing the memory leak from occurring.

## How to Test
Run through the reproduction steps and see if the memory leak occurs.

## Related Tickets & Packages
- [FOUR-7210](https://processmaker.atlassian.net/browse/FOUR-7210)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
