### PR TITLE
Bugfix/FOUR-7699: Linked assets observations (last modified undefined, non existing user N/A hyperlinked)

### DIFF
--- a/resources/js/components/shared/AssetTreeModal.vue
+++ b/resources/js/components/shared/AssetTreeModal.vue
@@ -37,11 +37,18 @@ export default {
       const formattedGroupChildren = group.items.map((item) => {
         item.html = `
           <div>Name: ${item.name}</div>
-          <div>Last modified: ${item.updated_at} By: <a href="/profile/${item.lastModifiedById}">${item.lastModifiedBy}</a></div>
-        `;
+          <span>Last modified: ${item.updatedAt}</span>`;
+
+        if (item.lastModifiedBy && item.lastModifiedById && item.lastModifiedBy !== "N/A") {
+          item.html += ` By: <a href="/profile/${item.lastModifiedById}">${item.lastModifiedBy}</a>`;
+        }
+        if (item.lastModifiedBy && !item.lastModifiedById && item.lastModifiedBy !== "N/A") {
+          item.html += ` By: ${item.lastModifiedBy}`;
+        }
         if (item.assetLink) {
           item.html += `<div><a href="${item.assetLink}" target="_blank"><i class="mr-1 fas fa-external-link-alt"></i> View ${item.typeHuman}</a></div>`;
         }
+
         return item;
       });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Please read https://processmaker.atlassian.net/browse/FOUR-7699

## Solution
- Fix the attribute for update at that was wrongly used updated_at instead updatedAt.
- Hide updated by if is null.

NOTE: In sync with @nolanpro Updated By is only available when the package versions is installed. 

## How to Test
- Go to export or import a process
- Click on linked assets link
- In the popup, check the updated at is showing and also the updated by when you have a different version of the asset.

**Screenshots**
![Screen Shot 2023-03-22 at 17 39 39](https://user-images.githubusercontent.com/90727999/227033606-7a08e7bf-bcd2-472d-908a-2726b3651658.png)
![Screen Shot 2023-03-22 at 17 39 18](https://user-images.githubusercontent.com/90727999/227033618-dae8a33f-fe00-4f04-bd56-325b6d13ae88.png)

## Related Tickets & Packages
- [FOUR-7699](https://processmaker.atlassian.net/browse/FOUR-7699)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7699]: https://processmaker.atlassian.net/browse/FOUR-7699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ