### PR TITLE
The "By user ID" assignment rule in sub-processes does not display the "Variable Name" field.

### DIFF
--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -390,8 +390,8 @@ ProcessMaker.EventBus.$on(
                 label: "Previous Task Assignee",
               },
               {
-                value: "user_by_id",
-                label: "By User ID",
+                value: "process_variable",
+                label: "Process Variable",
               },
             ],
           },


### PR DESCRIPTION
## Issue & Reproduction Steps

- Enter the modeler
- Create a task of type Sub-process
- Expand the "Assignment Rules" option
- In the "Start Sub Processes" option, select "By User ID"

## Solution
- change option "By user ID" to "Process Variable"

## How to Test
- Enter the modeler
- Create a task of type Sub-process
- Expand the "Assignment Rules" option
- In the "Start Sub Processes" option, select "Process Variable"

https://user-images.githubusercontent.com/1747025/234709946-bc4265d4-9c80-4859-8880-a4ac278d9ee8.mp4



## Related Tickets & Packages
- [FOUR-8130](https://processmaker.atlassian.net/browse/FOUR-8130)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8130]: https://processmaker.atlassian.net/browse/FOUR-8130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ