### PR TITLE
Users/Groups assignment is lost with self services configuration

### DIFF
--- a/resources/js/components/SelectUserGroup.vue
+++ b/resources/js/components/SelectUserGroup.vue
@@ -17,6 +17,7 @@
             :searchable="true"
             :internal-search="false"
             @open="load(null)"
+            @input="updateSeletected"
             @search-change="load">
 
             <template slot="noResult">
@@ -132,12 +133,6 @@
       }
     },
     watch: {
-      content: {
-        handler () {
-          this.lastEmitted = JSON.stringify(this.selected);
-          this.$emit("input", this.selected);
-        }
-      },
       value: {
         immediate: true,
         deep: true,
@@ -199,6 +194,10 @@
       }
     },
     methods: {
+      updateSeletected() {
+        this.lastEmitted = JSON.stringify(this.selected);
+        this.$emit("input", this.selected);
+      },
       addUsernameToFullName(user) {
         if (!user.fullname || ! user.username)
         {


### PR DESCRIPTION
## Issue & Reproduction Steps
When we assign users or groups to a task and then exit the task and reload the assignments, they disappear.

## Solution
- change watcher content selected users/groups in the component SelectUserGroup

## How to Test
1. Create a start event - task - end event process
2. Configure the task:
    Assignment Rules
       Type --Users/Groups
       Assigned --User/Group
       Click on --Self Service
3. Save
4. review assignments

*** Review sections where we used the component assign SelectUserGroup.


https://user-images.githubusercontent.com/1747025/235243741-604c6d34-1045-4ec3-ba26-efb82a434196.mp4


## Related Tickets & Packages
- [FOUR-8193](https://processmaker.atlassian.net/browse/FOUR-8193)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8193]: https://processmaker.atlassian.net/browse/FOUR-8193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ