### PR TITLE
[FOUR-8317] Fix recurring needless category queries

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1364,7 +1364,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
      */
     public function getProcessCategoryIdAttribute($value)
     {
-        return implode(',', $this->categories()->pluck('category_id')->toArray()) ?: $value;
+        return implode(',', $this->categories->pluck('category_id')->toArray()) ?: $value;
     }
 
     /**

--- a/ProcessMaker/Models/ProcessTemplates.php
+++ b/ProcessMaker/Models/ProcessTemplates.php
@@ -48,6 +48,6 @@ class ProcessTemplates extends Template
      */
     public function getProcessCategoryIdAttribute($value)
     {
-        return implode(',', $this->categories()->pluck('category_id')->toArray()) ?: $value;
+        return implode(',', $this->categories->pluck('category_id')->toArray()) ?: $value;
     }
 }

--- a/ProcessMaker/Models/Screen.php
+++ b/ProcessMaker/Models/Screen.php
@@ -180,7 +180,7 @@ class Screen extends ProcessMakerModel implements ScreenInterface
      */
     public function getScreenCategoryIdAttribute($value)
     {
-        return implode(',', $this->categories()->pluck('category_id')->toArray()) ?: $value;
+        return implode(',', $this->categories->pluck('category_id')->toArray()) ?: $value;
     }
 
     public function builderComponent()

--- a/ProcessMaker/Models/Script.php
+++ b/ProcessMaker/Models/Script.php
@@ -289,7 +289,7 @@ class Script extends ProcessMakerModel implements ScriptInterface
      */
     public function getScriptCategoryIdAttribute($value)
     {
-        return implode(',', $this->categories()->pluck('category_id')->toArray()) ?: $value;
+        return implode(',', $this->categories->pluck('category_id')->toArray()) ?: $value;
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Calling pluck on relationship **method** instead of **property** is causing unneeded duplicate queries.

## Related Package PRs
- https://github.com/ProcessMaker/package-data-sources/pull/269
- https://github.com/ProcessMaker/package-decision-engine/pull/17

## Solution
Call pluck on the relationship **property** instead.

## How to Test
Ensure that categories work as intended across the product.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-8317

ci:deploy
ci:package-data-sources:FOUR-8317
ci:package-decision-engine:FOUR-8317