### PR TITLE
Bugfix/FOUR-8333: The search by numeral digits, is changed to code on the screen

### DIFF
--- a/resources/js/components/shared/GlobalSearch.vue
+++ b/resources/js/components/shared/GlobalSearch.vue
@@ -204,7 +204,7 @@ export default {
       const url = this.getUrl(search);
       let { pmql } = search.response;
 
-      window.location.href = `${url}?pmql=${pmql}`;
+      window.location.href = `${url}?pmql=${encodeURIComponent(pmql)}`;
     },
     getUrl(item) {
       if (item.type === "collections" && !item.response.collectionError) {


### PR DESCRIPTION
## Issue & Reproduction Steps

- Steps to Reproduce: 
- Log in 
- have processes whose name contains numbers
- in the application header search engine look for the process
- click on the number found

**Expected Behavior:** 
we see that the name of the process with numerop, has been changed to ascii code 
when we search with consonants we do not have this problem   

## Solution
- Encode PMQL in URL

**Working video**

https://user-images.githubusercontent.com/90727999/235235188-17d849b8-986f-4cfa-a1e4-0c2bc7802491.mov


## How to Test
Test steps above

## Related Tickets & Packages
- [FOUR-8333](https://processmaker.atlassian.net/browse/FOUR-8333)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8333]: https://processmaker.atlassian.net/browse/FOUR-8333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ