### PR TITLE
[FOUR-8126] Recompiling Mix fails on instance when colors have been customized

### DIFF
--- a/resources/js/admin/cssOverride/components/SiteDesign.vue
+++ b/resources/js/admin/cssOverride/components/SiteDesign.vue
@@ -226,32 +226,32 @@ export default {
       colorDefault: [
         {
           id: '$primary',
-          value: '#3397E1',
+          value: '#0872C2',
           title: this.$t('Primary')
         },
         {
           id: '$secondary',
-          value: '#788793',
+          value: '#6C757D',
           title: this.$t('Secondary')
         },
         {
           id: '$success',
-          value: '#00BF9C',
+          value: '#00875A',
           title: this.$t('Success')
         },
         {
           id: '$info',
-          value: '#17A2B8',
+          value: '#104A75',
           title: this.$t('Info')
         },
         {
           id: '$warning',
-          value: '#FBBE02',
+          value: '#FFAB00',
           title: this.$t('Warning')
         },
         {
           id: '$danger',
-          value: '#ED4757',
+          value: '#E50130',
           title: this.$t('Danger')
         },
         {

--- a/resources/sass/_colors.scss
+++ b/resources/sass/_colors.scss
@@ -7,6 +7,3 @@ $warning: #FFAB00;
 $danger: #E50130;
 $dark: #000000;
 $light: #FFFFFF;
-$darkneutral: #42526E;
-$dangerlight: #FFEBE9;
-$successlight: #E6FFEB;

--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -135,3 +135,8 @@ $text-muted: #6c757d;
 
 //This z-index for the alert popup
 $alertZIndex: 1051;
+
+//Additional (non-customizable) colors
+$darkneutral: #42526E;
+$dangerlight: #FFEBE9;
+$successlight: #E6FFEB;


### PR DESCRIPTION
## Issue & Reproduction Steps
### Steps to Reproduce
1. Run `npm run prod` or `npm run dev` on a clean install with no custom CSS colors, ensuring that it runs as expected
2. Visit `/admin/customize-ui`
3. Change some of the default colors and click save, allowing the CSS to regenerate
4. Run `npm run prod` or `npm run dev` again

### Current Behavior

The build fails with the following error:
```
SassError: Undefined variable.
  ╷
6 │   color: $darkneutral;
  │          ^^^^^^^^^^^^
```

### Expected Behavior
The build should complete without error.

## Solution
- Removed the color variables that were added to support the new Import/Export functionality from the _colors.scss file and moved them to the _variables.scss file. Since the Customize UI functionality was replacing the _colors.scss file without those new colors in it, the build would fail. Now, those color variables exist regardless of the status of the _colors.scss file, so the build runs as expected.
- During testing it was also discovered that the default colors presented on the Customize UI page were based on the old default colors which have since changed. So those were updated as well.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8126

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
