### PR TITLE
Bugfix/FOUR-7693: Error when exporting a process with the Custom option in branch develop

### DIFF
--- a/resources/js/processes/export/components/MainAssetView.vue
+++ b/resources/js/processes/export/components/MainAssetView.vue
@@ -116,8 +116,7 @@ export default {
     "processName",
     "groups",
     "processId",
-    "processInfo",
-    "existingAssets"
+    "processInfo"
     ],
     components: {
         DataCard,


### PR DESCRIPTION
## Issue & Reproduction Steps
- Log in 
- Click on Designer
- Select a process 
- Click on Export 
- Choose custom option
- Click on export 

**Current behavior**
It shows us a js error when exporting a process, with the custom option

**Expected behavior**
errors should not appear when exporting a process, with the custom option


## Solution
- Remove prop existingAssets, because there is a computed property with the same name

**Working video**

https://user-images.githubusercontent.com/90727999/226998249-a3fae13f-f12b-4ada-85f8-6898f74144e1.mov

## How to Test
Follow the steps above

## Related Tickets & Packages
- [FOUR-7693](https://processmaker.atlassian.net/browse/FOUR-7693)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7693]: https://processmaker.atlassian.net/browse/FOUR-7693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ