### PR TITLE
FOUR-8391 - Get right number of overdue tasks

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -195,12 +195,6 @@ class TaskController extends Controller
             return $query->count();
         }
 
-        $inOverdueQuery = ProcessRequestToken::where('user_id', $user->id)
-            ->where('status', 'ACTIVE')
-            ->where('due_at', '<', Carbon::now());
-
-        $inOverdue = $inOverdueQuery->count();
-
         try {
             $response = $this->handleOrderByRequestName($request, $query->get());
         } catch (\Illuminate\Database\QueryException $e) {
@@ -226,7 +220,11 @@ class TaskController extends Controller
             return new Resource($processRequestToken);
         });
 
-        $response->inOverdue = $inOverdue;
+        $inOverdueQuery = ProcessRequestToken::query()
+            ->whereIn('id', $response->pluck('id'))
+            ->where('due_at', '<', Carbon::now());
+
+        $response->inOverdue = $inOverdueQuery->count();
 
         return new TaskCollection($response);
     }

--- a/database/factories/ProcessMaker/Models/ProcessRequestTokenFactory.php
+++ b/database/factories/ProcessMaker/Models/ProcessRequestTokenFactory.php
@@ -2,23 +2,21 @@
 
 namespace Database\Factories\ProcessMaker\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\User;
 
-/**
- * Model factory for a ProcessRequestToken
- */
 class ProcessRequestTokenFactory extends Factory
 {
+    protected $model = ProcessRequestToken::class;
+
     /**
      * Define the model's default state.
-     *
-     * @return array
      */
-    public function definition()
+    public function definition(): array
     {
         return [
             'element_type' => 'TASK',
@@ -35,9 +33,20 @@ class ProcessRequestTokenFactory extends Factory
                 return User::factory()->create()->getKey();
             },
             'completed_at' => $this->faker->dateTimeBetween($startDate = '-15 years', $endDate = 'now'),
-            'due_at' => $this->faker->dateTimeBetween($startDate = '-15 years', $endDate = 'now'),
+            'due_at' => Carbon::now()->addDays(3),
             'initiated_at' => $this->faker->dateTimeBetween($startDate = '-15 years', $endDate = 'now'),
             'riskchanges_at' => $this->faker->dateTimeBetween($startDate = '-15 years', $endDate = 'now'),
         ];
     }
+
+     public function overdue(): Factory
+     {
+         return $this->state(function (array $attributes) {
+             return [
+                 'status' => 'ACTIVE',
+                 'due_at' => Carbon::yesterday(),
+                 'completed_at' => null,
+             ];
+         });
+     }
 }

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -387,9 +387,7 @@ export default {
               )
               .then(response => {
                 this.data = this.transform(response.data);
-                if (response.data.meta.in_overdue > 0) {
-                  this.$emit("in-overdue", response.data.meta.in_overdue);
-                }
+                this.$emit("in-overdue", response.data.meta.in_overdue);
               })
               .catch(error => {
                 if (error.code === "ERR_CANCELED") {

--- a/resources/js/tasks/index.js
+++ b/resources/js/tasks/index.js
@@ -74,8 +74,12 @@ new Vue({
       }
     },
     setInOverdueMessage(inOverdue) {
-      const taskText = (inOverdue > 1) ? this.$t("Tasks").toLowerCase() : this.$t("Task").toLowerCase();
-      this.inOverdueMessage = this.$t("You have {{ inOverDue }} overdue {{ taskText }} pending", { inOverDue: inOverdue, taskText });
+      let inOverdueMessage = '';
+      if (inOverdue) {
+        const taskText = (inOverdue > 1) ? this.$t("Tasks").toLowerCase() : this.$t("Task").toLowerCase();
+        inOverdueMessage = this.$t("You have {{ inOverDue }} overdue {{ taskText }} pending", { inOverDue: inOverdue, taskText });
+      }
+      this.inOverdueMessage = inOverdueMessage;
     },
     getFullPmql() {
       let fullPmqlString = "";

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -18,7 +18,7 @@
   <div class="px-3 page-content mb-0" id="tasks">
     <div class="row">
       <div class="col" align="right">
-          <b-alert class="align-middle" show variant="danger" v-cloak v-if="inOverdueMessage.length>0"
+          <b-alert v-if="inOverdueMessage.length>0" class="align-middle" show variant="danger" v-cloak
             style="text-align: center;" data-cy="tasks-alert">
             @{{ inOverdueMessage }}
           </b-alert>
@@ -39,8 +39,8 @@
                 :ai-enabled="false"
                 :show-filters="true"
                 :aria-label="$t('Advanced Search (PMQL)')"
-                :param-status="status" 
-                :permission="{{ Auth::user()->hasPermissionsFor('users', 'groups') }}" 
+                :param-status="status"
+                :permission="{{ Auth::user()->hasPermissionsFor('users', 'groups') }}"
                 @submit="onNLQConversion"
                 @filterspmqlchange="onFiltersPmqlChange">
 

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -63,12 +63,12 @@ class TasksTest extends TestCase
         ProcessRequestToken::factory()->count(20)->create([
             'process_request_id' => $request->id,
         ]);
-        //Get a page of tokens
+        // Get a page of tokens
         $route = route('api.' . $this->resource . '.index', ['per_page' => 10, 'page' => 2]);
         $response = $this->apiCall('GET', $route);
-        //Verify the status
+        // Verify the status
         $response->assertStatus(200);
-        //Verify the structure
+        // Verify the structure
         $response->assertJsonStructure(['data' => ['*' => $this->structure]]);
     }
 
@@ -93,8 +93,8 @@ class TasksTest extends TestCase
             'status' => 'ACTIVE',
             'user_id' => $user_2->id,
         ]);
-        //Get a page of tokens
-        //Since PR #3470, user_id is required as parameter
+        // Get a page of tokens
+        // Since PR #3470, user_id is required as parameter
         $route = route('api.' . $this->resource . '.index', ['user_id' => $user_1->id]);
         $response = $this->apiCall('GET', $route);
 
@@ -108,7 +108,7 @@ class TasksTest extends TestCase
      */
     public function testGetListClosedTasks()
     {
-        //Run the permission seeder
+        // Run the permission seeder
         (new PermissionSeeder)->run();
 
         // Reboot our AuthServiceProvider. This is necessary so that it can
@@ -137,7 +137,7 @@ class TasksTest extends TestCase
             'status' => 'ACTIVE',
             'user_id' => $user_2->id,
         ]);
-        //Get a page of tokens
+        // Get a page of tokens
         $route = route('api.' . $this->resource . '.index', ['status' => 'CLOSED']);
         $response = $this->apiCall('GET', $route);
 
@@ -229,12 +229,12 @@ class TasksTest extends TestCase
             'process_request_id' => $request->id,
         ]);
 
-        //Get active tokens
+        // Get active tokens
         $route = route('api.' . $this->resource . '.index', ['per_page' => 10, 'status' => 'ACTIVE']);
         $response = $this->apiCall('GET', $route);
-        //Verify the status
+        // Verify the status
         $response->assertStatus(200);
-        //Verify the structure
+        // Verify the structure
         $response->assertJsonStructure(['data' => ['*' => $this->structure]]);
     }
 
@@ -263,14 +263,14 @@ class TasksTest extends TestCase
             'process_request_id' => $request->id,
         ]);
 
-        //Get tasks
+        // Get tasks
         $route = route('api.' . $this->resource . '.index', ['per_page' => 100]);
         $response = $this->apiCall('GET', $route);
 
-        //Verify the status
+        // Verify the status
         $response->assertStatus(200);
 
-        //Verify the element types
+        // Verify the element types
         $types = collect($response->json()['data'])->pluck('element_type')->unique()->toArray();
         $this->assertEquals($types, ['task']);
     }
@@ -293,21 +293,21 @@ class TasksTest extends TestCase
             'process_request_id' => $request->id,
         ]);
 
-        //List sorted by completed_at returns as first row {"completed_at": null}
+        // List sorted by completed_at returns as first row {"completed_at": null}
         $route = route('api.' . $this->resource . '.index', ['order_by' => 'completed_at', 'order_direction' => 'asc']);
         $response = $this->apiCall('GET', $route);
-        //Verify the status
+        // Verify the status
         $response->assertStatus(200);
-        //Verify the structure
+        // Verify the structure
         $response->assertJsonStructure(['data' => ['*' => $this->structure]]);
-        //Verify the first row
+        // Verify the first row
         $firstRow = $response->json('data')[0];
         $this->assertArraySubset(['completed_at' => null], $firstRow);
     }
 
     public function testSortByRequestName()
     {
-        //$request = ProcessRequest::factory()->create();
+        // $request = ProcessRequest::factory()->create();
 
         ProcessRequestToken::factory()->count(5)->create([
             'user_id' => $this->user->id,
@@ -379,17 +379,17 @@ class TasksTest extends TestCase
     public function testShowTask()
     {
         $request = ProcessRequest::factory()->create();
-        //Create a new process without category
+        // Create a new process without category
         $token = ProcessRequestToken::factory()->create([
             'process_request_id' => $request->id,
         ]);
 
-        //Test that is correctly displayed
+        // Test that is correctly displayed
         $route = route('api.' . $this->resource . '.show', [$token->id]);
         $response = $this->apiCall('GET', $route);
-        //Check the status
+        // Check the status
         $response->assertStatus(200);
-        //Check the structure
+        // Check the structure
         $response->assertJsonStructure($this->structure);
     }
 
@@ -399,17 +399,17 @@ class TasksTest extends TestCase
     public function testShowTaskWithUser()
     {
         $request = ProcessRequest::factory()->create();
-        //Create a new process without category
+        // Create a new process without category
         $token = ProcessRequestToken::factory()->create([
             'process_request_id' => $request->id,
         ]);
 
-        //Test that is correctly displayed
+        // Test that is correctly displayed
         $route = route('api.' . $this->resource . '.show', [$token->id, 'include' => 'user,definition']);
         $response = $this->apiCall('GET', $route);
-        //Check the status
+        // Check the status
         $this->assertStatus(200, $response);
-        //Check the structure
+        // Check the structure
         $response->assertJsonStructure($this->structure);
         $response->assertJsonStructure(['user' => ['id', 'email'], 'definition' => []]);
     }
@@ -427,12 +427,12 @@ class TasksTest extends TestCase
             'user_id' => $this->user->id,
         ]);
 
-        //Test that is correctly displayed
+        // Test that is correctly displayed
         $route = route('api.' . $this->resource . '.show', [$token->id, 'include' => 'processRequestParent']);
         $response = $this->apiCall('GET', $route);
-        //Check the status
+        // Check the status
         $this->assertStatus(200, $response);
-        //Check the structure
+        // Check the structure
         $json = $response->json();
         $this->assertFalse($json['can_view_parent_request']);
 
@@ -506,13 +506,13 @@ class TasksTest extends TestCase
         // We'll test viewing a new task with someone that is not authenticated
         $request = ProcessRequest::factory()->create();
 
-        //Create a new process without category
+        // Create a new process without category
         $token = ProcessRequestToken::factory()->create([
             'process_request_id' => $request->id,
         ]);
         $url = route('api.' . $this->resource . '.show', [$token->id, 'include' => 'user,definition']);
 
-        //The call is done without an authenticated user so it should return 401
+        // The call is done without an authenticated user so it should return 401
         $response = $this->actingAs(User::factory()->create())
             ->json('GET', $url, []);
         $response->assertStatus(401);


### PR DESCRIPTION
## Issue & Reproduction Steps

The number of overdue tasks in the red alert is not consistent with the filtered data from the table.

1. Create some tokens.
2. Create an overdue token.
3. Create an overdue self-service token.
4. Filter using PMQL: `due < NOW`.
5. You will notice that the number of tasks in the red alert is not the same as the data filtered by the table.

## Solution
- The number of overdue tasks is now obtained from table's filtered data to ensure consistency.

https://user-images.githubusercontent.com/90741874/235792339-f31d542e-0698-4adb-b7af-65584f099602.mov

## How to Test
- Please run `php artisan test tests/Feature/Api/TasksTest.php --filter testGetListOfOverdueTasks` and perform some manual testing.

## Related Tickets & Packages
- [FOUR-8391](https://processmaker.atlassian.net/browse/FOUR-8391)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8391]: https://processmaker.atlassian.net/browse/FOUR-8391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ