### PR TITLE
Fix export when dependent is in multicolumn or loop

### DIFF
--- a/resources/js/processes/export/components/MainAssetView.vue
+++ b/resources/js/processes/export/components/MainAssetView.vue
@@ -117,7 +117,6 @@ export default {
     "groups",
     "processId",
     "processInfo",
-    "existingAssets"
     ],
     components: {
         DataCard,

--- a/tests/Feature/ImportExport/UtilsTest.php
+++ b/tests/Feature/ImportExport/UtilsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\ImportExport\Exporters;
 
+use Illuminate\Support\Arr;
 use ProcessMaker\ImportExport\Utils;
 use ProcessMaker\Models\Process;
 use Tests\TestCase;
@@ -30,5 +31,62 @@ class UtilsTest extends TestCase
         $result = Utils::getServiceTasks($this->process, 'package-data-sources/data-source-task-service');
         $config = Utils::getPmConfig($result->first());
         $this->assertEquals('list', $config['endpoint']);
+    }
+
+    public function testFindScreenDependent()
+    {
+        $config = [
+            [
+                'items' => [
+                    [
+                        'component' => 'MyComponent',
+                        'test' => 'first',
+                    ],
+                    [
+                        'component' => 'FormMultiColumn',
+                        'items' => [
+                            [
+                                ['component' => 'MyComponent', 'test' => 'second'],
+                            ],
+                            [
+                                ['component' => 'OtherComponent', 'test' => 'other'],
+                                ['component' => 'MyComponent', 'test' => 'third'],
+                                [
+                                    'component' => 'FormLoop',
+                                    'items' => [
+                                        ['component' => 'MyComponent', 'test' => 'fourth'],
+                                        [
+                                            'component' => 'FormMultiColumn',
+                                            'items' => [
+                                                [],
+                                                [
+                                                    ['component' => 'MyComponent', 'test' => 'fifth'],
+                                                ],
+                                            ],
+                                            ['component' => 'OtherComponent', 'test' => 'other'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'items' => [
+                    ['component' => 'MyComponent', 'test' => 'sixth'],
+                ],
+            ],
+        ];
+        $matches = Utils::findScreenDependent($config, 'MyComponent', 'test');
+
+        $this->assertCount(6, $matches);
+
+        foreach (['first', 'second', 'third', 'fourth', 'fifth', 'sixth'] as $i => $nth) {
+            $this->assertEquals($matches[$i]['value'], $nth);
+            $this->assertEquals(Arr::get($config, $matches[$i]['path']), $nth);
+            $component = Arr::get($config, $matches[$i]['component_path']);
+            $this->assertEquals($component['component'], 'MyComponent');
+        }
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
When a process has screen that has a chart or data source select list inside a multicolumn or loop it does not export.

## Solution
- Recursively search the screen config for dependencies

## How to Test
- Create and configure a data connector
- Create a screen with a select list that uses the data connector for it's options
- Put the select list inside a multicolumn
- Add a task that uses the screen to a new process
- Export the process with custom export
- Ensure it shows the data source is exported
![image](https://user-images.githubusercontent.com/2546850/222812894-219b7f5a-2f04-403b-b1bb-a5685dfb632e.png)

- Import as new
- Ensure a copy of the data source is created

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7574

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
