### PR TITLE
Creating views for importing data to DataLake

### DIFF
--- a/ProcessMaker/Console/Commands/CreateDataLakeViews.php
+++ b/ProcessMaker/Console/Commands/CreateDataLakeViews.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class CreateDataLakeViews extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'processmaker:create-data-lake-views {--drop} {--preview}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create/replace and delete data lake views';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $drop = $this->option('drop');
+        $preview = $this->option('preview');
+        if ($drop) {
+            $this->info('Dropping views...' . PHP_EOL);
+            $this->down($preview);
+        } else {
+            $this->info('Creating or replacing views...' . PHP_EOL);
+            $this->up($preview);
+        }
+        $this->info('Done.');
+        return 0;
+    }
+
+    /**
+     * @param bool $preview
+     * @return void
+     */
+    public function up($preview)
+    {
+        $tables = $this->getTables();
+        foreach ($tables as $tableName) {
+            $columns = $this->getTableColumns($tableName);
+            $aliases = [];
+            foreach ($columns as $column) {
+                $aliases[] = sprintf('`%s` AS `%s`', $column, $this->parseColumnName($column));
+            }
+            $sql = sprintf('CREATE OR REPLACE VIEW %s AS SELECT %s FROM `%s`;',
+                $this->getViewName($tableName),
+                implode(', ', $aliases),
+                $tableName
+            );
+            if ($preview) {
+                $this->comment($sql . PHP_EOL);
+            } else {
+                DB::statement($sql);
+            }
+        }
+    }
+
+    /**
+     * @param bool $preview
+     * @return void
+     */
+    public function down($preview)
+    {
+        foreach ($this->getTables() as $tableName) {
+            $viewName = $this->getViewName($tableName);
+            $sql = sprintf('DROP VIEW IF EXISTS `%s`;', $viewName);
+            if ($preview) {
+                $this->comment($sql . PHP_EOL);
+            } else {
+                DB::statement($sql);
+            }
+        }
+    }
+
+    /**
+     * @param string $tableName
+     * @return string
+     */
+    protected function getViewName($tableName)
+    {
+        return 'dlv_' . $tableName;
+    }
+
+    /**
+     * @param string $name
+     * @return string
+     */
+    protected function parseColumnName(string $name)
+    {
+        return strtolower($name) . '_';
+    }
+
+    /**
+     * @param string $tableName
+     * @return string[]
+     */
+    protected function getTableColumns($tableName)
+    {
+        return Schema::getColumnListing($tableName);
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getTables()
+    {
+        return DB::connection()->getDoctrineSchemaManager()->listTableNames();
+    }
+}

--- a/database/migrations/2023_03_13_172619_create_data_lake_views.php
+++ b/database/migrations/2023_03_13_172619_create_data_lake_views.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Artisan;
+
+class CreateDataLakeViews extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Artisan::call('processmaker:create-data-lake-views');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Artisan::call('processmaker:create-data-lake-views --drop');
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
While importing data into the Data Lake using the AWS Lake Formation tools, we encountered issues related to reserved table and column names. Names like "groups".

The AWS support said:

> Please allow me to inform you that this error usually occurs when column names, or table names contain any reserved keywords that are used by mysql such as ‘groups’, where','order' etc.

## Solution
To workaround this problem, views were created to create aliases for table and column names.

Added prefix `dlv_` (data lake view) for each table and suffix `_` for each column.

So, the corresponding view for the `groups` table is:

```sql
-- table groups
CREATE TABLE `groups` (
  `id` int unsigned NOT NULL AUTO_INCREMENT,
  `uuid` char(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
  `description` text COLLATE utf8mb4_unicode_ci,
  `status` enum('ACTIVE','INACTIVE') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ACTIVE',
  `created_at` timestamp NULL DEFAULT NULL,
  `updated_at` timestamp NULL DEFAULT NULL,
  `manager_id` int unsigned DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `groups_uuid_unique` (`uuid`),
  KEY `groups_manager_id_foreign` (`manager_id`),
  CONSTRAINT `groups_manager_id_foreign` FOREIGN KEY (`manager_id`) REFERENCES `users` (`id`) ON DELETE RESTRICT
) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

-- corresponding view
CREATE OR REPLACE VIEW dlv_groups AS SELECT `id` AS `id_`, `uuid` AS `uuid_`, `name` AS `name_`, `description` AS `description_`, `status` AS `status_`, `created_at` AS `created_at_`, `updated_at` AS `updated_at_`, `manager_id` AS `manager_id_` FROM `groups`;
```

In all migrations it will be necessary to call the artisan command.

```php
/**
 * Run the migrations.
 *
 * @return void
 */
public function up()
{
    Artisan::call('processmaker:create-data-lake-views');
}
```

## How to Test

```
php artisan processmaker:create-data-lake-views
```

## Related Tickets & Packages
- [SCO-15702](https://processmaker.atlassian.net/browse/SCO-15702)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[SCO-15702]: https://processmaker.atlassian.net/browse/SCO-15702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ