### PR TITLE
FOUR-7264 - Default timezone for new users

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -158,6 +158,7 @@ class UserController extends Controller
             $fields['password'] = Hash::make($fields['password']);
         }
 
+        $user->setTimezoneAttribute();
         $user->fill($fields);
         $user->saveOrFail();
 

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -158,7 +158,6 @@ class UserController extends Controller
             $fields['password'] = Hash::make($fields['password']);
         }
 
-        $user->setTimezoneAttribute();
         $user->fill($fields);
         $user->saveOrFail();
 
@@ -371,10 +370,10 @@ class UserController extends Controller
      */
     private function uploadAvatar(User $user, Request $request)
     {
-        //verify data
+        // verify data
         $data = $request->all();
 
-        //if the avatar is an url (neither page nor file) we do not update the avatar
+        // if the avatar is an url (neither page nor file) we do not update the avatar
         if (filter_var($data['avatar'], FILTER_VALIDATE_URL)) {
             return;
         }

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -335,7 +335,9 @@ class User extends Authenticatable implements HasMedia
             return config('app.timezone');
         }
 
-        return $setting->config;
+        $config = (object) $setting->config;
+
+        return $config->timezone;
     }
 
     /**

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -2,12 +2,10 @@
 
 namespace ProcessMaker\Models;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Session\Store as Session;
 use Illuminate\Validation\Rule;
 use Laravel\Passport\HasApiTokens;
 use ProcessMaker\Notifications\ResetPassword as ResetPasswordNotification;
@@ -36,10 +34,10 @@ class User extends Authenticatable implements HasMedia
 
     protected $connection = 'processmaker';
 
-    //Disk
+    // Disk
     public const DISK_PROFILE = 'profile';
 
-    //collection media library
+    // collection media library
     public const COLLECTION_PROFILE = 'profile';
 
     // Session key to save request ids that the user started
@@ -320,6 +318,27 @@ class User extends Authenticatable implements HasMedia
     }
 
     /**
+     * Set the user's timezone.
+     */
+    public function setTimezoneAttribute(string $value = ''): void
+    {
+        $this->attributes['timezone'] = $value ?: $this->getDefaultTimezone();
+    }
+
+    /**
+     * Get default timezone for new users.
+     */
+    public function getDefaultTimezone(): string
+    {
+        $setting = Setting::byKey('users.timezone');
+        if ($setting === null) {
+            return config('app.timezone');
+        }
+
+        return $setting->config;
+    }
+
+    /**
      * Returns the list of notifications not read by the user
      *
      * @return \Illuminate\Support\Collection
@@ -402,12 +421,10 @@ class User extends Authenticatable implements HasMedia
         if (array_key_exists('users', $task->self_service_groups) && in_array(\Auth::user()->id, $task->self_service_groups['users'])) {
             return true;
         } elseif (array_key_exists('groups', $task->self_service_groups)) {
-            $groups = collect($task->self_service_groups['groups'])
+            return collect($task->self_service_groups['groups'])
                 ->intersect(
                     $this->groups()->pluck('groups.id')
                 )->count() > 0;
-
-            return $groups;
         } else {
             // For older processes
             return collect($task->self_service_groups)

--- a/ProcessMaker/Observers/UserObserver.php
+++ b/ProcessMaker/Observers/UserObserver.php
@@ -10,6 +10,14 @@ use ProcessMaker\Models\User;
 class UserObserver
 {
     /**
+     * Handle the user "creating" event.
+     */
+    public function creating(User $user)
+    {
+        $user->setTimezoneAttribute();
+    }
+
+    /**
      * Handle the user "deleting" event.
      *
      * @param User $user
@@ -17,14 +25,14 @@ class UserObserver
      */
     public function deleting(User $user)
     {
-        //Validate if the user has Request processes assigned
-        //An user can not be deleted if it has requests
+        // Validate if the user has Request processes assigned
+        // An user can not be deleted if it has requests
         $query = ProcessRequest::where('user_id', $user->id);
         $count = $query->count();
         if ($count > 0) {
             throw new ReferentialIntegrityException($user, $query->first());
         }
-        //Remove comments
+        // Remove comments
         Comment::query()
             ->where('user_id', $user->id)
             ->delete();

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -106,7 +106,7 @@ class UsersTest extends TestCase
 
     public function testDefaultValuesOfUser()
     {
-        putenv('APP_TIMEZONE=America/Los_Angeles');
+        config()->set('app.timezone', 'America/Los_Angeles');
         putenv('DATE_FORMAT=m/d/Y H:i');
         putenv('APP_LANG=en');
 
@@ -126,7 +126,7 @@ class UsersTest extends TestCase
 
         // Validate that the created user has the correct default values.
         $createdUser = $response->json();
-        $this->assertEquals(getenv('APP_TIMEZONE'), $createdUser['timezone']);
+        $this->assertEquals(config()->get('app.timezone'), $createdUser['timezone']);
         $this->assertEquals(getenv('DATE_FORMAT'), $createdUser['datetime_format']);
         $this->assertEquals(getenv('APP_LANG'), $createdUser['language']);
 

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -133,8 +133,8 @@ class UsersTest extends TestCase
         // Create a user setting fields that have default.
         $setting = Setting::factory()->create([
             'key' => 'users.timezone',
-            'format' => 'text',
-            'config' => 'America/New_York',
+            'format' => 'object',
+            'config' => ['timezone' => 'America/New_York'],
         ]);
         $dateFormat = 'testFormat';
         $response = $this->apiCall('POST', $url, [
@@ -150,7 +150,7 @@ class UsersTest extends TestCase
         // Validate that the created user has the correct values.
         $response->assertStatus(201);
         $createdUser = $response->json();
-        $this->assertEquals($createdUser['timezone'], $setting->config);
+        $this->assertEquals($createdUser['timezone'], $setting->config->timezone);
         $this->assertEquals($createdUser['datetime_format'], $dateFormat);
     }
 

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -4,8 +4,6 @@ namespace Tests\Feature\Api;
 
 use Faker\Factory as Faker;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Storage;
 use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
@@ -46,10 +44,10 @@ class UsersTest extends TestCase
      */
     public function testNotCreatedForParameterRequired()
     {
-        //Post should have the parameter required
+        // Post should have the parameter required
         $response = $this->apiCall('POST', self::API_TEST_URL, []);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(422);
         $this->assertArrayHasKey('message', $response->json());
     }
@@ -59,7 +57,7 @@ class UsersTest extends TestCase
      */
     public function testCreateUser()
     {
-        //Post title duplicated
+        // Post title duplicated
         $faker = Faker::create();
         $url = self::API_TEST_URL;
         $response = $this->apiCall('POST', $url, [
@@ -71,7 +69,7 @@ class UsersTest extends TestCase
             'password' => $faker->sentence(10),
         ]);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(201);
     }
 
@@ -164,7 +162,7 @@ class UsersTest extends TestCase
             'username' => 'mytestusername',
         ]);
 
-        //Post username duplicated
+        // Post username duplicated
         $faker = Faker::create();
         $response = $this->apiCall('POST', self::API_TEST_URL, [
             'username' => 'mytestusername',
@@ -172,7 +170,7 @@ class UsersTest extends TestCase
             'deuserion' => $faker->sentence(10),
         ]);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(422);
         $this->assertArrayHasKey('message', $response->json());
     }
@@ -184,13 +182,11 @@ class UsersTest extends TestCase
     {
         User::query()->delete();
 
-        $faker = Faker::create();
-
         User::factory()->count(10)->create();
 
         $response = $this->apiCall('GET', self::API_TEST_URL);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(200);
 
         // Verify structure
@@ -236,15 +232,15 @@ class UsersTest extends TestCase
             'username' => $username,
         ]);
 
-        //List User with filter option
+        // List User with filter option
         $perPage = Faker::create()->randomDigitNotNull;
         $query = '?page=1&per_page=' . $perPage . '&order_by=firstname&order_direction=DESC&filter=' . $username;
         $response = $this->apiCall('GET', self::API_TEST_URL . $query);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(200);
 
-        //verify structure paginate
+        // verify structure paginate
         $response->assertJsonStructure([
             'data',
             'meta',
@@ -268,10 +264,10 @@ class UsersTest extends TestCase
         $query = '?filter=' . urlencode('test@example.com');
         $response = $this->apiCall('GET', self::API_TEST_URL . $query);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(200);
 
-        //verify structure paginate
+        // verify structure paginate
         $response->assertJsonStructure([
             'data',
             'meta',
@@ -287,50 +283,32 @@ class UsersTest extends TestCase
      */
     public function testGetUser()
     {
-        //get the id from the factory
+        // get the id from the factory
         $user = User::factory()->create()->id;
 
-        //load api
+        // load api
         $response = $this->apiCall('GET', self::API_TEST_URL . '/' . $user);
 
-        //Validate the status is correct
+        // Validate the status is correct
         $response->assertStatus(200);
 
-        //verify structure
+        // verify structure
         $response->assertJsonStructure(self::STRUCTURE);
     }
-
-    /**
-     * Get a user with the memberships
-     */
-    // public function testGetUserIncledMembership()
-    // {
-    //     //get the id from the factory
-    //     $user = User::factory()->create()->id;
-    //
-    //     //load api
-    //     $response = $this->apiCall('GET', self::API_TEST_URL. '/' . $user . '?include=memberships');
-    //
-    //     //Validate the status is correct
-    //     $response->assertStatus(200);
-    //
-    //     //verify structure
-    //     $response->assertJsonFragment(['memberships']);
-    // }
 
     /**
      * Parameters required for update of user
      */
     public function testUpdateUserParametersRequired()
     {
-        //The post must have the required parameters
+        // The post must have the required parameters
         $url = self::API_TEST_URL . '/' . User::factory()->create()->id;
 
         $response = $this->apiCall('PUT', $url, [
             'username' => '',
         ]);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(422);
     }
 
@@ -343,10 +321,10 @@ class UsersTest extends TestCase
 
         $url = self::API_TEST_URL . '/' . User::factory()->create()->id;
 
-        //Load the starting user data
+        // Load the starting user data
         $verify = $this->apiCall('GET', $url);
 
-        //Post saved success
+        // Post saved success
         $response = $this->apiCall('PUT', $url, [
             'username' => 'updatemytestusername',
             'email' => $faker->email,
@@ -367,13 +345,13 @@ class UsersTest extends TestCase
             'force_change_password' => $faker->boolean,
         ]);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(204);
 
-        //Load the updated user data
+        // Load the updated user data
         $verify_new = $this->apiCall('GET', $url);
 
-        //Check that it has changed
+        // Check that it has changed
         $this->assertNotEquals($verify, $verify_new);
     }
 
@@ -386,7 +364,7 @@ class UsersTest extends TestCase
 
         $url = self::API_TEST_URL . '/' . User::factory()->create()->id;
 
-        //Post saved success
+        // Post saved success
         $response = $this->apiCall('PUT', $url, [
             'username' => 'updatemytestusername',
             'email' => $faker->email,
@@ -397,10 +375,10 @@ class UsersTest extends TestCase
             'force_change_password' => 0,
         ]);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(204);
 
-        //Validate Flag force_change_password was changed
+        // Validate Flag force_change_password was changed
         $this->assertDatabaseHas('users', [
             'force_change_password' => 0,
         ]);
@@ -422,7 +400,7 @@ class UsersTest extends TestCase
         $response = $this->apiCall('PUT', $url, [
             'username' => 'MyUserName',
         ]);
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(422);
         $response->assertSeeText('The Username has already been taken');
     }
@@ -432,11 +410,11 @@ class UsersTest extends TestCase
      */
     public function testDeleteUser()
     {
-        //Remove user
+        // Remove user
         $url = self::API_TEST_URL . '/' . User::factory()->create()->id;
         $response = $this->apiCall('DELETE', $url);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(204);
     }
 
@@ -445,11 +423,11 @@ class UsersTest extends TestCase
      */
     public function testDeleteUserNotExist()
     {
-        //User not exist
+        // User not exist
         $url = self::API_TEST_URL . '/' . User::factory()->make()->id;
         $response = $this->apiCall('DELETE', $url);
 
-        //Validate the header status code
+        // Validate the header status code
         $response->assertStatus(405);
     }
 
@@ -458,22 +436,22 @@ class UsersTest extends TestCase
      */
     public function testUpdateUserAvatar()
     {
-        //Create a new user
+        // Create a new user
         $user = User::factory()->create([
             'username' => 'AvatarUser',
         ]);
 
-        //Set our API url for this users
+        // Set our API url for this users
         $url = self::API_TEST_URL . '/' . $user->id;
 
-        //Create a fake image and encode it to base64
+        // Create a fake image and encode it to base64
         $fakeImage = UploadedFile::fake()
                                  ->image('avatar.jpg', 1200, 1200)
                                  ->size(1500)
                                  ->get();
         $avatar = 'data:image/png;base64,' . base64_encode($fakeImage);
 
-        //Update the user with the fake image as an avatar
+        // Update the user with the fake image as an avatar
         $putResponse = $this->apiCall('PUT', $url, [
             'username' => $user->username,
             'firstname' => 'name',
@@ -483,20 +461,20 @@ class UsersTest extends TestCase
             'avatar' => $avatar,
         ]);
 
-        //Validate the header status code
+        // Validate the header status code
         $putResponse->assertStatus(204);
 
-        //Request the user from the API
+        // Request the user from the API
         $getResponse = $this->apiCall('GET', $url);
 
-        //Assert that the 'avatar' key exists
+        // Assert that the 'avatar' key exists
         $getResponse->assertJsonStructure(['avatar']);
 
-        //Assert that the file was saved
+        // Assert that the file was saved
         $json = $getResponse->json();
         $path = parse_url($json['avatar'], PHP_URL_PATH);
         $media = $user->getMedia('profile')[0];
-        $this->assertEquals("/storage/profile/$media->id/img.png", $path);
+        $this->assertEquals("/storage/profile/{$media->id}/img.png", $path);
         $this->assertFileExists($media->getPath());
     }
 
@@ -664,7 +642,7 @@ class UsersTest extends TestCase
                 'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
                 'password' => $faker->sentence(10),
             ]);
-            //Validate the header status code
+            // Validate the header status code
             $response->assertStatus(201);
         }
 
@@ -694,7 +672,7 @@ class UsersTest extends TestCase
                 'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
                 'password' => $faker->sentence(10),
             ]);
-            //Validate the header status code
+            // Validate the header status code
             $response->assertStatus(422);
         }
     }


### PR DESCRIPTION
## Issue & Reproduction Steps

As a ProcessMaker admin, I want to be able to configure a default timezone for users created. So I can create users (via UI or integration) without having to go their profile and set the timezone.

**Steps to reproduce:**

1. Go to `/admin/users`.
2. Click "+ User" to add a new user.
3. The user created above will have the default timezone of "America/Los_Angeles".

## Solution
- Added a new setting in `admin/settings` to select the default timezone (see package-auth PR).
- The timezone is set using a mutator when creating the user, taking into account the new setting.

## How to Test
- Execute `phpunit tests/Feature/Api/UsersTest.php --filter testDefaultValuesOfUser`.

## Related Tickets & Packages
- [FOUR-7264](https://processmaker.atlassian.net/browse/FOUR-7264)
- [Package Auth PR](https://github.com/ProcessMaker/package-auth/pull/72)
- [Package Ellucian Ethos PR](https://github.com/ProcessMaker/package-ellucian-ethos/pull/90)
- [Package Saved Search PR](https://github.com/ProcessMaker/package-savedsearch/pull/343)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7264]: https://processmaker.atlassian.net/browse/FOUR-7264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:package-savedsearch:feature/FOUR-7264