### PR TITLE
FOUR-7331 - Autosave Process

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     Snap: true,
     Dispatcher: true,
     ProcessMaker: true,
+    _: true,
   },
   extends: ["eslint:recommended", "plugin:vue/recommended", "airbnb-base"],
   parserOptions: {

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ cypress/downloads
 .phpunit.result.cache
 .php-cs-fixer.cache
 .phpunit.result.cache
+.editorconfig

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -181,7 +181,7 @@ class ProcessController extends Controller
     {
         $request->validate(Process::rules());
         $data = $request->all();
-        //Validate if exists file bpmn
+        // Validate if exists file bpmn
         if ($request->has('file')) {
             $data['bpmn'] = $request->file('file')->get();
             $request->request->add(['bpmn' => $data['bpmn']]);
@@ -200,7 +200,7 @@ class ProcessController extends Controller
         $process = new Process();
         $process->fill($data);
 
-        //set current user
+        // set current user
         $process->user_id = Auth::user()->id;
 
         if (isset($data['bpmn'])) {
@@ -265,7 +265,7 @@ class ProcessController extends Controller
     {
         $request->validate(Process::rules($process));
 
-        //bpmn validation
+        // bpmn validation
         if ($schemaErrors = $this->validateBpmn($request)) {
             $warnings = [];
             foreach ($schemaErrors as $error) {
@@ -286,22 +286,22 @@ class ProcessController extends Controller
             $process->manager_id = $request->input('manager_id', null);
         }
 
-        //If we are specifying cancel assignments...
+        // If we are specifying cancel assignments...
         if ($request->has('cancel_request')) {
             $this->cancelRequestAssignment($process, $request);
         }
 
-        //If we are specifying edit data assignments...
+        // If we are specifying edit data assignments...
         if ($request->has('edit_data')) {
             $this->editDataAssignments($process, $request);
         }
 
-        //Save any request notification settings...
+        // Save any request notification settings...
         if ($request->has('notifications')) {
             $this->saveRequestNotifications($process, $request);
         }
 
-        //Save any task notification settings...
+        // Save any task notification settings...
         if ($request->has('task_notifications')) {
             $this->saveTaskNotifications($process, $request);
         }
@@ -324,13 +324,13 @@ class ProcessController extends Controller
     {
         $cancelRequest = $request->input('cancel_request');
 
-        //Adding method to users array
+        // Adding method to users array
         $cancelUsers = [];
         foreach ($cancelRequest['users'] as $item) {
             $cancelUsers[$item] = ['method' => 'CANCEL'];
         }
 
-        //Adding method to groups array
+        // Adding method to groups array
         $cancelGroups = [];
         foreach ($cancelRequest['groups'] as $item) {
             $cancelGroups[$item] = ['method' => 'CANCEL'];
@@ -344,45 +344,45 @@ class ProcessController extends Controller
             }
         }
 
-        //Syncing users and groups that can cancel this process
+        // Syncing users and groups that can cancel this process
         $process->usersCanCancel()->sync($cancelUsers, ['method' => 'CANCEL']);
         $process->groupsCanCancel()->sync($cancelGroups, ['method' => 'CANCEL']);
     }
 
     private function editDataAssignments(Process $process, Request $request)
     {
-        //Adding method to users array
+        // Adding method to users array
         $editDataUsers = [];
         foreach ($request->input('edit_data')['users'] as $item) {
             $editDataUsers[$item] = ['method' => 'EDIT_DATA'];
         }
 
-        //Adding method to groups array
+        // Adding method to groups array
         $editDataGroups = [];
         foreach ($request->input('edit_data')['groups'] as $item) {
             $editDataGroups[$item] = ['method' => 'EDIT_DATA'];
         }
 
-        //Syncing users and groups that can cancel this process
+        // Syncing users and groups that can cancel this process
         $process->usersCanEditData()->sync($editDataUsers, ['method' => 'EDIT_DATA']);
         $process->groupsCanEditData()->sync($editDataGroups, ['method' => 'EDIT_DATA']);
     }
 
     private function saveRequestNotifications($process, $request)
     {
-        //Retrieve input
+        // Retrieve input
         $input = $request->input('notifications');
 
-        //For each notifiable type...
+        // For each notifiable type...
         foreach ($process->requestNotifiableTypes as $notifiable) {
-            //And for each notification type...
+            // And for each notification type...
             foreach ($process->requestNotificationTypes as $notification) {
-                //If this input has been set
+                // If this input has been set
                 if (isset($input[$notifiable][$notification])) {
-                    //Determine if this notification is wanted
+                    // Determine if this notification is wanted
                     $notificationWanted = filter_var($input[$notifiable][$notification], FILTER_VALIDATE_BOOLEAN);
 
-                    //If we want the notification, find or create it
+                    // If we want the notification, find or create it
                     if ($notificationWanted === true) {
                         $process->notification_settings()->firstOrCreate([
                             'element_id' => null,
@@ -391,7 +391,7 @@ class ProcessController extends Controller
                         ]);
                     }
 
-                    //If we do not want the notification, delete it
+                    // If we do not want the notification, delete it
                     if ($notificationWanted === false) {
                         $process->notification_settings()
                             ->whereNull('element_id')
@@ -465,21 +465,21 @@ class ProcessController extends Controller
 
     private function saveTaskNotifications($process, $request)
     {
-        //Retrieve input
+        // Retrieve input
         $inputs = $request->input('task_notifications');
 
-        //For each node...
+        // For each node...
         foreach ($inputs as $nodeId => $input) {
-            //For each notifiable type...
+            // For each notifiable type...
             foreach ($process->taskNotifiableTypes as $notifiable) {
-                //And for each notification type...
+                // And for each notification type...
                 foreach ($process->taskNotificationTypes as $notification) {
-                    //If this input has been set
+                    // If this input has been set
                     if (isset($input[$notifiable][$notification])) {
-                        //Determine if this notification is wanted
+                        // Determine if this notification is wanted
                         $notificationWanted = filter_var($input[$notifiable][$notification], FILTER_VALIDATE_BOOLEAN);
 
-                        //If we want the notification, find or create it
+                        // If we want the notification, find or create it
                         if ($notificationWanted === true) {
                             $process->notification_settings()->firstOrCreate([
                                 'element_id' => $nodeId,
@@ -488,7 +488,7 @@ class ProcessController extends Controller
                             ]);
                         }
 
-                        //If we do not want the notification, delete it
+                        // If we do not want the notification, delete it
                         if ($notificationWanted === false) {
                             $process->notification_settings()
                                 ->where('element_id', $nodeId)
@@ -949,11 +949,11 @@ class ProcessController extends Controller
      */
     public function importAssignments(Process $process, Request $request)
     {
-        //If we are specifying assignments...
+        // If we are specifying assignments...
         if ($request->has('assignable')) {
             $assignable = $request->input('assignable');
 
-            //Update assignments in scripts
+            // Update assignments in scripts
             $xmlAssignable = [];
             $callActivity = [];
             $watcherDataSources = [];
@@ -970,7 +970,7 @@ class ProcessController extends Controller
                 }
             }
 
-            //Update assignments in start Events, task, user Tasks
+            // Update assignments in start Events, task, user Tasks
             $definitions = $process->getDefinitions();
             $tags = ['startEvent', 'task', 'userTask', 'manualTask'];
             foreach ($tags as $tag) {
@@ -1000,7 +1000,7 @@ class ProcessController extends Controller
                 }
             }
 
-            //Update assignments call Activity
+            // Update assignments call Activity
             if ($callActivity) {
                 $elements = $definitions->getElementsByTagName('callActivity');
                 foreach ($elements as $element) {
@@ -1031,22 +1031,22 @@ class ProcessController extends Controller
             $process->bpmn = $definitions->saveXML();
         }
 
-        //If we are specifying cancel assignments...
+        // If we are specifying cancel assignments...
         if ($request->has('cancel_request')) {
             $this->cancelRequestAssignment($process, $request);
         }
 
-        //If we are specifying edit data assignments...
+        // If we are specifying edit data assignments...
         if ($request->has('edit_data')) {
             $this->editDataAssignments($process, $request);
         }
 
-        //If we are specifying a manager id
+        // If we are specifying a manager id
         if ($request->has('manager_id')) {
             $process->manager_id = $request->input('manager_id');
         }
 
-        //If we are specifying a status
+        // If we are specifying a status
         if ($request->has('status')) {
             $process->status = $request->input('status');
         }
@@ -1106,7 +1106,7 @@ class ProcessController extends Controller
      */
     public function triggerStartEvent(Process $process, Request $request)
     {
-        //Get the event BPMN element
+        // Get the event BPMN element
         $id = $request->query('event');
         if (!$id) {
             return abort(404);

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -309,10 +309,7 @@ class ProcessController extends Controller
         // Catch errors to send more specific status
         try {
             if ($request->input('is_draft', false)) {
-                $process->withoutEvents(function () use ($process) {
-                    $process->saveOrFail();
-                    $process->saveDraft();
-                });
+                $process->saveDraft();
             } else {
                 $process->saveOrFail();
             }
@@ -1259,5 +1256,12 @@ class ProcessController extends Controller
             $config['web_entry']['webentryRouteConfig']['entryUrl'] = $newEntryUrl;
             $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config', json_encode($config));
         }
+    }
+
+    public function close(Process $process)
+    {
+        $process->deleteDraft();
+
+        return new Resource($process);
     }
 }

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -26,7 +26,7 @@ class ModelerController extends Controller
          */
         event(new ModelerStarting($manager));
 
-        $draft = $process->versions()->where('draft', true)->first();
+        $draft = $process->versions()->draft()->first();
         if ($draft) {
             $process->fill($draft->only(['svg', 'bpmn']));
         }

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -8,6 +8,7 @@ use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Managers\ModelerManager;
 use ProcessMaker\Managers\SignalManager;
 use ProcessMaker\Models\Process;
+use ProcessMaker\PackageHelper;
 use ProcessMaker\Traits\HasControllerAddons;
 
 class ModelerController extends Controller
@@ -35,6 +36,7 @@ class ModelerController extends Controller
             'process' => $process->append('notifications', 'task_notifications'),
             'manager' => $manager,
             'signalPermissions' => SignalManager::permissions($request->user()),
+            'isVersionsInstalled' => PackageHelper::isPackageInstalled('ProcessMaker\Package\Versions\PluginServiceProvider'),
         ]);
     }
 }

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -26,6 +26,11 @@ class ModelerController extends Controller
          */
         event(new ModelerStarting($manager));
 
+        $draft = $process->versions()->where('draft', true)->first();
+        if ($draft) {
+            $process->fill($draft->only(['svg', 'bpmn']));
+        }
+
         return view('processes.modeler.index', [
             'process' => $process->append('notifications', 'task_notifications'),
             'manager' => $manager,

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1265,14 +1265,6 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
     }
 
     /**
-     * Get the latest version of the process
-     */
-    public function getLatestVersion()
-    {
-        return $this->versions()->orderBy('id', 'desc')->first();
-    }
-
-    /**
      * Check if process is valid for execution
      *
      * @return bool

--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -2,7 +2,7 @@
 
 namespace ProcessMaker\Models;
 
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Builder;
 use ProcessMaker\Contracts\ProcessModelInterface;
 use ProcessMaker\Traits\HasCategories;
 use ProcessMaker\Traits\HasSelfServiceTasks;
@@ -132,5 +132,21 @@ class ProcessVersion extends ProcessMakerModel implements ProcessModelInterface
     public function parent()
     {
         return $this->belongsTo(Process::class, 'process_id', 'id');
+    }
+
+    /**
+     * Scope to only return draft versions.
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('draft', true);
+    }
+
+    /**
+     * Scope to only return published versions.
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('draft', false);
     }
 }

--- a/ProcessMaker/Models/ScreenVersion.php
+++ b/ProcessMaker/Models/ScreenVersion.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use ProcessMaker\Contracts\ScreenInterface;
 use ProcessMaker\Traits\HasCategories;
 
@@ -47,5 +48,21 @@ class ScreenVersion extends ProcessMakerModel implements ScreenInterface
     public function parent()
     {
         return $this->belongsTo(Screen::class, 'screen_id', 'id');
+    }
+
+    /**
+     * Scope to only return draft versions.
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('draft', true);
+    }
+
+    /**
+     * Scope to only return published versions.
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('draft', false);
     }
 }

--- a/ProcessMaker/Models/ScriptExecutorVersion.php
+++ b/ProcessMaker/Models/ScriptExecutorVersion.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Models;
 
+use Illuminate\Database\Eloquent\Builder;
+
 class ScriptExecutorVersion extends ProcessMakerModel
 {
     protected $fillable = [

--- a/ProcessMaker/Models/ScriptExecutorVersion.php
+++ b/ProcessMaker/Models/ScriptExecutorVersion.php
@@ -5,6 +5,22 @@ namespace ProcessMaker\Models;
 class ScriptExecutorVersion extends ProcessMakerModel
 {
     protected $fillable = [
-        'title', 'description', 'language', 'config',
+        'title', 'description', 'language', 'config', 'draft',
     ];
+
+    /**
+     * Scope to only return draft versions.
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('draft', true);
+    }
+
+    /**
+     * Scope to only return published versions.
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('draft', false);
+    }
 }

--- a/ProcessMaker/Models/ScriptVersion.php
+++ b/ProcessMaker/Models/ScriptVersion.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use ProcessMaker\Contracts\ScriptInterface;
 use ProcessMaker\Traits\HasCategories;
 
@@ -58,5 +59,21 @@ class ScriptVersion extends ProcessMakerModel implements ScriptInterface
         }
 
         return $script->runScript($data, $config, $tokenId);
+    }
+
+    /**
+     * Scope to only return draft versions.
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('draft', true);
+    }
+
+    /**
+     * Scope to only return published versions.
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('draft', false);
     }
 }

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 use ProcessMaker\Models\ProcessRequest;
 
 trait HasVersioning
@@ -26,8 +27,12 @@ trait HasVersioning
      */
     public function scopePublished($query)
     {
-        $query->whereHas('versions', static function ($query) {
-            $query->where('draft', false);
+        $query->whereHas('versions', function ($query) {
+            // Avoid migration errors when 'draft' column does not exist.
+            $hasDraftColumn = Schema::hasColumn($query->getModel()->getTable(), 'draft');
+            $query->when($hasDraftColumn, function ($query) {
+                $query->where('draft', false);
+            });
         });
     }
 
@@ -36,7 +41,7 @@ trait HasVersioning
      */
     public function scopeDraft($query)
     {
-        $query->whereHas('versions', static function ($query) {
+        $query->whereHas('versions', function ($query) {
             $query->where('draft', true);
         });
     }

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -2,17 +2,43 @@
 
 namespace ProcessMaker\Traits;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use ProcessMaker\Models\ProcessRequest;
 
 trait HasVersioning
 {
     /**
-     * Save a version every time the model is saved
+     * The "boot" method of HasVersioning.
      */
     public static function bootHasVersioning()
     {
+        static::addGlobalScope('published', function (Builder $builder) {
+            $builder->published();
+        });
+
+        // Save a version every time the model is saved.
         static::saved([static::class, 'saveNewVersion']);
+    }
+
+    /**
+     * Get the published for the model.
+     */
+    public function scopePublished($query)
+    {
+        $query->whereHas('versions', static function ($query) {
+            $query->where('draft', false);
+        });
+    }
+
+    /**
+     * Get the drafts for the model.
+     */
+    public function scopeDraft($query)
+    {
+        $query->whereHas('versions', static function ($query) {
+            $query->where('draft', true);
+        });
     }
 
     /**

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -53,7 +53,7 @@ trait HasVersioning
         $this->versions()->create($attributes);
 
         // Delete draft version.
-        $this->versions()->draft()->delete();
+        $this->deleteDraft();
     }
 
     /**
@@ -67,6 +67,11 @@ trait HasVersioning
         $this->versions()->updateOrCreate([
             'draft' => true,
         ], $attributes);
+    }
+
+    public function deleteDraft()
+    {
+        $this->versions()->draft()->delete();
     }
 
     private function getModelAttributes(): array

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -53,7 +53,7 @@ trait HasVersioning
         $this->versions()->create($attributes);
 
         // Delete draft version.
-        $this->versions()->where('draft', true)->delete();
+        $this->versions()->draft()->delete();
     }
 
     /**
@@ -89,7 +89,7 @@ trait HasVersioning
      */
     public function getLatestVersion()
     {
-        return $this->versions()->orderBy('id', 'desc')->first();
+        return $this->versions()->orderBy('id', 'desc')->published()->first();
     }
 
     /**

--- a/database/migrations/2023_02_27_130520_add_draft_column_to_versions_tables.php
+++ b/database/migrations/2023_02_27_130520_add_draft_column_to_versions_tables.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDraftColumnToVersionsTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('process_versions', function (Blueprint $table) {
+            $table->boolean('draft')->default(false)->after('user_id');
+        });
+        Schema::table('screen_versions', function (Blueprint $table) {
+            $table->boolean('draft')->default(false)->after('screen_category_id');
+        });
+        Schema::table('script_versions', function (Blueprint $table) {
+            $table->boolean('draft')->default(false)->after('script_id');
+        });
+        Schema::table('script_executor_versions', function (Blueprint $table) {
+            $table->boolean('draft')->default(false)->after('script_executor_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('process_versions', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+        Schema::table('screen_versions', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+        Schema::table('script_versions', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+        Schema::table('script_executor_versions', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+    }
+}

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -1,7 +1,16 @@
 <template>
-  <b-container id="modeler-app" class="container p-0">
-    <b-card no-body class="h-100 border-top-0">
-      <b-card-body class="overflow-hidden position-relative p-0 vh-100" data-test="body-container">
+  <b-container
+    id="modeler-app"
+    class="container p-0"
+  >
+    <b-card
+      no-body
+      class="h-100 border-top-0"
+    >
+      <b-card-body
+        class="overflow-hidden position-relative p-0 vh-100"
+        data-test="body-container"
+      >
         <modeler
           ref="modeler"
           :owner="self"
@@ -20,20 +29,29 @@
         :owner="self"
         :xml-manager="xmlManager"
       >
-        <component v-for="(component, index) in validationBar" :key="`validation-status-${index}`" :is="component" :owner="self" />
+        <component
+          :is="component"
+          v-for="(component, index) in validationBar"
+          :key="`validation-status-${index}`"
+          :owner="self"
+        />
       </validation-status>
 
-      <component v-for="(component, index) in external" :key="`external-${index}`" :is="component.type" :options="component.options"/>
-
+      <component
+        :is="component.type"
+        v-for="(component, index) in external"
+        :key="`external-${index}`"
+        :options="component.options"
+      />
     </b-card>
   </b-container>
 </template>
 
 <script>
-  import {Modeler, ValidationStatus} from "@processmaker/modeler";
+import { Modeler, ValidationStatus } from "@processmaker/modeler";
 
-  export default {
-  name: 'ModelerApp',
+export default {
+  name: "ModelerApp",
   components: {
     Modeler,
     ValidationStatus,
@@ -43,7 +61,7 @@
       self: this,
       validationBar: [],
       external: [],
-      externalEmit : [],
+      externalEmit: [],
       dataXmlSvg: {},
       decorations: {
         borderOutline: {},
@@ -54,60 +72,90 @@
       xmlManager: null,
     };
   },
+  watch: {
+    validationErrors: {
+      deep: true,
+      handler() {
+        this.updateBpmnValidations();
+      },
+    },
+    warnings: {
+      deep: true,
+      handler() {
+        this.updateBpmnValidations();
+      },
+    },
+  },
+  mounted() {
+    ProcessMaker.$modeler = this.$refs.modeler;
+
+    window.ProcessMaker.EventBus.$emit("modeler-app-init", this);
+
+    window.ProcessMaker.EventBus.$on("modeler-save", (onSuccess, onError) => {
+      this.saveProcess(onSuccess, onError);
+    });
+    window.ProcessMaker.EventBus.$on("modeler-change", () => {
+      this.refreshSession();
+      window.ProcessMaker.EventBus.$emit("new-changes");
+    });
+  },
   methods: {
     updateBpmnValidations() {
-      const statusBar = this.$refs.validationStatus;
-      const warnings = this.warnings;
-      if(warnings instanceof Array) {
+      const { warnings } = this;
+      if (warnings instanceof Array) {
         const bpmnWarnings = [];
         warnings.forEach((warning) => {
           if (warning.errors instanceof Object) {
-            Object.keys(warning.errors).forEach(node => {
-              warning.errors[node].forEach(error => {
+            Object.keys(warning.errors).forEach((node) => {
+              warning.errors[node].forEach((error) => {
                 bpmnWarnings.push({
-                  category: 'error',
+                  category: "error",
                   id: node,
-                  message: error
+                  message: error,
                 });
               });
             });
           }
         });
-        JSON.stringify(bpmnWarnings) !== JSON.stringify(this.$refs.modeler.validationErrors.bpmn)
-          ? this.$refs.modeler.$set(this.$refs.modeler.validationErrors, 'bpmn', bpmnWarnings) : null;
-        JSON.stringify(bpmnWarnings) !== JSON.stringify(this.validationErrors.bpmn)
-          ? this.$set(this.validationErrors, 'bpmn', bpmnWarnings) : null;
+        const hasErrors = JSON.stringify(bpmnWarnings) !== JSON.stringify(this.$refs.modeler.validationErrors.bpmn);
+        if (hasErrors) {
+          this.$refs.modeler.$set(this.$refs.modeler.validationErrors, "bpmn", bpmnWarnings);
+        }
+        const hasValidationErrors = JSON.stringify(bpmnWarnings) !== JSON.stringify(this.validationErrors.bpmn);
+        if (hasValidationErrors) {
+          this.$set(this.validationErrors, "bpmn", bpmnWarnings);
+        }
       }
     },
     refreshSession: _.throttle(() => {
       ProcessMaker.apiClient({
-        method: 'POST',
-        url: '/keep-alive',
-        baseURL: '/',
-      })
+        method: "POST",
+        url: "/keep-alive",
+        baseURL: "/",
+      });
     }, 60000),
     runningInCypressTest() {
       return !!window.Cypress;
     },
     getTaskNotifications() {
-      var notifications = {};
-      this.$refs.modeler.nodes.forEach(function(node) {
-        let id = node.definition.id;
+      const notifications = {};
+      this.$refs.modeler.nodes.forEach((node) => {
+        const { id } = node.definition;
         if (node.notifications !== undefined) {
           notifications[id] = node.notifications;
         }
       });
       return notifications;
     },
-    emitRegisteredEvents ({xml, svg}) {
+    emitRegisteredEvents({ xml, svg }) {
       this.dataXmlSvg.xml = xml;
       this.dataXmlSvg.svg = svg;
 
-      this.externalEmit.forEach(item => {
+      this.externalEmit.forEach((item) => {
         window.ProcessMaker.EventBus.$emit(item);
-      })
+      });
       if (!this.externalEmit.length) {
-        window.ProcessMaker.EventBus.$emit('modeler-save');
+        window.ProcessMaker.EventBus.$emit("modeler-save");
       }
     },
     saveProcess(onSuccess, onError) {
@@ -116,64 +164,36 @@
         description: this.process.description,
         task_notifications: this.getTaskNotifications(),
         bpmn: this.dataXmlSvg.xml,
-        svg: this.dataXmlSvg.svg
+        svg: this.dataXmlSvg.svg,
       };
 
       const savedSuccessfully = (response) => {
         this.process.updated_at = response.data.updated_at;
         // Now show alert
-        ProcessMaker.alert(this.$t('The process was saved.'), 'success');
-        window.ProcessMaker.EventBus.$emit('save-changes');
-        this.$set(this, 'warnings', response.data.warnings || []);
+        ProcessMaker.alert(this.$t("The process was saved."), "success");
+        window.ProcessMaker.EventBus.$emit("save-changes");
+        this.$set(this, "warnings", response.data.warnings || []);
         if (response.data.warnings && response.data.warnings.length > 0) {
           this.$refs.validationStatus.autoValidate = true;
         }
-        if (typeof onSuccess === 'function') {
+        if (typeof onSuccess === "function") {
           onSuccess(response);
         }
       };
 
       const saveFailed = (err) => {
-        const message = err.response.data.message;
-        const errors = err.response.data.errors;
-        ProcessMaker.alert(message, 'danger');
+        const { message } = err.response.data;
+        ProcessMaker.alert(message, "danger");
 
-        if (typeof onError === 'function') {
+        if (typeof onError === "function") {
           onError(err);
         }
       };
 
-      ProcessMaker.apiClient.put('/processes/' + this.process.id, data)
-              .then(savedSuccessfully)
-              .catch(saveFailed);
-    }
-  },
-  mounted() {
-    ProcessMaker.$modeler = this.$refs.modeler;
-
-    window.ProcessMaker.EventBus.$emit('modeler-app-init', this);
-
-    window.ProcessMaker.EventBus.$on('modeler-save', (onSuccess, onError) => {
-      this.saveProcess(onSuccess, onError);
-    });
-    window.ProcessMaker.EventBus.$on('modeler-change', () => {
-      this.refreshSession();
-      window.ProcessMaker.EventBus.$emit('new-changes');
-    });
-  },
-  watch: {
-    validationErrors: {
-      deep: true,
-      handler() {
-        this.updateBpmnValidations();
-      }
+      ProcessMaker.apiClient.put(`/processes/${this.process.id}`, data)
+        .then(savedSuccessfully)
+        .catch(saveFailed);
     },
-    warnings: {
-      deep: true,
-      handler() {
-        this.updateBpmnValidations();
-      }
-    }
-  }
+  },
 };
 </script>

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -98,7 +98,7 @@ export default {
     });
     window.ProcessMaker.EventBus.$on("modeler-change", () => {
       this.refreshSession();
-      this.autosaveProcess();
+      this.autoSaveProcess();
       window.ProcessMaker.EventBus.$emit("new-changes");
     });
     window.ProcessMaker.EventBus.$on("modeler-close", () => {
@@ -211,7 +211,7 @@ export default {
         .then(savedSuccessfully)
         .catch(saveFailed);
     },
-    async autosaveProcess() {
+    async autoSaveProcess() {
       if (this.isVersionsInstalled === false) {
         return;
       }
@@ -238,12 +238,12 @@ export default {
         })
           .then((response) => {
             this.process.updated_at = response.data.updated_at;
-            ProcessMaker.alert(this.$t("The process was saved."), "success");
             window.ProcessMaker.EventBus.$emit("save-changes");
             this.$set(this, "warnings", response.data.warnings || []);
             if (response.data.warnings && response.data.warnings.length > 0) {
               this.$refs.validationStatus.autoValidate = true;
             }
+            this.$refs.modeler.showSavedNotification();
           })
           .catch((error) => {
             const { message } = error.response.data;

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -68,6 +68,7 @@ export default {
         borderOutline: {},
       },
       process: window.ProcessMaker.modeler.process,
+      isVersionsInstalled: window.ProcessMaker.modeler.isVersionsInstalled,
       validationErrors: {},
       warnings: [],
       xmlManager: null,
@@ -211,6 +212,10 @@ export default {
         .catch(saveFailed);
     },
     async autosaveProcess() {
+      if (this.isVersionsInstalled === false) {
+        return;
+      }
+
       const svg = document.querySelector(".mini-paper svg");
       const css = "text { font-family: sans-serif; }";
       const style = document.createElement("style");

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -96,7 +96,7 @@ export default {
     });
     window.ProcessMaker.EventBus.$on("modeler-change", () => {
       this.refreshSession();
-      this.autoSaveProcess();
+      this.autosaveProcess();
       window.ProcessMaker.EventBus.$emit("new-changes");
     });
   },
@@ -195,7 +195,7 @@ export default {
         .then(savedSuccessfully)
         .catch(saveFailed);
     },
-    async autoSaveProcess() {
+    async autosaveProcess() {
       const svg = document.querySelector(".mini-paper svg");
       const css = "text { font-family: sans-serif; }";
       const style = document.createElement("style");
@@ -229,9 +229,15 @@ export default {
         ProcessMaker.alert(message, "danger");
       };
 
-      ProcessMaker.apiClient.put(`/processes/${this.process.id}`, data)
-        .then(savedSuccessfully)
-        .catch(saveFailed);
+      if (this.debounceTimeout) {
+        clearTimeout(this.debounceTimeout);
+      }
+
+      this.debounceTimeout = setTimeout(() => {
+        ProcessMaker.apiClient.put(`/processes/${this.process.id}`, data)
+          .then(savedSuccessfully)
+          .catch(saveFailed);
+      }, 5000);
     },
   },
 };

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -36,7 +36,7 @@ div.main {
 
 @section('js')
   <script src="{{mix('js/leave-warning.js')}}"></script>
-  <script> 
+  <script>
   const breadcrumbData = [
     {
       'text':'{{__('Designer')}}',
@@ -58,6 +58,7 @@ div.main {
   window.ProcessMaker.modeler = {
     process: @json($process),
     xml: @json($process->bpmn),
+    isVersionsInstalled: @json($isVersionsInstalled),
     processName: @json($process->name),
     signalPermissions: @json($signalPermissions),
     // list of toggles in assignment rules
@@ -74,7 +75,7 @@ div.main {
     ],
   }
   const warnings = @json($process->warnings);
- 
+
   window.ProcessMaker.EventBus.$on('modeler-start', ({ loadXML, addWarnings, addBreadcrumbs }) => {
     loadXML(window.ProcessMaker.modeler.xml);
     addWarnings(warnings || []);

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,6 +118,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('processes/{process}/import/assignments', [ProcessController::class, 'importAssignments'])->name('processes.import.assignments')->middleware('can:import-processes');
     Route::post('processes', [ProcessController::class, 'store'])->name('processes.store')->middleware('can:create-processes');
     Route::put('processes/{process}', [ProcessController::class, 'update'])->name('processes.update')->middleware('can:edit-processes');
+    Route::post('processes/{process}/close', [ProcessController::class, 'close'])->name('processes.close')->middleware('can:edit-processes');
     Route::delete('processes/{process}', [ProcessController::class, 'destroy'])->name('processes.destroy')->middleware('can:archive-processes');
     Route::put('processes/{processId}/restore', [ProcessController::class, 'restore'])->name('processes.restore')->middleware('can:archive-processes');
     Route::post('process_events/{process}', [ProcessController::class, 'triggerStartEvent'])->name('process_events.trigger')->middleware('can:start,process');

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,6 +118,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('processes/{process}/import/assignments', [ProcessController::class, 'importAssignments'])->name('processes.import.assignments')->middleware('can:import-processes');
     Route::post('processes', [ProcessController::class, 'store'])->name('processes.store')->middleware('can:create-processes');
     Route::put('processes/{process}', [ProcessController::class, 'update'])->name('processes.update')->middleware('can:edit-processes');
+    Route::put('processes/{process}/draft', [ProcessController::class, 'updateDraft'])->name('processes.update_draft')->middleware('can:edit-screens');
     Route::post('processes/{process}/close', [ProcessController::class, 'close'])->name('processes.close')->middleware('can:edit-processes');
     Route::delete('processes/{process}', [ProcessController::class, 'destroy'])->name('processes.destroy')->middleware('can:archive-processes');
     Route::put('processes/{processId}/restore', [ProcessController::class, 'restore'])->name('processes.restore')->middleware('can:archive-processes');

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -1158,4 +1158,28 @@ class ProcessTest extends TestCase
         // Delete the draft after the item is published.
         $this->assertEquals(0, $process->versions()->draft()->count());
     }
+
+    public function testDiscardDraft()
+    {
+        $process = Process::factory()->create();
+        $url = route('api.processes.update', ['process' => $process]);
+        $params = [
+            'name' => 'Process',
+            'description' => 'Description',
+            'is_draft' => true,
+        ];
+
+        $response = $this->apiCall('PUT', $url, $params);
+        $response->assertStatus(200);
+
+        // Assert draft version is created.
+        $this->assertEquals(1, $process->versions()->draft()->count());
+
+        // Discard the draft.
+        $url = route('api.processes.close', ['process' => $process]);
+        $response = $this->apiCall('POST', $url, $params);
+
+        // Assert draft version is deleted.
+        $this->assertEquals(0, $process->versions()->draft()->count());
+    }
 }

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -52,7 +52,7 @@ class ProcessTest extends TestCase
         // Create some processes
         $countProcesses = 20;
         Process::factory()->count($countProcesses)->create();
-        //Get a page of processes
+        // Get a page of processes
         $page = 2;
         $perPage = 10;
         $this->assertCorrectModelListing(
@@ -89,7 +89,7 @@ class ProcessTest extends TestCase
         $process = Process::factory()->create(['bpmn' => $bpmn]);
         $process->usersCanStart('StartEventUID')->attach($this->user->id);
 
-        //Get a page of processes
+        // Get a page of processes
         $page = 1;
         $perPage = 10;
         $this->assertCorrectModelListing(
@@ -115,7 +115,7 @@ class ProcessTest extends TestCase
             'is_administrator' => false,
         ]);
 
-        //Create default All Users group
+        // Create default All Users group
         $group = Group::factory()->create([
             'name' => 'Test Group',
             'status' => 'ACTIVE',
@@ -123,7 +123,7 @@ class ProcessTest extends TestCase
         $group->save();
         $group->refresh();
 
-        //Add user to group
+        // Add user to group
         GroupMember::factory()->create([
             'member_id' => $this->user->id,
             'member_type' => User::class,
@@ -143,7 +143,7 @@ class ProcessTest extends TestCase
         $process = Process::factory()->create(['bpmn' => $bpmn]);
         $process->groupsCanStart('StartEventUID')->attach($group->id);
 
-        //Get a page of processes
+        // Get a page of processes
         $page = 1;
         $perPage = 10;
         $this->assertCorrectModelListing(
@@ -165,7 +165,7 @@ class ProcessTest extends TestCase
     {
         ProcessRequest::query()->delete();
 
-        //get process with start event
+        // get process with start event
         $file = Process::getProcessTemplatesPath() . '/SingleTask.bpmn';
         $bpmn = file_get_contents($file);
 
@@ -202,7 +202,7 @@ class ProcessTest extends TestCase
     {
         ProcessRequest::query()->delete();
 
-        //get process with start event
+        // get process with start event
         $startSingleEventFile = Process::getProcessTemplatesPath() . '/StartSingleEvent.bpmn';
         $startTimerEventFile = Process::getProcessTemplatesPath() . '/StartTimerEvent.bpmn';
         $startConditionalEventFile = Process::getProcessTemplatesPath() . '/StartConditionalEvent.bpmn';
@@ -254,7 +254,7 @@ class ProcessTest extends TestCase
     {
         ProcessRequest::query()->delete();
 
-        //get process with start event
+        // get process with start event
         $startSingleEventFile = Process::getProcessTemplatesPath() . '/StartSingleEvent.bpmn';
         $startTimerEventFile = Process::getProcessTemplatesPath() . '/StartTimerEvent.bpmn';
         $startConditionalEventFile = Process::getProcessTemplatesPath() . '/StartConditionalEvent.bpmn';
@@ -329,7 +329,7 @@ class ProcessTest extends TestCase
 
         $responseData = $response->getData()->data;
 
-        //just the process with assignment as process manager and the process assigned to the user should be returned
+        // just the process with assignment as process manager and the process assigned to the user should be returned
         $this->assertEquals(count($responseData), 2);
         $this->assertTrue(in_array($responseData[0]->id, [$processWithManager->id, $processAssigned->id]));
         $this->assertTrue(in_array($responseData[1]->id, [$processWithManager->id, $processAssigned->id]));
@@ -499,7 +499,7 @@ class ProcessTest extends TestCase
         Process::factory()->count($processInactive['num'])->create(['status' => $processInactive['status']]);
         Process::factory()->count($processArchived['num'])->create(['status' => $processArchived['status']]);
 
-        //Get active processes
+        // Get active processes
         $response = $this->assertCorrectModelListing(
             '?status=active&include=category&per_page=' . $perPage,
             [
@@ -508,10 +508,10 @@ class ProcessTest extends TestCase
                 'per_page' => $perPage,
             ]
         );
-        //verify include
+        // verify include
         $response->assertJsonStructure(['*' => ['category']], $response->json('data'));
 
-        //Get active processes
+        // Get active processes
         $response = $this->assertCorrectModelListing(
             '?status=archived&include=category,user&per_page=' . $perPage,
             [
@@ -520,7 +520,7 @@ class ProcessTest extends TestCase
                 'per_page' => $perPage,
             ]
         );
-        //verify include
+        // verify include
         $response->assertJsonStructure(['*' => ['category', 'user']], $response->json('data'));
     }
 
@@ -539,17 +539,17 @@ class ProcessTest extends TestCase
             'description' => 'yyyyy',
         ]);
 
-        //Test the list sorted by name returns as first row {"name": "aaaaaa"}
+        // Test the list sorted by name returns as first row {"name": "aaaaaa"}
         $this->assertModelSorting('?order_by=name&order_direction=asc', [
             'name' => 'aaaaaa',
         ]);
 
-        //Test the list sorted desc returns as first row {"name": "zzzzz"}
+        // Test the list sorted desc returns as first row {"name": "zzzzz"}
         $this->assertModelSorting('?order_by=name&order_direction=DESC', [
             'name' => 'zzzzz',
         ]);
 
-        //Test the list sorted by description in desc returns as first row {"description": "yyyyy"}
+        // Test the list sorted by description in desc returns as first row {"description": "yyyyy"}
         $this->assertModelSorting('?order_by=description&order_direction=desc', [
             'description' => 'yyyyy',
         ]);
@@ -583,7 +583,7 @@ class ProcessTest extends TestCase
      */
     public function testProcessCreation()
     {
-        //Create a process without category
+        // Create a process without category
         $this->assertModelCreationFails(
             Process::class,
             [
@@ -592,7 +592,7 @@ class ProcessTest extends TestCase
             ]
         );
 
-        //Create a process without sending the category
+        // Create a process without sending the category
         $this->assertCorrectModelCreation(
             Process::class,
             [
@@ -602,7 +602,7 @@ class ProcessTest extends TestCase
             ]
         );
 
-        //Create a process with a category
+        // Create a process with a category
         $category = ProcessCategory::factory()->create();
         $this->assertCorrectModelCreation(
             Process::class,
@@ -625,7 +625,7 @@ class ProcessTest extends TestCase
             'process_category_id' => static::$DO_NOT_SEND,
         ]);
         $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
-        //Add a bpmn content
+        // Add a bpmn content
         $array['bpmn'] = trim(Process::getProcessTemplate('OnlyStartElement.bpmn'));
         $response = $this->apiCall('POST', $route, $array);
         $response->assertStatus(201);
@@ -640,7 +640,7 @@ class ProcessTest extends TestCase
      */
     public function testCreateProcessFieldsValidation()
     {
-        //Test to create a process with an empty name
+        // Test to create a process with an empty name
         $this->assertModelCreationFails(
             Process::class,
             [
@@ -648,13 +648,13 @@ class ProcessTest extends TestCase
                 'user_id' => static::$DO_NOT_SEND,
                 'process_category_id' => static::$DO_NOT_SEND,
             ],
-            //Fields that should fail
+            // Fields that should fail
             [
                 'name',
             ]
         );
 
-        //Test to create a process with duplicate name
+        // Test to create a process with duplicate name
         $name = 'Some name';
         Process::factory()->create(['name' => $name]);
         $this->assertModelCreationFails(
@@ -664,20 +664,20 @@ class ProcessTest extends TestCase
                 'user_id' => static::$DO_NOT_SEND,
                 'process_category_id' => static::$DO_NOT_SEND,
             ],
-            //Fields that should fail
+            // Fields that should fail
             [
                 'name',
             ]
         );
 
-        //Test to create a process with a process category id that does not exist
+        // Test to create a process with a process category id that does not exist
         $this->assertModelCreationFails(
             Process::class,
             [
                 'user_id' => static::$DO_NOT_SEND,
                 'process_category_id' => 'id-not-exists',
             ],
-            //Fields that should fail
+            // Fields that should fail
             [
                 'process_category_id',
             ]
@@ -695,10 +695,10 @@ class ProcessTest extends TestCase
             'process_category_id' => static::$DO_NOT_SEND,
         ]);
         $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
-        //Add a bpmn content
+        // Add a bpmn content
         $array['bpmn'] = trim(Process::getProcessTemplate('ProcessWithErrors.bpmn'));
         $response = $this->apiCall('POST', $route, $array);
-        //A validation error should be displayed
+        // A validation error should be displayed
         $response->assertStatus(422);
     }
 
@@ -713,10 +713,10 @@ class ProcessTest extends TestCase
             'process_category_id' => static::$DO_NOT_SEND,
         ]);
         $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
-        //Add a bpmn content
+        // Add a bpmn content
         $array['bpmn'] = 'foo';
         $response = $this->apiCall('POST', $route, $array);
-        //A validation error should be displayed
+        // A validation error should be displayed
         $response->assertStatus(422);
     }
 
@@ -727,22 +727,22 @@ class ProcessTest extends TestCase
     {
         $this->markTestSkipped('FOUR-6653');
 
-        //Create a new process without category
+        // Create a new process without category
         $process = Process::factory()->create([
             'process_category_id' => null,
         ]);
 
-        //Test that is correctly displayed
+        // Test that is correctly displayed
         $this->assertModelShow($process->id, []);
 
-        //Test that is correctly displayed with null category
+        // Test that is correctly displayed with null category
         $this->assertModelShow($process->id, ['category'])
             ->assertJsonFragment(['category' => []]);
 
-        //Create a new process with category
+        // Create a new process with category
         $process = Process::factory()->create();
 
-        //Test that is correctly displayed including category and user
+        // Test that is correctly displayed including category and user
         $this->assertModelShow($process->id, ['category', 'user']);
     }
 
@@ -751,10 +751,10 @@ class ProcessTest extends TestCase
      */
     public function testUpdateProcess()
     {
-        //Seeder Permissions
+        // Seeder Permissions
         (new PermissionSeeder())->run($this->user);
 
-        //Test to update name process
+        // Test to update name process
         $name = $this->faker->sentence(3);
         $this->assertModelUpdate(
             Process::class,
@@ -772,10 +772,10 @@ class ProcessTest extends TestCase
      */
     public function testUpdateProcessWithCategoryNull()
     {
-        //Seeder Permissions
+        // Seeder Permissions
         (new PermissionSeeder())->run($this->user);
 
-        //Test update process category to null
+        // Test update process category to null
         $this->assertModelUpdateFails(
             Process::class,
             [
@@ -792,10 +792,10 @@ class ProcessTest extends TestCase
      */
     public function testUpdateProcessWithCategory()
     {
-        //Seeder Permissions
+        // Seeder Permissions
         (new PermissionSeeder())->run($this->user);
 
-        //Test update process category
+        // Test update process category
         $this->assertModelUpdate(
             Process::class,
             [
@@ -812,7 +812,7 @@ class ProcessTest extends TestCase
      */
     public function testUpdateProcessFails()
     {
-        //Test to update name and description if required
+        // Test to update name and description if required
         $this->assertModelUpdateFails(
             Process::class,
             [
@@ -827,7 +827,7 @@ class ProcessTest extends TestCase
             ]
         );
 
-        //Test update process category of null
+        // Test update process category of null
         $this->assertModelUpdateFails(
             Process::class,
             [
@@ -839,7 +839,7 @@ class ProcessTest extends TestCase
             ]
         );
 
-        //Test validate name is unique
+        // Test validate name is unique
         $name = 'Some name';
         Process::factory()->create(['name' => $name]);
         $this->assertModelUpdateFails(
@@ -860,7 +860,7 @@ class ProcessTest extends TestCase
      */
     public function testUpdateBPMN()
     {
-        //Seeder Permissions
+        // Seeder Permissions
         (new PermissionSeeder())->run($this->user);
 
         $process = Process::factory()->create([
@@ -874,7 +874,7 @@ class ProcessTest extends TestCase
             'description' => 'test description',
             'bpmn' => $newBpmn,
         ]);
-        //validate status
+        // validate status
         $this->assertStatus(200, $response);
         $response->assertJsonStructure($this->structure);
         $updatedProcess = Process::where('id', $id)->first();
@@ -893,7 +893,7 @@ class ProcessTest extends TestCase
         $response = $this->apiCall('PUT', $route, [
             'bpmn' => $newBpmn,
         ]);
-        //validate status
+        // validate status
         $this->assertStatus(422, $response);
         $response->assertJsonStructure($this->errorStructure);
     }
@@ -1056,7 +1056,7 @@ class ProcessTest extends TestCase
             'process_category_id' => static::$DO_NOT_SEND,
         ]);
         $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
-        //Add a bpmn content
+        // Add a bpmn content
         $array['bpmn'] = file_get_contents(__DIR__ . '/processes/C.4.0-export.bpmn');
         $response = $this->apiCall('POST', $route, $array);
         $response->assertStatus(422);

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -1145,7 +1145,7 @@ class ProcessTest extends TestCase
         $response->assertStatus(200);
 
         // Assert draft version is created.
-        $this->assertEquals(1, $process->versions()->where('draft', true)->count());
+        $this->assertEquals(1, $process->versions()->draft()->count());
 
         // Publish.
         $params = [
@@ -1156,6 +1156,6 @@ class ProcessTest extends TestCase
         $response = $this->apiCall('PUT', $url, $params);
 
         // Delete the draft after the item is published.
-        $this->assertEquals(0, $process->versions()->where('draft', true)->count());
+        $this->assertEquals(0, $process->versions()->draft()->count());
     }
 }

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -1130,4 +1130,32 @@ class ProcessTest extends TestCase
         $process->refresh();
         $this->assertFalse($process->properties['manager_can_cancel_request']);
     }
+
+    public function testUpdateProcessVersions()
+    {
+        $process = Process::factory()->create();
+        $url = route('api.processes.update', ['process' => $process]);
+        $params = [
+            'name' => 'Process',
+            'description' => 'Description',
+            'is_draft' => true,
+        ];
+
+        $response = $this->apiCall('PUT', $url, $params);
+        $response->assertStatus(200);
+
+        // Assert draft version is created.
+        $this->assertEquals(1, $process->versions()->where('draft', true)->count());
+
+        // Publish.
+        $params = [
+            'name' => 'Process',
+            'description' => 'Description',
+            'is_draft' => false,
+        ];
+        $response = $this->apiCall('PUT', $url, $params);
+
+        // Delete the draft after the item is published.
+        $this->assertEquals(0, $process->versions()->where('draft', true)->count());
+    }
 }

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -119,7 +119,7 @@ class UsersTest extends TestCase
             'lastname' => $faker->lastName,
             'email' => $faker->email,
             'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
-            'password' => $faker->password(8, 20),
+            'password' => $faker->password(8) . 'A' . '1',
         ]);
 
         $response->assertStatus(201);
@@ -143,7 +143,7 @@ class UsersTest extends TestCase
             'lastname' => $faker->lastName,
             'email' => $faker->email,
             'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
-            'password' => $faker->password(8, 20),
+            'password' => $faker->password(8) . 'A' . '1',
             'datetime_format' => $dateFormat,
         ]);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR adds backend and frontend changes for Autosave in Modeler.

## Solution
- Added a new `draft` column (boolean default false) to all *_vesions tables.
    - Added new column in ScriptExecutorVersion and VocabularyVersion to be consistent, even though there is no autosave for those items.
- Each process, script, screen should only have one draft (see HasVersioning@saveDraft).
- Added a global scope to HasVersioning that sets the published scope to all queries by default.
    - Also, see HasVersioning@getLatestVersion to make sure we're getting always the published version.
- Delete the draft after the item is published, see HasVersioning@saveVersion.
- About: Adding API controller endpoints to get and put the version, I've followed another approach.
    - GET
        - Load the draft (if exists) within the ModelerController@show method.
    - PUT
        - Use the same endpoint that saves the process but send an `is_draft` flag from the frontend. (See ProcessMaker/Http/Controllers/Api/ProcessController@update).
- Added a debounce of 5 seconds when there's any change in modeler. (later we should change this value through some setting?)
- Added discard draft feature.

## How to Test
Please execute the following tests:
- `phpunit tests/Feature/Api/ProcessTest.php --filter testUpdateProcessVersions`
- `phpunit tests/Feature/Api/ProcessTest.php --filter testDiscardDraft`
- Execute a manual test by linking package-version and modeler in Core.

## Related Tickets & Packages
- [FOUR-7331](https://processmaker.atlassian.net/browse/FOUR-7331)
- [FOUR-7332](https://processmaker.atlassian.net/browse/FOUR-7333)
- [FOUR-7333](https://processmaker.atlassian.net/browse/FOUR-7333)
- [FOUR-7334](https://processmaker.atlassian.net/browse/FOUR-7333)
- [Package Vocabularies PR](https://github.com/ProcessMaker/package-vocabularies/pull/70)
- [Package Versions PR](https://github.com/ProcessMaker/package-versions/pull/56)
- [Modeler PR](https://github.com/ProcessMaker/modeler/pull/1468)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-vocabularies:feature/FOUR-7331


[FOUR-7331]: https://processmaker.atlassian.net/browse/FOUR-7331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ