### PR TITLE
FOUR-8308:  Enabling the "Edit Decision Table Categories" permission for a no admin user doesn't work

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -88,7 +88,6 @@ export default {
   },
   computed: {
     filterActions() {
-      console.log('filter actions');
       let btns = this.actions.filter(action => {
         if (!action.hasOwnProperty('permission')
             || action.hasOwnProperty('permission') && this.permission[action.permission]

--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -88,8 +88,11 @@ export default {
   },
   computed: {
     filterActions() {
+      console.log('filter actions');
       let btns = this.actions.filter(action => {
-        if (!action.hasOwnProperty('permission') || action.hasOwnProperty('permission') && this.permission[action.permission] || action.hasOwnProperty('permission') && this.permission.includes(action.permission)) {
+        if (!action.hasOwnProperty('permission')
+            || action.hasOwnProperty('permission') && this.permission[action.permission]
+            || Array.isArray(this.permission) && action.hasOwnProperty('permission') && this.permission.includes(action.permission)) {
           return action;
         }
       });


### PR DESCRIPTION
NOTE: THis tickes was reporte for Decision Tables but it affects any element that has categories (screens, scripts, etc.) Just repeat the same steps but using screen, script categories.

## Issue & Reproduction Steps

-     Create a new user
-     Go to Admin tab
-     Click on User option in sidebar menu
-     Search the user created above
-     Click on Edit button
-     Go to permission tab
-     Click on Decision Tables option
-     Enable The following Permissions: Create Decision Table, Edit Decision Table, View Decision Table Categories, View Decision Table
-     Login with the user created in step 1
-  The categories listing does not show the button to edit a category.

## Solution
- I added a check to validate if the permissions variables is an array before using the .includes function.

## How to Test
Repeat the reproduction steps and verify that now the edit option is enabled in the ellipsis menu.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-8308](https://processmaker.atlassian.net/browse/FOUR-8308)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
