### PR TITLE
FOUR-3375 The file preview control shows the same file in all multi-instance tasks

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -68,6 +68,9 @@ class Task extends ApiResource
             }
             $array['request_data'] = $data;
         }
+        if (in_array('loopContext', $include)) {
+            $array['loop_context'] = $this->getLoopContext();
+        }
         if (in_array('definition', $include)) {
             $array['definition'] = $this->getDefinition();
         }

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -899,6 +899,29 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         return false;
     }
 
+    public function getLoopContext()
+    {
+        $isMultiInstance = isset($this->token_properties['data']);
+        if (!$isMultiInstance) {
+            return '';
+        }
+        $loopData = $this->token_properties['data'];
+        $index = $loopData['loopCounter'];
+        $definition = $this->getDefinition(true);
+        if (!$definition instanceof ActivityInterface) {
+            return '';
+        }
+        $loop = $definition->getLoopCharacteristics();
+        if ($loop && $loop->isExecutable() && $loop instanceof MultiInstanceLoopCharacteristicsInterface) {
+            $output = $loop->getLoopDataOutput();
+            $variable = $output ? $output->getName() : '';
+        } else {
+            return '';
+        }
+        $loopContext = $variable . '.' . $index;
+        return $loopContext;
+    }
+
     /**
      * Get a config parameter from the bpmn element definition.
      *

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -56,6 +56,7 @@
                               :initial-request-id="{{ $task->process_request_id }}"
                               :user-id="{{ Auth::user()->id }}"
                               csrf-token="{{ csrf_token() }}"
+                              initial-loop-context="{{ $task->getLoopContext() }}"
                               @task-updated="taskUpdated"
                               @submit="submit"
                               @completed="completed"


### PR DESCRIPTION
## Issue & Reproduction Steps
The file preview control shows the same file in all multi-instance tasks

Expected behavior: 
The file controls should shows the same file in all multi-instance tasks

Actual behavior: 
The file was being uploaded to the global scope instead to the task instance scope.

## Solution
- Add the proper loop context to the file-upload component

## How to Test
Follow the steps of the ticket.

1. Create a process with Start Event -> Task 1 -> Task 2 -> End Event
2. Configure the task 2 with parallel multiinstance
3. Create a screen with file control and line input
4. Create a Request 
5. Route to the parallel task
6. For each parallel task put a different value in the line input
7. And upload a different file in each multi-instance task
8. Go go to files Manager
9. Go to Forms 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-3375
- Requires: https://github.com/ProcessMaker/screen-builder/pull/1349
- Requires: https://github.com/ProcessMaker/package-files/pull/93

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:connector-docusign:v1.1.0
ci:connector-pdf-print:v1.9.0
ci:package-actions-by-email:v1.8.4
ci:package-advanced-user-manager:v1.2.0
ci:package-auth:v1.8.0
ci:package-collections:v2.6.1
ci:package-comments:v1.4.0
ci:package-data-sources:v1.13.0
ci:package-dynamic-ui:v1.5.0
ci:package-savedsearch:v1.20.0
ci:package-vocabularies:v2.7.0
ci:connector-send-email:v1.14.0
ci:package-webentry:v2.8.0