### PR TITLE
Bugfix/FOUR-7636: Fix the regex that detects PMQL

### DIFF
--- a/resources/js/modules/isPMQL.js
+++ b/resources/js/modules/isPMQL.js
@@ -1,3 +1,3 @@
 String.prototype.isPMQL = function () {
-  return /^.+(?:[=><]|LIKE).+$/i.test(this);
+  return /^.+(?:[=><]|LIKE|NOT IN \[|IN \[).+$/i.test(this);
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
Improved isPMQL function to detect IN and NOT IN operators. 

To reproduce the issue try to search in settings using the following valid PMQL query:
`name IN ["IMAP Server"]` or `name NOT IN ["IMAP Server"]`


https://user-images.githubusercontent.com/90727999/224812595-c6cb787c-5446-408c-b71d-18731f69780c.mov


**Current behavior**
It is not detecting the search input as a valid PMQL query

**Current behavior**
Should detect the IN and NOT IN operators as a valid PMQL query


## Solution
- Added IN and NOT IN operators to the regular expression in the isPMQL function.

**Working video**

https://user-images.githubusercontent.com/90727999/224812904-794f246c-b168-4e02-858d-f8867cbf038a.mov


## Related Tickets & Packages
- [FOUR-7636](https://processmaker.atlassian.net/browse/FOUR-7636)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7636]: https://processmaker.atlassian.net/browse/FOUR-7636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ