### PR TITLE
Set processmaker_intended cookie to sameSite=none

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -59,7 +59,7 @@ class LoginController extends Controller
         // clear cookie to avoid an issue when logout SLO and then try to login with simple PM login form
         \Cookie::queue(\Cookie::forget(config('session.cookie')));
         // cookie required here because SSO redirect resets the session
-        $cookie = cookie('processmaker_intended', redirect()->intended()->getTargetUrl(), 10, '/');
+        $cookie = cookie('processmaker_intended', redirect()->intended()->getTargetUrl(), 10, null, null, true, true, false, 'none');
         $response = response(view('auth.login', compact('addons', 'block')));
         $response->withCookie($cookie);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-7350

## Solution
The processmaker_intended cookie needs to be set with the options sameSite=none and secure=true.

This is because the SSO login post originated from a 3rd party domain (In this case, the SAML IDP) and chrome doesn't allow that unless sameSite is none. 

![image](https://user-images.githubusercontent.com/2546850/216723504-d6d24f36-4b87-459f-b94d-6d0eaffb9020.png)

It looks like in Laravel 7 they [changed some defaults](https://github.com/laravel/framework/commit/f81b6ed01fb60580ade8c7fb4386aff4cb4d7719#diff-8ac2d435acb71caedbdd807ad9fb43e4c22e62db958e41b7ba91029bfd76f192). 

I didn't see anything in the release notes about it.

## How to Test
See reproduction steps in the the issue. You need to set up SSO (I think any provider will have the same issue). You only need an authenticated web entry and you can directly go to the web entry URL in an incognito window. Login with SSO and you should be redirected to the authenticated web entry from.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7350

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
