### PR TITLE
Allow exporting when models are missing

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ExportController.php
+++ b/ProcessMaker/Http/Controllers/Api/ExportController.php
@@ -41,7 +41,7 @@ class ExportController extends Controller
 
             return response()->json($exporter->payload(true), 200);
         } catch (ExportModelNotFoundException $error) {
-            return response()->json(['error' => $error->getMessage()], 400);
+            \Log::error(response()->json(['error' => $error->getMessage()], 400));
         }
     }
 

--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -188,7 +188,7 @@ abstract class ExporterBase implements ExporterInterface
             $this->export();
             $extensions->runExtensions($this, 'postExport');
         } catch (ModelNotFoundException $e) {
-            throw new ExportModelNotFoundException($e, $this);
+            \Log::error($e->getMessage());
         }
     }
 

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -99,9 +99,12 @@ class ProcessExporter extends ExporterBase
         $process->save();
 
         $process->notification_settings()->delete();
-        foreach ($this->getReference('notification_settings') as $setting) {
-            unset($setting['process_id']);
-            $process->notification_settings()->create($setting);
+        $notificationSettings = $this->getReference('notification_settings');
+        if (!is_null($this->getReference('notification_settings'))) {
+            foreach ($notificationSettings as $setting) {
+                unset($setting['process_id']);
+                $process->notification_settings()->create($setting);
+            }
         }
 
         return true;
@@ -210,9 +213,12 @@ class ProcessExporter extends ExporterBase
     private function importSignals()
     {
         // Remove discarded signals from process
-        foreach ($this->getReference('signals') as [$signalUuid, $signalId]) {
-            if ($this->options->get('mode', $signalUuid) === 'discard') {
-                Signal::removeFromProcess($signalId, $this->model);
+        $signals = $this->getReference('signals');
+        if (!is_null($signals)) {
+            foreach ($signals as [$signalUuid, $signalId]) {
+                if ($this->options->get('mode', $signalUuid) === 'discard') {
+                    Signal::removeFromProcess($signalId, $this->model);
+                }
             }
         }
 

--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\ImportExport\Exporters;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ProcessMaker\Assets\ScreensInScreen;
@@ -81,7 +82,7 @@ class ScreenExporter extends ExporterBase
         foreach ($screenFinder->referencesToExport($this->model, [], null, false) as $screen) {
             try {
                 $screens[] = Screen::findOrFail($screen[1]);
-            } catch (\Exception $error) {
+            } catch (ModelNotFoundException $error) {
                 \Log::error($error->getMessage());
                 continue;
             }

--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -79,7 +79,12 @@ class ScreenExporter extends ExporterBase
         $screens = [];
         $screenFinder = new ScreensInScreen();
         foreach ($screenFinder->referencesToExport($this->model, [], null, false) as $screen) {
-            $screens[] = Screen::findOrFail($screen[1]);
+            try {
+                $screens[] = Screen::findOrFail($screen[1]);
+            } catch (\Exception $error) {
+                \Log::error($error->getMessage());
+                continue;
+            }
         }
 
         return $screens;


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket: [FOUR-8315](https://processmaker.atlassian.net/browse/FOUR-8315)

When exporting processes, missing models previously caused the export to fail, preventing users from continuing. This PR addresses this issue by implementing a try-catch block to catch the missing model exception, log the error, and continue the loop. This allows users to continue with the export even if some models are missing, improving the reliability and usability of the feature.

**To Replicate:**

1. Create a process using a data connector.
2. Download the process BPMN file in the modeler.
3. Delete the data connector used in the process.
4. Create a new process and upload the BPMN file.
5. Click on the data connector and verify that the 'not found' error is displayed.
6. Save the created process.
7. Navigate to the process listing page and attempt to export or save the new process as a template.

**Expected Behavior**

Users should be able to export or save as a template processes that contain missing models.

**Current Behavior**

When attempting to export or save a process as a template that contains a missing model, an error message is displayed, preventing the process from being exported.

## Solution
- Use try-catch block to catch model missing exception, log the error, and continue with the export
- Check for null values in a foreach

## How to Test
Test the replication steps above

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8315]: https://processmaker.atlassian.net/browse/FOUR-8315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ