### PR TITLE
FOUR-8349 Add index to order_column in media table

### DIFF
--- a/database/migrations/2023_05_02_183152_add_order_column_index_to_media_table.php
+++ b/database/migrations/2023_05_02_183152_add_order_column_index_to_media_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOrderColumnIndexToMediaTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('media', function (Blueprint $table) {
+            $table->index('order_column', 'media_order_column_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('media', function (Blueprint $table) {
+            $table->dropIndex('media_order_column_index');
+        });
+    }
+}

--- a/tests/unit/ProcessMaker/MediaOrderColumnIndexTest.php
+++ b/tests/unit/ProcessMaker/MediaOrderColumnIndexTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ProcessMaker;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class MediaOrderColumnIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_has_order_column_index_on_media_table()
+    {
+        // Run the migration to add the index
+        $this->artisan('migrate');
+
+        // Check if the index exists
+        $indexExists = Schema::getConnection()
+            ->getDoctrineSchemaManager()
+            ->listTableIndexes('media');
+
+        $this->assertArrayHasKey('media_order_column_index', $indexExists);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
[Performance] Add index to order_column in media table.

## Solution
- Add index to order_column in media table.

## How to Test
- Run the migration to update the schema
- Check into the database the new index was created

![image](https://user-images.githubusercontent.com/8028650/235757147-2fa477f5-a3b4-412c-9043-59a75e1f9f20.png)


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8349

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
