### PR TITLE
FOUR-7335 - Autosave Script 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     Snap: true,
     Dispatcher: true,
     ProcessMaker: true,
+    _: true,
   },
   extends: ["eslint:recommended", "plugin:vue/recommended", "airbnb-base"],
   parserOptions: {

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ cypress/downloads
 .phpunit.result.cache
 .php-cs-fixer.cache
 .phpunit.result.cache
+.editorconfig

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -181,7 +181,7 @@ class ProcessController extends Controller
     {
         $request->validate(Process::rules());
         $data = $request->all();
-        //Validate if exists file bpmn
+        // Validate if exists file bpmn
         if ($request->has('file')) {
             $data['bpmn'] = $request->file('file')->get();
             $request->request->add(['bpmn' => $data['bpmn']]);
@@ -200,7 +200,7 @@ class ProcessController extends Controller
         $process = new Process();
         $process->fill($data);
 
-        //set current user
+        // set current user
         $process->user_id = Auth::user()->id;
 
         if (isset($data['bpmn'])) {
@@ -265,7 +265,7 @@ class ProcessController extends Controller
     {
         $request->validate(Process::rules($process));
 
-        //bpmn validation
+        // bpmn validation
         if ($schemaErrors = $this->validateBpmn($request)) {
             $warnings = [];
             foreach ($schemaErrors as $error) {
@@ -286,22 +286,22 @@ class ProcessController extends Controller
             $process->manager_id = $request->input('manager_id', null);
         }
 
-        //If we are specifying cancel assignments...
+        // If we are specifying cancel assignments...
         if ($request->has('cancel_request')) {
             $this->cancelRequestAssignment($process, $request);
         }
 
-        //If we are specifying edit data assignments...
+        // If we are specifying edit data assignments...
         if ($request->has('edit_data')) {
             $this->editDataAssignments($process, $request);
         }
 
-        //Save any request notification settings...
+        // Save any request notification settings...
         if ($request->has('notifications')) {
             $this->saveRequestNotifications($process, $request);
         }
 
-        //Save any task notification settings...
+        // Save any task notification settings...
         if ($request->has('task_notifications')) {
             $this->saveTaskNotifications($process, $request);
         }
@@ -324,13 +324,13 @@ class ProcessController extends Controller
     {
         $cancelRequest = $request->input('cancel_request');
 
-        //Adding method to users array
+        // Adding method to users array
         $cancelUsers = [];
         foreach ($cancelRequest['users'] as $item) {
             $cancelUsers[$item] = ['method' => 'CANCEL'];
         }
 
-        //Adding method to groups array
+        // Adding method to groups array
         $cancelGroups = [];
         foreach ($cancelRequest['groups'] as $item) {
             $cancelGroups[$item] = ['method' => 'CANCEL'];
@@ -344,45 +344,45 @@ class ProcessController extends Controller
             }
         }
 
-        //Syncing users and groups that can cancel this process
+        // Syncing users and groups that can cancel this process
         $process->usersCanCancel()->sync($cancelUsers, ['method' => 'CANCEL']);
         $process->groupsCanCancel()->sync($cancelGroups, ['method' => 'CANCEL']);
     }
 
     private function editDataAssignments(Process $process, Request $request)
     {
-        //Adding method to users array
+        // Adding method to users array
         $editDataUsers = [];
         foreach ($request->input('edit_data')['users'] as $item) {
             $editDataUsers[$item] = ['method' => 'EDIT_DATA'];
         }
 
-        //Adding method to groups array
+        // Adding method to groups array
         $editDataGroups = [];
         foreach ($request->input('edit_data')['groups'] as $item) {
             $editDataGroups[$item] = ['method' => 'EDIT_DATA'];
         }
 
-        //Syncing users and groups that can cancel this process
+        // Syncing users and groups that can cancel this process
         $process->usersCanEditData()->sync($editDataUsers, ['method' => 'EDIT_DATA']);
         $process->groupsCanEditData()->sync($editDataGroups, ['method' => 'EDIT_DATA']);
     }
 
     private function saveRequestNotifications($process, $request)
     {
-        //Retrieve input
+        // Retrieve input
         $input = $request->input('notifications');
 
-        //For each notifiable type...
+        // For each notifiable type...
         foreach ($process->requestNotifiableTypes as $notifiable) {
-            //And for each notification type...
+            // And for each notification type...
             foreach ($process->requestNotificationTypes as $notification) {
-                //If this input has been set
+                // If this input has been set
                 if (isset($input[$notifiable][$notification])) {
-                    //Determine if this notification is wanted
+                    // Determine if this notification is wanted
                     $notificationWanted = filter_var($input[$notifiable][$notification], FILTER_VALIDATE_BOOLEAN);
 
-                    //If we want the notification, find or create it
+                    // If we want the notification, find or create it
                     if ($notificationWanted === true) {
                         $process->notification_settings()->firstOrCreate([
                             'element_id' => null,
@@ -391,7 +391,7 @@ class ProcessController extends Controller
                         ]);
                     }
 
-                    //If we do not want the notification, delete it
+                    // If we do not want the notification, delete it
                     if ($notificationWanted === false) {
                         $process->notification_settings()
                             ->whereNull('element_id')
@@ -465,21 +465,21 @@ class ProcessController extends Controller
 
     private function saveTaskNotifications($process, $request)
     {
-        //Retrieve input
+        // Retrieve input
         $inputs = $request->input('task_notifications');
 
-        //For each node...
+        // For each node...
         foreach ($inputs as $nodeId => $input) {
-            //For each notifiable type...
+            // For each notifiable type...
             foreach ($process->taskNotifiableTypes as $notifiable) {
-                //And for each notification type...
+                // And for each notification type...
                 foreach ($process->taskNotificationTypes as $notification) {
-                    //If this input has been set
+                    // If this input has been set
                     if (isset($input[$notifiable][$notification])) {
-                        //Determine if this notification is wanted
+                        // Determine if this notification is wanted
                         $notificationWanted = filter_var($input[$notifiable][$notification], FILTER_VALIDATE_BOOLEAN);
 
-                        //If we want the notification, find or create it
+                        // If we want the notification, find or create it
                         if ($notificationWanted === true) {
                             $process->notification_settings()->firstOrCreate([
                                 'element_id' => $nodeId,
@@ -488,7 +488,7 @@ class ProcessController extends Controller
                             ]);
                         }
 
-                        //If we do not want the notification, delete it
+                        // If we do not want the notification, delete it
                         if ($notificationWanted === false) {
                             $process->notification_settings()
                                 ->where('element_id', $nodeId)
@@ -949,11 +949,11 @@ class ProcessController extends Controller
      */
     public function importAssignments(Process $process, Request $request)
     {
-        //If we are specifying assignments...
+        // If we are specifying assignments...
         if ($request->has('assignable')) {
             $assignable = $request->input('assignable');
 
-            //Update assignments in scripts
+            // Update assignments in scripts
             $xmlAssignable = [];
             $callActivity = [];
             $watcherDataSources = [];
@@ -970,7 +970,7 @@ class ProcessController extends Controller
                 }
             }
 
-            //Update assignments in start Events, task, user Tasks
+            // Update assignments in start Events, task, user Tasks
             $definitions = $process->getDefinitions();
             $tags = ['startEvent', 'task', 'userTask', 'manualTask'];
             foreach ($tags as $tag) {
@@ -1000,7 +1000,7 @@ class ProcessController extends Controller
                 }
             }
 
-            //Update assignments call Activity
+            // Update assignments call Activity
             if ($callActivity) {
                 $elements = $definitions->getElementsByTagName('callActivity');
                 foreach ($elements as $element) {
@@ -1031,22 +1031,22 @@ class ProcessController extends Controller
             $process->bpmn = $definitions->saveXML();
         }
 
-        //If we are specifying cancel assignments...
+        // If we are specifying cancel assignments...
         if ($request->has('cancel_request')) {
             $this->cancelRequestAssignment($process, $request);
         }
 
-        //If we are specifying edit data assignments...
+        // If we are specifying edit data assignments...
         if ($request->has('edit_data')) {
             $this->editDataAssignments($process, $request);
         }
 
-        //If we are specifying a manager id
+        // If we are specifying a manager id
         if ($request->has('manager_id')) {
             $process->manager_id = $request->input('manager_id');
         }
 
-        //If we are specifying a status
+        // If we are specifying a status
         if ($request->has('status')) {
             $process->status = $request->input('status');
         }
@@ -1106,7 +1106,7 @@ class ProcessController extends Controller
      */
     public function triggerStartEvent(Process $process, Request $request)
     {
-        //Get the event BPMN element
+        // Get the event BPMN element
         $id = $request->query('event');
         if (!$id) {
             return abort(404);

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -309,10 +309,7 @@ class ProcessController extends Controller
         // Catch errors to send more specific status
         try {
             if ($request->input('is_draft', false)) {
-                $process->withoutEvents(function () use ($process) {
-                    $process->saveOrFail();
-                    $process->saveDraft();
-                });
+                $process->saveDraft();
             } else {
                 $process->saveOrFail();
             }
@@ -1259,5 +1256,12 @@ class ProcessController extends Controller
             $config['web_entry']['webentryRouteConfig']['entryUrl'] = $newEntryUrl;
             $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config', json_encode($config));
         }
+    }
+
+    public function close(Process $process)
+    {
+        $process->deleteDraft();
+
+        return new Resource($process);
     }
 }

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -3,9 +3,7 @@
 namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
-use Mockery\Exception;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\Script as ScriptResource;
@@ -264,7 +262,7 @@ class ScriptController extends Controller
      */
     public function execution($key)
     {
-        return response()->json(Cache::get("srn.$key"));
+        return response()->json(Cache::get("srn.{$key}"));
     }
 
     /**
@@ -371,15 +369,54 @@ class ScriptController extends Controller
     {
         $request->validate(Script::rules($script));
 
-        $script->fill($request->input());
-
-        $script->saveOrFail();
+        $script->fill($request->input())->saveOrFail();
 
         return response($request, 204);
     }
 
     /**
-     * duplicate a Script.
+     * Update a draft script.
+     *
+     * @param Script $script
+     * @param Request $request
+     *
+     * @return ResponseFactory|Response
+     *
+     *     @OA\Put(
+     *     path="/scripts/{script_id}/draft",
+     *     summary="Update a draft script",
+     *     operationId="updateDraftScript",
+     *     tags={"Scripts"},
+     *     @OA\Parameter(
+     *         descriptionc="ID of script to return",
+     *         in="path",
+     *         name="script_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\RequestBody(
+     *       required=true,
+     *       @OA\JsonContent(ref="#/components/schemas/scriptsEditable")
+     *     ),
+     *     @OA\Response(
+     *         response=204,
+     *         description="success",
+     *     ),
+     * )
+     */
+    public function draft(Script $script, Request $request)
+    {
+        $request->validate(Script::rules($script));
+
+        $script->saveDraft();
+
+        return response($request, 204);
+    }
+
+    /**
+     * Duplicate a Script.
      *
      * @param Script $script
      * @param Request $request

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -410,6 +410,7 @@ class ScriptController extends Controller
     {
         $request->validate(Script::rules($script));
 
+        $script->fill(['code' => $request->code]);
         $script->saveDraft();
 
         return response($request, 204);

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -507,4 +507,11 @@ class ScriptController extends Controller
 
         return response([], 204);
     }
+
+    public function close(Script $script)
+    {
+        $script->deleteDraft();
+
+        return response([], 204);
+    }
 }

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -388,7 +388,7 @@ class ScriptController extends Controller
      *     operationId="updateDraftScript",
      *     tags={"Scripts"},
      *     @OA\Parameter(
-     *         descriptionc="ID of script to return",
+     *         description="ID of script to return",
      *         in="path",
      *         name="script_id",
      *         required=true,

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -26,7 +26,7 @@ class ModelerController extends Controller
          */
         event(new ModelerStarting($manager));
 
-        $draft = $process->versions()->where('draft', true)->first();
+        $draft = $process->versions()->draft()->first();
         if ($draft) {
             $process->fill($draft->only(['svg', 'bpmn']));
         }

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -35,6 +35,7 @@ class ModelerController extends Controller
             'process' => $process->append('notifications', 'task_notifications'),
             'manager' => $manager,
             'signalPermissions' => SignalManager::permissions($request->user()),
+            'autoSaveDelay' => config('versions.delay.process', 5000),
         ]);
     }
 }

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -26,6 +26,11 @@ class ModelerController extends Controller
          */
         event(new ModelerStarting($manager));
 
+        $draft = $process->versions()->where('draft', true)->first();
+        if ($draft) {
+            $process->fill($draft->only(['svg', 'bpmn']));
+        }
+
         return view('processes.modeler.index', [
             'process' => $process->append('notifications', 'task_notifications'),
             'manager' => $manager,

--- a/ProcessMaker/Http/Controllers/Process/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScriptController.php
@@ -70,6 +70,11 @@ class ScriptController extends Controller
             '_request' => $processRequestAttributes,
         ];
 
+        $draft = $script->versions()->draft()->first();
+        if ($draft) {
+            $script->fill($draft->only(['code']));
+        }
+
         /**
          * Emit the ScriptBuilderStarting event, passing in our ScriptBuilderManager instance. This will
          * allow packages to add additional javascript for Script Builder initialization which

--- a/ProcessMaker/Http/Controllers/Process/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScriptController.php
@@ -82,7 +82,12 @@ class ScriptController extends Controller
          */
         event(new ScriptBuilderStarting($manager));
 
-        return view('processes.scripts.builder', compact('script', 'testData', 'manager'));
+        return view('processes.scripts.builder', [
+            'script' => $script,
+            'manager' => $manager,
+            'testData' => $testData,
+            'autoSaveDelay' => config('versions.delay.script', 5000),
+        ]);
     }
 
     private function getProcessRequestAttributes()

--- a/ProcessMaker/Http/Controllers/Process/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScriptController.php
@@ -12,6 +12,7 @@ use ProcessMaker\Models\Script;
 use ProcessMaker\Models\ScriptCategory;
 use ProcessMaker\Models\ScriptExecutor;
 use ProcessMaker\Models\User;
+use ProcessMaker\PackageHelper;
 use ProcessMaker\Traits\HasControllerAddons;
 
 class ScriptController extends Controller
@@ -87,6 +88,7 @@ class ScriptController extends Controller
             'manager' => $manager,
             'testData' => $testData,
             'autoSaveDelay' => config('versions.delay.script', 5000),
+            'isVersionsInstalled' => PackageHelper::isPmPackageVersionsInstalled(),
         ]);
     }
 

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1265,14 +1265,6 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
     }
 
     /**
-     * Get the latest version of the process
-     */
-    public function getLatestVersion()
-    {
-        return $this->versions()->orderBy('id', 'desc')->first();
-    }
-
-    /**
      * Check if process is valid for execution
      *
      * @return bool

--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -2,7 +2,7 @@
 
 namespace ProcessMaker\Models;
 
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Builder;
 use ProcessMaker\Contracts\ProcessModelInterface;
 use ProcessMaker\Traits\HasCategories;
 use ProcessMaker\Traits\HasSelfServiceTasks;
@@ -132,5 +132,21 @@ class ProcessVersion extends ProcessMakerModel implements ProcessModelInterface
     public function parent()
     {
         return $this->belongsTo(Process::class, 'process_id', 'id');
+    }
+
+    /**
+     * Scope to only return draft versions.
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('draft', true);
+    }
+
+    /**
+     * Scope to only return published versions.
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('draft', false);
     }
 }

--- a/ProcessMaker/Models/ScreenVersion.php
+++ b/ProcessMaker/Models/ScreenVersion.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use ProcessMaker\Contracts\ScreenInterface;
 use ProcessMaker\Traits\HasCategories;
 
@@ -47,5 +48,21 @@ class ScreenVersion extends ProcessMakerModel implements ScreenInterface
     public function parent()
     {
         return $this->belongsTo(Screen::class, 'screen_id', 'id');
+    }
+
+    /**
+     * Scope to only return draft versions.
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('draft', true);
+    }
+
+    /**
+     * Scope to only return published versions.
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('draft', false);
     }
 }

--- a/ProcessMaker/Models/ScriptExecutorVersion.php
+++ b/ProcessMaker/Models/ScriptExecutorVersion.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Models;
 
+use Illuminate\Database\Eloquent\Builder;
+
 class ScriptExecutorVersion extends ProcessMakerModel
 {
     protected $fillable = [

--- a/ProcessMaker/Models/ScriptExecutorVersion.php
+++ b/ProcessMaker/Models/ScriptExecutorVersion.php
@@ -5,6 +5,22 @@ namespace ProcessMaker\Models;
 class ScriptExecutorVersion extends ProcessMakerModel
 {
     protected $fillable = [
-        'title', 'description', 'language', 'config',
+        'title', 'description', 'language', 'config', 'draft',
     ];
+
+    /**
+     * Scope to only return draft versions.
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('draft', true);
+    }
+
+    /**
+     * Scope to only return published versions.
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('draft', false);
+    }
 }

--- a/ProcessMaker/Models/ScriptVersion.php
+++ b/ProcessMaker/Models/ScriptVersion.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use ProcessMaker\Contracts\ScriptInterface;
 use ProcessMaker\Traits\HasCategories;
 
@@ -58,5 +59,21 @@ class ScriptVersion extends ProcessMakerModel implements ScriptInterface
         }
 
         return $script->runScript($data, $config, $tokenId);
+    }
+
+    /**
+     * Scope to only return draft versions.
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('draft', true);
+    }
+
+    /**
+     * Scope to only return published versions.
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('draft', false);
     }
 }

--- a/ProcessMaker/PackageHelper.php
+++ b/ProcessMaker/PackageHelper.php
@@ -42,6 +42,8 @@ class PackageHelper
 
     const PM_PACKAGE_WEBENTRY = 'ProcessMaker\Package\WebEntry\WebEntryServiceProvider';
 
+    const PM_PACKAGE_VERSIONS = 'ProcessMaker\Package\Versions\PluginServiceProvider';
+
     public static function isPackageInstalled(string $serviceProviderClass): bool
     {
         if (!$serviceProviderClass) {

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 use ProcessMaker\Models\ProcessRequest;
 
 trait HasVersioning
@@ -26,8 +27,12 @@ trait HasVersioning
      */
     public function scopePublished($query)
     {
-        $query->whereHas('versions', static function ($query) {
-            $query->where('draft', false);
+        $query->whereHas('versions', function ($query) {
+            // Avoid migration errors when 'draft' column does not exist.
+            $hasDraftColumn = Schema::hasColumn($query->getModel()->getTable(), 'draft');
+            $query->when($hasDraftColumn, function ($query) {
+                $query->where('draft', false);
+            });
         });
     }
 
@@ -36,7 +41,7 @@ trait HasVersioning
      */
     public function scopeDraft($query)
     {
-        $query->whereHas('versions', static function ($query) {
+        $query->whereHas('versions', function ($query) {
             $query->where('draft', true);
         });
     }

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -2,17 +2,43 @@
 
 namespace ProcessMaker\Traits;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use ProcessMaker\Models\ProcessRequest;
 
 trait HasVersioning
 {
     /**
-     * Save a version every time the model is saved
+     * The "boot" method of HasVersioning.
      */
     public static function bootHasVersioning()
     {
+        static::addGlobalScope('published', function (Builder $builder) {
+            $builder->published();
+        });
+
+        // Save a version every time the model is saved.
         static::saved([static::class, 'saveNewVersion']);
+    }
+
+    /**
+     * Get the published for the model.
+     */
+    public function scopePublished($query)
+    {
+        $query->whereHas('versions', static function ($query) {
+            $query->where('draft', false);
+        });
+    }
+
+    /**
+     * Get the drafts for the model.
+     */
+    public function scopeDraft($query)
+    {
+        $query->whereHas('versions', static function ($query) {
+            $query->where('draft', true);
+        });
     }
 
     /**

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -53,7 +53,7 @@ trait HasVersioning
         $this->versions()->create($attributes);
 
         // Delete draft version.
-        $this->versions()->draft()->delete();
+        $this->deleteDraft();
     }
 
     /**
@@ -67,6 +67,11 @@ trait HasVersioning
         $this->versions()->updateOrCreate([
             'draft' => true,
         ], $attributes);
+    }
+
+    public function deleteDraft()
+    {
+        $this->versions()->draft()->delete();
     }
 
     private function getModelAttributes(): array

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -53,7 +53,7 @@ trait HasVersioning
         $this->versions()->create($attributes);
 
         // Delete draft version.
-        $this->versions()->where('draft', true)->delete();
+        $this->versions()->draft()->delete();
     }
 
     /**
@@ -89,7 +89,7 @@ trait HasVersioning
      */
     public function getLatestVersion()
     {
-        return $this->versions()->orderBy('id', 'desc')->first();
+        return $this->versions()->orderBy('id', 'desc')->published()->first();
     }
 
     /**

--- a/database/migrations/2023_02_27_130520_add_draft_column_to_versions_tables.php
+++ b/database/migrations/2023_02_27_130520_add_draft_column_to_versions_tables.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDraftColumnToVersionsTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('process_versions', function (Blueprint $table) {
+            $table->boolean('draft')->default(false)->after('user_id');
+        });
+        Schema::table('screen_versions', function (Blueprint $table) {
+            $table->boolean('draft')->default(false)->after('screen_category_id');
+        });
+        Schema::table('script_versions', function (Blueprint $table) {
+            $table->boolean('draft')->default(false)->after('script_id');
+        });
+        Schema::table('script_executor_versions', function (Blueprint $table) {
+            $table->boolean('draft')->default(false)->after('script_executor_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('process_versions', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+        Schema::table('screen_versions', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+        Schema::table('script_versions', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+        Schema::table('script_executor_versions', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+    }
+}

--- a/resources/js/components/Menu.vue
+++ b/resources/js/components/Menu.vue
@@ -3,134 +3,156 @@
     <b-row>
       <b-col>
         <template v-for="(item, index) in section.left">
-          <b-button-group v-if="isVisible(item, 'group')" size="sm" :key="index">
+          <b-button-group
+            v-if="isVisible(item, 'group')"
+            :key="index"
+            size="sm"
+          >
             <b-button
-              v-for="(button, indexButton) in item.items"
+              v-for="(button, indexButton) in visibleItems(item)"
+              :key="indexButton"
               :variant="button.variant || 'secondary'"
               class="text-capitalize"
               :title="button.title"
-              :key="indexButton"
               tabindex="1"
               @click="executeFunction(button.action)"
-              v-if="button.hide !== true"
             >
-              <i :class="button.icon"></i>
+              <i :class="button.icon" />
               {{ button.name }}
             </b-button>
           </b-button-group>
 
           <b-button
             v-if="isVisible(item, 'button')"
-            :variant="item.variant || 'secondary'"
-            size="sm"
-            class="text-capitalize"
-            :title="item.title"
             :key="index"
+            class="text-capitalize"
+            size="sm"
+            :variant="item.variant || 'secondary'"
+            :title="item.title"
             @click="executeFunction(item.action)"
           >
-            <i :class="item.icon"></i>
+            <i :class="item.icon" />
             {{ item.name }}
           </b-button>
 
           <component
-            v-if="item.type !== 'group' && item.type !== 'button'"
             :is="item.type"
-            :options="item.options"
+            v-if="item.type !== 'group' && item.type !== 'button'"
             :key="index"
-          ></component>
+            :options="item.options"
+          />
         </template>
       </b-col>
 
-      <b-col class="text-right" v-if="sectionRight">
+      <b-col
+        v-if="sectionRight"
+        class="text-right"
+      >
         <template v-for="(item, index) in section.right">
-          <b-button-group v-if="isVisible(item, 'group')" size="sm" :key="index">
+          <b-button-group
+            v-if="isVisible(item, 'group')"
+            :key="index"
+            size="sm"
+          >
             <b-button
-              v-for="(button, indexButton) in item.items"
+              v-for="(button, indexButton) in visibleItems(item)"
+              :key="`group-${indexButton}`"
               :variant="button.variant || 'secondary'"
               class="text-capitalize"
               :title="button.title"
-              :key="`group-${indexButton}`"
               @click="executeFunction(button.action)"
-              v-if="button.hide !== true"
             >
-              <i :class="button.icon"></i>
+              <i :class="button.icon" />
               {{ button.name }}
             </b-button>
           </b-button-group>
 
           <b-button
             v-if="isVisible(item, 'button')"
+            :key="index"
             size="sm"
             :variant="item.variant || 'secondary'"
             class="text-capitalize"
             :title="item.title"
-            :key="index"
             @click="executeFunction(item.action)"
           >
-            <i :class="item.icon"></i>
+            <i :class="item.icon" />
             {{ item.name }}
           </b-button>
 
           <component
-            v-if="item.type !== 'group' && item.type !== 'button'"
             :is="item.type"
-            :options="item.options"
+            v-if="item.type !== 'group' && item.type !== 'button'"
             :key="index"
-          ></component>
+            :options="item.options"
+          />
         </template>
       </b-col>
     </b-row>
   </b-card-header>
 </template>
 
-
 <script>
 export default {
-  props: ["options", "environment"],
+  props: {
+    options: {
+      type: Array,
+      default: () => [],
+    },
+    environment: {
+      type: Object,
+      default: () => {},
+    },
+  },
   data() {
     return {
       changeItems: {},
       newItems: [],
       sectionRight: true,
-      items: []
+      items: [],
     };
   },
-  watch: {},
   computed: {
     section() {
-      let response = {};
+      const response = {};
       response.left = [];
       response.right = [];
+      // eslint-disable-next-line vue/no-side-effects-in-computed-properties
       this.items = [];
 
-      this.options.forEach(item => {
+      this.options.forEach((item) => {
         if (item.type === "group") {
-          item.items.forEach(sub => {
+          item.items.forEach((sub) => {
             this.items.push(sub.id);
             return Object.assign(sub, this.changeItems[sub.id]);
           });
         }
         response[item.section].push(
-          Object.assign(item, this.changeItems[item.id])
+          Object.assign(item, this.changeItems[item.id]),
         );
         this.items.push(item.id);
       });
-      this.newItems.forEach(item => {
+      this.newItems.forEach((item) => {
         if (this.items.indexOf(item.id) === -1) {
           response[item.section].push(item);
           this.items.push(item.id);
         }
       });
       return response;
-    }
+    },
   },
+  watch: {},
   methods: {
     executeFunction(callback) {
       if (typeof callback === "function") {
         callback();
       } else {
+        // eslint-disable-next-line no-eval
         eval(`this.environment.${callback}`);
       }
+    },
+    visibleItems(item) {
+      return item.items.filter((button) => button.hide !== true);
     },
     isVisible(item, type) {
       return item.type === type && item.hide !== true;
@@ -141,16 +163,22 @@ export default {
       this.changeOptions(this.section.right);
     },
     changeOptions(data) {
-      data.forEach(item => {
-        item = Object.assign(item, this.changeItems[item.id]);
-        if (item.type === "group") {
-          this.changeOptions(item.items);
+      data.forEach((item) => {
+        const newItem = Object.assign(item, this.changeItems[item.id]);
+        if (newItem.type === "group") {
+          this.changeOptions(newItem.items);
         }
       });
     },
     addItem(value) {
       this.newItems.push(value);
-    }
-  }
+    },
+    unshiftItem(value) {
+      this.newItems.unshift(value);
+    },
+    shiftItem() {
+      this.newItems.shift();
+    },
+  },
 };
 </script>

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -1,7 +1,16 @@
 <template>
-  <b-container id="modeler-app" class="container p-0">
-    <b-card no-body class="h-100 border-top-0">
-      <b-card-body class="overflow-hidden position-relative p-0 vh-100" data-test="body-container">
+  <b-container
+    id="modeler-app"
+    class="container p-0"
+  >
+    <b-card
+      no-body
+      class="h-100 border-top-0"
+    >
+      <b-card-body
+        class="overflow-hidden position-relative p-0 vh-100"
+        data-test="body-container"
+      >
         <modeler
           ref="modeler"
           :owner="self"
@@ -20,20 +29,29 @@
         :owner="self"
         :xml-manager="xmlManager"
       >
-        <component v-for="(component, index) in validationBar" :key="`validation-status-${index}`" :is="component" :owner="self" />
+        <component
+          :is="component"
+          v-for="(component, index) in validationBar"
+          :key="`validation-status-${index}`"
+          :owner="self"
+        />
       </validation-status>
 
-      <component v-for="(component, index) in external" :key="`external-${index}`" :is="component.type" :options="component.options"/>
-
+      <component
+        :is="component.type"
+        v-for="(component, index) in external"
+        :key="`external-${index}`"
+        :options="component.options"
+      />
     </b-card>
   </b-container>
 </template>
 
 <script>
-  import {Modeler, ValidationStatus} from "@processmaker/modeler";
+import { Modeler, ValidationStatus } from "@processmaker/modeler";
 
-  export default {
-  name: 'ModelerApp',
+export default {
+  name: "ModelerApp",
   components: {
     Modeler,
     ValidationStatus,
@@ -43,7 +61,7 @@
       self: this,
       validationBar: [],
       external: [],
-      externalEmit : [],
+      externalEmit: [],
       dataXmlSvg: {},
       decorations: {
         borderOutline: {},
@@ -54,60 +72,90 @@
       xmlManager: null,
     };
   },
+  watch: {
+    validationErrors: {
+      deep: true,
+      handler() {
+        this.updateBpmnValidations();
+      },
+    },
+    warnings: {
+      deep: true,
+      handler() {
+        this.updateBpmnValidations();
+      },
+    },
+  },
+  mounted() {
+    ProcessMaker.$modeler = this.$refs.modeler;
+
+    window.ProcessMaker.EventBus.$emit("modeler-app-init", this);
+
+    window.ProcessMaker.EventBus.$on("modeler-save", (onSuccess, onError) => {
+      this.saveProcess(onSuccess, onError);
+    });
+    window.ProcessMaker.EventBus.$on("modeler-change", () => {
+      this.refreshSession();
+      window.ProcessMaker.EventBus.$emit("new-changes");
+    });
+  },
   methods: {
     updateBpmnValidations() {
-      const statusBar = this.$refs.validationStatus;
-      const warnings = this.warnings;
-      if(warnings instanceof Array) {
+      const { warnings } = this;
+      if (warnings instanceof Array) {
         const bpmnWarnings = [];
         warnings.forEach((warning) => {
           if (warning.errors instanceof Object) {
-            Object.keys(warning.errors).forEach(node => {
-              warning.errors[node].forEach(error => {
+            Object.keys(warning.errors).forEach((node) => {
+              warning.errors[node].forEach((error) => {
                 bpmnWarnings.push({
-                  category: 'error',
+                  category: "error",
                   id: node,
-                  message: error
+                  message: error,
                 });
               });
             });
           }
         });
-        JSON.stringify(bpmnWarnings) !== JSON.stringify(this.$refs.modeler.validationErrors.bpmn)
-          ? this.$refs.modeler.$set(this.$refs.modeler.validationErrors, 'bpmn', bpmnWarnings) : null;
-        JSON.stringify(bpmnWarnings) !== JSON.stringify(this.validationErrors.bpmn)
-          ? this.$set(this.validationErrors, 'bpmn', bpmnWarnings) : null;
+        const hasErrors = JSON.stringify(bpmnWarnings) !== JSON.stringify(this.$refs.modeler.validationErrors.bpmn);
+        if (hasErrors) {
+          this.$refs.modeler.$set(this.$refs.modeler.validationErrors, "bpmn", bpmnWarnings);
+        }
+        const hasValidationErrors = JSON.stringify(bpmnWarnings) !== JSON.stringify(this.validationErrors.bpmn);
+        if (hasValidationErrors) {
+          this.$set(this.validationErrors, "bpmn", bpmnWarnings);
+        }
       }
     },
     refreshSession: _.throttle(() => {
       ProcessMaker.apiClient({
-        method: 'POST',
-        url: '/keep-alive',
-        baseURL: '/',
-      })
+        method: "POST",
+        url: "/keep-alive",
+        baseURL: "/",
+      });
     }, 60000),
     runningInCypressTest() {
       return !!window.Cypress;
     },
     getTaskNotifications() {
-      var notifications = {};
-      this.$refs.modeler.nodes.forEach(function(node) {
-        let id = node.definition.id;
+      const notifications = {};
+      this.$refs.modeler.nodes.forEach((node) => {
+        const { id } = node.definition;
         if (node.notifications !== undefined) {
           notifications[id] = node.notifications;
         }
       });
       return notifications;
     },
-    emitRegisteredEvents ({xml, svg}) {
+    emitRegisteredEvents({ xml, svg }) {
       this.dataXmlSvg.xml = xml;
       this.dataXmlSvg.svg = svg;
 
-      this.externalEmit.forEach(item => {
+      this.externalEmit.forEach((item) => {
         window.ProcessMaker.EventBus.$emit(item);
-      })
+      });
       if (!this.externalEmit.length) {
-        window.ProcessMaker.EventBus.$emit('modeler-save');
+        window.ProcessMaker.EventBus.$emit("modeler-save");
       }
     },
     saveProcess(onSuccess, onError) {
@@ -116,64 +164,36 @@
         description: this.process.description,
         task_notifications: this.getTaskNotifications(),
         bpmn: this.dataXmlSvg.xml,
-        svg: this.dataXmlSvg.svg
+        svg: this.dataXmlSvg.svg,
       };
 
       const savedSuccessfully = (response) => {
         this.process.updated_at = response.data.updated_at;
         // Now show alert
-        ProcessMaker.alert(this.$t('The process was saved.'), 'success');
-        window.ProcessMaker.EventBus.$emit('save-changes');
-        this.$set(this, 'warnings', response.data.warnings || []);
+        ProcessMaker.alert(this.$t("The process was saved."), "success");
+        window.ProcessMaker.EventBus.$emit("save-changes");
+        this.$set(this, "warnings", response.data.warnings || []);
         if (response.data.warnings && response.data.warnings.length > 0) {
           this.$refs.validationStatus.autoValidate = true;
         }
-        if (typeof onSuccess === 'function') {
+        if (typeof onSuccess === "function") {
           onSuccess(response);
         }
       };
 
       const saveFailed = (err) => {
-        const message = err.response.data.message;
-        const errors = err.response.data.errors;
-        ProcessMaker.alert(message, 'danger');
+        const { message } = err.response.data;
+        ProcessMaker.alert(message, "danger");
 
-        if (typeof onError === 'function') {
+        if (typeof onError === "function") {
           onError(err);
         }
       };
 
-      ProcessMaker.apiClient.put('/processes/' + this.process.id, data)
-              .then(savedSuccessfully)
-              .catch(saveFailed);
-    }
-  },
-  mounted() {
-    ProcessMaker.$modeler = this.$refs.modeler;
-
-    window.ProcessMaker.EventBus.$emit('modeler-app-init', this);
-
-    window.ProcessMaker.EventBus.$on('modeler-save', (onSuccess, onError) => {
-      this.saveProcess(onSuccess, onError);
-    });
-    window.ProcessMaker.EventBus.$on('modeler-change', () => {
-      this.refreshSession();
-      window.ProcessMaker.EventBus.$emit('new-changes');
-    });
-  },
-  watch: {
-    validationErrors: {
-      deep: true,
-      handler() {
-        this.updateBpmnValidations();
-      }
+      ProcessMaker.apiClient.put(`/processes/${this.process.id}`, data)
+        .then(savedSuccessfully)
+        .catch(saveFailed);
     },
-    warnings: {
-      deep: true,
-      handler() {
-        this.updateBpmnValidations();
-      }
-    }
-  }
+  },
 };
 </script>

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -68,6 +68,7 @@ export default {
         borderOutline: {},
       },
       process: window.ProcessMaker.modeler.process,
+      autoSaveDelay: window.ProcessMaker.modeler.autoSaveDelay,
       validationErrors: {},
       warnings: [],
       xmlManager: null,
@@ -252,7 +253,7 @@ export default {
         ProcessMaker.apiClient.put(`/processes/${this.process.id}`, data)
           .then(savedSuccessfully)
           .catch(saveFailed);
-      }, 5000);
+      }, this.autoSaveDelay);
     },
   },
 };

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -98,7 +98,7 @@ export default {
     });
     window.ProcessMaker.EventBus.$on("modeler-change", () => {
       this.refreshSession();
-      this.autosaveProcess();
+      this.autoSaveProcess();
       window.ProcessMaker.EventBus.$emit("new-changes");
     });
     window.ProcessMaker.EventBus.$on("modeler-close", () => {
@@ -211,7 +211,7 @@ export default {
         .then(savedSuccessfully)
         .catch(saveFailed);
     },
-    async autosaveProcess() {
+    async autoSaveProcess() {
       const svg = document.querySelector(".mini-paper svg");
       const css = "text { font-family: sans-serif; }";
       const style = document.createElement("style");
@@ -232,12 +232,12 @@ export default {
 
       const savedSuccessfully = (response) => {
         this.process.updated_at = response.data.updated_at;
-        ProcessMaker.alert(this.$t("The process was saved."), "success");
         window.ProcessMaker.EventBus.$emit("save-changes");
         this.$set(this, "warnings", response.data.warnings || []);
         if (response.data.warnings && response.data.warnings.length > 0) {
           this.$refs.validationStatus.autoValidate = true;
         }
+        this.$refs.modeler.showSavedNotification();
       };
 
       const saveFailed = (error) => {

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -96,7 +96,7 @@ export default {
     });
     window.ProcessMaker.EventBus.$on("modeler-change", () => {
       this.refreshSession();
-      this.autoSaveProcess();
+      this.autosaveProcess();
       window.ProcessMaker.EventBus.$emit("new-changes");
     });
   },
@@ -195,7 +195,7 @@ export default {
         .then(savedSuccessfully)
         .catch(saveFailed);
     },
-    async autoSaveProcess() {
+    async autosaveProcess() {
       const svg = document.querySelector(".mini-paper svg");
       const css = "text { font-family: sans-serif; }";
       const style = document.createElement("style");
@@ -229,9 +229,15 @@ export default {
         ProcessMaker.alert(message, "danger");
       };
 
-      ProcessMaker.apiClient.put(`/processes/${this.process.id}`, data)
-        .then(savedSuccessfully)
-        .catch(saveFailed);
+      if (this.debounceTimeout) {
+        clearTimeout(this.debounceTimeout);
+      }
+
+      this.debounceTimeout = setTimeout(() => {
+        ProcessMaker.apiClient.put(`/processes/${this.process.id}`, data)
+          .then(savedSuccessfully)
+          .catch(saveFailed);
+      }, 5000);
     },
   },
 };

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -1,31 +1,52 @@
 <template>
   <b-container class="h-100">
-    <b-card no-body class="h-100">
-      <top-menu ref="menuScript" :options="optionsMenu"/>
+    <b-card
+      no-body
+      class="h-100"
+    >
+      <top-menu
+        ref="menuScript"
+        :options="optionsMenu"
+      />
 
-      <b-card-body class="overflow-hidden p-4" ref="editorContainer">
+      <b-card-body
+        ref="editorContainer"
+        class="overflow-hidden p-4"
+      >
         <b-row class="h-100">
-          <b-col cols="9" class="h-100 p-0">
+          <b-col
+            cols="9"
+            class="h-100 p-0"
+          >
             <monaco-editor
-              :options="monacoOptions"
               v-model="code"
+              :options="monacoOptions"
               :language="language"
               class="h-100"
               :class="{hidden: resizing}"
             />
           </b-col>
-          <b-col cols="3" class="h-100">
-            <b-card no-body class="h-100">
+          <b-col
+            cols="3"
+            class="h-100"
+          >
+            <b-card
+              no-body
+              class="h-100"
+            >
               <b-card-header class="light-gray-background">
                 <b-row class="d-flex align-items-center">
                   <b-col>{{ $t('Debugger') }}</b-col>
 
-                  <b-col align-self="end" class="text-right">
+                  <b-col
+                    align-self="end"
+                    class="text-right"
+                  >
                     <b-button
                       class="text-capitalize pl-3 pr-3"
                       :disabled="preview.executing"
-                      @click="execute"
                       size="sm"
+                      @click="execute"
                     >
                       <i class="fas fa-caret-square-right" />
                       {{ $t('Run') }}
@@ -42,7 +63,11 @@
                         <i class="fas fa-cog" />
                         {{ $t('Configuration') }}
                       </b-col>
-                      <b-col align-self="end" cols="1" class="mr-2">
+                      <b-col
+                        align-self="end"
+                        cols="1"
+                        class="mr-2"
+                      >
                         <i class="fas fa-chevron-down accordion-icon" />
                       </b-col>
                     </b-row>
@@ -50,8 +75,8 @@
                   <b-list-group-item class="p-0 border-left-0 border-right-0 border-top-0 mb-0">
                     <b-collapse id="configuration">
                       <monaco-editor
-                        :options="{ ...monacoOptions, minimap: { enabled: false } }"
                         v-model="preview.config"
+                        :options="{ ...monacoOptions, minimap: { enabled: false } }"
                         language="json"
                         class="editor-inspector"
                       />
@@ -64,7 +89,11 @@
                         <i class="fas fa-sign-in-alt" />
                         {{ $t('Sample Input') }}
                       </b-col>
-                      <b-col align-self="end" cols="1" class="mr-2">
+                      <b-col
+                        align-self="end"
+                        cols="1"
+                        class="mr-2"
+                      >
                         <i class="fas fa-chevron-down accordion-icon" />
                       </b-col>
                     </b-row>
@@ -72,8 +101,8 @@
                   <b-list-group-item class="p-0 border-left-0 border-right-0 border-top-0 mb-0">
                     <b-collapse id="input">
                       <monaco-editor
-                        :options="{ ...monacoOptions, minimap: { enabled: false } }"
                         v-model="preview.data"
+                        :options="{ ...monacoOptions, minimap: { enabled: false } }"
                         language="json"
                         class="editor-inspector"
                       />
@@ -91,18 +120,33 @@
                         <i class="far fa-caret-square-right" />
                         {{ $t('Output') }}
                       </b-col>
-                      <b-col align-self="end" cols="1" class="mr-2">
+                      <b-col
+                        align-self="end"
+                        cols="1"
+                        class="mr-2"
+                      >
                         <i class="fas fa-chevron-down accordion-icon" />
                       </b-col>
                     </b-row>
                   </b-list-group-item>
                   <b-list-group-item class="p-0 border-left-0 border-right-0 border-top-0 mb-0">
-                    <b-collapse id="output" class="bg-dark" :visible="outputOpen">
+                    <b-collapse
+                      id="output"
+                      class="bg-dark"
+                      :visible="outputOpen"
+                    >
                       <div class="output text-white">
-                        <pre v-if="preview.success" class="text-white"><samp>{{ preview.output }}</samp></pre>
+                        <pre
+                          v-if="preview.success"
+                          class="text-white"
+                        ><samp>{{ preview.output }}</samp></pre>
                         <div v-if="preview.failure">
-                          <div class="text-light bg-danger">{{preview.error.exception}}</div>
-                          <div class="text-light text-monospace small">{{preview.error.message}}</div>
+                          <div class="text-light bg-danger">
+                            {{ preview.error.exception }}
+                          </div>
+                          <div class="text-light text-monospace small">
+                            {{ preview.error.message }}
+                          </div>
                         </div>
                       </div>
                     </b-collapse>
@@ -120,9 +164,18 @@
           <span class="text-uppercase">{{ language }}</span>
         </span>
         <span class="ml-auto">
-          <i v-if="preview.executing" class="fas fa-spinner fa-spin"></i>
-          <i v-if="preview.success" class="fas fa-check text-success"></i>
-          <i v-if="preview.failure" class="fas fa-times-circle text-danger"></i>
+          <i
+            v-if="preview.executing"
+            class="fas fa-spinner fa-spin"
+          />
+          <i
+            v-if="preview.success"
+            class="fas fa-check text-success"
+          />
+          <i
+            v-if="preview.failure"
+            class="fas fa-times-circle text-danger"
+          />
         </span>
       </b-card-footer>
     </b-card>
@@ -132,11 +185,27 @@
 <script>
 import MonacoEditor from "vue-monaco";
 import _ from "lodash";
-import customFilters from "../customFilters";
-import TopMenu from "../../../components/Menu";
+import TopMenu from "../../../components/Menu.vue";
 
 export default {
-  props: ["process", "script", "scriptExecutor", "testData"],
+  components: {
+    MonacoEditor,
+    TopMenu,
+  },
+  props: {
+    script: {
+      type: Object,
+      required: true,
+    },
+    scriptExecutor: {
+      type: Object,
+      required: true,
+    },
+    testData: {
+      type: String,
+      default: "{}",
+    },
+  },
   data() {
     const options = [
       {
@@ -148,50 +217,43 @@ export default {
         icon: "fas fa-save",
         action: () => {
           ProcessMaker.EventBus.$emit("save-script");
-        }
-      }
+        },
+      },
     ];
 
     return {
       executionKey: null,
       resizing: false,
       monacoOptions: {
-        automaticLayout: true
+        automaticLayout: true,
       },
       code: this.script.code,
       preview: {
         error: {
-          exception: '',
-          message: ''
+          exception: "",
+          message: "",
         },
         executing: false,
         data: this.testData ? this.testData : "{}",
         config: "{}",
         output: "",
         success: false,
-        failure: false
+        failure: false,
       },
       outputOpen: true,
       optionsMenu: options,
-      boilerPlateTemplate: this.$t(` \r Welcome to ProcessMaker 4 Script Editor \r To access Environment Variables use {accessEnvVar} \r To access Request Data use {dataVariable} \r To access Configuration Data use {configVariable} \r To preview your script, click the Run button using the provided input and config data \r Return an array and it will be merged with the processes data \r Example API to retrieve user email by their ID {apiExample} \r API Documentation {apiDocsUrl} \r `),
+      // eslint-disable-next-line max-len
+      boilerPlateTemplate: this.$t(" \r Welcome to ProcessMaker 4 Script Editor \r To access Environment Variables use {accessEnvVar} \r To access Request Data use {dataVariable} \r To access Configuration Data use {configVariable} \r To preview your script, click the Run button using the provided input and config data \r Return an array and it will be merged with the processes data \r Example API to retrieve user email by their ID {apiExample} \r API Documentation {apiDocsUrl} \r "),
       nonce: null,
     };
-  },
-  watch: {
-    "preview.output"(output) {
-      if (output && !this.outputOpen) {
-        this.outputOpen = true;
-      }
-    }
-  },
-  components: {
-    MonacoEditor,
-    TopMenu,
   },
   computed: {
     language() {
       return this.scriptExecutor.language;
-    }
+    },
+  },
+  watch: {
+    "preview.output": "handlePreviewOutputChange",
   },
   mounted() {
     ProcessMaker.EventBus.$emit("script-builder-init", this);
@@ -200,23 +262,28 @@ export default {
     });
 
     window.addEventListener("resize", this.handleResize);
-    let userID = document.head.querySelector('meta[name="user-id"]');
+    const userID = document.head.querySelector("meta[name=\"user-id\"]");
     window.Echo.private(
-      `ProcessMaker.Models.User.${userID.content}`
-    ).listen('.ProcessMaker\\Events\\ScriptResponseEvent', response => {
+      `ProcessMaker.Models.User.${userID.content}`,
+    ).listen(".ProcessMaker\\Events\\ScriptResponseEvent", (response) => {
       this.outputResponse(response);
     });
-    this.loadBoilerplateTemplate();    
+    this.loadBoilerplateTemplate();
   },
-  beforeDestroy: function() {
+  beforeDestroy() {
     window.removeEventListener("resize", this.handleResize);
   },
 
   methods: {
     resizeEditor() {
       const domNode = this.editorReference.getDomNode();
-      const clientHeight =  this.$refs.editorContainer.clientHeight;
-      domNode.style.height = clientHeight.toString() + 'px';
+      const { clientHeight } = this.$refs.editorContainer;
+      domNode.style.height = `${clientHeight.toString()}px`;
+    },
+    handlePreviewOutputChange(output) {
+      if (output && !this.outputOpen) {
+        this.outputOpen = true;
+      }
     },
     outputResponse(response) {
       if (response.nonce !== this.nonce) {
@@ -226,16 +293,16 @@ export default {
       if (this.executionKey && this.executionKey !== response.data.watcher) {
         return;
       }
-      ProcessMaker.apiClient.get("scripts/execution/" + response.response.key).then((response) => {
-        if (response.data.exception) {
+      ProcessMaker.apiClient.get(`scripts/execution/${response.response.key}`).then((r) => {
+        if (r.data.exception) {
           this.preview.executing = false;
           this.preview.failure = true;
-          this.preview.error.exception = response.data.exception;
-          this.preview.error.message = response.data.message;
+          this.preview.error.exception = r.data.exception;
+          this.preview.error.message = r.data.message;
         } else {
           this.preview.executing = false;
           this.preview.success = true;
-          this.preview.output = response.data;
+          this.preview.output = r.data;
         }
       });
 
@@ -246,9 +313,8 @@ export default {
         this.preview.error.message = response.response;
       }
     },
-    stopResizing: _.debounce(function() {
+    stopResizing: _.debounce(() => {
       this.resizing = false;
-      //this.resizeEditor();
     }, 50),
     handleResize() {
       this.resizing = true;
@@ -261,7 +327,7 @@ export default {
       this.preview.output = undefined;
       // Attempt to execute a script, using our temp variables
       this.nonce = Math.random().toString(36);
-      ProcessMaker.apiClient.post("scripts/" + this.script.id + "/preview", {
+      ProcessMaker.apiClient.post(`scripts/${this.script.id}/preview`, {
         code: this.code,
         data: this.preview.data,
         config: this.preview.config,
@@ -276,52 +342,52 @@ export default {
     },
     save(onSuccess, onError) {
       ProcessMaker.apiClient
-        .put("scripts/" + this.script.id, {
+        .put(`scripts/${this.script.id}`, {
           code: this.code,
           title: this.script.title,
           description: this.script.description,
           script_executor_id: this.script.script_executor_id,
           run_as_user_id: this.script.run_as_user_id,
           timeout: this.script.timeout,
-          description: this.script.description
         })
-        .then(response => {
+        .then((response) => {
           ProcessMaker.alert(this.$t("The script was saved."), "success");
           if (typeof onSuccess === "function") {
             onSuccess(response);
           }
-        }).catch(err => {
+        }).catch((err) => {
           if (typeof onError === "function") {
             onError(err);
           }
         });
     },
     loadBoilerplateTemplate() {
-      if (this.script.code === `[]`) {
-      switch(this.script.language) {
-        case 'php':
-          this.code = Vue.filter('php')(this.boilerPlateTemplate);
-          break;
-        case 'lua':
-          this.code = Vue.filter('lua')(this.boilerPlateTemplate);
-          break; 
-        case 'javascript':
-          this.code = Vue.filter('javascript')(this.boilerPlateTemplate);
-          break;
-        case 'csharp':
-          this.code = Vue.filter('csharp')(this.boilerPlateTemplate);
-          break;
-        case 'java':
-          this.code = Vue.filter('java')(this.boilerPlateTemplate);
-          break;
-        case 'python':
-          this.code = Vue.filter('python')(this.boilerPlateTemplate);
-          break;
+      if (this.script.code === "[]") {
+        switch (this.script.language) {
+          case "php":
+            this.code = Vue.filter("php")(this.boilerPlateTemplate);
+            break;
+          case "lua":
+            this.code = Vue.filter("lua")(this.boilerPlateTemplate);
+            break;
+          case "javascript":
+            this.code = Vue.filter("javascript")(this.boilerPlateTemplate);
+            break;
+          case "csharp":
+            this.code = Vue.filter("csharp")(this.boilerPlateTemplate);
+            break;
+          case "java":
+            this.code = Vue.filter("java")(this.boilerPlateTemplate);
+            break;
+          case "python":
+            this.code = Vue.filter("python")(this.boilerPlateTemplate);
+            break;
+          default:
+            break;
         }
-
       }
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -205,6 +205,10 @@ export default {
       type: String,
       default: "{}",
     },
+    autoSaveDelay: {
+      type: Number,
+      default: 5000,
+    },
   },
   data() {
     const options = [
@@ -380,7 +384,7 @@ export default {
           .then(() => {
             ProcessMaker.alert(this.$t("The script was saved."), "success");
           });
-      }, 5000);
+      }, this.autoSaveDelay);
     },
     close() {
       ProcessMaker.apiClient

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -261,6 +261,9 @@ export default {
     ProcessMaker.EventBus.$on("save-script", (onSuccess, onError) => {
       this.save(onSuccess, onError);
     });
+    ProcessMaker.EventBus.$on("script-close", () => {
+      this.close();
+    });
 
     window.addEventListener("resize", this.handleResize);
     const userID = document.head.querySelector("meta[name=\"user-id\"]");
@@ -378,6 +381,13 @@ export default {
             ProcessMaker.alert(this.$t("The script was saved."), "success");
           });
       }, 5000);
+    },
+    close() {
+      ProcessMaker.apiClient
+        .post(`/scripts/${this.script.id}/close`)
+        .then(() => {
+          window.location.reload();
+        });
     },
     loadBoilerplateTemplate() {
       if (this.script.code === "[]") {

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -209,6 +209,10 @@ export default {
       type: Number,
       default: 5000,
     },
+    isVersionsInstalled: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     const options = [
@@ -367,6 +371,10 @@ export default {
         });
     },
     handleAutosave() {
+      if (this.isVersionsInstalled === false) {
+        return;
+      }
+
       if (this.debounceTimeout) {
         clearTimeout(this.debounceTimeout);
       }

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -382,7 +382,16 @@ export default {
             timeout: this.script.timeout,
           })
           .then(() => {
-            ProcessMaker.alert(this.$t("The script was saved."), "success");
+            // Display saved notification.
+            this.$refs.menuScript.unshiftItem({
+              id: "SavedNotification",
+              type: "SavedNotification",
+              section: "right",
+            });
+            // Hide the notification after 2 seconds.
+            setTimeout(() => {
+              this.$refs.menuScript.shiftItem();
+            }, 2000);
           });
       }, this.autoSaveDelay);
     },

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -36,7 +36,7 @@ div.main {
 
 @section('js')
   <script src="{{mix('js/leave-warning.js')}}"></script>
-  <script> 
+  <script>
   const breadcrumbData = [
     {
       'text':'{{__('Designer')}}',
@@ -57,6 +57,7 @@ div.main {
   ]
   window.ProcessMaker.modeler = {
     process: @json($process),
+    autoSaveDelay: @json($autoSaveDelay),
     xml: @json($process->bpmn),
     processName: @json($process->name),
     signalPermissions: @json($signalPermissions),
@@ -74,7 +75,7 @@ div.main {
     ],
   }
   const warnings = @json($process->warnings);
- 
+
   window.ProcessMaker.EventBus.$on('modeler-start', ({ loadXML, addWarnings, addBreadcrumbs }) => {
     loadXML(window.ProcessMaker.modeler.xml);
     addWarnings(warnings || []);

--- a/resources/views/processes/scripts/builder.blade.php
+++ b/resources/views/processes/scripts/builder.blade.php
@@ -21,7 +21,7 @@
 @section('content')
   <div id="script-container">
     <script-editor :script="{{ $script }}" :script-executor='{!! json_encode($script->scriptExecutor) !!}'
-      test-data="{{ json_encode($testData, JSON_PRETTY_PRINT) }}" :auto-save-delay="{{ $autoSaveDelay }}"></script-editor>
+      test-data="{{ json_encode($testData, JSON_PRETTY_PRINT) }}" :auto-save-delay="{{ $autoSaveDelay }}" :is-versions-installed="@json($isVersionsInstalled)"></script-editor>
   </div>
 @endsection
 

--- a/resources/views/processes/scripts/builder.blade.php
+++ b/resources/views/processes/scripts/builder.blade.php
@@ -1,46 +1,50 @@
 @extends('layouts.layout', ['content_margin' => ''])
 
 @section('title')
-  {{__('Edit Script')}}
+  {{ __('Edit Script') }}
 @endsection
 
 @section('sidebar')
-@include('layouts.sidebar', ['sidebar'=> Menu::get('sidebar_processes')])
+  @include('layouts.sidebar', ['sidebar' => Menu::get('sidebar_processes')])
 @endsection
 
 @section('breadcrumbs')
-  @include('shared.breadcrumbs', ['routes' => [
-      __('Designer') => route('processes.index'),
-      __('Scripts') => route('scripts.index'),
-      __('Edit') . " " . $script->title => null,
-  ]])
+  @include('shared.breadcrumbs', [
+      'routes' => [
+          __('Designer') => route('processes.index'),
+          __('Scripts') => route('scripts.index'),
+          __('Edit') . ' ' . $script->title => null,
+      ],
+  ])
 @endsection
 
 @section('content')
-<div id="script-container">
-    <script-editor :script="{{$script}}" :script-executor='{!! json_encode($script->scriptExecutor) !!}' test-data="{{ json_encode($testData, JSON_PRETTY_PRINT) }}"></script-editor>
-</div>
+  <div id="script-container">
+    <script-editor :script="{{ $script }}" :script-executor='{!! json_encode($script->scriptExecutor) !!}'
+      test-data="{{ json_encode($testData, JSON_PRETTY_PRINT) }}" :auto-save-delay="{{ $autoSaveDelay }}"></script-editor>
+  </div>
 @endsection
 
 @section('css')
-<style>
-div.main {
-  position: relative;
-}
-#script-container {
-  position: absolute;
-  width: 100%;
-  max-width: 100%;
-  height: 100%;
-  max-height: 100%;
-  overflow: hidden;
-}
-</style>
+  <style>
+    div.main {
+      position: relative;
+    }
+
+    #script-container {
+      position: absolute;
+      width: 100%;
+      max-width: 100%;
+      height: 100%;
+      max-height: 100%;
+      overflow: hidden;
+    }
+  </style>
 @endsection
 
 @section('js')
-    @foreach($manager->getScripts() as $script)
-      <script src="{{$script}}"></script>
-    @endforeach
-    <script src="{{mix('js/processes/scripts/edit.js')}}"></script>
+  @foreach ($manager->getScripts() as $script)
+    <script src="{{ $script }}"></script>
+  @endforeach
+  <script src="{{ mix('js/processes/scripts/edit.js') }}"></script>
 @endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -96,6 +96,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('scripts', [ScriptController::class, 'store'])->name('scripts.store')->middleware('can:create-scripts');
     Route::put('scripts/{script}', [ScriptController::class, 'update'])->name('scripts.update')->middleware('can:edit-scripts');
     Route::put('scripts/{script}/draft', [ScriptController::class, 'draft'])->name('scripts.draft')->middleware('can:edit-scripts');
+    Route::post('scripts/{script}/close', [ScriptController::class, 'close'])->name('scripts.close')->middleware('can:edit-scripts');
     Route::put('scripts/{script}/duplicate', [ScriptController::class, 'duplicate'])->name('scripts.duplicate')->middleware('can:create-scripts');
     Route::delete('scripts/{script}', [ScriptController::class, 'destroy'])->name('scripts.destroy')->middleware('can:delete-scripts');
     Route::post('scripts/{script}/preview', [ScriptController::class, 'preview'])->name('scripts.preview')->middleware('can:view-scripts');

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,6 +118,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('processes/{process}/import/assignments', [ProcessController::class, 'importAssignments'])->name('processes.import.assignments')->middleware('can:import-processes');
     Route::post('processes', [ProcessController::class, 'store'])->name('processes.store')->middleware('can:create-processes');
     Route::put('processes/{process}', [ProcessController::class, 'update'])->name('processes.update')->middleware('can:edit-processes');
+    Route::post('processes/{process}/close', [ProcessController::class, 'close'])->name('processes.close')->middleware('can:edit-processes');
     Route::delete('processes/{process}', [ProcessController::class, 'destroy'])->name('processes.destroy')->middleware('can:archive-processes');
     Route::put('processes/{processId}/restore', [ProcessController::class, 'restore'])->name('processes.restore')->middleware('can:archive-processes');
     Route::post('process_events/{process}', [ProcessController::class, 'triggerStartEvent'])->name('process_events.trigger')->middleware('can:start,process');

--- a/routes/api.php
+++ b/routes/api.php
@@ -95,6 +95,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('scripts/{script}', [ScriptController::class, 'show'])->name('scripts.show')->middleware('can:view-scripts');
     Route::post('scripts', [ScriptController::class, 'store'])->name('scripts.store')->middleware('can:create-scripts');
     Route::put('scripts/{script}', [ScriptController::class, 'update'])->name('scripts.update')->middleware('can:edit-scripts');
+    Route::put('scripts/{script}/draft', [ScriptController::class, 'draft'])->name('scripts.draft')->middleware('can:edit-scripts');
     Route::put('scripts/{script}/duplicate', [ScriptController::class, 'duplicate'])->name('scripts.duplicate')->middleware('can:create-scripts');
     Route::delete('scripts/{script}', [ScriptController::class, 'destroy'])->name('scripts.destroy')->middleware('can:delete-scripts');
     Route::post('scripts/{script}/preview', [ScriptController::class, 'preview'])->name('scripts.preview')->middleware('can:view-scripts');

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -1158,4 +1158,28 @@ class ProcessTest extends TestCase
         // Delete the draft after the item is published.
         $this->assertEquals(0, $process->versions()->draft()->count());
     }
+
+    public function testDiscardDraft()
+    {
+        $process = Process::factory()->create();
+        $url = route('api.processes.update', ['process' => $process]);
+        $params = [
+            'name' => 'Process',
+            'description' => 'Description',
+            'is_draft' => true,
+        ];
+
+        $response = $this->apiCall('PUT', $url, $params);
+        $response->assertStatus(200);
+
+        // Assert draft version is created.
+        $this->assertEquals(1, $process->versions()->draft()->count());
+
+        // Discard the draft.
+        $url = route('api.processes.close', ['process' => $process]);
+        $response = $this->apiCall('POST', $url, $params);
+
+        // Assert draft version is deleted.
+        $this->assertEquals(0, $process->versions()->draft()->count());
+    }
 }

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -52,7 +52,7 @@ class ProcessTest extends TestCase
         // Create some processes
         $countProcesses = 20;
         Process::factory()->count($countProcesses)->create();
-        //Get a page of processes
+        // Get a page of processes
         $page = 2;
         $perPage = 10;
         $this->assertCorrectModelListing(
@@ -89,7 +89,7 @@ class ProcessTest extends TestCase
         $process = Process::factory()->create(['bpmn' => $bpmn]);
         $process->usersCanStart('StartEventUID')->attach($this->user->id);
 
-        //Get a page of processes
+        // Get a page of processes
         $page = 1;
         $perPage = 10;
         $this->assertCorrectModelListing(
@@ -115,7 +115,7 @@ class ProcessTest extends TestCase
             'is_administrator' => false,
         ]);
 
-        //Create default All Users group
+        // Create default All Users group
         $group = Group::factory()->create([
             'name' => 'Test Group',
             'status' => 'ACTIVE',
@@ -123,7 +123,7 @@ class ProcessTest extends TestCase
         $group->save();
         $group->refresh();
 
-        //Add user to group
+        // Add user to group
         GroupMember::factory()->create([
             'member_id' => $this->user->id,
             'member_type' => User::class,
@@ -143,7 +143,7 @@ class ProcessTest extends TestCase
         $process = Process::factory()->create(['bpmn' => $bpmn]);
         $process->groupsCanStart('StartEventUID')->attach($group->id);
 
-        //Get a page of processes
+        // Get a page of processes
         $page = 1;
         $perPage = 10;
         $this->assertCorrectModelListing(
@@ -165,7 +165,7 @@ class ProcessTest extends TestCase
     {
         ProcessRequest::query()->delete();
 
-        //get process with start event
+        // get process with start event
         $file = Process::getProcessTemplatesPath() . '/SingleTask.bpmn';
         $bpmn = file_get_contents($file);
 
@@ -202,7 +202,7 @@ class ProcessTest extends TestCase
     {
         ProcessRequest::query()->delete();
 
-        //get process with start event
+        // get process with start event
         $startSingleEventFile = Process::getProcessTemplatesPath() . '/StartSingleEvent.bpmn';
         $startTimerEventFile = Process::getProcessTemplatesPath() . '/StartTimerEvent.bpmn';
         $startConditionalEventFile = Process::getProcessTemplatesPath() . '/StartConditionalEvent.bpmn';
@@ -254,7 +254,7 @@ class ProcessTest extends TestCase
     {
         ProcessRequest::query()->delete();
 
-        //get process with start event
+        // get process with start event
         $startSingleEventFile = Process::getProcessTemplatesPath() . '/StartSingleEvent.bpmn';
         $startTimerEventFile = Process::getProcessTemplatesPath() . '/StartTimerEvent.bpmn';
         $startConditionalEventFile = Process::getProcessTemplatesPath() . '/StartConditionalEvent.bpmn';
@@ -329,7 +329,7 @@ class ProcessTest extends TestCase
 
         $responseData = $response->getData()->data;
 
-        //just the process with assignment as process manager and the process assigned to the user should be returned
+        // just the process with assignment as process manager and the process assigned to the user should be returned
         $this->assertEquals(count($responseData), 2);
         $this->assertTrue(in_array($responseData[0]->id, [$processWithManager->id, $processAssigned->id]));
         $this->assertTrue(in_array($responseData[1]->id, [$processWithManager->id, $processAssigned->id]));
@@ -499,7 +499,7 @@ class ProcessTest extends TestCase
         Process::factory()->count($processInactive['num'])->create(['status' => $processInactive['status']]);
         Process::factory()->count($processArchived['num'])->create(['status' => $processArchived['status']]);
 
-        //Get active processes
+        // Get active processes
         $response = $this->assertCorrectModelListing(
             '?status=active&include=category&per_page=' . $perPage,
             [
@@ -508,10 +508,10 @@ class ProcessTest extends TestCase
                 'per_page' => $perPage,
             ]
         );
-        //verify include
+        // verify include
         $response->assertJsonStructure(['*' => ['category']], $response->json('data'));
 
-        //Get active processes
+        // Get active processes
         $response = $this->assertCorrectModelListing(
             '?status=archived&include=category,user&per_page=' . $perPage,
             [
@@ -520,7 +520,7 @@ class ProcessTest extends TestCase
                 'per_page' => $perPage,
             ]
         );
-        //verify include
+        // verify include
         $response->assertJsonStructure(['*' => ['category', 'user']], $response->json('data'));
     }
 
@@ -539,17 +539,17 @@ class ProcessTest extends TestCase
             'description' => 'yyyyy',
         ]);
 
-        //Test the list sorted by name returns as first row {"name": "aaaaaa"}
+        // Test the list sorted by name returns as first row {"name": "aaaaaa"}
         $this->assertModelSorting('?order_by=name&order_direction=asc', [
             'name' => 'aaaaaa',
         ]);
 
-        //Test the list sorted desc returns as first row {"name": "zzzzz"}
+        // Test the list sorted desc returns as first row {"name": "zzzzz"}
         $this->assertModelSorting('?order_by=name&order_direction=DESC', [
             'name' => 'zzzzz',
         ]);
 
-        //Test the list sorted by description in desc returns as first row {"description": "yyyyy"}
+        // Test the list sorted by description in desc returns as first row {"description": "yyyyy"}
         $this->assertModelSorting('?order_by=description&order_direction=desc', [
             'description' => 'yyyyy',
         ]);
@@ -583,7 +583,7 @@ class ProcessTest extends TestCase
      */
     public function testProcessCreation()
     {
-        //Create a process without category
+        // Create a process without category
         $this->assertModelCreationFails(
             Process::class,
             [
@@ -592,7 +592,7 @@ class ProcessTest extends TestCase
             ]
         );
 
-        //Create a process without sending the category
+        // Create a process without sending the category
         $this->assertCorrectModelCreation(
             Process::class,
             [
@@ -602,7 +602,7 @@ class ProcessTest extends TestCase
             ]
         );
 
-        //Create a process with a category
+        // Create a process with a category
         $category = ProcessCategory::factory()->create();
         $this->assertCorrectModelCreation(
             Process::class,
@@ -625,7 +625,7 @@ class ProcessTest extends TestCase
             'process_category_id' => static::$DO_NOT_SEND,
         ]);
         $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
-        //Add a bpmn content
+        // Add a bpmn content
         $array['bpmn'] = trim(Process::getProcessTemplate('OnlyStartElement.bpmn'));
         $response = $this->apiCall('POST', $route, $array);
         $response->assertStatus(201);
@@ -640,7 +640,7 @@ class ProcessTest extends TestCase
      */
     public function testCreateProcessFieldsValidation()
     {
-        //Test to create a process with an empty name
+        // Test to create a process with an empty name
         $this->assertModelCreationFails(
             Process::class,
             [
@@ -648,13 +648,13 @@ class ProcessTest extends TestCase
                 'user_id' => static::$DO_NOT_SEND,
                 'process_category_id' => static::$DO_NOT_SEND,
             ],
-            //Fields that should fail
+            // Fields that should fail
             [
                 'name',
             ]
         );
 
-        //Test to create a process with duplicate name
+        // Test to create a process with duplicate name
         $name = 'Some name';
         Process::factory()->create(['name' => $name]);
         $this->assertModelCreationFails(
@@ -664,20 +664,20 @@ class ProcessTest extends TestCase
                 'user_id' => static::$DO_NOT_SEND,
                 'process_category_id' => static::$DO_NOT_SEND,
             ],
-            //Fields that should fail
+            // Fields that should fail
             [
                 'name',
             ]
         );
 
-        //Test to create a process with a process category id that does not exist
+        // Test to create a process with a process category id that does not exist
         $this->assertModelCreationFails(
             Process::class,
             [
                 'user_id' => static::$DO_NOT_SEND,
                 'process_category_id' => 'id-not-exists',
             ],
-            //Fields that should fail
+            // Fields that should fail
             [
                 'process_category_id',
             ]
@@ -695,10 +695,10 @@ class ProcessTest extends TestCase
             'process_category_id' => static::$DO_NOT_SEND,
         ]);
         $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
-        //Add a bpmn content
+        // Add a bpmn content
         $array['bpmn'] = trim(Process::getProcessTemplate('ProcessWithErrors.bpmn'));
         $response = $this->apiCall('POST', $route, $array);
-        //A validation error should be displayed
+        // A validation error should be displayed
         $response->assertStatus(422);
     }
 
@@ -713,10 +713,10 @@ class ProcessTest extends TestCase
             'process_category_id' => static::$DO_NOT_SEND,
         ]);
         $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
-        //Add a bpmn content
+        // Add a bpmn content
         $array['bpmn'] = 'foo';
         $response = $this->apiCall('POST', $route, $array);
-        //A validation error should be displayed
+        // A validation error should be displayed
         $response->assertStatus(422);
     }
 
@@ -727,22 +727,22 @@ class ProcessTest extends TestCase
     {
         $this->markTestSkipped('FOUR-6653');
 
-        //Create a new process without category
+        // Create a new process without category
         $process = Process::factory()->create([
             'process_category_id' => null,
         ]);
 
-        //Test that is correctly displayed
+        // Test that is correctly displayed
         $this->assertModelShow($process->id, []);
 
-        //Test that is correctly displayed with null category
+        // Test that is correctly displayed with null category
         $this->assertModelShow($process->id, ['category'])
             ->assertJsonFragment(['category' => []]);
 
-        //Create a new process with category
+        // Create a new process with category
         $process = Process::factory()->create();
 
-        //Test that is correctly displayed including category and user
+        // Test that is correctly displayed including category and user
         $this->assertModelShow($process->id, ['category', 'user']);
     }
 
@@ -751,10 +751,10 @@ class ProcessTest extends TestCase
      */
     public function testUpdateProcess()
     {
-        //Seeder Permissions
+        // Seeder Permissions
         (new PermissionSeeder())->run($this->user);
 
-        //Test to update name process
+        // Test to update name process
         $name = $this->faker->sentence(3);
         $this->assertModelUpdate(
             Process::class,
@@ -772,10 +772,10 @@ class ProcessTest extends TestCase
      */
     public function testUpdateProcessWithCategoryNull()
     {
-        //Seeder Permissions
+        // Seeder Permissions
         (new PermissionSeeder())->run($this->user);
 
-        //Test update process category to null
+        // Test update process category to null
         $this->assertModelUpdateFails(
             Process::class,
             [
@@ -792,10 +792,10 @@ class ProcessTest extends TestCase
      */
     public function testUpdateProcessWithCategory()
     {
-        //Seeder Permissions
+        // Seeder Permissions
         (new PermissionSeeder())->run($this->user);
 
-        //Test update process category
+        // Test update process category
         $this->assertModelUpdate(
             Process::class,
             [
@@ -812,7 +812,7 @@ class ProcessTest extends TestCase
      */
     public function testUpdateProcessFails()
     {
-        //Test to update name and description if required
+        // Test to update name and description if required
         $this->assertModelUpdateFails(
             Process::class,
             [
@@ -827,7 +827,7 @@ class ProcessTest extends TestCase
             ]
         );
 
-        //Test update process category of null
+        // Test update process category of null
         $this->assertModelUpdateFails(
             Process::class,
             [
@@ -839,7 +839,7 @@ class ProcessTest extends TestCase
             ]
         );
 
-        //Test validate name is unique
+        // Test validate name is unique
         $name = 'Some name';
         Process::factory()->create(['name' => $name]);
         $this->assertModelUpdateFails(
@@ -860,7 +860,7 @@ class ProcessTest extends TestCase
      */
     public function testUpdateBPMN()
     {
-        //Seeder Permissions
+        // Seeder Permissions
         (new PermissionSeeder())->run($this->user);
 
         $process = Process::factory()->create([
@@ -874,7 +874,7 @@ class ProcessTest extends TestCase
             'description' => 'test description',
             'bpmn' => $newBpmn,
         ]);
-        //validate status
+        // validate status
         $this->assertStatus(200, $response);
         $response->assertJsonStructure($this->structure);
         $updatedProcess = Process::where('id', $id)->first();
@@ -893,7 +893,7 @@ class ProcessTest extends TestCase
         $response = $this->apiCall('PUT', $route, [
             'bpmn' => $newBpmn,
         ]);
-        //validate status
+        // validate status
         $this->assertStatus(422, $response);
         $response->assertJsonStructure($this->errorStructure);
     }
@@ -1056,7 +1056,7 @@ class ProcessTest extends TestCase
             'process_category_id' => static::$DO_NOT_SEND,
         ]);
         $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
-        //Add a bpmn content
+        // Add a bpmn content
         $array['bpmn'] = file_get_contents(__DIR__ . '/processes/C.4.0-export.bpmn');
         $response = $this->apiCall('POST', $route, $array);
         $response->assertStatus(422);

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -1145,7 +1145,7 @@ class ProcessTest extends TestCase
         $response->assertStatus(200);
 
         // Assert draft version is created.
-        $this->assertEquals(1, $process->versions()->where('draft', true)->count());
+        $this->assertEquals(1, $process->versions()->draft()->count());
 
         // Publish.
         $params = [
@@ -1156,6 +1156,6 @@ class ProcessTest extends TestCase
         $response = $this->apiCall('PUT', $url, $params);
 
         // Delete the draft after the item is published.
-        $this->assertEquals(0, $process->versions()->where('draft', true)->count());
+        $this->assertEquals(0, $process->versions()->draft()->count());
     }
 }

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -1130,4 +1130,32 @@ class ProcessTest extends TestCase
         $process->refresh();
         $this->assertFalse($process->properties['manager_can_cancel_request']);
     }
+
+    public function testUpdateProcessVersions()
+    {
+        $process = Process::factory()->create();
+        $url = route('api.processes.update', ['process' => $process]);
+        $params = [
+            'name' => 'Process',
+            'description' => 'Description',
+            'is_draft' => true,
+        ];
+
+        $response = $this->apiCall('PUT', $url, $params);
+        $response->assertStatus(200);
+
+        // Assert draft version is created.
+        $this->assertEquals(1, $process->versions()->where('draft', true)->count());
+
+        // Publish.
+        $params = [
+            'name' => 'Process',
+            'description' => 'Description',
+            'is_draft' => false,
+        ];
+        $response = $this->apiCall('PUT', $url, $params);
+
+        // Delete the draft after the item is published.
+        $this->assertEquals(0, $process->versions()->where('draft', true)->count());
+    }
 }

--- a/tests/Feature/Api/ScriptsTest.php
+++ b/tests/Feature/Api/ScriptsTest.php
@@ -6,20 +6,16 @@ use Database\Seeders\PermissionSeeder;
 use Faker\Factory as Faker;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Notification;
-use Mockery;
 use ProcessMaker\Events\ScriptResponseEvent;
 use ProcessMaker\Exception\ScriptLanguageNotSupported;
 use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Jobs\ImportProcess;
 use ProcessMaker\Models\Process;
-use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\Script;
 use ProcessMaker\Models\ScriptCategory;
 use ProcessMaker\Models\ScriptExecutor;
-use ProcessMaker\Models\ScriptVersion;
 use ProcessMaker\Models\User;
 use ProcessMaker\PolicyExtension;
 use ProcessMaker\Providers\AuthServiceProvider;
@@ -51,10 +47,10 @@ class ScriptsTest extends TestCase
      */
     public function testNotCreatedForParameterRequired()
     {
-        //Post should have the parameter required
+        // Post should have the parameter required
         $url = self::API_TEST_SCRIPT;
         $response = $this->apiCall('POST', $url);
-        //validating the answer is an error
+        // validating the answer is an error
         $response->assertStatus(422);
         $this->assertArrayHasKey('message', $response->json());
     }
@@ -68,7 +64,7 @@ class ScriptsTest extends TestCase
         $user = User::factory()->create(['is_administrator' => true]);
         $category = ScriptCategory::factory()->create(['status' => 'ACTIVE']);
 
-        //Post saved correctly
+        // Post saved correctly
         $url = self::API_TEST_SCRIPT;
         $response = $this->apiCall('POST', $url, [
             'title' => 'Script Title',
@@ -78,8 +74,8 @@ class ScriptsTest extends TestCase
             'script_category_id' => $category->getkey(),
             'run_as_user_id' => $user->id,
         ]);
-        //validating the answer is correct.
-        //Check structure of response.
+        // validating the answer is correct.
+        // Check structure of response.
         $response->assertJsonStructure(self::STRUCTURE);
     }
 
@@ -128,7 +124,7 @@ class ScriptsTest extends TestCase
             'title' => 'Script Title',
         ]);
 
-        //Post title duplicated
+        // Post title duplicated
         $faker = Faker::create();
         $url = self::API_TEST_SCRIPT;
         $response = $this->apiCall('POST', $url, [
@@ -166,7 +162,7 @@ class ScriptsTest extends TestCase
      */
     public function testListScripts()
     {
-        //add scripts to process
+        // add scripts to process
         Script::query()->delete();
         $faker = Faker::create();
         $total = $faker->randomDigitNotNull;
@@ -179,19 +175,19 @@ class ScriptsTest extends TestCase
             'key' => 'some-key',
         ]);
 
-        //List scripts
+        // List scripts
         $url = self::API_TEST_SCRIPT;
         $response = $this->apiCall('GET', $url);
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(200);
 
-        //verify structure paginate
+        // verify structure paginate
         $response->assertJsonStructure([
             'data' => ['*' => self::STRUCTURE],
             'meta',
         ]);
 
-        //verify count of data
+        // verify count of data
         $this->assertEquals($total, $response->json()['meta']['total']);
     }
 
@@ -227,19 +223,19 @@ class ScriptsTest extends TestCase
             'title' => $title,
         ]);
 
-        //List Document with filter option
+        // List Document with filter option
         $perPage = Faker::create()->randomDigitNotNull;
         $query = '?page=1&per_page=' . $perPage . '&order_by=description&order_direction=DESC&filter=' . urlencode($title);
         $url = self::API_TEST_SCRIPT . $query;
         $response = $this->apiCall('GET', $url);
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(200);
-        //verify structure paginate
+        // verify structure paginate
         $response->assertJsonStructure([
             'data' => ['*' => self::STRUCTURE],
             'meta',
         ]);
-        //verify response in meta
+        // verify response in meta
         $json = $response->json();
         $meta = $json['meta'];
         $this->assertEquals(1, $meta['total']);
@@ -256,16 +252,16 @@ class ScriptsTest extends TestCase
      */
     public function testGetScript()
     {
-        //add scripts to process
+        // add scripts to process
         $script = Script::factory()->create();
 
-        //load script
+        // load script
         $url = self::API_TEST_SCRIPT . '/' . $script->id;
         $response = $this->apiCall('GET', $url);
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(200);
 
-        //verify structure paginate
+        // verify structure paginate
         $response->assertJsonStructure(self::STRUCTURE);
     }
 
@@ -278,7 +274,7 @@ class ScriptsTest extends TestCase
 
         $script = Script::factory()->create(['code' => $faker->sentence(50)])->id;
 
-        //The post must have the required parameters
+        // The post must have the required parameters
         $url = self::API_TEST_SCRIPT . '/' . $script;
 
         $response = $this->apiCall('PUT', $url, [
@@ -287,7 +283,7 @@ class ScriptsTest extends TestCase
             'code' => $faker->sentence(3),
         ]);
 
-        //Validate the answer is incorrect
+        // Validate the answer is incorrect
         $response->assertStatus(422);
     }
 
@@ -299,7 +295,7 @@ class ScriptsTest extends TestCase
         $faker = Faker::create();
         $user = User::factory()->create(['is_administrator' => true]);
 
-        //Post saved success
+        // Post saved success
         $yesterday = \Carbon\Carbon::now()->subDay();
         $script = Script::factory()->create([
             'description' => 'ufufu',
@@ -317,7 +313,7 @@ class ScriptsTest extends TestCase
             'script_category_id' => $script->script_category_id,
         ]);
 
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(204);
 
         // assert it creates a script version
@@ -345,7 +341,7 @@ class ScriptsTest extends TestCase
         $response = $this->apiCall('PUT', $url, [
             'title' => 'Some title',
         ]);
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(422);
         $response->assertSeeText('The Name has already been taken');
     }
@@ -441,10 +437,10 @@ class ScriptsTest extends TestCase
      */
     public function testDeleteScript()
     {
-        //Remove script
+        // Remove script
         $url = self::API_TEST_SCRIPT . '/' . Script::factory()->create()->id;
         $response = $this->apiCall('DELETE', $url);
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(204);
     }
 
@@ -453,10 +449,10 @@ class ScriptsTest extends TestCase
      */
     public function testDeleteScriptNotExist()
     {
-        //Script not exist
+        // Script not exist
         $url = self::API_TEST_SCRIPT . '/' . Script::factory()->make()->id;
         $response = $this->apiCall('DELETE', $url);
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(405);
     }
 
@@ -508,13 +504,13 @@ class ScriptsTest extends TestCase
             'status' => 'active',
         ]);
 
-        //List Screen with filter option
+        // List Screen with filter option
         $query = '?filter=' . urlencode($name);
         $url = self::API_TEST_SCRIPT . $query;
         $response = $this->apiCall('GET', $url);
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(200);
-        //verify structure paginate
+        // verify structure paginate
         $response->assertJsonStructure([
             'data',
             'meta',
@@ -522,21 +518,21 @@ class ScriptsTest extends TestCase
 
         $json = $response->json();
 
-        //verify response in meta
+        // verify response in meta
         $this->assertEquals(1, $json['meta']['total']);
         $this->assertEquals(1, $json['meta']['current_page']);
         $this->assertEquals($name, $json['meta']['filter']);
-        //verify structure of model
+        // verify structure of model
         $response->assertJsonStructure(['*' => self::STRUCTURE], $json['data']);
 
-        //List Screen without peers
+        // List Screen without peers
         $name = 'Search category that does not exist';
         $query = '?filter=' . urlencode($name);
         $url = self::API_TEST_SCRIPT . $query;
         $response = $this->apiCall('GET', $url);
-        //Validate the answer is correct
+        // Validate the answer is correct
         $response->assertStatus(200);
-        //verify structure paginate
+        // verify structure paginate
         $response->assertJsonStructure([
             'data',
             'meta',
@@ -544,11 +540,11 @@ class ScriptsTest extends TestCase
 
         $json = $response->json();
 
-        //verify response in meta
+        // verify response in meta
         $this->assertEquals(0, $json['meta']['total']);
         $this->assertEquals(1, $json['meta']['current_page']);
         $this->assertEquals($name, $json['meta']['filter']);
-        //verify structure of model
+        // verify structure of model
         $response->assertJsonStructure(['*' => self::STRUCTURE], $json['data']);
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR is based on [feature/FOUR-7331](https://github.com/ProcessMaker/processmaker/pull/4627) branch.

## Solution
- Create draft version for scripts.
- Load draft version.
- Added close/discard functionality.
- Added config values for autosave delay.
- Display "Saved Notification" on draft update.

## How to Test
- `php artisan test tests/Feature/Api/ScriptsTest.php --filter testUpdateDraftScript`
- `php artisan test tests/Feature/Api/ScriptsTest.php --filter testCloseDraftScript`.
- Execute a manual test by linking Package Version in Core.

## Related Tickets & Packages
- [FOUR-7335](https://processmaker.atlassian.net/browse/FOUR-7335)
- [Package Versions PR](https://github.com/ProcessMaker/package-versions/pull/57) 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7335]: https://processmaker.atlassian.net/browse/FOUR-7335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:package-vocabularies:feature/FOUR-7331