### PR TITLE
FOUR-8608 | Photo/Video Control Is Shown Running in the Form Tab

### DIFF
--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -21,7 +21,7 @@
       </button>
     </div>
     <div v-for="page in printablePages" :key="page" class="card">
-      <div class="card-body h-100" style="pointer-events: none;">
+      <div class="card-body h-100" :style="styles">
         <component
           ref="print"
           :is="component"
@@ -85,6 +85,8 @@
         variant: 'transparent',
         opacity: 0.85,
         blur: '2px',
+        isPhotoVideo: false,
+        styles: '',
       }
     },
     computed: {
@@ -177,8 +179,11 @@
       disableForm(json) {
         if (json instanceof Array) {
           for (let i = json.length - 1; i >= 0; i--) {
-            if (json[i].component === 'FormButton' || json[i].component === 'FileUpload' || json[i].component === 'PhotoVideo') {
+            if (json[i].component === 'FormButton' || json[i].component === 'FileUpload') {
               json.splice(i, 1);
+            } else if (json[i].component === 'PhotoVideo') {
+              json.splice(i, 1);
+              this.isPhotoVideo === true;
             } else {
               this.disableForm(json[i]);
             }
@@ -209,6 +214,9 @@
         handler() {
           this.loadPages();
         }
+      },
+      isPhotoVideo() {
+        this.styles = this.isPhotoVideo ? 'pointer-events : all' : 'pointer-events : none';
       }
     }
   }

--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -177,7 +177,7 @@
       disableForm(json) {
         if (json instanceof Array) {
           for (let i = json.length - 1; i >= 0; i--) {
-            if (json[i].component === 'FormButton' || json[i].component === 'FileUpload') {
+            if (json[i].component === 'FormButton' || json[i].component === 'FileUpload' || json[i].component === 'PhotoVideo') {
               json.splice(i, 1);
             } else {
               this.disableForm(json[i]);


### PR DESCRIPTION
# Issue
Ticket: [FOUR-8608](https://processmaker.atlassian.net/browse/FOUR-8608)

In the Forms tab of the Request details, the Photo/Video control is live. The camera is on and you are able to record a video or take a picture.

# Solution
Remove the Photo/Video control when in the Forms tab, similarly to how the File Upload control is removed.

# Steps to Reproduce
1. Log in to ProcessMaker.
2. Create a new Screen with a Photo/Video control. Configure the Control.
3. Add the Screen to a Process and start a new Request of the Process.
4. Complete the Process, open the Request, and go to the Forms tab.

# How to Test
1. Go to branch `observation/FOUR-8608` in core.
2. Install `package-photo-video`.
3. Follow the Steps to Reproduce.
4. The Photo/Video control should not show in the Forms tab of the Request details.

# Related Tickets & Packages
- [FOUR-8179](https://processmaker.atlassian.net/browse/FOUR-8179) | Photo/Video Capture Control

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-8608]: https://processmaker.atlassian.net/browse/FOUR-8608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8179]: https://processmaker.atlassian.net/browse/FOUR-8179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ