### PR TITLE
Improve 'save as template' error handling

### DIFF
--- a/resources/js/components/templates/CreateTemplateModal.vue
+++ b/resources/js/components/templates/CreateTemplateModal.vue
@@ -172,6 +172,10 @@ export default {
             this.toggleButtons();
             this.existingAssetId = error.response.data.id;
             this.existingAssetName = error.response.data.templateName;
+          } else {
+            const str = error.response.data.message;
+            const message = str.charAt(0).toUpperCase() + str.slice(1);
+            ProcessMaker.alert(this.$t(message), "danger");
           }
         });
       },  


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket: [FOUR-8163](https://processmaker.atlassian.net/browse/FOUR-8163)

This PR adds Improvements for handling errors when unable to save a process as a template. 

## Solution
- Show error alert banner to inform user.

## How to Test

1. Create a new process and upload this BPMN file 
[bpmnProcess (4).xml.txt](https://github.com/ProcessMaker/processmaker/files/11347203/bpmnProcess.4.xml.txt)
2. Publish the process
3. Navigate back to the process designer page
4. Convert this process into a template
5. Fill out form and select 'save'

**Expected Behavior**

An error alert banner appears indicating what prevented the template from being saved.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8163]: https://processmaker.atlassian.net/browse/FOUR-8163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ