### PR TITLE
It is possible to import a process in the templates tab

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ImportController.php
+++ b/ProcessMaker/Http/Controllers/Api/ImportController.php
@@ -54,13 +54,21 @@ class ImportController extends Controller
         $importer = new Importer($payload, $options);
         $manifest = $importer->doImport();
 
-        if ($manifest[$payload['root']]->model instanceof ProcessTemplates) {
-            return response()->json([], 200);
-        }
-
         $newProcessId = $manifest[$payload['root']]->log['newId'];
 
         return response()->json(['processId' => $newProcessId], 200);
+    }
+
+    public function importTemplate(String $type, Request $request): JsonResponse
+    {
+        $jsonData = $request->file('file')->get();
+        $payload = json_decode($jsonData, true);
+
+        $options = new Options(json_decode(file_get_contents(utf8_decode($request->file('options'))), true));
+        $importer = new Importer($payload, $options);
+        $manifest = $importer->doImport();
+
+        return response()->json([], 200);
     }
 
     private function handlePasswordDecrypt(Request $request, array $payload)

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -902,7 +902,7 @@ class ProcessController extends Controller
 
         if (!$result = $this->validateImportedFile($content, $request)) {
             return response(
-                ['message' => __('The selected file is invalid or not supported for import.')],
+                ['message' => __('The selected file is is a invalid or not supported for the Process importer. Please verify that this file is a Process.')],
                 422
             );
         }
@@ -1336,7 +1336,7 @@ class ProcessController extends Controller
         $validVersion = $hasVersion && method_exists(ImportProcess::class, "parseFileV{$decoded->version}");
         $useNewImporter = $decoded !== null && property_exists($decoded, 'version') && (int) $decoded->version === 2;
 
-        if ($useNewImporter) {
+        if ($validType && $useNewImporter) {
             return (new ImportController())->preview($request, $decoded->version);
         }
 

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -902,7 +902,7 @@ class ProcessController extends Controller
 
         if (!$result = $this->validateImportedFile($content, $request)) {
             return response(
-                ['message' => __('The selected file is is a invalid or not supported for the Process importer. Please verify that this file is a Process.')],
+                ['message' => __('The selected file is invalid or not supported for the Process importer. Please verify that this file is a Process.')],
                 422
             );
         }

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -134,7 +134,7 @@ class TemplateController extends Controller
 
         if (!$result = $this->validateImportedFile($content, $request)) {
             return response(
-                ['message' => __('The selected file is is a invalid or not supported for the Templates importer. Please verify that this file is a Template.')],
+                ['message' => __('The selected file is invalid or not supported for the Templates importer. Please verify that this file is a Template.')],
                 422
             );
         }

--- a/resources/js/components/shared/DraggableFileUpload.vue
+++ b/resources/js/components/shared/DraggableFileUpload.vue
@@ -61,7 +61,7 @@ export default {
           file.ignored = false;
         }
         if (file.ignored) {
-          ProcessMaker.alert(this.$t("File not allowed."), "danger");
+          ProcessMaker.alert(this.$t("The selected file is invalid or not supported. Please verify that this file is in JSON format."), "danger");
           return false
         }
       }

--- a/resources/js/processes/export/DataProvider.js
+++ b/resources/js/processes/export/DataProvider.js
@@ -20,6 +20,22 @@ export default {
         }
     });
   },
+  doImportTemplate(file, options, type) {
+    let formData = new FormData();
+    const optionsBlob = new Blob([JSON.stringify(options)], {
+        type: 'application/json'
+    });
+  
+    formData.append('file', file);
+    formData.append('options', optionsBlob);
+    
+    return ProcessMaker.apiClient.post(`/template/do-import/${type}`, formData,
+    {
+        headers: {
+            'Content-Type': 'multipart/form-data'
+        }
+    });
+  },
   importOlderVersion(file) {
     let formData = new FormData();
     formData.append('file', file);

--- a/resources/js/processes/import/components/ImportManagerView.vue
+++ b/resources/js/processes/import/components/ImportManagerView.vue
@@ -159,6 +159,10 @@ export default {
                 });
             }
             return [];
+        },
+        importType() {
+            const assetType = document.querySelector("meta[name='import-template-asset-type']") ? _.get(document.querySelector('meta[name="import-template-asset-type"]'),"content") : null;
+            return assetType  && assetType === 'process' ? 'process_templates' : 'processes';
         }
     },
     methods: {
@@ -269,6 +273,19 @@ export default {
                 formData.append('password', this.password);
             }
 
+
+            switch (this.importType) {
+                case 'process_templates':
+                    this.validateProcessTemplateFile(formData);
+                break;
+            
+                default:
+                this.validateProcessFile(formData);
+            }
+
+
+        },
+        validateProcessFile(formData) {
             ProcessMaker.apiClient.post('/processes/import/validation', formData,
                 {
                     headers: {
@@ -281,13 +298,6 @@ export default {
                     this.$root.manifest = response.data.manifest;
                     this.$root.rootUuid = response.data.rootUuid;
                     this.processVersion = response.data.processVersion;
-                    const model = response.data.manifest[response.data.rootUuid].model;
-                    
-                    if (model === 'ProcessMaker\\Models\\ProcessTemplates') {
-                        // disable 'custom' import type for templates
-                        this.importTypeOptions[1].disabled = true;
-                        this.showTemplateWarning = true;
-                    }
                 }  
                
                 if (this.processVersion === null) {
@@ -310,6 +320,33 @@ export default {
                     ProcessMaker.alert(message, 'danger');
                 }
             });
+        },
+        validateProcessTemplateFile(formData) {
+            ProcessMaker.apiClient.post('/templates/process/import/validation', formData,
+                {
+                    headers: {
+                        'Content-Type': 'multipart/form-data'
+                    }
+                }
+            )
+            .then(response => {   
+                if (typeof response.data === 'object') {
+                    this.$root.manifest = response.data.manifest;
+                    this.$root.rootUuid = response.data.rootUuid;
+                    this.processVersion = response.data.processVersion;
+                    
+                    // disable 'custom' import type for templates
+                    this.importTypeOptions[1].disabled = true;
+                    this.showTemplateWarning = true;
+                }  
+               
+                this.fileIsValid = true;
+                this.$root.setInitialState(this.$root.manifest, this.$root.rootUuid);
+
+            }).catch(error => {
+                const message = error.response?.data?.error || error.response?.data?.message || error.message;
+                ProcessMaker.alert(message, 'danger');
+            });       
         },
          removeFile() {
             this.file = '';
@@ -349,21 +386,48 @@ export default {
             this.loading = true;
             this.submitted = true;
 
+            switch (this.importType) {
+                case 'process_templates':
+                    this.handleProcessTemplateImport();
+                break;
+            
+                default:
+                    this.handleProcessImport();
+            }
+
+        },
+        handleProcessImport() {
             DataProvider.doImport(this.file, this.$root.exportOptions(), this.password)
             .then((response) => {
                 if (response?.data) {
                     const { processId } = response.data;
-                    const successMessage =
-                        processId
-                            ? this.$t('Process was successfully imported')
-                            : this.$t('Process Template was successfully imported');
+                    const successMessage = this.$t('Process was successfully imported');
 
                     ProcessMaker.alert(successMessage, 'success');
                     window.location.href = processId ? `/modeler/${processId}` : '/processes/';
                     this.submitted = false; // the form was successfully submitted
                 } else {
                     // the request was successful but did not return expected data
-                    throw new Error(this.$t('Unknown error while importing the process.'));
+                    throw new Error(this.$t('Unknown error while importing the Process.'));
+                }
+            })
+            .catch((error) => {
+                this.handleError(error); // a shared method that displays the error message and resets loading/submitted
+            });
+        },
+        handleProcessTemplateImport() {
+            DataProvider.doImportTemplate(this.file, this.$root.exportOptions(), 'process')
+            .then((response) => {
+                if (response?.data) {
+                    const { processId } = response.data;
+                    const successMessage = this.$t('Process Template was successfully imported');
+
+                    ProcessMaker.alert(successMessage, 'success');
+                    window.location.href = processId ? `/modeler/${processId}` : '/processes/';
+                    this.submitted = false; // the form was successfully submitted
+                } else {
+                    // the request was successful but did not return expected data
+                    throw new Error(this.$t('Unknown error while importing the Process Template.'));
                 }
             })
             .catch((error) => {

--- a/routes/api.php
+++ b/routes/api.php
@@ -120,7 +120,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('processes/{process}', [ProcessController::class, 'show'])->name('processes.show')->middleware('can:view-processes');
     Route::post('processes/{process}/export', [ProcessController::class, 'export'])->name('processes.export')->middleware('can:export-processes');
     Route::post('processes/import', [ProcessController::class, 'import'])->name('processes.import')->middleware('can:import-processes');
-    Route::post('processes/import/validation', [ProcessController::class, 'preimportValidation'])->name('processes.preimportValidation')->middleware('template-authorization');
+    Route::post('processes/import/validation', [ProcessController::class, 'preimportValidation'])->name('processes.preimportValidation')->middleware('can:import-processes');
     Route::get('processes/import/{code}/is_ready', [ProcessController::class, 'import_ready'])->name('processes.import_is_ready')->middleware('can:import-processes');
     Route::post('processes/{process}/import/assignments', [ProcessController::class, 'importAssignments'])->name('processes.import.assignments')->middleware('can:import-processes');
     Route::post('processes', [ProcessController::class, 'store'])->name('processes.store')->middleware('can:create-processes');
@@ -232,7 +232,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('export/manifest/{type}/{id}/', [ExportController::class, 'manifest'])->name('export.manifest')->middleware('can:export-processes');
     Route::post('export/{type}/download/{id}', [ExportController::class, 'download'])->name('export.download')->middleware('template-authorization');
     Route::post('import/preview', [ImportController::class, 'preview'])->name('import.preview')->middleware('can:export-processes');
-    Route::post('import/do-import', [ImportController::class, 'import'])->name('import.do_import')->middleware('template-authorization');
+    Route::post('import/do-import', [ImportController::class, 'import'])->name('import.do_import')->middleware('can:import-processes');
 
     // Templates
     Route::get('templates/{type}', [TemplateController::class, 'index'])->name('template.index')->middleware('template-authorization');
@@ -243,6 +243,8 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::put('template/settings/{type}/{id}', [TemplateController::class, 'updateTemplateConfigs'])->name('template.settings.update')->middleware('template-authorization');
     Route::delete('template/{type}/{id}', [TemplateController::class, 'delete'])->name('template.delete')->middleware('template-authorization');
     Route::get('modeler/templates/{type}/{id}', [TemplateController::class, 'show'])->name('modeler.template.show')->middleware('template-authorization');
+    Route::post('template/do-import/{type}', [ImportController::class, 'importTemplate'])->name('import.do_importTemplate')->middleware('template-authorization');
+    Route::post('templates/{type}/import/validation', [TemplateController::class, 'preImportValidation'])->name('template.preImportValidation')->middleware('template-authorization');
 
     // debugging javascript errors
     Route::post('debug', [DebugController::class, 'store'])->name('debug.store')->middleware('throttle');


### PR DESCRIPTION
## Issue & Reproduction Steps
The importers allow importing a Template or Process without validation.

Steps to Reproduce : 
- Log in 
- Go to Designer
- Click on Template->Import
- Import a Process
- The process will import 

## Solution
- Created validation for each importer

## How to Test
Click on Process->Import a and import a Template file (It should not allow the import)
Click on Template->Import and import a Process file (It should not allow the import)

## Related Tickets & Packages
- Ticket [FOUR-7861](https://processmaker.atlassian.net/browse/FOUR-7861)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7861]: https://processmaker.atlassian.net/browse/FOUR-7861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ