### PR TITLE
FOUR-7766 - Script with Draft status can be added in a Watcher. Then an error occurs

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScriptController.php
@@ -89,6 +89,7 @@ class ScriptController extends Controller
             'testData' => $testData,
             'autoSaveDelay' => config('versions.delay.script', 5000),
             'isVersionsInstalled' => PackageHelper::isPmPackageVersionsInstalled(),
+            'isDraft' => $draft !== null,
         ]);
     }
 

--- a/resources/js/components/Menu.vue
+++ b/resources/js/components/Menu.vue
@@ -173,6 +173,12 @@ export default {
     addItem(value) {
       this.newItems.push(value);
     },
+    removeItem(idToRemove) {
+      const indexToRemove = this.newItems.findIndex((element) => element.id === idToRemove);
+      if (indexToRemove !== -1) {
+        this.newItems.splice(indexToRemove, 1);
+      }
+    },
     unshiftItem(value) {
       this.newItems.unshift(value);
     },

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -186,6 +186,8 @@
 import MonacoEditor from "vue-monaco";
 import _ from "lodash";
 import TopMenu from "../../../components/Menu.vue";
+// eslint-disable-next-line no-unused-vars
+import customFilters from "../customFilters";
 
 export default {
   components: {
@@ -210,6 +212,10 @@ export default {
       default: 5000,
     },
     isVersionsInstalled: {
+      type: Boolean,
+      default: false,
+    },
+    isDraft: {
       type: Boolean,
       default: false,
     },
@@ -281,6 +287,9 @@ export default {
       this.outputResponse(response);
     });
     this.loadBoilerplateTemplate();
+
+    // Display version indicator.
+    this.setVersionIndicator();
   },
   beforeDestroy() {
     window.removeEventListener("resize", this.handleResize);
@@ -361,6 +370,8 @@ export default {
         })
         .then((response) => {
           ProcessMaker.alert(this.$t("The script was saved."), "success");
+          // Update version indicator.
+          this.setVersionIndicator(false);
           if (typeof onSuccess === "function") {
             onSuccess(response);
           }
@@ -396,6 +407,10 @@ export default {
               type: "SavedNotification",
               section: "right",
             });
+
+            // Update version indicator.
+            this.setVersionIndicator(true);
+
             // Hide the notification after 2 seconds.
             setTimeout(() => {
               this.$refs.menuScript.shiftItem();
@@ -434,6 +449,20 @@ export default {
           default:
             break;
         }
+      }
+    },
+    setVersionIndicator(isDraft = null) {
+      const draft = isDraft ?? this.isDraft;
+      if (this.isVersionsInstalled) {
+        this.$refs.menuScript.removeItem("VersionIndicator");
+        this.$refs.menuScript.addItem({
+          id: "VersionIndicator",
+          type: "VersionIndicator",
+          section: "right",
+          options: {
+            is_draft: draft,
+          },
+        });
       }
     },
   },

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -449,6 +449,9 @@ export default {
           default:
             break;
         }
+
+        // Save boilerplate template to avoid issues when script code is [].
+        ProcessMaker.EventBus.$emit("save-script");
       }
     },
     setVersionIndicator(isDraft = null) {

--- a/resources/views/processes/scripts/builder.blade.php
+++ b/resources/views/processes/scripts/builder.blade.php
@@ -21,7 +21,8 @@
 @section('content')
   <div id="script-container">
     <script-editor :script="{{ $script }}" :script-executor='{!! json_encode($script->scriptExecutor) !!}'
-      test-data="{{ json_encode($testData, JSON_PRETTY_PRINT) }}" :auto-save-delay="{{ $autoSaveDelay }}" :is-versions-installed="@json($isVersionsInstalled)"></script-editor>
+      test-data="{{ json_encode($testData, JSON_PRETTY_PRINT) }}" :auto-save-delay="{{ $autoSaveDelay }}"
+      :is-versions-installed="@json($isVersionsInstalled)" :is-draft="@json($isDraft)"></script-editor>
   </div>
 @endsection
 


### PR DESCRIPTION
## Issue & Reproduction Steps
An error occurs when a script with Draft status is assigned in a watcher.

1. Create a new Script. Do not edit/update.
2. Create a new Screen.
3. Add a watcher using the script of above.
4. Preview and test watcher.
5. Get error 500.

## Solution
- There's an issue when creating a new Script, it's `code` column is created with an empty array [].
- Now, when a new script is created, we trigger the save-script event to store the boilerplate template.

## How to Test
Please follow the reproduction steps of above.

## Related Tickets & Packages
- [FOUR-7766](https://processmaker.atlassian.net/browse/FOUR-7766)


[FOUR-7766]: https://processmaker.atlassian.net/browse/FOUR-7766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ