### PR TITLE
Refactor package installation command logic

### DIFF
--- a/ProcessMaker/Console/PackageInstallCommand.php
+++ b/ProcessMaker/Console/PackageInstallCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace ProcessMaker\Console;
+
+use Illuminate\Console\Command;
+
+abstract class PackageInstallCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = '';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '';
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->addOption('preinstall', null, null, 'Run preinstall tasks')
+            ->addOption('install', null, null, 'Run install tasks')
+            ->addOption('postinstall', null, null, 'Run postinstall tasks');
+    }
+
+    /**
+     * Preinstall Tasks. This method will be executed before install() method.
+     *
+     * This method must execute task that not required database connection like publish assets, copy files, etc.
+     * @return void
+     */
+    abstract protected function preinstall();
+
+    /**
+     * Install Tasks. This method will be executed after preinstall() method and before postinstall() method.
+     *
+     * This method must execute task that required database connection like migrations, upgrade tasks etc.
+     * Avoid to include tasks that could require external services like API calls, or trigger events and jobs
+     */
+    abstract protected function install();
+
+    /**
+     * Postinstall Tasks. This method will be executed after install() method.
+     *
+     * This method must execute tasks that required database connections, API calls or trigger events and jobs.
+     */
+    abstract protected function postinstall();
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if ($this->isFullInstall()) {
+            $this->preinstall();
+            $this->install();
+            $this->postinstall();
+
+            return;
+        }
+        if ($this->option('preinstall')) {
+            $this->preinstall();
+        }
+        if ($this->option('install')) {
+            $this->install();
+        }
+        if ($this->option('postinstall')) {
+            $this->postinstall();
+        }
+    }
+
+    /**
+     * Determine if the command is a full install.
+     * @return bool
+     */
+    private function isFullInstall()
+    {
+        $options = ['preinstall', 'install', 'postinstall'];
+
+        return !array_sum(array_map(function ($option) {
+            return $this->option($option) ? 1 : 0;
+        }, $options));
+    }
+}

--- a/tests/Feature/Console/PackageInstallCommandTest.php
+++ b/tests/Feature/Console/PackageInstallCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+class PackageInstallCommandTest extends TestCase
+{
+    public function setUp() : void
+    {
+        parent::setUp();
+        $this->app->register(TestPackage\TestPackageServiceProvider::class);
+    }
+
+    public function testFullInstall()
+    {
+        $this->artisan('processmaker:test-package-install')
+            ->expectsOutput('PreInstall')
+            ->expectsOutput('Install')
+            ->expectsOutput('PostInstall')
+            ->assertExitCode(0);
+    }
+
+    public function testOptionPreinstall()
+    {
+        $this->artisan('processmaker:test-package-install --preinstall')
+            ->expectsOutput('PreInstall')
+            ->assertExitCode(0);
+    }
+
+    public function testOptionInstall()
+    {
+        $this->artisan('processmaker:test-package-install --install')
+            ->expectsOutput('Install')
+            ->assertExitCode(0);
+    }
+
+    public function testOptionPostinstall()
+    {
+        $this->artisan('processmaker:test-package-install --postinstall')
+            ->expectsOutput('PostInstall')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/Console/TestPackage/TestPackageInstallCommand.php
+++ b/tests/Feature/Console/TestPackage/TestPackageInstallCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Console\TestPackage;
+
+use ProcessMaker\Console\PackageInstallCommand;
+
+class TestPackageInstallCommand extends PackageInstallCommand
+{
+    protected $signature = 'processmaker:test-package-install';
+
+    protected $description = 'Test Package Install Logic';
+
+    public function preinstall()
+    {
+        $this->info('PreInstall');
+    }
+
+    public function install()
+    {
+        $this->info('Install');
+    }
+
+    public function postinstall()
+    {
+        $this->info('PostInstall');
+    }
+}

--- a/tests/Feature/Console/TestPackage/TestPackageServiceProvider.php
+++ b/tests/Feature/Console/TestPackage/TestPackageServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Feature\Console\TestPackage;
+
+class TestPackageServiceProvider extends \Illuminate\Support\ServiceProvider
+{
+    public function register()
+    {
+        $this->commands([
+            TestPackageInstallCommand::class,
+        ]);
+    }
+}


### PR DESCRIPTION
## Description
This PR includes a new abstract class to be used by all enterprise and custom packages.

Abstract Class includes 3 install stages that will be used to separate logic at instalation time.

Stages:
1. Preinstall - Must include all tasks where database connection is not required. ie. publish assets.
2. Install - Must include tasks requiring database connection like  migrations, upgrades, etc. where are not triggering events or jobs
3. Postinstall - Must include tasks where events and jobs are involving.

## Usage
After apply the refactor (split the install logic in different stages) on the enterprise or custom packages, the install command  will remain working as expected. However the install command will have new options injected automaticate to execute separately the different stages on demand, this behavior is required for STM image building and serverless environments

Example: package-test-new-installer
- `php artisan package-test-new-installer:install` will execute all stages at once.
- `php artisan package-test-new-installer:install --preinstall` will execute only the preinstall stage
- `php artisan package-test-new-installer:install --install --postinstall` will execute the install and postinstall stages.

## How to Test
PR includes a test unit proving the command extension.

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
