### PR TITLE
FOUR-8342 Duplicate media queries

### DIFF
--- a/ProcessMaker/Console/Commands/PopulateAvatarColumn.php
+++ b/ProcessMaker/Console/Commands/PopulateAvatarColumn.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use ProcessMaker\Models\User;
+
+class PopulateAvatarColumn extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'users:populate-avatar';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Populate the avatar column with the current media files';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // Fetch all users
+        $users = User::cursor();
+
+        // Iterate through each user and populate the avatar column
+        foreach ($users as $user) {
+            $user->avatar = $user->getAvatar();
+            $user->save();
+        }
+
+        // Output a message indicating success
+        $this->info('Avatar column populated successfully.');
+
+        return 0;
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -400,7 +400,6 @@ class UserController extends Controller
             }
 
             file_put_contents("/tmp/img.{$type}", $data);
-
             $user->addMedia("/tmp/img.{$type}")
                 ->toMediaCollection(User::COLLECTION_PROFILE, User::DISK_PROFILE);
         } elseif (isset($data['avatar']) && !empty($data['avatar'])) {
@@ -411,6 +410,8 @@ class UserController extends Controller
             $user->addMedia($request->avatar)
                 ->toMediaCollection(User::COLLECTION_PROFILE, User::DISK_PROFILE);
         }
+        $user->avatar = $user->getAvatar();
+        $user->saveOrFail();
     }
 
     /**

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -124,7 +124,6 @@ class User extends Authenticatable implements HasMedia
 
     protected $appends = [
         'fullname',
-        'avatar',
     ];
 
     protected $casts = [
@@ -277,31 +276,6 @@ class User extends Authenticatable implements HasMedia
     }
 
     /**
-     * Get the avatar URL
-     *
-     * @return string
-     */
-    public function getAvatarAttribute()
-    {
-        return $this->getAvatar();
-    }
-
-    /**
-     * Define the avatar mutator. Within, we set the avatar attribute only if
-     * it is not null. This prevents the model from attempting to send an
-     * avatar field to the database on update, which has been known to
-     * cause errors from time to time.
-     *
-     * @return string
-     */
-    public function setAvatarAttribute($value = null)
-    {
-        if ($value) {
-            $this->attributes['avatar'] = $value;
-        }
-    }
-
-    /**
      * Get url Avatar
      *
      * @return string
@@ -309,7 +283,8 @@ class User extends Authenticatable implements HasMedia
     public function getAvatar()
     {
         $media = $this->getMedia(self::COLLECTION_PROFILE);
-        $url = $media->last()->getFullUrl();
+        $lastUpload = $media->last();
+        $url = $lastUpload ? $lastUpload->getFullUrl() : null;
         return $url;
     }
 

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -284,7 +284,7 @@ class User extends Authenticatable implements HasMedia
     {
         $media = $this->getMedia(self::COLLECTION_PROFILE);
         $lastUpload = $media->last();
-        $url = $lastUpload ? $lastUpload->getFullUrl() : null;
+        $url = $lastUpload ? $lastUpload->getFullUrl() : "";
         return $url;
     }
 

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -308,12 +308,8 @@ class User extends Authenticatable implements HasMedia
      */
     public function getAvatar()
     {
-        $mediaFile = $this->getMedia(self::COLLECTION_PROFILE);
-        $url = '';
-        foreach ($mediaFile as $media) {
-            $url = $media->getFullUrl();
-        }
-
+        $media = $this->getMedia(self::COLLECTION_PROFILE);
+        $url = $media->last()->getFullUrl();
         return $url;
     }
 

--- a/database/migrations/2023_05_03_131855_add_avatar_to_users_table.php
+++ b/database/migrations/2023_05_03_131855_add_avatar_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAvatarToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('avatar')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('avatar');
+        });
+    }
+}

--- a/database/migrations/2023_05_03_131855_add_avatar_to_users_table.php
+++ b/database/migrations/2023_05_03_131855_add_avatar_to_users_table.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 
 class AddAvatarToUsersTable extends Migration
@@ -16,6 +18,14 @@ class AddAvatarToUsersTable extends Migration
         Schema::table('users', function (Blueprint $table) {
             $table->string('avatar')->nullable();
         });
+
+        // Call the Artisan command to populate the avatar column
+        try {
+            Artisan::call('users:populate-avatar');
+        } catch (Exception $e) {
+            // Log the error message and continue with the migration
+            Log::error('Error populating avatar column: ' . $e->getMessage());
+        }
     }
 
     /**

--- a/database/migrations/2023_05_03_131855_add_avatar_to_users_table.php
+++ b/database/migrations/2023_05_03_131855_add_avatar_to_users_table.php
@@ -2,8 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 
 class AddAvatarToUsersTable extends Migration
@@ -18,14 +16,6 @@ class AddAvatarToUsersTable extends Migration
         Schema::table('users', function (Blueprint $table) {
             $table->string('avatar')->nullable();
         });
-
-        // Call the Artisan command to populate the avatar column
-        try {
-            Artisan::call('users:populate-avatar');
-        } catch (Exception $e) {
-            // Log the error message and continue with the migration
-            Log::error('Error populating avatar column: ' . $e->getMessage());
-        }
     }
 
     /**

--- a/upgrades/2023_05_03_131855_add_avatar_to_users_table.php
+++ b/upgrades/2023_05_03_131855_add_avatar_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class AddAvatarToUsersTable extends Upgrade
+{
+    public $to = '4.6.0-RC6';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Artisan::call('users:populate-avatar');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
208 duplicate queries; not huge savings but unnecessary DB load If don't need avatar on every API query, don't append it
User:129

## Solution
- Convert `avatar` into a real column with URL of the avatar to avoid the query that constantly gets the avatar for each user every time an User is loaded.
- This URL is updated when the User profile is updated

## How to Test
- Download the branch with the change.
- Run the migrations
- Run the artisan command `php artisan users:populate-avatar`
- Test the Process Maker User Avatars, changing avatars, see the proper avatar is displayed in each place:
  - List of Processes
  - List of requests
  - Filters
  - Open Request
  - Open Task
  - Participants in Saved Searches

## Important step for CloudOps
- Run the migrations to add the avatar column
- Run the artisan command `php artisan users:populate-avatar` to populate with the current avatar URLs

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8342

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
