### PR TITLE
FOUR-7729: Fix Import/Export Process Template Permissions

### DIFF
--- a/ProcessMaker/Http/Middleware/TemplateAuthorization.php
+++ b/ProcessMaker/Http/Middleware/TemplateAuthorization.php
@@ -9,20 +9,78 @@ class TemplateAuthorization
 {
     public function handle($request, Closure $next)
     {
-        $templateType = $request->route()->parameter('type');
-
+        $templateType = $this->getTemplateType($request);
         if ($templateType) {
-            $middlewares = [
-                "can:view-{$templateType}-templates",
-                "can:edit-{$templateType}-templates",
-                "can:archive-{$templateType}-templates",
-                "can:create-{$templateType}-templates",
-                "can:import-{$templateType}-templates",
-                "can:export-{$templateType}-templates",
-            ];
+            $middlewares = $this->getMiddlewareForTemplateType($templateType);
             $request->route()->middleware($middlewares);
+
+            if ($this->isImportRoute($request)) {
+                return $this->handleImportRoute($request, $next, $templateType);
+            }
+
+            if ($this->isExportRoute($request)) {
+                return $this->handleExportRoute($request, $next, $templateType);
+            }
         }
 
         return $next($request);
+    }
+
+    protected function getTemplateType(Request $request)
+    {
+        $templateType = $request->route()->parameter('type');
+        if ($templateType === 'process_templates') {
+            return 'process';
+        }
+
+        return $templateType;
+    }
+
+    protected function getMiddlewareForTemplateType($templateType)
+    {
+        return [
+            "can:view-{$templateType}-templates",
+            "can:edit-{$templateType}-templates",
+            "can:archive-{$templateType}-templates",
+            "can:create-{$templateType}-templates",
+            "can:import-{$templateType}-templates",
+            "can:export-{$templateType}-templates",
+        ];
+    }
+
+    protected function isImportRoute(Request $request)
+    {
+        return $request->route()->named('import.do_import') || $request->route()->named('processes.preimportValidation');
+    }
+
+    protected function isExportRoute(Request $request)
+    {
+        return $request->route()->named('export.download');
+    }
+
+    protected function handleImportRoute(Request $request, Closure $next, $templateType)
+    {
+        if ($request->user()->can("import-{$templateType}-templates")) {
+            return $next($request);
+        }
+
+        if ($request->user()->can('import-processes')) {
+            return $next($request);
+        }
+
+        // abort(403);
+    }
+
+    protected function handleExportRoute(Request $request, Closure $next, $templateType)
+    {
+        if ($request->user()->can("export-{$templateType}-templates")) {
+            return $next($request);
+        }
+
+        if ($request->user()->can('export-processes')) {
+            return $next($request);
+        }
+
+        // abort(403);
     }
 }

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -649,7 +649,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         $instanceData = $dataManager->getData($token);
 
         $assignedUsers = $usersVariable ? $instanceData[$usersVariable] : [];
-        $assignedGroups = $groupsVariable ?  $instanceData[$groupsVariable] : [];
+        $assignedGroups = $groupsVariable ? $instanceData[$groupsVariable] : [];
 
         if (!is_array($assignedUsers)) {
             $assignedUsers = [$assignedUsers];
@@ -660,14 +660,14 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         }
 
         // We need to remove inactive users.
-        $users = User::whereIn('id', array_unique($assignedUsers)) ->where('status', 'ACTIVE')->pluck('id')->toArray();
+        $users = User::whereIn('id', array_unique($assignedUsers))->where('status', 'ACTIVE')->pluck('id')->toArray();
 
         foreach ($assignedGroups as $groupId) {
             // getConsolidatedUsers already removes inactive users
             $this->getConsolidatedUsers($groupId, $users);
         }
 
-        $nextAssignee =  $this->getNextUserFromGroupAssignment($activity->getId(), $users);
+        $nextAssignee = $this->getNextUserFromGroupAssignment($activity->getId(), $users);
 
         return $nextAssignee;
     }
@@ -867,7 +867,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
 
             // If no rule was applied, use the default configured user/group
             if (empty($users) && empty($groups)) {
-                foreach($default as $item) {
+                foreach ($default as $item) {
                     if ($item->type === 'group') {
                         $groups[] = $item->assignee;
                     } elseif ($item->type === 'user') {

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -737,7 +737,6 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         return $assignment;
     }
 
-
     /**
      * Returns if the token has the self service option activated
      */
@@ -935,6 +934,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
             return '';
         }
         $loopContext = $variable . '.' . $index;
+
         return $loopContext;
     }
 

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -109,7 +109,7 @@ class TokenRepository implements TokenRepositoryInterface
         $selfServiceTasks = $token->getInstance()->processVersion->self_service_tasks;
         $token->self_service_groups = $selfServiceTasks && isset($selfServiceTasks[$activity->getId()]) ? $selfServiceTasks[$activity->getId()] : [];
 
-        if($token->getSelfServiceAttribute()) {
+        if ($token->getSelfServiceAttribute()) {
             $selfServiceUsers = !empty($token->getDefinition()['assignedUsers']) ? $token->getDefinition()['assignedUsers'] : [];
             $selfServiceGroups = !empty($token->getDefinition()['assignedGroups']) ? $token->getDefinition()['assignedGroups'] : [];
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -114,7 +114,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('processes/{process}', [ProcessController::class, 'show'])->name('processes.show')->middleware('can:view-processes');
     Route::post('processes/{process}/export', [ProcessController::class, 'export'])->name('processes.export')->middleware('can:export-processes');
     Route::post('processes/import', [ProcessController::class, 'import'])->name('processes.import')->middleware('can:import-processes');
-    Route::post('processes/import/validation', [ProcessController::class, 'preimportValidation'])->name('processes.preimportValidation')->middleware('can:import-processes');
+    Route::post('processes/import/validation', [ProcessController::class, 'preimportValidation'])->name('processes.preimportValidation')->middleware('template-authorization');
     Route::get('processes/import/{code}/is_ready', [ProcessController::class, 'import_ready'])->name('processes.import_is_ready')->middleware('can:import-processes');
     Route::post('processes/{process}/import/assignments', [ProcessController::class, 'importAssignments'])->name('processes.import.assignments')->middleware('can:import-processes');
     Route::post('processes', [ProcessController::class, 'store'])->name('processes.store')->middleware('can:create-processes');
@@ -222,9 +222,9 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
 
     // Import & Export
     Route::get('export/manifest/{type}/{id}/', [ExportController::class, 'manifest'])->name('export.manifest')->middleware('can:export-processes');
-    Route::post('export/{type}/download/{id}', [ExportController::class, 'download'])->name('export.download')->middleware('can:export-processes');
+    Route::post('export/{type}/download/{id}', [ExportController::class, 'download'])->name('export.download')->middleware('template-authorization');
     Route::post('import/preview', [ImportController::class, 'preview'])->name('import.preview')->middleware('can:export-processes');
-    Route::post('import/do-import', [ImportController::class, 'import'])->name('import.do_import')->middleware('can:export-processes');
+    Route::post('import/do-import', [ImportController::class, 'import'])->name('import.do_import')->middleware('template-authorization');
 
     // Templates
     Route::get('templates/{type}', [TemplateController::class, 'index'])->name('template.index')->middleware('template-authorization');

--- a/tests/Feature/Api/TaskAssignmentByVariableTest.php
+++ b/tests/Feature/Api/TaskAssignmentByVariableTest.php
@@ -29,13 +29,13 @@ class TaskAssignmentByVariableTest extends TestCase
         // The first assignment should be to user (is the first created user)
         $response = $this->startTestProcess($process, ['usersVariable' => $user->id, 'groupsVariable' => $group->id]);
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
         $this->assertEquals($user->id, $task->user_id);
 
         // The second assignment should be to the first user of the created group
         $response = $this->startTestProcess($process, ['usersVariable' => $user->id, 'groupsVariable' => $group->id]);
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
         $this->assertEquals($group->users->first()->id, $task->user_id);
     }
 
@@ -50,31 +50,31 @@ class TaskAssignmentByVariableTest extends TestCase
         // The first assignment should be to user (is the first created user)
         $response = $this->startTestProcess($process, [
             'usersVariable' => $users->pluck('id')->toArray(),
-            'groupsVariable' => [$group1->id, $group2->id]
+            'groupsVariable' => [$group1->id, $group2->id],
         ]);
 
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
         $this->assertEquals($users->first()->id, $task->user_id);
 
         // The second assignment should be to the second user
         $response = $this->startTestProcess($process, [
             'usersVariable' => $users->pluck('id')->toArray(),
-            'groupsVariable' => [$group1->id, $group2->id]
+            'groupsVariable' => [$group1->id, $group2->id],
         ]);
 
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
         $this->assertEquals($users->get(1)->id, $task->user_id);
 
         // The third assignment should be to the first user of the first created group
         $response = $this->startTestProcess($process, [
             'usersVariable' => $users->pluck('id')->toArray(),
-            'groupsVariable' => [$group1->id, $group2->id]
+            'groupsVariable' => [$group1->id, $group2->id],
         ]);
 
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
         $this->assertEquals($group1->users->first()->id, $task->user_id);
     }
 
@@ -89,11 +89,11 @@ class TaskAssignmentByVariableTest extends TestCase
         // The first assignment should be to user (is the first created user)
         $response = $this->startTestProcess($process, [
             'usersVariable' => $users->pluck('id')->toArray(),
-            'groupsVariable' => [$group1->id, $group2->id]
+            'groupsVariable' => [$group1->id, $group2->id],
         ]);
 
         $requestId = $response['id'];
-        $assignedTasks = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])
+        $assignedTasks = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])
             ->get()
             ->count();
         $this->assertEquals(0, $assignedTasks);
@@ -107,13 +107,13 @@ class TaskAssignmentByVariableTest extends TestCase
 
         $response = $this->startTestProcess($process, ['usersVariable' => $user->id, 'groupsVariable' => [$group->id]]);
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
 
         $this->assertEquals(1, $task->is_self_service);
         // As it is self service the user must be null
         $this->assertEquals(null, $task->user_id);
         // The column self_service_groups should have the configured groups and users
-        $this->assertEquals(["users" => [$user->id], "groups" =>[$group->id]], $task->self_service_groups);
+        $this->assertEquals(['users' => [$user->id], 'groups' =>[$group->id]], $task->self_service_groups);
     }
 
     public function testSelfServiceClaims()
@@ -126,7 +126,7 @@ class TaskAssignmentByVariableTest extends TestCase
 
         $response = $this->startTestProcess($process, ['usersVariable' => $user->id, 'groupsVariable' => [$group->id]]);
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
 
         // Assert some users that can claim the task
         $updateTaskUrl = route('api.tasks.update', [$task->id]);
@@ -138,7 +138,7 @@ class TaskAssignmentByVariableTest extends TestCase
         $response->assertStatus(200);
 
         // Reset task assignment
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
         $task['is_self_service'] = true;
         $task['user_id'] = null;
         $task->save();
@@ -153,7 +153,7 @@ class TaskAssignmentByVariableTest extends TestCase
         $response->assertStatus(200);
 
         // Reset task assignment
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
         $task['is_self_service'] = true;
         $task['user_id'] = null;
         $task->save();
@@ -176,13 +176,13 @@ class TaskAssignmentByVariableTest extends TestCase
 
         $response = $this->startTestProcess($process, []);
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
 
         $this->assertEquals(1, $task->is_self_service);
         // As it is self service the user must be null
         $this->assertEquals(null, $task->user_id);
         // The column self_service_groups should have the configured groups and users
-        $this->assertEquals(["users" => $users->pluck('id')->toArray(), "groups" =>[$group->id]], $task->self_service_groups);
+        $this->assertEquals(['users' => $users->pluck('id')->toArray(), 'groups' =>[$group->id]], $task->self_service_groups);
     }
 
     public function testSelfServiceWithExpressionAssignment()
@@ -201,22 +201,22 @@ class TaskAssignmentByVariableTest extends TestCase
 
         $response = $this->startTestProcess($process, ['TestVar' => 5]);
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
 
         // Assert that the task has been stored correctly in the database
         $this->assertEquals(1, $task->is_self_service);
         $this->assertEquals(null, $task->user_id);
-        $this->assertEquals(["users" => [$users->get(0)->id, $users->get(1)->id], "groups" =>[$group->id]], $task->self_service_groups);
+        $this->assertEquals(['users' => [$users->get(0)->id, $users->get(1)->id], 'groups' =>[$group->id]], $task->self_service_groups);
 
         // Now we'll test that the default assignment rule runs correctly
         $response = $this->startTestProcess($process, ['TestVar' => 10]);
         $requestId = $response['id'];
-        $task = ProcessRequestToken::where([ 'process_request_id' => $requestId, 'status' => 'ACTIVE', ])->firstOrFail();
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
 
         // Assert that the task has been stored correctly in the database
         $this->assertEquals(1, $task->is_self_service);
         $this->assertEquals(null, $task->user_id);
-        $this->assertEquals(["users" => [$users->get(3)->id], "groups" =>[]], $task->self_service_groups);
+        $this->assertEquals(['users' => [$users->get(3)->id], 'groups' =>[]], $task->self_service_groups);
     }
 
     private function createProcess($assignment, $assignedUsers, $assignedGroups, $rules, $isSelfService)
@@ -233,7 +233,7 @@ class TaskAssignmentByVariableTest extends TestCase
         }
 
         $process = Process::factory()->create([
-            'bpmn' => $bpmn
+            'bpmn' => $bpmn,
         ]);
 
         if ($assignment === 'user_group') {
@@ -270,12 +270,14 @@ class TaskAssignmentByVariableTest extends TestCase
                 'group_id' => $group->id,
             ]);
         }
+
         return $group;
     }
 
     private function startTestProcess($process, $processData)
     {
         $route = route('api.process_events.trigger', [$process->id, 'event' => 'start_node']);
+
         return $this->apiCall('POST', $route, $processData)->json();
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket: [FOUR-7729](https://processmaker.atlassian.net/browse/FOUR-7729)

Currently, a user with all template permissions but without Processes Import/Export permissions is unable to import a template. This issue can be reproduced by following these steps:

1. Create a new user with only the permissions for Processes: Create, Edit, and all Process Templates.
2. Ensure that a template has been created.
3. Log in as the new user.
4. Navigate to the Templates tab.
5. Attempt to import or export a template.

**Expected Behavior:**
Users with Process Templates permissions should be able to import/export templates without encountering any issues.

**Current Behavior**
When Processes Import/Export permissions are disabled and only Process Templates permissions are granted, users are unable to import/export templates.

## Solution
To address this issue, we updated the middleware for the import/export routes to check for both Processes and Process Templates permissions.

## How to Test
To test the solution, please follow the reproduction steps above after the middleware update has been implemented. This should ensure that users with Process Templates permissions can import/export templates without any problems.

## Tickets
Fixes  [FOUR-7730](https://processmaker.atlassian.net/browse/FOUR-7730)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7729]: https://processmaker.atlassian.net/browse/FOUR-7729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FOUR-7730]: https://processmaker.atlassian.net/browse/FOUR-7730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ