### PR TITLE
Bugfix/FOUR-8220: Problem when trying to export a process

### DIFF
--- a/ProcessMaker/Exception/ExportEmptyProcessException.php
+++ b/ProcessMaker/Exception/ExportEmptyProcessException.php
@@ -8,6 +8,6 @@ class ExportEmptyProcessException extends Exception
 {
     public function __construct(Exception $e)
     {
-        parent::__construct("The process to export is empty.");
+        parent::__construct('The process to export is empty.');
     }
 }

--- a/ProcessMaker/Exception/ExportEmptyProcessException.php
+++ b/ProcessMaker/Exception/ExportEmptyProcessException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ProcessMaker\Exception;
+
+use Exception;
+
+class ExportEmptyProcessException extends Exception
+{
+    public function __construct(Exception $e)
+    {
+        parent::__construct("The process to export is empty.");
+    }
+}

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -284,6 +284,7 @@ class ProcessExporter extends ExporterBase
 
             $screenId = $element->getAttribute('pm:screenRef');
             $interstitialScreenId = $element->getAttribute('pm:interstitialScreenRef');
+            $allowInterstitial = $element->getAttribute('pm:allowInterstitial');
 
             if (is_numeric($screenId)) {
                 $screen = Screen::findOrFail($screenId);
@@ -291,7 +292,7 @@ class ProcessExporter extends ExporterBase
             }
 
             // Let's check if interstitialScreen exist
-            if (is_numeric($interstitialScreenId)) {
+            if (is_numeric($interstitialScreenId) && $allowInterstitial === "true") {
                 $interstitialScreen = Screen::findOrFail($interstitialScreenId);
                 $this->addDependent(DependentType::INTERSTITIAL_SCREEN, $interstitialScreen, ScreenExporter::class, $meta);
             }

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -292,7 +292,7 @@ class ProcessExporter extends ExporterBase
             }
 
             // Let's check if interstitialScreen exist
-            if (is_numeric($interstitialScreenId) && $allowInterstitial === "true") {
+            if (is_numeric($interstitialScreenId) && $allowInterstitial === 'true') {
                 $interstitialScreen = Screen::findOrFail($interstitialScreenId);
                 $this->addDependent(DependentType::INTERSTITIAL_SCREEN, $interstitialScreen, ScreenExporter::class, $meta);
             }

--- a/ProcessMaker/ImportExport/Utils.php
+++ b/ProcessMaker/ImportExport/Utils.php
@@ -3,8 +3,10 @@
 namespace ProcessMaker\ImportExport;
 
 use DOMXPath;
+use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use ProcessMaker\Exception\ExportEmptyProcessException;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Nayra\Storage\BpmnElement;
 
@@ -39,9 +41,15 @@ class Utils
 
     public static function getElementsByPath($document, $path)
     {
-        $xpath = new DOMXPath($document);
-
-        return $xpath->query($path);
+        try {
+            $xpath = new DOMXPath($document);
+            return $xpath->query($path);
+        } catch (Exception $e) {
+            if ($e->getMessage() === 'DOMXPath::query(): Undefined namespace prefix') {
+                throw new ExportEmptyProcessException($e);
+            }
+            throw $e;
+        }
     }
 
     public static function getElementByMultipleTags($document, array $tags = [])

--- a/ProcessMaker/ImportExport/Utils.php
+++ b/ProcessMaker/ImportExport/Utils.php
@@ -43,6 +43,7 @@ class Utils
     {
         try {
             $xpath = new DOMXPath($document);
+
             return $xpath->query($path);
         } catch (Exception $e) {
             if ($e->getMessage() === 'DOMXPath::query(): Undefined namespace prefix') {

--- a/resources/js/processes/export/DataProvider.js
+++ b/resources/js/processes/export/DataProvider.js
@@ -57,6 +57,11 @@ export default {
       return this.formatAssets(assets, rootUuid, response.data.passwordRequired);
     }).catch((error) => {
       let message = error.response?.data?.error;
+
+      if (error.response?.data?.exception === "ProcessMaker\\Exception\\ExportEmptyProcessException") {
+        message = error.response?.data?.message;
+      }
+
       if (!message) {
         message = error.message;
       }


### PR DESCRIPTION
## Issue & Reproduction Steps
**NOTE:**  Two different bugs where addressed with this PR

### Bug 1:
- Create a process
- Add a start event
- Check the option Display Next Assigned Task to Task Assignee
- Select a screen
- Save the process
- Uncheck the option
- Save the process
- Delete the interstitial screen selected
- Go to processes list and select the export option for the process created

**Current behavior**
An error will display saying that screen does not exists

 **Solution**
- Only export interstitial screens if the attribute **pm:allowInterstitial** is true

### Bug 2:
- You need to install **connector-send-email**
- Go to edit the previous process you created
- Delete the start event (if there are more elements, remove all of them, the process should be empty)
- Go to processes list and select the export option for the process created

**Current behavior**
- An error will display: DOMXPath::query(): Undefined namespace prefix

 **Solution**
- Catch the error for empty processes and show a prettier message

## How to Test
Follow the steps above

## Related Tickets & Packages
- [FOUR-8220](https://processmaker.atlassian.net/browse/FOUR-8220)
- You need to install connector-send-email

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
