### PR TITLE
Check if user exists before adding dependent

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -35,7 +35,9 @@ class ProcessExporter extends ExporterBase
 
         $this->manager = resolve(ExportManager::class);
 
-        $this->addDependent('user', $process->user, UserExporter::class);
+        if ($process->user) {
+            $this->addDependent('user', $process->user, UserExporter::class);
+        }
 
         if ($process->manager) {
             $this->addDependent('manager', $process->manager, UserExporter::class, null, ['properties']);


### PR DESCRIPTION
## Issue & Reproduction Steps
See steps in Jira ticket.

## Solution
A process that was imported may not have a user associated with it. Check if the user exists first before exporting.

## How to Test
- Import Process_ SImple only Task 4.5.0.json from the Jira ticket
- Try to export it

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8429

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
