### PR TITLE
CSP for ADOA and LogRocket - FOUR-7388

### DIFF
--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \ProcessMaker\Http\Middleware\TrustProxies::class,
         \ProcessMaker\Http\Middleware\BrowserCache::class,
+        \ProcessMaker\Http\Middleware\CSP::class,
     ];
 
     /**

--- a/ProcessMaker/Http/Middleware/CSP.php
+++ b/ProcessMaker/Http/Middleware/CSP.php
@@ -37,13 +37,7 @@ class CSP
     public static function getRules()
     {
         $parsed = new Parser(request()->headers->get('user-agent'));
-        $rules = [
-            'connect-src' => "*",
-            'script-src' => "* 'unsafe-inline' 'unsafe-eval'",
-            'object-src' => "'self' 'unsafe-inline' blob: data:",
-            'child-src' => "'self' blob:",
-            'worker-src' => "'self' blob:",
-        ];
+        $rules = config('csp.rules');
 
         //Recommended by logrocket.
         //Compatible from version 15

--- a/ProcessMaker/Http/Middleware/CSP.php
+++ b/ProcessMaker/Http/Middleware/CSP.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use WhichBrowser\Parser;
+
+class CSP
+{
+    const HEADER = 'Content-Security-Policy';
+
+    /**
+     * Generate the core menus that are used in web requests for our application
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+        /** @var $response Response|ResponseHeaderBag|BinaryFileResponse */
+        if (method_exists($response, 'header')) {
+            $response->header(static::HEADER, static::getRules());
+        } elseif ($response instanceof ResponseHeaderBag) {
+            $response->set(static::HEADER, static::getRules());
+        } elseif (property_exists($response, 'headers') && $response->headers instanceof ResponseHeaderBag) {
+            $response->headers->set(static::HEADER, static::getRules());
+        }
+        return $response;
+    }
+
+    public static function getRules()
+    {
+        $parsed = new Parser(request()->headers->get('user-agent'));
+        $rules = [
+            'connect-src' => "*",
+            'script-src' => "* 'unsafe-inline' 'unsafe-eval'",
+            'object-src' => "'self' 'unsafe-inline' blob: data:",
+            'child-src' => "'self' blob:",
+            'worker-src' => "'self' blob:",
+        ];
+
+        //Recommended by logrocket.
+        //Compatible from version 15
+        if ($parsed->browser->name === 'Safari' && $parsed->browser->version->toString() < 15) {
+            unset($rules['worker-src']);
+        }
+
+        $value = '';
+        foreach ($rules as $key => $rule){
+            if ($value) {
+                $value.= ' ';
+            }
+            $value.= $key . ' ' . $rule . ';';
+        }
+        return $value;
+    }
+}

--- a/config/csp.php
+++ b/config/csp.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Content Security Policy (CSP) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your settings for CSP. These rules will be added
+    | to the response header and allows web site administrators to control
+    | resources the user agent is allowed to load for a given page.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+    |
+    */
+
+    'rules' => [
+        'connect-src' => "*",
+        'script-src' => "* 'unsafe-inline' 'unsafe-eval' blob:",
+        'object-src' => "'self' 'unsafe-inline' blob: data:",
+        'child-src' => "'self' blob:",
+        'worker-src' => "'self' blob:",
+    ]
+];

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'none';">
+    <meta http-equiv="{{ \ProcessMaker\Http\Middleware\CSP::HEADER  }}" content="{!! \ProcessMaker\Http\Middleware\CSP::getRules() !!}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="app-url" content="{{ config('app.url') }}">

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -4,7 +4,6 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="{{ \ProcessMaker\Http\Middleware\CSP::HEADER  }}" content="{!! \ProcessMaker\Http\Middleware\CSP::getRules() !!}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="app-url" content="{{ config('app.url') }}">

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'none';"> 
+    <meta http-equiv="{{ \ProcessMaker\Http\Middleware\CSP::HEADER  }}" content="{!! \ProcessMaker\Http\Middleware\CSP::getRules() !!}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -3,7 +3,6 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="{{ \ProcessMaker\Http\Middleware\CSP::HEADER  }}" content="{!! \ProcessMaker\Http\Middleware\CSP::getRules() !!}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>


### PR DESCRIPTION
## Issue & Reproduction Steps
Adding CSP settings to work with ADOA, Logrocket and product-analytics

## Solution
- Add the tags recommended in the logrocket documentation and those present in the adoa and product-analytics packages

## How to Test
Open any page in PM. In the Network Tab, check the response header. Should be:
```Content-Security-Policy: connect-src *; script-src * 'unsafe-inline' 'unsafe-eval' blob:; object-src 'self' 'unsafe-inline' blob: data:; child-src 'self' blob:; worker-src 'self' blob:;```

## Related Tickets & Packages
- [FOUR-7388](https://processmaker.atlassian.net/browse/FOUR-7388)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
