### PR TITLE
Store all changes for internal use

### DIFF
--- a/ProcessMaker/Contracts/SecurityLogEventInterface.php
+++ b/ProcessMaker/Contracts/SecurityLogEventInterface.php
@@ -6,5 +6,7 @@ interface SecurityLogEventInterface
 {
     public function getData(): array;
 
+    public function getChanges(): array;
+
     public function getEventName(): string;
 }

--- a/ProcessMaker/Events/SettingsUpdated.php
+++ b/ProcessMaker/Events/SettingsUpdated.php
@@ -29,6 +29,11 @@ class SettingsUpdated implements SecurityLogEventInterface
         $this->original = $original;
     }
 
+    public function getChanges(): array
+    {
+        return $this->changes;
+    }
+
     public function getData(): array
     {
         return array_merge([

--- a/ProcessMaker/Listeners/SecurityLogger.php
+++ b/ProcessMaker/Listeners/SecurityLogger.php
@@ -28,12 +28,14 @@ class SecurityLogger
 
         if ($event instanceof SecurityLogEventInterface) {
             $data = $event->getData();
+            $changes = $event->getChanges();
             SecurityLog::create([
                 'event' => $event->getEventName(),
                 'ip' => request()->ip(),
                 'meta' => $this->getMeta(),
                 'user_id' => isset($event->user) ? $event->user->id : Auth::id(),
-                'data' => $data ? SensitiveDataHelper::parseArray($data) : null
+                'data' => $data ? SensitiveDataHelper::parseArray($data) : null,
+                'changes' => $changes ? SensitiveDataHelper::parseArray($changes) : null
             ]);
         } elseif (array_key_exists($class, $this->eventTypes)) {
             $eventType = $this->eventTypes[$class];

--- a/ProcessMaker/Models/SecurityLog.php
+++ b/ProcessMaker/Models/SecurityLog.php
@@ -63,8 +63,16 @@ class SecurityLog extends ProcessMakerModel
      */
     protected $casts = [
         'data' => 'object',
+        'changes' => 'object',
         'meta' => 'object',
     ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = ['changes'];
 
     /**
      * Get the associated user, if any.
@@ -122,6 +130,7 @@ class SecurityLog extends ProcessMakerModel
             'user_id' => ['required', 'int'],
             'occurred_at' => ['required', 'int'],
             'data' => ['nullable', 'array'],
+            'changes' => ['nullable', 'array'],
         ];
     }
 }

--- a/ProcessMaker/Traits/FormatSecurityLogChanges.php
+++ b/ProcessMaker/Traits/FormatSecurityLogChanges.php
@@ -6,6 +6,8 @@ trait FormatSecurityLogChanges
 {
     public function formatChanges(array $changes, array $original)
     {
+        unset($changes['updated_at']);
+        unset($original['updated_at']);
         //return $changes;
         $formatted = [];
         foreach ($changes as $key => $newValue) {

--- a/database/migrations/2023_05_22_161025_add_changes_column_to_security_logs_table.php
+++ b/database/migrations/2023_05_22_161025_add_changes_column_to_security_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddChangesColumnToSecurityLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('security_logs', function (Blueprint $table) {
+            $table->json('changes')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('security_logs', function (Blueprint $table) {
+            $table->dropColumn('changes');
+        });
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
All changes must be stored but only some fields must be displayed in the front end.

## Solution
- Create a column for unique storage of all changes for internal use.

## Related Tickets & Packages
- [FOUR-8669](https://processmaker.atlassian.net/browse/FOUR-8669)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8669]: https://processmaker.atlassian.net/browse/FOUR-8669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ