### PR TITLE
500 Error in Public files

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -183,9 +183,20 @@ class FileController extends Controller
         }
 
         $mediaCollection = $request->input('collection', 'local');
+        $file = $model->addMediaFromRequest('file');
+        $user = pmUser();
+        $originalCreatedBy = $user ? $user->id : null;
+        $data_name = $request->input('data_name', '');
+        $rowId = $request->input('row_id', null);
+        $parent = (int) $request->input('parent', null);
 
-        $addedMedia = $model->addMediaFromRequest('file')
-            ->withCustomProperties(['data_name' => $request->input('data_name', '')])
+        $addedMedia = $file
+            ->withCustomProperties([
+                'data_name' => $data_name,
+                'parent' => $parent != 0 ? $parent : null,
+                'row_id' => $rowId,
+                'createdBy' => $originalCreatedBy,
+            ])
             ->toMediaCollection($mediaCollection);
 
         return response([


### PR DESCRIPTION
## Issue & Reproduction Steps
the problem is when on table media library in filed custom_property the property parent is not defined.

you can reproduce it by uploading a file by API on the POST/files endpoint or removing the parent property in the database in some record

## Solution
- add de parameter in endpoint post files.

## How to Test
- Upload file by API Post /files
- review request and file-manager in tab Admin (display files)


https://user-images.githubusercontent.com/1747025/234927156-34ce4814-3fb2-4413-8daa-b4a9176178e1.mp4



## Related Tickets & Packages
- [FOUR-8165](https://processmaker.atlassian.net/browse/FOUR-8165)

depends on PR https://github.com/ProcessMaker/package-files/pull/95
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8165]: https://processmaker.atlassian.net/browse/FOUR-8165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ