### PR TITLE
FOUR-470 - Translations: &#039; instead of single quote

### DIFF
--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -177,7 +177,7 @@
               () => {
                 ProcessMaker.apiClient.delete(`${this.apiRoute}/${data.id}`)
                   .then(() => {
-                    ProcessMaker.alert("The category was deleted.", "success");
+                    ProcessMaker.alert(this.$t("The category was deleted."), "success");
                     this.$emit("reload");
                   });
 

--- a/resources/js/processes/screens/components/modal/modal-screen-add.vue
+++ b/resources/js/processes/screens/components/modal/modal-screen-add.vue
@@ -46,7 +46,7 @@
             },
             afterSave() {
                 this.onClose();
-                ProcessMaker.alert('The screen was created.', 'success');
+                ProcessMaker.alert(this.$t('The screen was created.'), 'success');
                 this.$emit('reload');
             }
         }

--- a/resources/views/admin/groups/index.blade.php
+++ b/resources/views/admin/groups/index.blade.php
@@ -121,7 +121,7 @@
             this.disabled = true;
             ProcessMaker.apiClient.post('groups', this.formData)
               .then(response => {
-                ProcessMaker.alert('{{__('The group was created.')}}', 'success');
+                ProcessMaker.alert(this.$t('The group was created.'), 'success');
                 //redirect show group
                 window.location = "/admin/groups/" + response.data.id + "/edit"
               })

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -320,7 +320,7 @@
         mounted() {
           let created = (new URLSearchParams(window.location.search)).get('created');
           if (created) {
-            ProcessMaker.alert('{{__('The user was successfully created')}}', 'success');
+            ProcessMaker.alert(this.$t('The user was successfully created'), 'success');
           }
         },
         watch: {
@@ -415,7 +415,7 @@
             if (!this.validatePassword()) return false;
             ProcessMaker.apiClient.put('users/' + this.formData.id, this.formData)
               .then(response => {
-                ProcessMaker.alert('{{__('User Updated Successfully ')}}', 'success');
+                ProcessMaker.alert(this.$t('User Updated Successfully '), 'success');
                 if (this.formData.id == window.ProcessMaker.user.id) {
                   window.ProcessMaker.events.$emit('update-profile-avatar');
                 }
@@ -431,9 +431,9 @@
               user_id: this.formData.id
             })
               .then(response => {
-                ProcessMaker.alert('{{__('User Permissions Updated Successfully')}}', 'success');
+                ProcessMaker.alert(this.$t('User Permissions Updated Successfully'), 'success');
                 if (this.userId === this.currentUserId) {
-                  ProcessMaker.alert('{{__('Please logout and login again to reflect permission changes')}}', 'warning');
+                  ProcessMaker.alert(this.$t('Please logout and login again to reflect permission changes'), 'warning');
                 }
               })
           },
@@ -480,7 +480,7 @@
                 groups: groups
             })
             .then(response => {
-              ProcessMaker.alert('{{__('Groups Updated Successfully ')}}', 'success');
+              ProcessMaker.alert(this.$t('Groups Updated Successfully '), 'success');
             })
             .catch(error => {
               this.errors = error.response.data.errors;

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -381,7 +381,7 @@
             this.formData.manager_id = this.formatValueScreen(this.manager);
             ProcessMaker.apiClient.put('processes/' + that.formData.id, that.formData)
               .then(response => {
-                ProcessMaker.alert('{{__('The process was saved.')}}', 'success', 5, true);
+                ProcessMaker.alert(this.$t('The process was saved.'), 'success', 5, true);
                 that.onClose();
               })
               .catch(error => {

--- a/resources/views/processes/environment-variables/edit.blade.php
+++ b/resources/views/processes/environment-variables/edit.blade.php
@@ -86,7 +86,7 @@
                     this.resetErrors();
                     ProcessMaker.apiClient.put('environment_variables/' + this.formData.id, this.formData)
                         .then(response => {
-                            ProcessMaker.alert('{{__('The environment variable was saved.')}}', 'success');
+                            ProcessMaker.alert(this.$t('The environment variable was saved.'), 'success');
                             this.onClose();
                         })
                         .catch(error => {

--- a/resources/views/processes/export.blade.php
+++ b/resources/views/processes/export.blade.php
@@ -52,7 +52,7 @@
                     ProcessMaker.apiClient.post('processes/' + this.processId + '/export')
                         .then(response => {
                             window.location = response.data.url;
-                            ProcessMaker.alert('{{__('The process was exported.')}}', 'success');
+                            ProcessMaker.alert(this.$t('The process was exported.'), 'success');
                         })
                         .catch(error => {
                             ProcessMaker.alert(error.response.data.message, 'danger');

--- a/resources/views/processes/import.blade.php
+++ b/resources/views/processes/import.blade.php
@@ -575,7 +575,7 @@
               });
           },
           importReady(response) {
-            let message = '{{__("Unable to import the process.")}}';
+            let message = this.$t("Unable to import the process.");
             if (!response.data.status) {
               ProcessMaker.alert(message, 'danger');
               return;

--- a/resources/views/processes/screens/edit.blade.php
+++ b/resources/views/processes/screens/edit.blade.php
@@ -108,7 +108,7 @@
                     this.resetErrors();
                     ProcessMaker.apiClient.put('screens/' + this.formData.id, this.formData)
                         .then(response => {
-                            ProcessMaker.alert('{{__('The screen was saved.')}}', 'success');
+                            ProcessMaker.alert(this.$t('The screen was saved.'), 'success');
                             this.onClose();
                         })
                         .catch(error => {

--- a/resources/views/processes/screens/export.blade.php
+++ b/resources/views/processes/screens/export.blade.php
@@ -57,7 +57,7 @@
             ProcessMaker.apiClient.post('screens/' + this.screenId + '/export')
               .then(response => {
                 window.location = response.data.url;
-                ProcessMaker.alert('{{__('The screen was exported.')}}', 'success');
+                ProcessMaker.alert(this.$t('The screen was exported.'), 'success');
               })
               .catch(error => {
                 ProcessMaker.alert(error.response.data.message, 'danger');

--- a/resources/views/processes/screens/import.blade.php
+++ b/resources/views/processes/screens/import.blade.php
@@ -99,15 +99,15 @@
               }
             ).then(response => {
               if (!response.data.status) {
-                ProcessMaker.alert('{{__('Unable to import the screen.')}}', 'danger');
+                ProcessMaker.alert(this.$t('Unable to import the screen.'), 'danger');
                 return;
               }
               this.options = response.data.status;
-              let message = '{{__('The screen was imported.')}}';
+              let message = this.$t('The screen was imported.');
               let variant = 'success';
               for (let item in this.options) {
                 if (!this.options[item].success) {
-                  message = '{{__('The screen was imported, but with errors.')}}';
+                  message = this.$t('The screen was imported, but with errors.');
                   variant = 'warning'
                 }
               }

--- a/resources/views/processes/signals/index.blade.php
+++ b/resources/views/processes/signals/index.blade.php
@@ -125,7 +125,7 @@
                     this.disabled = true;
                     ProcessMaker.apiClient.post('signals', this.formData)
                         .then(response => {
-                            ProcessMaker.alert("{{__('The signal was created.')}}", 'success');
+                            ProcessMaker.alert(this.$t('The signal was created.'), 'success');
                             //redirect list signal
                             window.location = '/designer/signals';
                         })

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -535,7 +535,7 @@
               data: data,
             }).then(response => {
               this.fieldsToUpdate.splice(0);
-              ProcessMaker.alert("{{__('The request data was saved.')}}", 'success');
+              ProcessMaker.alert(this.$t('The request data was saved.'), 'success');
             });
           },
           saveJsonData() {

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -359,7 +359,7 @@
               })
               .then(response => {
                 this.fieldsToUpdate.splice(0);
-                ProcessMaker.alert("{{__('The request data was saved.')}}", "success");
+                ProcessMaker.alert(this.$t('The request data was saved.'), "success");
               });
           },
           saveJsonData () {


### PR DESCRIPTION
## Issue & Reproduction Steps

French Alert-success banner when updating user settings has `&#039;` instead of single quote.

1. Install package-translations.
2. Go to Edit Profile `/profile/edit`.
3. Change the language to `fr`.
4. Go to Admin Users `/admin/users`.
5. Click on Edit a User.
6. Click "Enregistrer" button to save.
7. Verify the pop-up success message is displayed correctly. 

## Solution

Currently, there's a problem when the string passed to the alert uses the echo {{}} syntax: `ProcessMaker.alert('{{__('User Updated Successfully ')}}', 'success');`.

The problem is solved using the $t function of VueI18Next: `ProcessMaker.alert(this.$t('User Updated Successfully '), 'success');`.

- Changes were made by replacing strings to $t function.
- Checked every ProcessMaker.alert() for missing translations.

Before changes:

https://user-images.githubusercontent.com/90741874/212121945-b90c3139-b553-431f-b282-be67046e7599.mov

After changes:

https://user-images.githubusercontent.com/90741874/212122002-6d9fadff-089a-4eaf-821e-4f6b783bd4f3.mov

## How to Test
Please, follow the reproduction steps of above.

## Related Tickets & Packages
- [FOUR-470](https://processmaker.atlassian.net/browse/FOUR-470)

NOTE: Later, we should consider adding these changes in the following packages:

- package-vocabularies
- package-collections
- package-google-places
- package-data-sources

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-470]: https://processmaker.atlassian.net/browse/FOUR-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ