### PR TITLE
Use subquery instead of passing in list of IDs

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -699,14 +699,12 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
         $user = User::where('username', $value)->get()->first();
 
         if ($user) {
-            $tokens = ProcessRequestToken::select('process_request_id')
-                ->where('user_id', $expression->operator, $user->id)
-                ->whereIn('element_type', ['task', 'userTask', 'startEvent'])
-                ->distinct()
-                ->get();
-
-            return function ($query) use ($tokens) {
-                $query->whereIn('id', $tokens->pluck('process_request_id'));
+            return function ($query) use ($user, $expression) {
+                $query->whereIn('id', function ($subquery) use ($user, $expression) {
+                    $subquery->select('process_request_id')->from('process_request_tokens')
+                        ->where('user_id', $expression->operator, $user->id)
+                        ->whereIn('element_type', ['task', 'userTask', 'startEvent']);
+                });
             };
         } else {
             throw new PmqlMethodException('participant', 'The specified participant username does not exist.');

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -177,6 +177,32 @@ class ProcessRequestsTest extends TestCase
     }
 
     /**
+     * Test that we can filter by participant
+     */
+    public function testFilterByParticipant()
+    {
+        $participant = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $request = ProcessRequest::factory()->create(['status' => 'ACTIVE']);
+        $otherRequest = ProcessRequest::factory()->create(['status' => 'ACTIVE']);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'user_id' => $participant->id,
+        ]);
+
+        $otherToken = ProcessRequestToken::factory()->create([
+            'process_request_id' => $otherRequest->id,
+            'user_id' => $otherUser->id,
+        ]);
+
+        $response = $this->apiCall('GET', self::API_TEST_URL, ['pmql' => "participant = \"{$participant->username}\""]);
+        $this->assertEquals(1, $response->json()['meta']['total']);
+        $this->assertEquals($request->id, $response->json()['data'][0]['id']);
+    }
+
+    /**
      * Test that paged values are returned as expected
      */
     public function testWithPagination()


### PR DESCRIPTION
## Issue & Reproduction Steps
See google doc linked in https://processmaker.atlassian.net/browse/PM4EH-400

We are passing a list of IDs to a `whereIn`. This causes performance issues when there are lots of IDs.

## Solution
- Change it to a subquery

## How to Test
- It's not possible to see the performance improvements without a large data set so make sure searching with PMQL participant continues to work as expected.
- Create a process with a task, assign the task to a user
- Run the process
- On the requests page, verify using the PMQL `participant = "username"` returns the request

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7978

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
