### PR TITLE
Fix the process request view policy check in 4.3.1

### DIFF
--- a/ProcessMaker/Policies/ProcessRequestPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestPolicy.php
@@ -34,7 +34,9 @@ class ProcessRequestPolicy
     public function view(User $user, ProcessRequest $processRequest)
     {
         // Policy defined in ForUserScope
-        return $processRequest->forUser($user)->exists();
+        return ProcessRequest::forUser($user)
+            ->where('process_requests.id', $processRequest->id)
+            ->exists();
     }
 
     /**

--- a/tests/Feature/Api/ProcessRequestPolicyTest.php
+++ b/tests/Feature/Api/ProcessRequestPolicyTest.php
@@ -25,6 +25,21 @@ class ProcessRequestPolicyTest extends TestCase
         $this->user = User::factory()->create();
     }
 
+    public function testUserStartedProcessRequest()
+    {
+        $request = ProcessRequest::factory()->create(['user_id' => $this->user->id]);
+        $anotherUser = User::factory()->create();
+        $anotherRequest = ProcessRequest::factory()->create(['user_id' => $anotherUser->id]);
+
+        $route = route('api.requests.show', [$anotherRequest]);
+        $response = $this->apiCall('GET', $route);
+        $response->assertStatus(403);
+
+        $route = route('api.requests.show', [$request]);
+        $response = $this->apiCall('GET', $route);
+        $response->assertStatus(200);
+    }
+
     public function testUserHasParticipated()
     {
         $request = ProcessRequest::factory()->create();


### PR DESCRIPTION
## Issue & Reproduction Steps
We found an issue with the process request view policy while reviewing https://processmaker.atlassian.net/browse/FOUR-7325 that was introduced in https://processmaker.atlassian.net/browse/FOUR-7193

We fixed in on develop. This PR is to backport it to 4.3.1

## Solution
- Change how we query if the process request exists in the `forUser` scope of process requests

## How to Test
- Create 2 users without permissions.
- Create a new group without permissions and assign the 2 users to them
- Create a simple process Start->end and assign start permission to the new group
- Login as one user and start/complete the process
- Log in as the 2nd user and start/complete the process
- Manually go to the request started by the first user (logged in as the 2nd user)

You'll notice the 2nd user has access to the 1st user's request, even though they should not
This fixes that

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7325

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
