### PR TITLE
FOUR-8228

### DIFF
--- a/ProcessMaker/Listeners/SecurityLogger.php
+++ b/ProcessMaker/Listeners/SecurityLogger.php
@@ -39,10 +39,19 @@ class SecurityLogger
             ]);
         } elseif (array_key_exists($class, $this->eventTypes)) {
             $eventType = $this->eventTypes[$class];
+            $meta = $this->getMeta();
+            $data = [
+                'ip_address' => request()->ip(),
+                'browser_name' => $meta['browser']['name'],
+                'browser_version' => $meta['browser']['version'],
+                'os_name' => $meta['os']['name'],
+                'os_version' => $meta['os']['version'],
+            ];
             SecurityLog::create([
                 'event' => $eventType,
                 'ip' => request()->ip(),
-                'meta' => $this->getMeta(),
+                'meta' => $meta,
+                'data' => $data,
                 'user_id' => isset($event->user) ? $event->user->id : null
             ]);
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
Register some events related to user activity events according to the [PRD](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3084320783/User+Activity+Logging).
The following actions/events will register in the Security Logs:

- Login
- Logout
- Attemps


## How to Test
`php vendor/phpunit/phpunit/phpunit --colors --stop-on-failure tests/Feature/Api/SecurityLogsTest.php`

## Related Tickets & Packages
- [FOUR-8228](https://processmaker.atlassian.net/browse/FOUR-8228)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

## Enviroment
ci:deploy