### PR TITLE
FOUR-8430 - Trigger save event on Script Editor focusout

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
+++ b/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
@@ -28,7 +28,6 @@
       centered
       :title="$t('Script Config Editor')"
       header-close-content="&times;"
-      @hide="handleHide"
     >
       <div class="editor-container">
         <monaco-editor
@@ -36,6 +35,7 @@
           :options="monacoLargeOptions"
           language="json"
           class="editor"
+          @focusout.native="handleBlur"
         />
       </div>
       <div slot="modal-footer">
@@ -84,7 +84,7 @@ export default {
     closePopup() {
       this.showPopup = false;
     },
-    handleHide() {
+    handleBlur() {
       // Update the undoStack when the modal is hidden to trigger the autosave.
       const child = this.$root.$children.find((c) => c.$refs.modeler);
       child.$refs.modeler.pushToUndoStack();


### PR DESCRIPTION
## Issue & Reproduction Steps
The Script Editor should trigger the event to save when it loses focus and not when the Modal is closed.

1. Add a script task:
2. Open the script editor in a Modal.
3. Add some text.
4. Click anywhere on the screen outside the Script Editor to trigger the focusout event.
5. Currently, the focusout event does not trigger in the Editor within a modal.

## Solution
- Added the focusout.native to trigger the autosave event in the Script Editor within a modal.
- Removed the previous behavior, when the Modal was closed.

https://user-images.githubusercontent.com/90741874/236058217-29be4a73-0864-4163-8a62-9f75e1ad9b6d.mov

## How to Test
- Follow the steps of above.

## Related Tickets & Packages
- [FOUR-8430](https://processmaker.atlassian.net/browse/FOUR-8430)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8430]: https://processmaker.atlassian.net/browse/FOUR-8430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ