### PR TITLE
401 response when trying to claim a self service task via web entry in Firefox

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -205,6 +205,7 @@ const token = document.head.querySelector("meta[name=\"csrf-token\"]");
 
 if (token) {
   window.ProcessMaker.apiClient.defaults.headers.common["X-CSRF-TOKEN"] = token.content;
+  window.ProcessMaker.apiClient.defaults.withCredentials = true;
 } else {
   console.error("CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token");
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The steps are in the ticket

## Solution
- Force sending cookies on the Axios.
## How to Test
npm run dev
clear browser cache

- Test process on ticket
- Also try with package-webentry and anonymous user.

## Related Tickets & Packages
- [FOUR-7239](url[)](https://processmaker.atlassian.net/browse/FOUR-7239)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7239]: https://processmaker.atlassian.net/browse/FOUR-7239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ