### PR TITLE
FOUR-8318 | Add ‘Save as Template’ Button to Modeler

### DIFF
--- a/resources/js/components/templates/CreateTemplateModal.vue
+++ b/resources/js/components/templates/CreateTemplateModal.vue
@@ -118,7 +118,7 @@ export default {
           return asset + ' Template with the same name already exists';
       },
       descriptionText() {
-        return this.$t(`This will create a re-usable template based on the <strong>${this.assetName}</strong> ${this.assetType}`)
+        return this.$t(`This will create a re-usable template based on the <strong>${this.assetName}</strong> ${this.assetType}.`)
       }
     },
     watch: {

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -46,7 +46,7 @@
         :key="`external-${index}`"
         :options="component.options"
       />
-      <create-template-modal ref="create-template-modal" />
+      <create-template-modal ref="create-template-modal" assetType="process" :assetName="processName" :assetId="processId" :currentUserId="currentUserId"/>
     </b-card>
   </b-container>
 </template>
@@ -79,6 +79,9 @@ export default {
       validationErrors: {},
       warnings: [],
       xmlManager: null,
+      processName: window.ProcessMaker.modeler.process.name,
+      processId: window.ProcessMaker.modeler.process.id,
+      currentUserId: window.ProcessMaker.modeler.process.user_id,
     };
   },
   watch: {


### PR DESCRIPTION
# Description
Ticket: [FOUR-8318](https://processmaker.atlassian.net/browse/FOUR-8318)

We need to add a ‘Save as Template’ button to Modeler so that users can save a Process as a Template from the Process Modeler.

# How to Test
1. Go to branch `feature/FOUR-8318` in Modeler.
2. Go to branch `feature/FOUR-8318` in Core. Link Modeler to Core.
3. In the UI, open up the Process Modeler. From the Ellipsis Menu, select 'Save as Template'.
	- The template should save successfully and show up in your Templates listing.
4. In the UI, open up the Template editor. In the Ellipsis Menu, there should be no option to 'Save as Template'.

# Related Tickets & Packages
- [FOUR-7955](https://processmaker.atlassian.net/browse/FOUR-7955) | Implement the New Ellipsis Menu for Specified Menus Across the Platform
- [FOUR-7878](https://processmaker.atlassian.net/browse/FOUR-7637) | Ellipsis Menu
- [FOUR-7375](https://processmaker.atlassian.net/browse/FOUR-7375) | Process Templates - Spring 2023

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-8318]: https://processmaker.atlassian.net/browse/FOUR-8318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7955]: https://processmaker.atlassian.net/browse/FOUR-7955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7878]: https://processmaker.atlassian.net/browse/FOUR-7878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7375]: https://processmaker.atlassian.net/browse/FOUR-7375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ