### PR TITLE
FOUR-7920 - Modeler Toolbar Improvements

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -5,6 +5,8 @@
     no-flip
     lazy
     class="dropdown-right ellipsis-dropdown-main"
+    @show="onShow"
+    @hide="onHide"
   >
     <template v-if="customButton" #button-content>
       <i
@@ -84,7 +86,7 @@ export default {
       let btns = this.actions.filter(action => {
         if (!action.hasOwnProperty('permission') || action.hasOwnProperty('permission') && this.permission.includes(action.permission)) {
           return action;
-        } 
+        }
       });
 
       btns = btns.filter(btn => {
@@ -121,6 +123,12 @@ export default {
   methods: {
     onClick(action, data) {
       this.$emit("navigate", action, data);
+    },
+    onShow() {
+      this.$emit('show');
+    },
+    onHide() {
+      this.$emit('hide');
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR is part of [Modeler toolbar improvements PR](https://github.com/ProcessMaker/modeler/pull/1489). 

Fix drop-down menu ellipsis content overlapping in Modeler.

Expected behavior: 
- The drop-down’s content should be displayed above the Inspector column.

Actual behavior: 
- The drop-down’s content is displayed under the Inspector column.

## Solution
- Added emit events on <b-dropdown> MenuEllipsis component to be handled in Modeler.

## How to Test
- run `npm run build-bundle`
- copy dist folder to `node_modules/@processmaker/modeler/`
- run `npm run dev` in core.
- manually test Modeler.

## Related Tickets & Packages
- [FOUR-7920](https://processmaker.atlassian.net/browse/FOUR-7920)
- [FOUR-7973](https://processmaker.atlassian.net/browse/FOUR-7973)

[FOUR-7920]: https://processmaker.atlassian.net/browse/FOUR-7920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7973]: https://processmaker.atlassian.net/browse/FOUR-7973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ