### PR TITLE
FOUR-6704: Updated Task API with processRequestParent()

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -39,9 +39,8 @@ class Task extends ApiResource
             $array['process_request'] = new Users($this->processRequest);
         }
 
-        if (in_array('processRequestParent', $include)) {
-            $array['process_request_parent'] = $this->processRequest->parentRequest;
-        }
+        $parentProcessRequest = $this->processRequest->parentRequest;
+        $array['can_view_parent_request'] = $parentProcessRequest && $request->user()->can('view', $parentProcessRequest);
 
         if (in_array('component', $include)) {
             $array['component'] = $this->getScreenVersion() ? $this->getScreenVersion()->parent->renderComponent() : null;

--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -38,6 +38,11 @@ class Task extends ApiResource
         if (in_array('processRequest', $include)) {
             $array['process_request'] = new Users($this->processRequest);
         }
+
+        if (in_array('processRequestParent', $include)) {
+            $array['process_request_parent'] = $this->processRequest->parentRequest;
+        }
+
         if (in_array('component', $include)) {
             $array['component'] = $this->getScreenVersion() ? $this->getScreenVersion()->parent->renderComponent() : null;
         }

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -416,11 +416,15 @@ class TasksTest extends TestCase
 
     public function testShowTaskWithParentRequest()
     {
+        $this->user = User::factory()->create();
         $parent = ProcessRequest::factory()->create();
-        $request = ProcessRequest::factory()->create(['parent_request_id' => $parent->id]);
+        $request = ProcessRequest::factory()->create([
+            'parent_request_id' => $parent->id,
+        ]);
 
         $token = ProcessRequestToken::factory()->create([
             'process_request_id' => $request->id,
+            'user_id' => $this->user->id,
         ]);
 
         //Test that is correctly displayed
@@ -430,9 +434,14 @@ class TasksTest extends TestCase
         $this->assertStatus(200, $response);
         //Check the structure
         $json = $response->json();
+        $this->assertFalse($json['can_view_parent_request']);
 
-        $this->assertEquals($parent->id, $json['process_request_parent']['id']);
-        $this->assertArrayNotHasKey('data', $json['process_request_parent']);
+        $parent->user_id = $this->user->id;
+        $parent->save();
+
+        $response = $this->apiCall('GET', $route);
+        $json = $response->json();
+        $this->assertTrue($json['can_view_parent_request']);
     }
 
     public function testUpdateTask()

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -414,6 +414,27 @@ class TasksTest extends TestCase
         $response->assertJsonStructure(['user' => ['id', 'email'], 'definition' => []]);
     }
 
+    public function testShowTaskWithParentRequest()
+    {
+        $parent = ProcessRequest::factory()->create();
+        $request = ProcessRequest::factory()->create(['parent_request_id' => $parent->id]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+        ]);
+
+        //Test that is correctly displayed
+        $route = route('api.' . $this->resource . '.show', [$token->id, 'include' => 'processRequestParent']);
+        $response = $this->apiCall('GET', $route);
+        //Check the status
+        $this->assertStatus(200, $response);
+        //Check the structure
+        $json = $response->json();
+
+        $this->assertEquals($parent->id, $json['process_request_parent']['id']);
+        $this->assertArrayNotHasKey('data', $json['process_request_parent']);
+    }
+
     public function testUpdateTask()
     {
         $this->user = User::factory()->create(); // normal user


### PR DESCRIPTION
Ticket [FOUR-6704](https://processmaker.atlassian.net/browse/FOUR-6704)

## Issue & Reproduction Steps
In a subprocess after completing a task assigned to a user "By user ID" the message "Not Authorized" is displayed.

Current behavior: 
After completing the task with the assigned user, the message "Not Authorized" is displayed.

Expected behavior: 
After the thread's task completes, the summary of the completed task should be displayed, as in previous versions.

## Solution
- Updated processCompleted() with a processRequestParent() in the Task.view file.

## How to Test
- Import the process and sub-process using the files from the ticket.
- Create a new user.
- Create a new request `test_subprocess_bsa`
- https://www.loom.com/share/f9a3ef8c56284c968085a0762d04190b


## Related Tickets & Packages
- Link to screen-builder- [PR](https://github.com/ProcessMaker/screen-builder/pull/1305)

ci:screen-builder:bugfix/FOUR-6704

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-6704]: https://processmaker.atlassian.net/browse/FOUR-6704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ