### PR TITLE
Improve error message for process exporting and saving as a template

### DIFF
--- a/ProcessMaker/Exception/ExportModelNotFoundException.php
+++ b/ProcessMaker/Exception/ExportModelNotFoundException.php
@@ -13,6 +13,6 @@ class ExportModelNotFoundException extends Exception
         $id = implode(',', $e->getIds());
         $type = $exporter->getClassName();
         $name = $exporter->getName($exporter->model);
-        parent::__construct("the $notFoundClass with id $id could not be found while exporting the $type '$name'.");
+        parent::__construct("The $notFoundClass with id $id could not be found while exporting the $type '$name'.");
     }
 }

--- a/ProcessMaker/Http/Controllers/Api/ExportController.php
+++ b/ProcessMaker/Http/Controllers/Api/ExportController.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use ProcessMaker\Exception\ExportModelNotFoundException;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\ImportExport\Exporter;
 use ProcessMaker\ImportExport\Exporters\ExporterBase;
@@ -34,11 +35,14 @@ class ExportController extends Controller
     public function manifest(string $type, int $id): JsonResponse
     {
         $model = $this->getModel($type)->findOrFail($id);
+        try {
+            $exporter = new Exporter(true);
+            $exporter->export($model, $this->types[$type][1]);
 
-        $exporter = new Exporter(true);
-        $exporter->export($model, $this->types[$type][1]);
-
-        return response()->json($exporter->payload(true), 200);
+            return response()->json($exporter->payload(true), 200);
+        } catch (ExportModelNotFoundException $error) {
+            return response()->json(['error' => $error->getMessage()], 400);
+        }
     }
 
     /**

--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -151,7 +151,7 @@ class ProcessTemplate implements TemplateInterface
         // Get the process manifest
         $response = $this->getManifest('process', $data['asset_id']);
         if (array_key_exists('error', $response)) {
-            return response()->json(['model' => $processTemplate]);
+            return response()->json($response, 400);
         }
 
         // Array of post options

--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -149,7 +149,10 @@ class ProcessTemplate implements TemplateInterface
         $model = (new ExportController)->getModel('process')->findOrFail($data['asset_id']);
 
         // Get the process manifest
-        $manifest = $this->getManifest('process', $data['asset_id']);
+        $response = $this->getManifest('process', $data['asset_id']);
+        if (array_key_exists('error', $response)) {
+            return response()->json(['model' => $processTemplate]);
+        }
 
         // Array of post options
         $uuid = $model->uuid;

--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -159,7 +159,7 @@ class ProcessTemplate implements TemplateInterface
 
         // Loop through each asset in the "export" array and set postOptions "mode" accordingly
         $postOptions = [];
-        foreach ($manifest['export'] as $key => $asset) {
+        foreach ($response['export'] as $key => $asset) {
             $mode = $data['saveAssetsMode'] === 'saveAllAssets' ? 'copy' : 'discard';
             if ($key === $uuid) {
                 $mode = 'copy';

--- a/resources/js/components/templates/CreateTemplateModal.vue
+++ b/resources/js/components/templates/CreateTemplateModal.vue
@@ -173,7 +173,7 @@ export default {
             this.existingAssetId = error.response.data.id;
             this.existingAssetName = error.response.data.templateName;
           } else {
-            const message = error.response.data;
+            const message = error.response.data.error;
             ProcessMaker.alert(this.$t(message), "danger");
           }
         });

--- a/resources/js/components/templates/CreateTemplateModal.vue
+++ b/resources/js/components/templates/CreateTemplateModal.vue
@@ -172,6 +172,9 @@ export default {
             this.toggleButtons();
             this.existingAssetId = error.response.data.id;
             this.existingAssetName = error.response.data.templateName;
+          } else {
+            const message = error.response.data;
+            ProcessMaker.alert(this.$t(message), "danger");
           }
         });
       },  

--- a/resources/js/processes/export/DataProvider.js
+++ b/resources/js/processes/export/DataProvider.js
@@ -56,7 +56,7 @@ export default {
       const assets = response.data.export;
       return this.formatAssets(assets, rootUuid, response.data.passwordRequired);
     }).catch((error) => {
-      let message = error.response?.data?.message;
+      let message = error.response?.data?.error;
       if (!message) {
         message = error.message;
       }

--- a/resources/js/processes/export/state.js
+++ b/resources/js/processes/export/state.js
@@ -185,8 +185,7 @@ export default {
           this.setInitialState(response.assets, response.rootUuid);
         })
         .catch((error) => {
-          console.log(error);
-          ProcessMaker.alert(error, "danger");
+          ProcessMaker.alert(this.$t(error), "danger");
         });
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
Resolves Tickets [FOUR-8143](https://processmaker.atlassian.net/browse/FOUR-8143), [FOUR-8314](https://processmaker.atlassian.net/browse/FOUR-8314) and [FOUR-8159](https://processmaker.atlassian.net/browse/FOUR-8159)

When creating a process from an uploaded BPMN and that BPMN file references assets that do not exist in the current instance, when exporting that process or saving it as a template an 'Server Error' appears. We need to improve this error message to the user is aware of what is preventing the process from being exported or saved as a template.

**To reproduce:**
1. Create a new process and upload this BPMN file 
[bpmnProcess (4).xml.txt](https://github.com/ProcessMaker/processmaker/files/11355942/bpmnProcess.4.xml.txt)

2. Navigate back to the Process Listing page and try to export the process
3. A error occurs without notifying the user of the cause.
4. Navigate back to the Process Listing page and try to save the process as a template
5. No error banner is displayed

## Solution
- Improve the returned error message to the user
- Display an error alert when saving as a template.

## How to Test
Test using the reproduce steps above

**Expected Behavior**
Proper error messages appear for both Exporting and Saving as Template 


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-814]: https://processmaker.atlassian.net/browse/FOUR-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8314]: https://processmaker.atlassian.net/browse/FOUR-8314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FOUR-8143]: https://processmaker.atlassian.net/browse/FOUR-8143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FOUR-8159]: https://processmaker.atlassian.net/browse/FOUR-8159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ