### PR TITLE
FOUR-8403: Added endpoints to save user pinned BPMN elements on Modeler

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -201,6 +201,43 @@ class UserController extends Controller
 
         return new UserResource($user);
     }
+    
+    /**
+     * Return the user's pinned nodes.
+     *
+     * @param  User $user
+     * @return \Illuminate\Http\Response
+     *
+     *     @OA\Get(
+     *     path="/users/{user_id}/get_pinned_controls",
+     *     summary="Get the pinned BPMN elements of a specific user",
+     *     operationId="getPinnnedControls",
+     *     tags={"Users"},
+     *     @OA\Parameter(
+     *         description="ID of user to return the pinned nodes of",
+     *         in="path",
+     *         name="user_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="integer",
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Pinned nodes returned succesfully",
+     *         @OA\JsonContent(ref="#/components/schemas/users")
+     *     ),
+     *     @OA\Response(response=404, ref="#/components/responses/404"),
+     * )
+     */
+    public function getPinnnedControls(User $user)
+    {
+        if (!Auth::user()->can('view', $user)) {
+            throw new AuthorizationException(__('Not authorized to update this user.'));
+        }
+
+        return $user->meta['pinnedControls'];
+    }
 
     /**
      * Update a user
@@ -257,6 +294,54 @@ class UserController extends Controller
             $this->uploadAvatar($user, $request);
         }
 
+        return response([], 204);
+    }
+
+    /**
+     * Update a user's pinned BPMN elements on Modeler
+     *
+     * @param User $user
+     * @param Request $request
+     *
+     * @return ResponseFactory|Response
+     *
+     *     @OA\Put(
+     *     path="/users/{user_id}/update_pinned_controls",
+     *     summary="Update a user's pinned BPMN elements on Modeler",
+     *     operationId="updatePinnedControls",
+     *     tags={"Users"},
+     *     @OA\Parameter(
+     *         description="ID of user to return",
+     *         in="path",
+     *         name="user_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="integer",
+     *         )
+     *     ),
+     *     @OA\RequestBody(
+     *       required=true,
+     *       @OA\JsonContent(ref="#/components/schemas/usersEditable")
+     *     ),
+     *     @OA\Response(
+     *         response=204,
+     *         description="success",
+     *     ),
+     *     @OA\Response(response=404, ref="#/components/responses/404"),
+     *     @OA\Response(response=422, ref="#/components/responses/422"),
+     * )
+     */
+    public function updatePinnedControls(User $user, Request $request)
+    {
+        if (!Auth::user()->can('edit', $user)) {
+            throw new AuthorizationException(__('Not authorized to update this user.'));
+        }
+        
+        if ($request->has('pinnedNodes')) {
+            $user->meta['pinnedControls'] = $request->get('pinnedNodes');
+        }
+
+        $user->saveOrFail();
         return response([], 204);
     }
 

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -345,7 +345,7 @@ class UserController extends Controller
         }
         
         if ($request->has('pinnedNodes')) {
-            $meta = $user->meta ?? [];
+            $meta = $user->meta ? (array) $user->meta : [];
             $meta['pinnedControls'] = $request->get('pinnedNodes');
             $user->meta = $meta;
         }

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -232,12 +232,15 @@ class UserController extends Controller
      */
     public function getPinnnedControls(User $user)
     {
-        if (!Auth::user()->can('view', $user)) {
+        $user = Auth::user();
+        if (!$user->can('view', $user)) {
             throw new AuthorizationException(__('Not authorized to update this user.'));
         }
 
-        return $user->meta && array_key_exists('pinnedControls', $user->meta)
-                ? $user->meta['pinnedControls']
+        $meta = $user->meta ? (array) $user->meta : [];
+
+        return array_key_exists('pinnedControls', $meta)
+                ? $meta['pinnedControls']
                 : [];
     }
 
@@ -336,12 +339,15 @@ class UserController extends Controller
      */
     public function updatePinnedControls(User $user, Request $request)
     {
-        if (!Auth::user()->can('edit', $user)) {
+        $user = Auth::user();
+        if (!$user->can('edit', $user)) {
             throw new AuthorizationException(__('Not authorized to update this user.'));
         }
         
         if ($request->has('pinnedNodes')) {
-            $user->meta['pinnedControls'] = $request->get('pinnedNodes');
+            $meta = $user->meta ?? [];
+            $meta['pinnedControls'] = $request->get('pinnedNodes');
+            $user->meta = $meta;
         }
 
         $user->saveOrFail();

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -236,8 +236,11 @@ class UserController extends Controller
             throw new AuthorizationException(__('Not authorized to update this user.'));
         }
 
-        return $user->meta['pinnedControls'];
+        return $user->meta && array_key_exists('pinnedControls', $user->meta)
+                ? $user->meta['pinnedControls']
+                : [];
     }
+
 
     /**
      * Update a user

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -15,7 +15,6 @@
           ref="modeler"
           :owner="self"
           :decorations="decorations"
-          :testToken="testToken"
           @validate="validationErrors = $event"
           @warnings="warnings = $event"
           @saveBpmn="emitSaveEvent"
@@ -68,7 +67,6 @@ export default {
   data() {
     return {
       self: this,
-      testToken: "abc123admin",
       validationBar: [],
       external: [],
       externalEmit: [],

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -15,6 +15,7 @@
           ref="modeler"
           :owner="self"
           :decorations="decorations"
+          :testToken="testToken"
           @validate="validationErrors = $event"
           @warnings="warnings = $event"
           @saveBpmn="emitSaveEvent"
@@ -67,6 +68,7 @@ export default {
   data() {
     return {
       self: this,
+      testToken: "abc123admin",
       validationBar: [],
       external: [],
       externalEmit: [],

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,9 +39,11 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('users', [UserController::class, 'index'])->name('users.index'); // Permissions handled in the controller
     Route::get('users/{user}', [UserController::class, 'show'])->name('users.show'); // Permissions handled in the controller
     Route::get('deleted_users', [UserController::class, 'deletedUsers'])->name('users.deletedUsers')->middleware('can:view-users');
+    Route::get('users/{user}/get_pinnned_controls', [UserController::class, 'getPinnnedControls'])->name('users.getPinnnedControls'); // Permissions handled in the controller
     Route::post('users', [UserController::class, 'store'])->name('users.store')->middleware('can:create-users');
     Route::put('users/restore', [UserController::class, 'restore'])->name('users.restore')->middleware('can:create-users');
     Route::put('users/{user}', [UserController::class, 'update'])->name('users.update'); // Permissions handled in the controller
+    Route::put('users/{user}/update_pinnned_controls', [UserController::class, 'updatePinnnedControls'])->name('users.updatePinnnedControls'); // Permissions handled in the controller
     Route::delete('users/{user}', [UserController::class, 'destroy'])->name('users.destroy')->middleware('can:delete-users');
     Route::put('password/change', [ChangePasswordController::class, 'update'])->name('password.update');
     // User Groups

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,7 +43,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('users', [UserController::class, 'store'])->name('users.store')->middleware('can:create-users');
     Route::put('users/restore', [UserController::class, 'restore'])->name('users.restore')->middleware('can:create-users');
     Route::put('users/{user}', [UserController::class, 'update'])->name('users.update'); // Permissions handled in the controller
-    Route::put('users/{user}/update_pinnned_controls', [UserController::class, 'updatePinnnedControls'])->name('users.updatePinnnedControls'); // Permissions handled in the controller
+    Route::put('users/{user}/update_pinned_controls', [UserController::class, 'updatePinnedControls'])->name('users.updatePinnnedControls'); // Permissions handled in the controller
     Route::delete('users/{user}', [UserController::class, 'destroy'])->name('users.destroy')->middleware('can:delete-users');
     Route::put('password/change', [ChangePasswordController::class, 'update'])->name('password.update');
     // User Groups


### PR DESCRIPTION
## Acceptance Criteria
The user will be able to click an icon on an element slat, which would then hold that slat at the top of the element list. The user can click that icon again to allow the slat to return to its normally defined position in the element list. The user will also be able to use a search bar to search for any modeler elements in the list. The bottom elements menu will reflect the pinned elements, and all pins will be preserved on a by-user basis, with each user seeing their personalized menu of pinned elements.

## Solution
- 2 new endpoints were created on api.php to serve data to Modeler.

## How to Test
Endpoints should be able to return data.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8403
- https://github.com/ProcessMaker/modeler/pull/1566

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
