### PR TITLE
FOUR-7913: Fix issue with template data not persisting after second use

### DIFF
--- a/resources/js/components/templates/SelectTemplateModal.vue
+++ b/resources/js/components/templates/SelectTemplateModal.vue
@@ -21,7 +21,7 @@
     >
       <template-search :type="type" :component="currentComponent" @show-details="updateModal($event)"/>
     </modal>
-    <create-process-modal ref="create-process-modal" :blank-template="blankTemplate" :count-categories="countCategories" :selected-template="selectedTemplate" :template-data="templateData"/>
+    <create-process-modal ref="create-process-modal" :blank-template="blankTemplate" :count-categories="countCategories" :selected-template="selectedTemplate" :template-data="templateData" @resetModal="resetModal()"/>
   </div>
 </template>
 
@@ -98,6 +98,10 @@
         this.$bvModal.hide("selectTemplate");
         this.showSelectTemplateComponent();
       },
+      resetModal() {
+        this.selectedTemplate = false;
+        this.templateData = {};
+      }
     },
     mounted() {
       this.title = this.$t(`New ${this.type}`);

--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -141,6 +141,7 @@
         this.addError = {};
         this.selectedFile = '';
         this.file = null;
+        this.$emit('resetModal');
       },
       onSubmit () {
         this.errors = Object.assign({}, {

--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -141,6 +141,7 @@
         this.addError = {};
         this.selectedFile = '';
         this.file = null;
+        this.manager = "";
         this.$emit('resetModal');
       },
       onSubmit () {


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket: [FOUR-7913](https://processmaker.atlassian.net/browse/FOUR-7913)

This PR addresses an issue where template data was not persisting after the second use. Specifically, when attempting to use a template for a second time, all of the data would appear empty.


## Solution
 Add an event listener to the select template modal that listens for a 'resetModal' event from the create process modal. Whenever this event is emitted, the modal data is reset, allowing users to reuse templates without losing any data.

## How to Test
1. Open the Create Process modal
2. Select a Template
3. Select the 'Use Template' button
4. Close the modal by either selecting the 'cancel' or 'close' button
5. Reopen the modal and select the same template
6. Verify that the template data is present
7. Repeat 2-6 with a different template
8. Verify that data persists across multiple users of different templates


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7913]: https://processmaker.atlassian.net/browse/FOUR-7913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ