### PR TITLE
Add section indexed on page about

### DIFF
--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -44,6 +44,8 @@
           @endforeach
         </ul>
         @endif
+        <div><strong>{{ __('Indexed Search') }}</strong>: {{ $indexedSearch ? __('Enabled') : __('Disabled') }}</div>
+        <hr>
         &copy; {{date('Y')}} - {{__('All Rights Reserved')}}
         @if($commit_hash)<br><small>Build #{{ $commit_hash }}</small>@endif
       </div>


### PR DESCRIPTION
## Issue & Reproduction Steps
The About page is missing the indexed section

## Solution
- put back the missing section.

original PR https://github.com/ProcessMaker/processmaker/pull/3372

## How to Test
- Review the About page and see the indexed section at the bottom.

![image](https://user-images.githubusercontent.com/1747025/219432676-df7c5422-28b5-4886-aa2b-516a8e41f9c3.png)



## Related Tickets & Packages
[FOUR-7419](https://processmaker.atlassian.net/browse/FOUR-7419)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7419]: https://processmaker.atlassian.net/browse/FOUR-7419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ