### PR TITLE
FOUR-7264 - Default timezone for new users - a

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -159,6 +159,7 @@ class UserController extends Controller
         }
 
         $user->fill($fields);
+        $user->setTimezoneAttribute($request->input('timezone', ''));
         $user->saveOrFail();
 
         return new UserResource($user->refresh());

--- a/ProcessMaker/Observers/UserObserver.php
+++ b/ProcessMaker/Observers/UserObserver.php
@@ -10,17 +10,8 @@ use ProcessMaker\Models\User;
 class UserObserver
 {
     /**
-     * Handle the user "creating" event.
-     */
-    public function creating(User $user)
-    {
-        $user->setTimezoneAttribute();
-    }
-
-    /**
      * Handle the user "deleting" event.
      *
-     * @param User $user
      * @throws ReferentialIntegrityException
      */
     public function deleting(User $user)


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR takes into account the use case of creating users via API and assigning a timezone that exists in the request body.

**Steps to reproduce:**


- Perform an API POST call to: `/api/1.0/user` and add the `timezone` query param.
  - If the timezone is defined in the body and it different to timezone default, the user should be create with the timezone set and it should not assigned the default timezone. 

## Solution
- Removed the `setTimezoneAttribute` from the Observer to prevent it from overwriting the timezone.

## How to Test
- Execute `phpunit tests/Feature/Api/UsersTest.php --filter testDefaultValuesOfUser`.

## Related Tickets & Packages
- [FOUR-7264](https://processmaker.atlassian.net/browse/FOUR-7264)
- [Package Auth PR](https://github.com/ProcessMaker/package-auth/pull/73)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:package-auth:bugfix/FOUR-7264-a
ci:connector-docusign:v1.1.0
ci:connector-pdf-print:v1.9.0
ci:connector-send-email:v1.14.0
ci:package-actions-by-email:v1.8.4
ci:package-advanced-user-manager:v1.2.0
ci:package-collections:v2.6.1
ci:package-comments:v1.4.0
ci:package-data-sources:v1.13.0
ci:package-dynamic-ui:v1.5.0
ci:package-savedsearch:v1.20.0
ci:package-vocabularies:v2.7.0
ci:package-webentry:v2.8.0

[FOUR-7264]: https://processmaker.atlassian.net/browse/FOUR-7264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ