### PR TITLE
FOUR-8303-Fix issues with RC upgrades is_template column

### DIFF
--- a/database/migrations/2023_04_26_164247_add_is_template_column_to_specific_version_tables.php
+++ b/database/migrations/2023_04_26_164247_add_is_template_column_to_specific_version_tables.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIsTemplateColumnToSpecificVersionTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Add the names of the tables you want to modify here
+        $tables_to_modify = ['process_versions', 'screen_versions', 'script_versions'];
+
+        foreach ($tables_to_modify as $table_name) {
+            if (Schema::hasTable($table_name)) {
+                Schema::table($table_name, function (Blueprint $table) {
+                    $table->boolean('is_template')->default(false);
+                });
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Add the names of the tables you want to modify here
+        $tables_to_modify = ['process_versions', 'screen_versions', 'script_versions'];
+
+        foreach ($tables_to_modify as $table_name) {
+            Schema::table($table_name, function (Blueprint $table) {
+                $table->dropColumn('is_template');
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
When upgrading from RC's error: unknown column` is_template` for script_versions, screen_versions is thrown.
The seems to be triggered by existing data in the database having the 'is_template' column but not the assets corresponding versions table. This PR adds a migration to create a 'is_template' column for the asset versions tables.

## Solution
- Add migration to create 'is_template' column for the asset versions table

## How to Test

1. Change your env to RC3, run migrations
2. Install connector-pdf and package-actions-by-email
3. Create scripts and screens
4. Change your env to RC4 run migrations
5. ReInstall connector-pdf and package-actions-by-email



## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
