### PR TITLE
Bugfix FOUR-7330-a 

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -424,6 +424,11 @@ class ProcessController extends Controller
             $process->warnings = null;
         }
 
+        // Save any task notification settings...
+        if ($request->has('task_notifications')) {
+            $this->saveTaskNotifications($process, $request);
+        }
+
         $process->fill($request->except('task_notifications'));
 
         try {

--- a/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
+++ b/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
@@ -1,73 +1,90 @@
 <template>
-    <div class="form-group">
-        <div>
-            <label>{{$t(label)}}</label>
-            <button type="button" :aria-label="$t('Expand Editor')" @click="expandEditor" class="btn-sm float-right"><i class="fas fa-expand"></i></button>
-        </div>
-        <div class="small-editor-container">
-            <monaco-editor :options="monacoOptions" v-model="code"
-                language="json" class="editor"></monaco-editor>
-        </div>
-        <small class="form-text text-muted">{{$t(helper)}}</small>
-        <b-modal v-model="showPopup" size="lg" centered :title="$t('Script Config Editor')" v-cloak header-close-content="&times;">
-            <div class="editor-container">
-                <monaco-editor :options="monacoLargeOptions" v-model="code"
-                    language="json" class="editor"></monaco-editor>
-            </div>
-            <div slot="modal-footer">
-                <b-button @click="closePopup" class="btn btn-secondary">
-                    {{ $t('Close') }}
-                </b-button>
-            </div>
-
-        </b-modal>
+  <div class="form-group">
+    <div>
+      <label>{{ $t(label) }}</label>
+      <button
+        type="button"
+        :aria-label="$t('Expand Editor')"
+        class="btn-sm float-right"
+        @click="expandEditor"
+      >
+        <i class="fas fa-expand" />
+      </button>
     </div>
+    <div class="small-editor-container">
+      <monaco-editor
+        ref="monacoEditor"
+        v-model="code"
+        :options="monacoOptions"
+        language="json"
+        class="editor"
+      />
+    </div>
+    <small class="form-text text-muted">{{ $t(helper) }}</small>
+    <b-modal
+      v-cloak
+      v-model="showPopup"
+      size="lg"
+      centered
+      :title="$t('Script Config Editor')"
+      header-close-content="&times;"
+    >
+      <div class="editor-container">
+        <monaco-editor
+          v-model="code"
+          :options="monacoLargeOptions"
+          language="json"
+          class="editor"
+        />
+      </div>
+      <div slot="modal-footer">
+        <b-button
+          class="btn btn-secondary"
+          @click="closePopup"
+        >
+          {{ $t('Close') }}
+        </b-button>
+      </div>
+    </b-modal>
+  </div>
 </template>
 
 <script>
-    export default {
-        props: ["value", "label", "helper", "property"],
-        data() {
-            return {
-                monacoOptions: {
-                    automaticLayout: true,
-                    fontSize: 8,
-                },
-                monacoLargeOptions: {
-                    automaticLayout: true,
-                },
-                code: '',
-                showPopup: false,
-            };
-        },
-        watch: {
-            value: {
-                handler() {
-                    this.code = this.value ? this.value : '';
-                },
-                immediate: true,
-            },
-            code() {
-                this.$emit('input', this.code)
-            },
-        },
-        methods: {
-            /**
-             * Open a popup editor
-             *
-             */
-            expandEditor() {
-                this.showPopup = true;
-            },
-            /**
-             * Close the popup editor
-             *
-             */
-            closePopup() {
-                this.showPopup = false;
-            },
-        }
+export default {
+  props: ["value", "label", "helper", "property"],
+  data() {
+    return {
+      monacoOptions: {
+        automaticLayout: true,
+        fontSize: 8,
+      },
+      monacoLargeOptions: {
+        automaticLayout: true,
+      },
+      code: "",
+      showPopup: false,
     };
+  },
+  watch: {
+    value: {
+      handler() {
+        this.code = this.value ? this.value : "";
+      },
+      immediate: true,
+    },
+    code() {
+      this.$emit("input", this.code);
+    },
+  },
+  methods: {
+    expandEditor() {
+      this.showPopup = true;
+    },
+    closePopup() {
+      this.showPopup = false;
+    },
+  },
+};
 </script>
 
 <style lang="scss" scoped>

--- a/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
+++ b/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
@@ -28,6 +28,7 @@
       centered
       :title="$t('Script Config Editor')"
       header-close-content="&times;"
+      @hide="handleHide"
     >
       <div class="editor-container">
         <monaco-editor
@@ -82,6 +83,11 @@ export default {
     },
     closePopup() {
       this.showPopup = false;
+    },
+    handleHide() {
+      // Update the undoStack when the modal is hidden to trigger the autosave.
+      const child = this.$root.$children.find((c) => c.$refs.modeler);
+      child.$refs.modeler.pushToUndoStack();
     },
   },
 };

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -407,7 +407,7 @@ select.pagination-nav-item {
   box-shadow: 0px 0px 0px 3px rgb(8 114 194 / 50%);
   border: 1px solid #0872C2 !important;
   border-left: 0!important;
-} 
+}
 
 .form-group label {
   margin-bottom: 4px;
@@ -913,8 +913,4 @@ nav {
       color: #ffffff;
     }
   }
-}
-
-.autosave-btn {
-  border-radius: 4px !important;
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR is part of improvements for Autosave (Processes).

## Solution

- Save notification settings -> https://processmaker.atlassian.net/browse/FOUR-8155
  - Settings were not being auto-saved, added the missing code.
- Save Script configuration when editing in the Modal -> https://processmaker.atlassian.net/browse/FOUR-8157
  - When a Script is modified from the modal, the focusout event is not fired to save the State and trigger the autosave. Added a listener for the hide event of the modal, so the autosave can be triggered. 
- Removed a CSS rule `.autosave-btn` and added in Modeler package.

## How to Test
Link Modeler and Core. Run manual tests.

## Related Tickets & Packages
- [Modeler PR](https://github.com/ProcessMaker/modeler/pull/1521)
- [Vue form elements PR](https://github.com/ProcessMaker/vue-form-elements/pull/392)

ci:modeler:bugfix/FOUR-7330-a
ci:vue-form-elements:bugfix/FOUR-7330-a
ci:deploy
