### PR TITLE
FOUR-8229 Log Unauthorized access attempts

### DIFF
--- a/ProcessMaker/Events/UnauthorizedAccessAttempt.php
+++ b/ProcessMaker/Events/UnauthorizedAccessAttempt.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use ProcessMaker\Contracts\SecurityLogEventInterface;
+
+class UnauthorizedAccessAttempt implements SecurityLogEventInterface
+{
+    use Dispatchable;
+
+    private array $data;
+
+    /**
+     * Create a new event instance.
+     *
+     */
+    public function __construct()
+    {
+        $this->data = [
+            'url' => [
+                'link' => url()->current(),
+                'label' => url()->current()
+            ]
+        ];
+    }
+
+    public function getChanges(): array
+    {
+        return [];
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getEventName(): string
+    {
+        return 'UnauthorizedAccessAttempt';
+    }
+}

--- a/ProcessMaker/Exception/Handler.php
+++ b/ProcessMaker/Exception/Handler.php
@@ -9,7 +9,9 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route as RouteFacade;
+use ProcessMaker\Events\UnauthorizedAccessAttempt;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
@@ -46,6 +48,11 @@ class Handler extends ExceptionHandler
             echo $exception->getMessage() . "\n";
             echo $exception->getFile() . ': Line: ' . $exception->getLine() . "\n";
             echo $exception;
+        }
+        if ($exception instanceof \Illuminate\Auth\Access\AuthorizationException) {
+            try {
+                UnauthorizedAccessAttempt::dispatch();
+            } catch (\Exception $e){}
         }
         parent::report($exception);
     }

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -36,6 +36,9 @@ class EventServiceProvider extends ServiceProvider
         'ProcessMaker\Events\SettingsUpdated' => [
             'ProcessMaker\Listeners\SecurityLogger',
         ],
+        'ProcessMaker\Events\UnauthorizedAccessAttempt' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
     ];
 
     /**

--- a/tests/Feature/Api/SecurityLogsTest.php
+++ b/tests/Feature/Api/SecurityLogsTest.php
@@ -150,8 +150,8 @@ class SecurityLogsTest extends TestCase
         ]);
         $response->assertStatus(201);
         $collection = SecurityLog::where('user_id', $this->user->id)->get();
-        $this->assertCount(1, $collection);
-        $securityLog = $collection->first();
+        $this->assertCount(2, $collection);
+        $securityLog = $collection->skip(1)->first();
         $this->assertEquals([
             'fullname' => $this->user->getAttribute('fullname')
         ], (array)$securityLog->data);


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## How to Test
- Create a user with only requests permissions
- Open the Admin Settings page `/admin/settings`

## Related Tickets & Packages
- [FOUR-8229](https://processmaker.atlassian.net/browse/FOUR-8229)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy


[FOUR-8229]: https://processmaker.atlassian.net/browse/FOUR-8229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ