### PR TITLE
Including user permissions data regarding the request - FOUR-7187

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -2,12 +2,14 @@
 
 namespace ProcessMaker\Http\Resources;
 
+use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\Screen as ScreenResource;
 use ProcessMaker\Http\Resources\ScreenVersion as ScreenVersionResource;
 use ProcessMaker\Http\Resources\Users;
 use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\GroupMember;
+use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\User;
 use StdClass;
@@ -73,6 +75,9 @@ class Task extends ApiResource
             $array['allow_interstitial'] = $interstitial['allow_interstitial'];
             $array['interstitial_screen'] = $interstitial['interstitial_screen'];
         }
+        if (in_array('userRequestPermission', $include)) {
+            $array['user_request_permission'] = $this->loadUserRequestPermission($this->processRequest, Auth::user(), []);
+        }
         /**
          * @deprecated since 4.1 Use instead `/api/1.0/users`
          */
@@ -102,6 +107,20 @@ class Task extends ApiResource
         }
 
         return $array;
+    }
+
+    private function loadUserRequestPermission(ProcessRequest $request, User $user = null, array $permissions)
+    {
+        $permissions[] = [
+            'process_request_id' => $request->id,
+            'allowed' => $user ? $user->can('view', $request) : false
+        ];
+
+        if ($request->parentRequest && $user) {
+            $permissions = $this->loadUserRequestPermission($request->parentRequest, $user, $permissions);
+        }
+
+        return $permissions;
     }
 
     private function addUser($data, $user)


### PR DESCRIPTION
## Issue & Reproduction Steps

Actual behavior: 
After completing the task, it was redirecting to a parent request that the user did not have access to.

https://user-images.githubusercontent.com/16992680/210136587-ce333c49-a2a9-4992-987f-e5c45d7b8328.mp4


Expected behavior: 
Redirect to the request where the user has access

https://user-images.githubusercontent.com/16992680/210136594-6d3b6f31-8f43-425c-a05e-958dd3e48e8f.mp4


## Solution
- Include uses permission data information when fetch task data

## How to Test
- Create a process with the next configuration
![1](https://user-images.githubusercontent.com/16992680/210136561-f1aa27b8-af7a-4296-ac6f-ada2ab7b94e6.png)

- Create a sub-process with the next configuration
![2](https://user-images.githubusercontent.com/16992680/210136570-4a485410-7296-4fa9-b607-ff1d457f073d.png)

- Create a user without permissions  to assign on the sub-process. Like the next image:
![3](https://user-images.githubusercontent.com/16992680/210136579-c434f4d6-4c2e-4ee5-8899-4cc3f340277d.png)

- Create a request with admin user
- Route to the sub-process, where the user without permission is assigned to the sup-process
- Log in with the user on the sub-process
- Go to a self service 
- Claim the task
- Complete the request 

## Related Tickets & Packages
- [FOUR-7187](https://processmaker.atlassian.net/browse/FOUR-7187)
- [PR for screen builder](https://github.com/ProcessMaker/screen-builder/pull/1307)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7187]: https://processmaker.atlassian.net/browse/FOUR-7187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ