### PR TITLE
FOUR-8446 - Trigger autosave when clicking Close

### DIFF
--- a/resources/js/leave-warning.js
+++ b/resources/js/leave-warning.js
@@ -14,7 +14,7 @@ if (window.ProcessMaker) {
   EventBus.$on("new-changes", () => { noUnsavedChanges = false; });
 }
 
-window.addEventListener("beforeunload", (event) => {
+const showLeaveWarning = (event) => {
   if (isTimedOut || noUnsavedChanges) {
     return;
   }
@@ -22,6 +22,8 @@ window.addEventListener("beforeunload", (event) => {
   event.preventDefault();
   const confirmationMessage = __("Are you sure you want to leave?");
   event.returnValue = confirmationMessage; // Gecko, Trident, Chrome 34+
+};
 
-  return confirmationMessage;
-});
+window.addEventListener("beforeunload", showLeaveWarning);
+
+export { showLeaveWarning };

--- a/resources/js/modules/autosave/autosaveMixin.js
+++ b/resources/js/modules/autosave/autosaveMixin.js
@@ -1,0 +1,30 @@
+export default {
+  data() {
+    return {
+      debounceTimeout: null,
+    };
+  },
+  methods: {
+    async handleAutosave(force = false) {
+      if (this.isVersionsInstalled === false) {
+        return;
+      }
+
+      if (typeof this.autosaveApiCall !== "function") {
+        return;
+      }
+
+      if (force) {
+        this.autosaveApiCall();
+      } else {
+        if (this.debounceTimeout) {
+          clearTimeout(this.debounceTimeout);
+        }
+
+        this.debounceTimeout = setTimeout(() => {
+          this.autosaveApiCall();
+        }, this.autoSaveDelay);
+      }
+    },
+  },
+};

--- a/resources/js/modules/autosave/closeMixin.js
+++ b/resources/js/modules/autosave/closeMixin.js
@@ -1,0 +1,18 @@
+import { showLeaveWarning } from "../../leave-warning";
+
+export default {
+  methods: {
+    onClose() {
+      window.removeEventListener("beforeunload", showLeaveWarning);
+      const href = this.closeHref || "/";
+      const forceAutosave = true;
+      this.handleAutosave(forceAutosave)
+        .then(() => {
+          window.location.href = href;
+        })
+        .catch(() => {
+          window.addEventListener("beforeunload", showLeaveWarning);
+        });
+    },
+  },
+};

--- a/resources/js/modules/autosave/mixins.js
+++ b/resources/js/modules/autosave/mixins.js
@@ -1,0 +1,6 @@
+import CloseMixin from "./closeMixin";
+import AutosaveMixin from "./autosaveMixin";
+
+const mixins = [CloseMixin, AutosaveMixin];
+
+export default mixins;

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -54,7 +54,7 @@
 <script>
 import { Modeler, ValidationStatus } from "@processmaker/modeler";
 import CreateTemplateModal from "../../../components/templates/CreateTemplateModal.vue";
-import { showLeaveWarning } from "../../../leave-warning";
+import autosaveMixins from "../../../modules/autosave/mixins";
 
 export default {
   name: "ModelerApp",
@@ -63,6 +63,7 @@ export default {
     ValidationStatus,
     CreateTemplateModal,
   },
+  mixins: [...autosaveMixins],
   data() {
     return {
       self: this,
@@ -83,7 +84,49 @@ export default {
       processName: window.ProcessMaker.modeler.process.name,
       processId: window.ProcessMaker.modeler.process.id,
       currentUserId: window.ProcessMaker.modeler.process.user_id,
+      closeHref: "/processes",
     };
+  },
+  computed: {
+    autosaveApiCall() {
+      return async () => {
+        const svg = document.querySelector(".mini-paper svg");
+        const css = "text { font-family: sans-serif; }";
+        const style = document.createElement("style");
+        style.textContent = css;
+        svg.appendChild(style);
+        const svgString = new XMLSerializer().serializeToString(svg);
+        const xml = await this.$refs.modeler.getXmlFromDiagram();
+
+        this.setLoadingState(true);
+        ProcessMaker.apiClient.put(`/processes/${this.process.id}/draft`, {
+          name: this.process.name,
+          description: this.process.description,
+          task_notifications: this.getTaskNotifications(),
+          bpmn: xml,
+          svg: svgString,
+        })
+          .then((response) => {
+            this.process.updated_at = response.data.updated_at;
+            window.ProcessMaker.EventBus.$emit("save-changes");
+            this.$set(this, "warnings", response.data.warnings || []);
+            if (response.data.warnings && response.data.warnings.length > 0) {
+              this.$refs.validationStatus.autoValidate = true;
+            }
+            // Set draft status.
+            this.setVersionIndicator(true);
+          })
+          .catch((error) => {
+            if (error.response) {
+              const { message } = error.response.data;
+              ProcessMaker.alert(message, "danger");
+            }
+          })
+          .finally(() => {
+            this.setLoadingState(false);
+          });
+      };
+    },
   },
   watch: {
     validationErrors: {
@@ -173,15 +216,6 @@ export default {
       }
       window.ProcessMaker.EventBus.$emit("modeler-save");
     },
-    onClose() {
-      window.removeEventListener("beforeunload", showLeaveWarning);
-      const forceAutosave = true;
-      this.handleAutosave(forceAutosave).then(() => {
-        window.location.href = "/processes";
-      }).catch(() => {
-        window.addEventListener("beforeunload", showLeaveWarning);
-      });
-    },
     emitDiscardEvent() {
       if (this.externalEmit.includes("open-versions-discard-modal")) {
         window.ProcessMaker.EventBus.$emit("open-versions-discard-modal");
@@ -237,61 +271,6 @@ export default {
       ProcessMaker.apiClient.put(`/processes/${this.process.id}`, data)
         .then(savedSuccessfully)
         .catch(saveFailed);
-    },
-    async handleAutosave(force = false) {
-      if (this.isVersionsInstalled === false) {
-        return;
-      }
-
-      const svg = document.querySelector(".mini-paper svg");
-      const css = "text { font-family: sans-serif; }";
-      const style = document.createElement("style");
-      style.textContent = css;
-      svg.appendChild(style);
-      const svgString = new XMLSerializer().serializeToString(svg);
-      const xml = await this.$refs.modeler.getXmlFromDiagram();
-
-      const apiCall = () => {
-        this.setLoadingState(true);
-        ProcessMaker.apiClient.put(`/processes/${this.process.id}/draft`, {
-          name: this.process.name,
-          description: this.process.description,
-          task_notifications: this.getTaskNotifications(),
-          bpmn: xml,
-          svg: svgString,
-        })
-          .then((response) => {
-            this.process.updated_at = response.data.updated_at;
-            window.ProcessMaker.EventBus.$emit("save-changes");
-            this.$set(this, "warnings", response.data.warnings || []);
-            if (response.data.warnings && response.data.warnings.length > 0) {
-              this.$refs.validationStatus.autoValidate = true;
-            }
-            // Set draft status.
-            this.setVersionIndicator(true);
-          })
-          .catch((error) => {
-            if (error.response) {
-              const { message } = error.response.data;
-              ProcessMaker.alert(message, "danger");
-            }
-          })
-          .finally(() => {
-            this.setLoadingState(false);
-          });
-      };
-
-      if (force) {
-        apiCall();
-      } else {
-        if (this.debounceTimeout) {
-          clearTimeout(this.debounceTimeout);
-        }
-
-        this.debounceTimeout = setTimeout(() => {
-          apiCall();
-        }, this.autoSaveDelay);
-      }
     },
     setVersionIndicator(isDraft = null) {
       if (this.isVersionsInstalled) {

--- a/resources/views/processes/scripts/builder.blade.php
+++ b/resources/views/processes/scripts/builder.blade.php
@@ -44,6 +44,7 @@
 @endsection
 
 @section('js')
+  <script src="{{mix('js/leave-warning.js')}}"></script>
   @foreach ($manager->getScripts() as $script)
     <script src="{{ $script }}"></script>
   @endforeach


### PR DESCRIPTION
## Issue & Reproduction Steps
When there are changes and the Close button is clicked displays a popup alert that prevents it from closing. 

1. Drag any element into modeler, screen designer, scripts builder or make any change.
2. Click close before the 5 seconds autosave delay.

**Expected behavior**:
When the Close button is clicked, it should auto-save and then redirect without showing the alert popup.

## Solution
- When the Close button is clicked, the leave warning is disabled, autosave is executed, and then redirect is performed.

NOTES for other future scenarios:
- It may be challenging to implement the same behavior when clicking on an href link such as "Designer, Admin, Request, etc." because the browser immediately aborts the axios call (or maybe I just followed a bad approach :).  
- Immediate Autosaving was not attempted when the browser or tab is closed. The behavior will be the same as showing the leave-warning.

https://user-images.githubusercontent.com/90741874/236352603-7ebae8ca-7699-4445-a538-783386d556c6.mov

## How to Test
Follow the steps of above.

## Related Tickets & Packages
- [FOUR-8446](https://processmaker.atlassian.net/browse/FOUR-8446)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8446]: https://processmaker.atlassian.net/browse/FOUR-8446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy