### PR TITLE
Fix 'API Failed' flash on Task List load

### DIFF
--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -325,11 +325,6 @@ export default {
 
     fetch() {
         Vue.nextTick(() => {
-            if (this.cancelToken) {
-              this.cancelToken();
-              this.cancelToken = null;
-            }
-            const CancelToken = ProcessMaker.apiClient.CancelToken;
 
             let pmql = '';
 
@@ -378,12 +373,7 @@ export default {
                   this.perPage +
                   filterParams +
                   this.getSortParam() +
-                  "&non_system=true",
-                {
-                  cancelToken: new CancelToken(c => {
-                    this.cancelToken = c;
-                  })
-                }
+                  "&non_system=true"
               )
               .then(response => {
                 this.data = this.transform(response.data);
@@ -392,9 +382,6 @@ export default {
                 }
               })
               .catch(error => {
-                if (error.code === "ERR_CANCELED") {
-                  return;
-                }
                 window.ProcessMaker.alert(error.response.data.message, "danger");
                 this.data = [];
               });


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket: [FOUR-8362](https://processmaker.atlassian.net/browse/FOUR-8362)

When loading the Task Listing page the Sorry, API Failed message flashes. This is due to an axios `ERR_CANCEL` being emitted. The Task List page was catching this error and displaying the Sorry API failed message even though the data was loaded successfully. The solution is to remove this catch and reference from the task listing.

**To Replicate:**
1. Load the task listing page

## How to Test
Load the task listing page

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8362]: https://processmaker.atlassian.net/browse/FOUR-8362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ