### PR TITLE
Bugfix: recent-search request triggering twice

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -90,6 +90,7 @@ window.ProcessMaker.navbar = new Vue({
       sessionTime: "",
       sessionWarnSeconds: "",
       taskTitle: "",
+      isMobile: false,
     };
   },
   watch: {
@@ -100,6 +101,9 @@ window.ProcessMaker.navbar = new Vue({
   mounted() {
     Vue.nextTick() // This is needed to override the default alert method.
       .then(() => {
+        this.onResize();
+        window.addEventListener("resize", this.onResize, { passive: true });
+
         if (document.querySelector("meta[name='alert']")) {
           ProcessMaker.alert(
             document.querySelector("meta[name='alertMessage']").getAttribute("content"),
@@ -146,6 +150,9 @@ window.ProcessMaker.navbar = new Vue({
         return this.$refs.breadcrumbs.updateRoutes(routes);
       }
       return false;
+    },
+    onResize() {
+      this.isMobile = window.innerWidth < 992;
     },
   },
 });

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -97,7 +97,9 @@
 
         <b-navbar-nav class="d-flex align-items-center ml-auto">
 
+            @if (config('app.open_ai_nlq_to_pmql') && shouldShow('globalSearchBar'))
             <global-search v-if="!isMobile" class="d-none d-lg-block"></global-search>
+            @endif
             @if (shouldShow('requestButton'))
             <component v-bind:is="'request-modal'" url="{{ route('processes.index') }}" v-bind:permission="{{ \Auth::user()->hasPermissionsFor('processes') }}"></component>
             @endif
@@ -109,18 +111,12 @@
             <li class="separator d-none d-lg-block"></li>
             <li class="d-none d-lg-block">
                 @php
-                    $items = [];
-                    foreach ($dropdown_nav->items as $item ) {
-                        $newItem = new stdClass();
-                        $newItem->class = 'fas ' . $item->attr('icon') . ' fa-fw fa-lg';
-                        $newItem->title = $item->title;
-                        $newItem->url = $item->url();
-                        $items[] = $newItem;
-                    }
-                    $items = json_encode($items);
                     $user = Auth::user();
+                    $permissions = json_encode([
+                        'edit-personal-profile' => $user->can('edit-personal-profile'),
+                    ]);
                 @endphp
-                <navbar-profile :info="{{$user}}" :items="{{$items}}"></navbar-profile>
+                <navbar-profile :info="{{$user}}" :permissions="{{$permissions}}"></navbar-profile>
             </li>
         </b-navbar-nav>
     </b-collapse>

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -9,7 +9,7 @@
     </div>
 
     <div class="d-flex d-lg-none w-100">
-      <global-search class="w-100 small-screen"></global-search>
+      <global-search v-if="isMobile" class="w-100 small-screen"></global-search>
     </div>
 
     <b-collapse is-nav id="nav-collapse">
@@ -97,9 +97,7 @@
 
         <b-navbar-nav class="d-flex align-items-center ml-auto">
 
-            @if (config('app.open_ai_nlq_to_pmql') && shouldShow('globalSearchBar'))
-            <global-search class="d-none d-lg-block"></global-search>
-            @endif
+            <global-search v-if="!isMobile" class="d-none d-lg-block"></global-search>
             @if (shouldShow('requestButton'))
             <component v-bind:is="'request-modal'" url="{{ route('processes.index') }}" v-bind:permission="{{ \Auth::user()->hasPermissionsFor('processes') }}"></component>
             @endif
@@ -111,12 +109,18 @@
             <li class="separator d-none d-lg-block"></li>
             <li class="d-none d-lg-block">
                 @php
+                    $items = [];
+                    foreach ($dropdown_nav->items as $item ) {
+                        $newItem = new stdClass();
+                        $newItem->class = 'fas ' . $item->attr('icon') . ' fa-fw fa-lg';
+                        $newItem->title = $item->title;
+                        $newItem->url = $item->url();
+                        $items[] = $newItem;
+                    }
+                    $items = json_encode($items);
                     $user = Auth::user();
-                    $permissions = json_encode([
-                        'edit-personal-profile' => $user->can('edit-personal-profile'),
-                    ]);
                 @endphp
-                <navbar-profile :info="{{$user}}" :permissions="{{$permissions}}"></navbar-profile>
+                <navbar-profile :info="{{$user}}" :items="{{$items}}"></navbar-profile>
             </li>
         </b-navbar-nav>
     </b-collapse>


### PR DESCRIPTION
## Issue & Reproduction Steps
The recent-searches request is triggering twice when navigating over  the pages. The problem was related to global search component that is used twice in navbar, one version for desktop and another for mobile and both of them was rendering.

## Solution
- Calculate screensize and depending of the screensize, render the corresponding global search bar 

**Working video**

https://user-images.githubusercontent.com/90727999/233440929-ccffcbc3-783e-49ee-ae01-1847aec81468.mov


## How to Test
Open the browser inspector and navigate over the app. Should be only one recent-searches request
