### PR TITLE
The Add button in LDAP Attributes looks distorted

### DIFF
--- a/resources/js/admin/settings/components/SettingObject.vue
+++ b/resources/js/admin/settings/components/SettingObject.vue
@@ -17,8 +17,9 @@
         </div>
         <button type="button" :aria-label="$t('Close')" class="close" @click="onCancel">×</button>
       </template>
-      <div v-if="!ui('single')" class="position-absolute w-100 d-flex justify-content-end">
-        <b-button class="setting-add-button" @click="onAdd()" variant="secondary" size="sm"><i class="fa fa-plus"></i> Add</b-button>
+      <div v-if="!ui('single')" class="position-absolute w-100 ml-n3 d-flex">
+        <div class="w-75"></div>
+        <div class="w-25 ml-n3 d-flex justify-content-end"><b-button class="setting-add-button" @click="onAdd()" variant="secondary" size="sm"><i class="fa fa-plus"></i> Add</b-button></div>
       </div>
       <b-table class="setting-object-table" :items="table" :fields="fields" striped>
         <template #cell(key)="data">


### PR DESCRIPTION
## Issue & Reproduction Steps
There were changes in the style sheets, so it was misaligned on this page.
The Add button in LDAP Attributes looks distorted

## Solution
- adjust settings add button

## How to Test

- Log in 
- Click on Admin
- Click on Settings 
- Click on LDAP 
- Clikc on  Edit  variable Map

https://user-images.githubusercontent.com/1747025/234614635-ab52d4eb-8538-4911-945b-2a45fbb3e817.mp4


## Related Tickets & Packages
- [FOUR-8174](https://processmaker.atlassian.net/browse/FOUR-8174)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8174]: https://processmaker.atlassian.net/browse/FOUR-8174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ