### PR TITLE
Cannot route a case to a self-service task

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -117,8 +117,8 @@ class TokenRepository implements TokenRepositoryInterface
                 case 'user_group':
                     // For this assignment type, users and groups arrive as comma separated numbers that
                     // we need to convert to arrays for the self_service_groups column
-                    $evaluatedUsers = explode(',', $selfServiceUsers);
-                    $evaluatedGroups = explode(',', $selfServiceGroups);
+                    $evaluatedUsers = $selfServiceUsers ? explode(',', $selfServiceUsers) : [];
+                    $evaluatedGroups = $selfServiceGroups ? explode(',', $selfServiceGroups) : [];
                     $token->self_service_groups = ['users' => $evaluatedUsers, 'groups' => $evaluatedGroups];
                     break;
                 case 'process_variable':


### PR DESCRIPTION
## Issue & Reproduction Steps

1. create a simple process (start, task, end)
3. configure task type self-service and assign user or group
5. save process and run a new request.

## Solution
- add validation when value assign (user or group) is empty

## How to Test

https://user-images.githubusercontent.com/1747025/229219287-795ee300-5829-4f9b-abe1-a674cb1e74c3.mp4


## Related Tickets & Packages
- [FOUR-7828](https://processmaker.atlassian.net/browse/FOUR-7828)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7828]: https://processmaker.atlassian.net/browse/FOUR-7828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ