### PR TITLE
FOUR-8145 | Template is Not Created With the Correct Time Zone

### DIFF
--- a/ProcessMaker/Models/Template.php
+++ b/ProcessMaker/Models/Template.php
@@ -13,6 +13,7 @@ use ProcessMaker\Traits\Exportable;
 use ProcessMaker\Traits\HasCategories;
 use ProcessMaker\Traits\HasUuids;
 use ProcessMaker\Traits\HideSystemResources;
+use ProcessMaker\Traits\SerializeToIso8601;
 
 class Template extends ProcessMakerModel
 {
@@ -21,6 +22,7 @@ class Template extends ProcessMakerModel
     use HideSystemResources;
     use HasCategories;
     use Exportable;
+    use SerializeToIso8601;
 
     protected $guarded = [
         'id',


### PR DESCRIPTION
# Issue
Ticket: [FOUR-8145](https://processmaker.atlassian.net/browse/FOUR-8145)

When saving a Template, the time zone of the user and user's machine are not accurately reflected in the Created time in the Templates listing.

# Solution
Add `SerializeToIso8601` trait to Template Model, similarly to how it is used in the Process Model.

# Reproduction Steps
1. Change the time zone of your machine
2. Change the user's time zone in ProcessMaker
3. Login the User
4. Create a Template
5. Find the Template in the Templates listing
6. See the Created date does not match the user's local time

# How to Test
1. Go to branch `bugfix/FOUR-8145` in Core.
2. Repeat the steps listed above.
	- The Created time for a Template should match the user's local time.

# Related Tickets & Packages
- [FOUR-7375](https://processmaker.atlassian.net/browse/FOUR-7375) | Process Templates - Spring 2023

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-8145]: https://processmaker.atlassian.net/browse/FOUR-8145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7375]: https://processmaker.atlassian.net/browse/FOUR-7375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ