### PR TITLE
FOUR-7891 - Profile Edit Permission

### DIFF
--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -3,10 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use ProcessMaker\Models\Group;
-use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Permission;
-use ProcessMaker\Models\User;
 
 class PermissionSeeder extends Seeder
 {
@@ -77,6 +74,7 @@ class PermissionSeeder extends Seeder
             'edit-users',
             'view-users',
             'view-other-users-profiles',
+            'edit-personal-profile',
         ],
         'Requests' => [
             'view-all_requests',

--- a/resources/js/components/NavbarProfile.vue
+++ b/resources/js/components/NavbarProfile.vue
@@ -33,7 +33,10 @@
             {{ viewProfileText }}
           </a>
         </li>
-        <li class="list-group-item px-2">
+        <li
+          v-if="permissions['edit-personal-profile']"
+          class="list-group-item px-2"
+        >
           <a
             href="/profile/edit"
             role="menuitem"
@@ -106,6 +109,10 @@ Vue.use(VueCroppie);
 export default {
   props: {
     info: {
+      type: Object,
+      required: true,
+    },
+    permissions: {
       type: Object,
       required: true,
     },

--- a/resources/js/components/NavbarProfile.vue
+++ b/resources/js/components/NavbarProfile.vue
@@ -3,68 +3,114 @@
     <div id="profileMenu">
       <avatar-image
         id="avatarMenu"
+        ref="userMenuButton"
         class-container="d-flex"
         size="40"
         class-image="m-0"
         :input-data="information"
         hide-name="true"
         popover
-        ref="userMenuButton"
-      ></avatar-image>
+      />
     </div>
 
-    <b-popover container="#userMenu" :target="getTarget" placement="bottomleft" offset="3" triggers="click blur" @shown="onShown" @hidden="onHidden">
-        <ul class="list-group list-group-flush px-1">
-          <li class="list-group-item px-2">
-            <a :href="user_id" role="menuitem" :aria-label="viewProfileText">
-              <i class="fas fa-user fa-fw fa-lg mr-1"></i>
-              {{ viewProfileText  }}
-            </a>
-          </li>
-          <li class="list-group-item px-2">
-            <a href="/profile/edit" role="menuitem" :aria-label="editProfileText">
-              <i class="fas fa-user-cog fa-fw fa-lg mr-1"></i>
-              {{ editProfileText  }}
-            </a>
-          </li>
-          <li v-if="displayMyFilesLink" class="list-group-item px-2">
-            <a href="/file-manager" role="menuitem" :aria-label="$t('Files')">
-              <i class="fas fa-folder fa-fw fa-lg mr-1"></i>
-              {{$t('Files')}}
-            </a>
-          </li>
-          <li class="list-group-item px-2">
-            <a href="https://processmaker.gitbook.io/processmaker/" role="menuitem" :aria-label="$t('Documentation')" target="_blank">
-              <i data-v-2eb90a9e class="fas fa-question-circle fa-fw fa-lg mr-1"></i>
-              {{$t('Documentation')}}
-            </a>
-          </li>
-          <li class="list-group-item px-2">
-            <a href="/about" role="menuitem" :aria-label="$t('About')">
-              <i class="fas fa-info-circle fa-fw fa-lg mr-1"></i>
-              {{$t('About')}}
-            </a>
-          </li>
-          <li class="list-group-item px-2">
-            <a href="/logout" role="menuitem" :aria-label="$t('Log Out')">
-              <i class="fas fa-sign-out-alt fa-fw fa-lg mr-1"></i>
-              {{$t('Log Out')}}
-            </a>
-          </li>
-        </ul>
+    <b-popover
+      container="#userMenu"
+      :target="getTarget"
+      placement="bottomleft"
+      offset="3"
+      triggers="click blur"
+      @shown="onShown"
+      @hidden="onHidden"
+    >
+      <ul class="list-group list-group-flush px-1">
+        <li class="list-group-item px-2">
+          <a
+            :href="user_id"
+            role="menuitem"
+            :aria-label="viewProfileText"
+          >
+            <i class="fas fa-user fa-fw fa-lg mr-1" />
+            {{ viewProfileText }}
+          </a>
+        </li>
+        <li class="list-group-item px-2">
+          <a
+            href="/profile/edit"
+            role="menuitem"
+            :aria-label="editProfileText"
+          >
+            <i class="fas fa-user-cog fa-fw fa-lg mr-1" />
+            {{ editProfileText }}
+          </a>
+        </li>
+        <li
+          v-if="displayMyFilesLink"
+          class="list-group-item px-2"
+        >
+          <a
+            href="/file-manager"
+            role="menuitem"
+            :aria-label="$t('Files')"
+          >
+            <i class="fas fa-folder fa-fw fa-lg mr-1" />
+            {{ $t('Files') }}
+          </a>
+        </li>
+        <li class="list-group-item px-2">
+          <a
+            href="https://processmaker.gitbook.io/processmaker/"
+            role="menuitem"
+            :aria-label="$t('Documentation')"
+            target="_blank"
+          >
+            <i
+              data-v-2eb90a9e
+              class="fas fa-question-circle fa-fw fa-lg mr-1"
+            />
+            {{ $t('Documentation') }}
+          </a>
+        </li>
+        <li class="list-group-item px-2">
+          <a
+            href="/about"
+            role="menuitem"
+            :aria-label="$t('About')"
+          >
+            <i class="fas fa-info-circle fa-fw fa-lg mr-1" />
+            {{ $t('About') }}
+          </a>
+        </li>
+        <li class="list-group-item px-2">
+          <a
+            href="/logout"
+            role="menuitem"
+            :aria-label="$t('Log Out')"
+          >
+            <i class="fas fa-sign-out-alt fa-fw fa-lg mr-1" />
+            {{ $t('Log Out') }}
+          </a>
+        </li>
+      </ul>
     </b-popover>
   </div>
 </template>
 
 <script>
 import Vue from "vue";
-import AvatarImage from "../components/AvatarImage";
 import VueCroppie from "vue-croppie";
+import AvatarImage from "./AvatarImage.vue";
 
-Vue.component("avatar-image", AvatarImage);
+Vue.component("AvatarImage", AvatarImage);
 Vue.use(VueCroppie);
 
 export default {
+  props: {
+    info: {
+      type: Object,
+      required: true,
+    },
+  },
+
   data() {
     return {
       sourceImage: false,
@@ -72,23 +118,28 @@ export default {
       username: null,
       user_id: null,
       popoverShow: true,
-      information: []
+      information: [],
     };
   },
-  props: ["info", "items"],
   computed: {
     displayMyFilesLink() {
-      return window.ProcessMaker.packages.includes('package-files');
+      return window.ProcessMaker.packages.includes("package-files");
     },
     viewProfileText() {
-      return this.$t("View {{user}} Profile", {user: this.username});
+      return this.$t("View {{user}} Profile", { user: this.username });
     },
     editProfileText() {
-      return this.$t("Edit {{user}} Profile", {user: this.username});
-    }
+      return this.$t("Edit {{user}} Profile", { user: this.username });
+    },
+  },
+  mounted() {
+    this.formatData(this.info);
+    window.ProcessMaker.events.$on("update-profile-avatar", this.updateAvatar);
   },
   methods: {
+    // eslint-disable-next-line no-underscore-dangle
     __(variable) {
+      // eslint-disable-next-line no-undef
       return __(variable);
     },
     onClose() {
@@ -105,38 +156,34 @@ export default {
         this.sourceImage = true;
       }
       this.fullName = user.fullname;
-      this.user_id = "/profile/" + user.id;
+      this.user_id = `/profile/${user.id}`;
       this.username = user.username;
       this.information = [
         {
-          id: '#',
+          id: "#",
           tooltip: user.fullname,
           src: user.avatar
-            ? user.avatar + "?" + new Date().getTime()
+            ? `${user.avatar}?${new Date().getTime()}`
             : user.avatar,
           title: "",
           initials:
             user.firstname && user.lastname
               ? user.firstname.match(/./u)[0] + user.lastname.match(/./u)[0]
-              : ""
-        }
+              : "",
+        },
       ];
     },
     updateAvatar() {
       ProcessMaker.apiClient
-        .get("users/" + window.ProcessMaker.user.id)
-        .then(response => {
+        .get(`users/${window.ProcessMaker.user.id}`)
+        .then((response) => {
           this.formatData(response.data);
         });
     },
     getTarget() {
       return this.$refs.userMenuButton.getTarget();
-    }
+    },
   },
-  mounted() {
-    this.formatData(this.info);
-    window.ProcessMaker.events.$on("update-profile-avatar", this.updateAvatar);
-  }
 };
 </script>
 

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -109,18 +109,12 @@
             <li class="separator d-none d-lg-block"></li>
             <li class="d-none d-lg-block">
                 @php
-                    $items = [];
-                    foreach ($dropdown_nav->items as $item ) {
-                        $newItem = new stdClass();
-                        $newItem->class = 'fas ' . $item->attr('icon') . ' fa-fw fa-lg';
-                        $newItem->title = $item->title;
-                        $newItem->url = $item->url();
-                        $items[] = $newItem;
-                    }
-                    $items = json_encode($items);
                     $user = Auth::user();
+                    $permissions = json_encode([
+                        'edit-personal-profile' => $user->can('edit-personal-profile'),
+                    ]);
                 @endphp
-                <navbar-profile :info="{{$user}}" :items="{{$items}}"></navbar-profile>
+                <navbar-profile :info="{{$user}}" :permissions="{{$permissions}}"></navbar-profile>
             </li>
         </b-navbar-nav>
     </b-collapse>

--- a/routes/web.php
+++ b/routes/web.php
@@ -96,7 +96,7 @@ Route::middleware('auth', 'sanitize', 'external.connection', 'force_change_passw
 
     Route::get('about', [AboutController::class, 'index'])->name('about.index');
 
-    Route::get('profile/edit', [ProfileController::class, 'edit'])->name('profile.edit');
+    Route::get('profile/edit', [ProfileController::class, 'edit'])->name('profile.edit')->middleware('can:edit-personal-profile');
     Route::get('profile/{id}', [ProfileController::class, 'show'])->name('profile.show');
     // Ensure our modeler loads at a distinct url
     Route::get('modeler/{process}', [ModelerController::class, 'show'])->name('modeler.show')->middleware('can:edit-processes');
@@ -147,7 +147,7 @@ Route::get('password/reset/{token}', [ResetPasswordController::class, 'showReset
 Route::post('password/reset', [ResetPasswordController::class, 'reset']);
 Route::get('password/change', [ChangePasswordController::class, 'edit'])->name('password.change');
 
-//overwrite laravel passport
+// overwrite laravel passport
 Route::get('oauth/clients', [ClientController::class, 'index'])->name('passport.clients.index')->middleware('can:view-auth_clients');
 Route::get('oauth/clients/{client_id}', [ClientController::class, 'show'])->name('passport.clients.show')->middleware('can:view-auth_clients');
 Route::post('oauth/clients', [ClientController::class, 'store'])->name('passport.clients.store')->middleware('can:create-auth_clients');

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -2,6 +2,10 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Support\Facades\Artisan;
+use ProcessMaker\Models\Group;
+use ProcessMaker\Models\GroupMember;
+use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
@@ -12,26 +16,37 @@ class ProfileTest extends TestCase
 
     /**
      * Test to make sure the controller and route work with the view
-     *
-     * @return void
      */
-    public function testEditRoute()
+    public function testEditRoute(): void
     {
-        $user_id = User::factory()->create()->id;
-        // get the URL
-        $response = $this->webCall('GET', '/profile/edit');
+        Artisan::call('db:seed', ['class' => 'PermissionSeeder']);
+        $user = User::factory()->create(['is_administrator' => false]);
 
+        // Set the URL & permission to test.
+        $url = route('profile.edit');
+        $permission = 'edit-personal-profile';
+
+        // User has no permissions, so this should return 403.
+        $response = $this->actingAs($user)->get($url);
+        $response->assertStatus(403);
+
+        // Attach the permission to our user.
+        $user->permissions()->attach(Permission::byName($permission)->id);
+        $user->is_administrator = true;
+        $user->save();
+        $user->refresh();
+
+        // Our user now has permissions, so this should return 200.
+        $this->assertTrue($user->hasPermission('edit-personal-profile'));
+        $response = $this->actingAs($user)->get($url);
         $response->assertStatus(200);
-        // check the correct view is called
         $response->assertViewIs('profile.edit');
     }
 
     /**
      * Test to make sure the controller and route work with the view
-     *
-     * @return void
      */
-    public function testShowRoute()
+    public function testShowRoute(): void
     {
         $user_id = User::factory()->create()->id;
         // get the URL
@@ -40,5 +55,38 @@ class ProfileTest extends TestCase
         $response->assertStatus(200);
         // check the correct view is called
         $response->assertViewIs('profile.show');
+    }
+
+    public function testEditProfileGroupPermission(): void
+    {
+        Artisan::call('db:seed', ['class' => 'PermissionSeeder']);
+        $user = User::factory()->create(['is_administrator' => false]);
+        $group = Group::factory()->create(['name' => 'Test Permissions']);
+
+        // Assign our user to the group.
+        GroupMember::factory()->create([
+            'group_id' => $group->id,
+            'member_type' => User::class,
+            'member_id' => $user->id,
+        ]);
+
+        // Set the URL & permission to test.
+        $url = route('profile.edit');
+        $permission = 'edit-personal-profile';
+
+        // Our group has no permissions, so this should return 403.
+        $response = $this->actingAs($user, 'web')->get($url);
+        $response->assertStatus(403);
+
+        // Attach the permission to our group.
+        $group->permissions()->sync([Permission::byName($permission)->id]);
+        $user->is_administrator = true;
+        $user->save();
+        $user->refresh();
+
+        // Our group now has permission, so this should return 200.
+        $this->assertTrue($user->hasPermission('edit-personal-profile'));
+        $response = $this->actingAs($user, 'web')->call('GET', $url);
+        $response->assertStatus(200);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

As an Administrator, I want to limit users from editing their own profiles so I can reliably control user details in my platform.

## Solution
- Added new permission: "Edit Personal Profile" (in Users tab) for users and groups. 
- When active it allows the user to edit their own profile.
- When inactive prevents user from access the `/profile/edit` route and make changes to their profile.

## How to Test

1. Run `php artisan db:seed --class="PermissionSeeder"`
2. Create a new user
3. Test the "Edit Personal Profile" permission.

- Run unit test: `php artisan test --filter ProfileTest`.

## Related Tickets & Packages
- [FOUR-7891](https://processmaker.atlassian.net/browse/FOUR-7891)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7879]: https://processmaker.atlassian.net/browse/FOUR-7879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FOUR-7891]: https://processmaker.atlassian.net/browse/FOUR-7891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
