### PR TITLE
Use mysql equals operator when matching numbers

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -151,7 +151,8 @@ class TaskController extends Controller
                     }
                 } else {
                     $key = array_search($column, $filterByFields);
-                    $query->where(is_string($key) ? $key : $column, 'like', $fieldFilter);
+                    $operator = is_numeric($fieldFilter) ? '=' : 'like';
+                    $query->where(is_string($key) ? $key : $column, $operator, $fieldFilter);
                 }
             }
         }

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -321,6 +321,39 @@ class TasksTest extends TestCase
     }
 
     /**
+     * Test filtering with string vs number
+     */
+    public function testFilteringWithStringOrNumber()
+    {
+        $request = ProcessRequest::factory()->create();
+        $process = $request->process;
+        $task = ProcessRequestToken::factory()->create([
+            'status' => 'ACTIVE',
+            'process_request_id' => $request->id,
+            'process_id' => $process->id,
+            'element_name' => 'foobar',
+        ]);
+        $anotherTask = ProcessRequestToken::factory()->create([
+            'status' => 'ACTIVE',
+            'element_name' => 'barbaz',
+        ]);
+
+        $route = route('api.' . $this->resource . '.index', ['process_id' => $process->id]);
+
+        $response = $this->apiCall('GET', $route);
+        $response->assertStatus(200);
+        $this->assertCount(1, $response->json()['data']);
+        $this->assertEquals($process->id, $response->json()['data'][0]['process_id']);
+
+        $route = route('api.' . $this->resource . '.index', ['element_name' => 'foo%']);
+
+        $response = $this->apiCall('GET', $route);
+        $response->assertStatus(200);
+        $this->assertCount(1, $response->json()['data']);
+        $this->assertEquals($process->id, $response->json()['data'][0]['process_id']);
+    }
+
+    /**
      * Test list of tokens sorting by completed_at
      */
     public function testSorting()


### PR DESCRIPTION
## Issue & Reproduction Steps
See google doc linked in https://processmaker.atlassian.net/browse/PM4EH-400

We are not using the index when querying by process id since it was using `like`. This was making API task searches very slow.

## Solution
If the searched value is number, use `=` operator instead of like

## How to Test
- It's not possible to see the performance improvements without a large data set so make sure searching by process id and element name still work as they did before the change.
- Run a process with a task
- Call the API endpoint to find the task by process ID, for example:
  - `GET http://processmaker.test/api/1.0/tasks?process_id=13`
- Call the API endpoint to find the task by element name (node name), for example:
  - `GET http://processmaker.test/api/1.0/tasks?element_name=foo%`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7979

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
