### PR TITLE
Bugfix/FOUR-8447: Error to export process Empty

### DIFF
--- a/ProcessMaker/Exception/ExportEmptyProcessException.php
+++ b/ProcessMaker/Exception/ExportEmptyProcessException.php
@@ -6,8 +6,27 @@ use Exception;
 
 class ExportEmptyProcessException extends Exception
 {
-    public function __construct(Exception $e)
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report()
     {
-        parent::__construct('The process to export is empty.');
     }
+
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        return response()->json([
+            'message' => __('The process to export is empty.'),
+            'exception' => 'ProcessMaker\\Exception\\ExportEmptyProcessException'
+        ], 500);
+    }
+    
 }

--- a/ProcessMaker/Exception/ExportEmptyProcessException.php
+++ b/ProcessMaker/Exception/ExportEmptyProcessException.php
@@ -25,8 +25,7 @@ class ExportEmptyProcessException extends Exception
     {
         return response()->json([
             'message' => __('The process to export is empty.'),
-            'exception' => 'ProcessMaker\\Exception\\ExportEmptyProcessException'
+            'exception' => 'ProcessMaker\\Exception\\ExportEmptyProcessException',
         ], 500);
     }
-    
 }

--- a/ProcessMaker/ImportExport/Utils.php
+++ b/ProcessMaker/ImportExport/Utils.php
@@ -47,7 +47,7 @@ class Utils
             return $xpath->query($path);
         } catch (Exception $e) {
             if ($e->getMessage() === 'DOMXPath::query(): Undefined namespace prefix') {
-                throw new ExportEmptyProcessException($e);
+                throw new ExportEmptyProcessException;
             }
             throw $e;
         }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -840,6 +840,7 @@
   "The page you are looking for could not be found": "The page you are looking for could not be found",
   "The placeholder is what is shown in the field when no value is provided yet": "The placeholder is what is shown in the field when no value is provided yet",
   "The process name must be unique.": "The process name must be unique.",
+  "The process to export is empty.": "The process to export is empty.",
   "The process was archived.": "The process was archived.",
   "The process was created.": "The process was created.",
   "The process was exported.": "The process was exported.",


### PR DESCRIPTION
## Issue & Reproduction Steps
Please refer to: https://processmaker.atlassian.net/browse/FOUR-8447

## Solution
- Show a friendly message to the user.

## How to Test
- Create an empty process or add some elements and delete all of them.
- Go to Processes list and try to export it

You should see a friendly error message: 'Error: The process to export is empty.'

## Related Tickets & Packages
- [FOUR-8447](https://processmaker.atlassian.net/browse/FOUR-8447)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
