### PR TITLE
Bugfix/FOUR-7718: The save process frame is distorted, compared to the previous version

### DIFF
--- a/resources/js/components/shared/Modal.vue
+++ b/resources/js/components/shared/Modal.vue
@@ -6,7 +6,7 @@
     footer-class="pm-modal-footer"
     cancel-variant="outline-secondary"
     :cancel-title="$t('Cancel')"
-    ok-variant="primary"
+    ok-variant="secondary"
     :ok-title="okTitleWithDefault"
     :ok-disabled="okDisabled"
     :size="size"


### PR DESCRIPTION
## Issue & Reproduction Steps

Please see the comments in https://processmaker.atlassian.net/browse/FOUR-7718

To maintain consistency across the platform the modal should look like the other places we use it. With import export some changes were introduced to fit the PRD. Buttons should show in the footer with the correct padding and primary button of the modal should use the primary color variant.

Steps to Reproduce: 


- Create or open a process
- Click on save
- The modal to save the version shows

**Current Behavior:** 
There is a padding in the footer (please notice the border line in the footer). The save button have an incorrect color variant.

**Expected Behavior:**
Footer should show without the extra body padding. The primary button should have the primary color variant.

## Solution
- Use the shared component Modal instead b-modal.

**Working video**

https://user-images.githubusercontent.com/90727999/228349855-2f5cba86-b93c-484a-a6e9-b0b5ad2a6acc.mov

**UPDATE**
In sync with @hvanlear primary buttons ins modal were rolled back from primary to secondary

![Screen Shot 2023-03-29 at 09 26 21](https://user-images.githubusercontent.com/90727999/228535467-90fcf019-e9f8-46ec-93a4-5c9280416a8c.png)

![Screen Shot 2023-03-29 at 09 26 49](https://user-images.githubusercontent.com/90727999/228535462-a6fa7efa-f7d0-4779-9151-7181d3322dfa.png)


## How to Test
- Follow the steps above

## Related Tickets & Packages
- [FOUR-7718](https://processmaker.atlassian.net/browse/FOUR-7718)
- [Package versions PR](https://github.com/ProcessMaker/package-versions/pull/60)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7718]: https://processmaker.atlassian.net/browse/FOUR-7718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:package-versions:bugfix/FOUR-7718