### PR TITLE
Fix category assignment on screen import

### DIFF
--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -502,10 +502,13 @@ class ImportProcess implements ShouldQueue
 
             // save categories
             if (isset($screen->categories)) {
+                $ids = [];
                 foreach ($screen->categories as $categoryDef) {
                     $category = $this->saveCategory('screen', $categoryDef);
-                    $new->categories()->save($category);
+                    $ids[] = $category->id;
                 }
+                $new->screen_category_id = implode(',', $ids);
+                $new->save();
             }
 
             return $new;

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -505,7 +505,9 @@ class ImportProcess implements ShouldQueue
                 $ids = [];
                 foreach ($screen->categories as $categoryDef) {
                     $category = $this->saveCategory('screen', $categoryDef);
-                    $ids[] = $category->id;
+                    if ($category) {
+                        $ids[] = $category->id;
+                    }
                 }
                 $new->screen_category_id = implode(',', $ids);
                 $new->save();


### PR DESCRIPTION
## Issue & Reproduction Steps
Main screen category was not assigned on import so it was not visible in the list of categories

## Solution
- Set category IDs using the screen attribute `screen_category_id`

## How to Test
Import the the screen in the ticket and make sure its visible in the list of screens

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8135

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
