### PR TITLE
FOUR-7198: Dynamic Assignment Rules (Fixes)

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -648,8 +648,8 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         $dataManager = new DataManager();
         $instanceData = $dataManager->getData($token);
 
-        $assignedUsers = $instanceData[$usersVariable];
-        $assignedGroups = $instanceData[$groupsVariable];
+        $assignedUsers = $usersVariable ? $instanceData[$usersVariable] : [];
+        $assignedGroups = $groupsVariable ?  $instanceData[$groupsVariable] : [];
 
         if (!is_array($assignedUsers)) {
             $assignedUsers = [$assignedUsers];

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -478,10 +478,10 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
 
         $definitions = $token->getInstance()->getVersionDefinitions();
         $properties = $definitions->findElementById($activity->getId())->getBpmnElementInstance()->getProperties();
-        $assignmentLock = array_key_exists('assignmentLock', $properties) ? $properties['assignmentLock'] : false;
+        $assignmentLock = array_key_exists('assignmentLock', $properties ?? []) ? $properties['assignmentLock'] : false;
 
-        $config = array_key_exists('config', $properties) ? json_decode($properties['config'], true) : [];
-        $isSelfService = array_key_exists('selfService', $config) ? $config['selfService'] : false;
+        $config = array_key_exists('config', $properties ?? []) ? json_decode($properties['config'], true) : [];
+        $isSelfService = array_key_exists('selfService', $config ?? []) ? $config['selfService'] : false;
 
         if ($assignmentType === 'rule_expression') {
             $userByRule = $isSelfService ? null : $this->getNextUserByRule($activity, $token);
@@ -557,7 +557,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
     private function checkAssignment(ProcessRequest $request, ActivityInterface $activity, $assignmentType, $escalateToManager, User $user = null)
     {
         $config = $activity->getProperty('config') ? json_decode($activity->getProperty('config'), true) : [];
-        $selfServiceToggle = array_key_exists('selfService', $config) ? $config['selfService'] : false;
+        $selfServiceToggle = array_key_exists('selfService', $config ?? []) ? $config['selfService'] : false;
         $isSelfService = $selfServiceToggle || $assignmentType === 'self_service';
 
         if ($activity instanceof ScriptTaskInterface

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -122,8 +122,8 @@ class TokenRepository implements TokenRepositoryInterface
                     $token->self_service_groups = ['users' => $evaluatedUsers, 'groups' => $evaluatedGroups];
                     break;
                 case 'process_variable':
-                    $evaluatedUsers = $token->getInstance()->getDataStore()->getData($selfServiceUsers);
-                    $evaluatedGroups = $token->getInstance()->getDataStore()->getData($selfServiceGroups);
+                    $evaluatedUsers = $selfServiceUsers ? $token->getInstance()->getDataStore()->getData($selfServiceUsers) : [];
+                    $evaluatedGroups = $selfServiceGroups ? $token->getInstance()->getDataStore()->getData($selfServiceGroups) : [];
 
                     // If we have single values we put it inside an array
                     $evaluatedUsers = is_array($evaluatedUsers) ? $evaluatedUsers : [$evaluatedUsers];


### PR DESCRIPTION
## Issue & Reproduction Steps

- Import the attached process "Hospital Triage"
- Create a data source "users" with 2 resources: one to get the list of PM users and other to get PM groups
- Configure the screen used by the process, using the 2 data sources created before in each select list (doctors and specialties)
-  Configure the task "Specialist Assignment", with assign type by "process variable". Set just the variable name for users or groups and letting the other one empty.
- The attached video shows all the steps for the configuration above.

https://user-images.githubusercontent.com/14875032/228949707-c5cc3e2f-c5bb-402b-bfec-a67068d8bf27.mp4

[Hospital_Triage.zip](https://github.com/ProcessMaker/processmaker/files/11115568/Hospital_Triage.zip)


The test  fail  because one of the fields, either Variable Name (Users) or Variable Name (Groups), is not set.

When both have variables set it works fine. 

Test tests/Feature/Api/CallActivityTest.php was failing for the same reasons to the ones reported by QA, now it is fixed

In the ticket is reported an importing problem, but it happens because in old versions of PM (4.3.0 and before) we had a bug:  (FOUR-4810: When I import a process that has assignment rules by user ID, the variable is lost in the configuration (#4200) )

I tested and my results were:
process from 4.1.27  to 4.5 → assignment variable lost. (bug 4810 was present)
process from 4.3.0 to 4.5 → assignment variable lost (bug 4810 was present)
Process from v4.4.0-RC4 → Process imported correctly (the bug was already resolved)

So the issue is related to a previous PM Core problem and not to the new feature.

## Solution
- Added guard conditions and default values when configuration parameters are empty


## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-7198](https://processmaker.atlassian.net/browse/FOUR-7198)



## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
