### PR TITLE
Add indexes to process_request_tokens

### DIFF
--- a/database/migrations/2023_05_02_184218_add_indexes_to_process_request_tokens.php
+++ b/database/migrations/2023_05_02_184218_add_indexes_to_process_request_tokens.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexesToProcessRequestTokens extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            $table->index('status');
+            $table->index('element_type');
+            $table->index(['status', 'is_self_service']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *rt mi
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            $table->dropIndex(['status']);
+            $table->dropIndex(['element_type']);
+            $table->dropIndex(['status', 'is_self_service']);
+        });
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Task PMQL searches and charts are slow.

## Solution
This adds 3 indexes recommended by Tighten
- status
- element_type
- composite status and is_self_service

## How to Test
- Performance will only be noticeable where there are lots of process requests and tasks
- Compare the XHR response time for http://processmaker-a.test/api/1.0/tasks when searching with PMQL `status = "active" AND is_self_service = 1` on the tasks page

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8347

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
