### PR TITLE
Bugfix/FOUR-7715: The category is not shown in the custom import template of a process,

### DIFF
--- a/ProcessMaker/ImportExport/Dependent.php
+++ b/ProcessMaker/ImportExport/Dependent.php
@@ -25,6 +25,7 @@ class Dependent
             'exporterClass' => $this->exporterClass,
             'modelClass' => $this->modelClass,
             'fallbackMatches' => $this->fallbackMatches,
+            'name' => $this->name,
             'discard' => $this->discard,
         ];
     }
@@ -68,6 +69,14 @@ class Dependent
                 return $asset->mode;
             } else {
                 return 'discard';
+            }
+        }
+
+        if ($property === 'name') {
+            if ($asset) {
+                return $asset->getName($this->model);
+            } else {
+                return '';
             }
         }
 

--- a/resources/js/processes/export/DataProvider.js
+++ b/resources/js/processes/export/DataProvider.js
@@ -144,9 +144,7 @@ export default {
   //   return match[1] || "N/A";
   // },
   getCategories(asset, allAssets) {
-    const categories = asset.dependents.filter((d) => d.type === "categories").map((category) => {
-      return allAssets[category.uuid] ? allAssets[category.uuid].name : "Unexported Category"
-    });
+    const categories = asset.dependents.filter((d) => d.type === "categories").map((category) => category.name);
     if (categories.length === 0) {
       categories.push("Uncategorized");
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce: 

- Log in 
- Import a process that has a category assigned
- select the Custom option

**Current Behavior:** 
As we can see, the categories option is not showing the category of the process 

This replicates when the user that exports the process is created or not in the second environment.

**Expected Behavior:**
In the categories option, the category that has the rpco that is going to be imported must be shown

## Solution
- Send with the dependents the name property from the backend.

**Working video**

https://user-images.githubusercontent.com/90727999/228326672-dd343f4c-45f0-4b0d-a21f-ba5a240a1748.mov


## How to Test
- Go to export a process with some categories. 
- Choose custom export
- In the summary page, check that the categories name are listed.
- Try the same with the import

## Related Tickets & Packages
- [FOUR-7715](https://processmaker.atlassian.net/browse/FOUR-7715)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7715]: https://processmaker.atlassian.net/browse/FOUR-7715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

.