### PR TITLE
FOUR-8244: Log creation, update, publish, archive, or unarchive of a process

### DIFF
--- a/ProcessMaker/Events/EnvironmentVariablesCreated.php
+++ b/ProcessMaker/Events/EnvironmentVariablesCreated.php
@@ -50,9 +50,7 @@ class EnvironmentVariablesCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return [
-            $this->enVariable
-        ];
+        return $this->enVariable->getAttributes();
     }
 
     /**

--- a/ProcessMaker/Events/EnvironmentVariablesDeleted.php
+++ b/ProcessMaker/Events/EnvironmentVariablesDeleted.php
@@ -46,9 +46,7 @@ class EnvironmentVariablesDeleted implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return [
-            $this->enVariable
-        ];
+        return $this->enVariable->getAttributes();
     }
 
     /**

--- a/ProcessMaker/Events/EnvironmentVariablesUpdated.php
+++ b/ProcessMaker/Events/EnvironmentVariablesUpdated.php
@@ -52,9 +52,7 @@ class EnvironmentVariablesUpdated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return [
-            $this->changes
-        ];
+        return $this->enVariable->getAttributes();
     }
 
     /**

--- a/ProcessMaker/Events/GroupDeleted.php
+++ b/ProcessMaker/Events/GroupDeleted.php
@@ -35,10 +35,8 @@ class GroupDeleted implements SecurityLogEventInterface
         foreach ($this->userIds as $user) {
             $user = User::find($user['member_id']);
             $this->userMembers[] = [
-                'username' => [
-                    'label' => $user->username,
-                    'link' => route('users.edit', $user),
-                ]
+                'label' => $user->username,
+                'link' => route('users.edit', $user),
             ];
         }
         // Get information about the groups assigned in the group
@@ -46,10 +44,8 @@ class GroupDeleted implements SecurityLogEventInterface
         foreach ($this->groupIds as $group) {
             $group = Group::find($group['member_id']);
             $this->groupMembers[] = [
-                'name' => [
-                    'label' => $group->name,
-                    'link' => route('groups.edit', $group),
-                ]
+                'label' => $group->name,
+                'link' => route('groups.edit', $group),
             ];
         }
     }
@@ -63,12 +59,8 @@ class GroupDeleted implements SecurityLogEventInterface
     {
         return [
             'name' => $this->group->getAttribute('name'),
-            'user_members' => [
-                $this->userMembers
-            ],
-            'group_members' => [
-                $this->groupMembers
-            ],
+            'user_members' => $this->userMembers,
+            'group_members' => $this->groupMembers,
             'deleted_at' => Carbon::now()
         ];
     }
@@ -84,12 +76,8 @@ class GroupDeleted implements SecurityLogEventInterface
             'group_name' => [
                 $this->group
             ],
-            'user_members' => [
-                $this->userMembers
-            ],
-            'group_members' => [
-                $this->groupMembers
-            ]
+            'user_members' => $this->userMembers,
+            'group_members' => $this->groupMembers
         ];
     }
 

--- a/ProcessMaker/Events/ProcessArchived.php
+++ b/ProcessMaker/Events/ProcessArchived.php
@@ -4,23 +4,24 @@ namespace ProcessMaker\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
-use ProcessMaker\Models\Group;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
 
-class GroupCreated implements SecurityLogEventInterface
+class ProcessArchived implements SecurityLogEventInterface
 {
     use Dispatchable;
     use FormatSecurityLogChanges;
 
-    private Group $group;
+    private Process $process;
+
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct(Group $data)
+    public function __construct(Process $data)
     {
-        $this->group = $data;
+        $this->process = $data;
     }
 
     /**
@@ -32,22 +33,25 @@ class GroupCreated implements SecurityLogEventInterface
     {
         return [
             'name' => [
-                'label' => $this->group->getAttribute('name'),
-                'link' => route('groups.edit', $this->group),
+                'label' => $this->process->getAttribute('name'),
+                'link' => route('modeler.show', $this->process),
             ],
-            'description' => $this->group->getAttribute('description'),
-            'created_at' => $this->group->getAttribute('created_at'),
+            'action' => $this->process->getAttribute('status'),
+            'updated_at' => $this->process->getAttribute('updated_at'),
         ];
     }
 
     /**
-     * Get specific changes without format related to the event
+     * Get specific data related to the event
      *
      * @return array
      */
     public function getChanges(): array
     {
-        return $this->group->getAttributes();
+        return [
+            'id' => $this->process->getAttribute('id'),
+            'status' => $this->process->getAttribute('status'),
+        ];
     }
 
     /**
@@ -57,6 +61,6 @@ class GroupCreated implements SecurityLogEventInterface
      */
     public function getEventName(): string
     {
-        return 'CreatedGroup';
+        return 'ProcessArchived';
     }
 }

--- a/ProcessMaker/Events/ProcessCreated.php
+++ b/ProcessMaker/Events/ProcessCreated.php
@@ -12,29 +12,63 @@ class ProcessCreated implements SecurityLogEventInterface
 
     private Process $process;
 
+    private string $typeCreation;
+
+    public const BLANK_CREATION = 'BLANK';
+    public const TEMPLATE_CREATION = 'TEMPLATE';
+
     /**
      * Create a new event instance.
      *
      * @param Process $process
      */
-    public function __construct(Process $process)
+    public function __construct(Process $process, string $typeCreation = '')
     {
         $this->process = $process;
+        $this->typeCreation = $typeCreation;
     }
 
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
     public function getData(): array
     {
         return [
-            'Name' => $this->process->getAttribute('name'),
-            'Description' => $this->process->getAttribute('description'),
-            'Category' => $this->process->category ? $this->process->category->name : null,
-            'Process Manager' => $this->process->user ? [
+            'name' => [
+                'label' => $this->process->getAttribute('name'),
+                'link' => route('modeler.show', $this->process),
+            ],
+            'description' => $this->process->getAttribute('description'),
+            'category' => $this->process->category ? $this->process->category->name : null,
+            'process_manager' => $this->process->user ? [
                 'label' => $this->process->user->getAttribute('fullname'),
                 'link' => route('users.edit', $this->process->user),
             ] : null,
+            'method_of_creation' => $this->typeCreation,
+            'created_at' => $this->process->getAttribute('created_at'),
         ];
     }
 
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getChanges(): array
+    {
+        return array_merge(
+            ['id' => $this->process->getAttribute('id')],
+            $this->getData()
+        );
+    }
+
+    /**
+     * Get the Event name with the syntax ‘[Past-test Action] [Object]’
+     *
+     * @return string
+     */
     public function getEventName(): string
     {
         return 'ProcessCreated';

--- a/ProcessMaker/Events/ProcessPublished.php
+++ b/ProcessMaker/Events/ProcessPublished.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use ProcessMaker\Contracts\SecurityLogEventInterface;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Traits\FormatSecurityLogChanges;
+
+class ProcessPublished implements SecurityLogEventInterface
+{
+    use Dispatchable;
+    use FormatSecurityLogChanges;
+    // Currently is not required to register the following columns (related to the diagram)
+    public const REMOVE_KEYS = [
+        'bpmn',
+        'svg',
+        'start_events',
+        'self_service_tasks',
+        'signal_events',
+        'conditional_events',
+        'properties'
+    ];
+
+    private Process $process;
+
+    private array $changes;
+    private array $original;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Process $data, array $changes, array $original)
+    {
+        $this->process = $data;
+        $this->changes = array_diff_key($changes, array_flip($this::REMOVE_KEYS));
+        $this->original = array_diff_key($original, array_flip($this::REMOVE_KEYS));
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getData(): array
+    {
+        return array_merge([
+            'name' => [
+                'label' => $this->process->getAttribute('name'),
+                'link' => route('modeler.show', $this->process),
+            ],
+            'category' => $this->process->category ? $this->process->category->name : null,
+            'action' => $this->process->getAttribute('status'),
+            'updated_at' => $this->process->getAttribute('updated_at'),
+        ], $this->formatChanges($this->changes, $this->original));
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getChanges(): array
+    {
+        return array_merge(
+            ['id' => $this->process->getAttribute('id')],
+            $this->getData()
+        );
+    }
+
+    /**
+     * Get the Event name with the syntax ‘[Past-test Action] [Object]’
+     *
+     * @return string
+     */
+    public function getEventName(): string
+    {
+        return 'ProcessUpdated';
+    }
+}

--- a/ProcessMaker/Events/ProcessRestored.php
+++ b/ProcessMaker/Events/ProcessRestored.php
@@ -4,23 +4,24 @@ namespace ProcessMaker\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
-use ProcessMaker\Models\Group;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
 
-class GroupCreated implements SecurityLogEventInterface
+class ProcessRestored implements SecurityLogEventInterface
 {
     use Dispatchable;
     use FormatSecurityLogChanges;
 
-    private Group $group;
+    private Process $process;
+
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct(Group $data)
+    public function __construct(Process $data)
     {
-        $this->group = $data;
+        $this->process = $data;
     }
 
     /**
@@ -32,22 +33,25 @@ class GroupCreated implements SecurityLogEventInterface
     {
         return [
             'name' => [
-                'label' => $this->group->getAttribute('name'),
-                'link' => route('groups.edit', $this->group),
+                'label' => $this->process->getAttribute('name'),
+                'link' => route('modeler.show', $this->process),
             ],
-            'description' => $this->group->getAttribute('description'),
-            'created_at' => $this->group->getAttribute('created_at'),
+            'action' => $this->process->getAttribute('status'),
+            'updated_at' => $this->process->getAttribute('updated_at'),
         ];
     }
 
     /**
-     * Get specific changes without format related to the event
+     * Get specific data related to the event
      *
      * @return array
      */
     public function getChanges(): array
     {
-        return $this->group->getAttributes();
+        return [
+            'id' => $this->process->getAttribute('id'),
+            'status' => $this->process->getAttribute('status'),
+        ];
     }
 
     /**
@@ -57,6 +61,6 @@ class GroupCreated implements SecurityLogEventInterface
      */
     public function getEventName(): string
     {
-        return 'CreatedGroup';
+        return 'ProcessRestored';
     }
 }

--- a/ProcessMaker/Events/UserCreated.php
+++ b/ProcessMaker/Events/UserCreated.php
@@ -52,9 +52,7 @@ class UserCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return [
-            $this->user->getAttributes()
-        ];
+        return $this->user->getAttributes();
     }
 
     /**

--- a/ProcessMaker/Events/UserDeleted.php
+++ b/ProcessMaker/Events/UserDeleted.php
@@ -46,9 +46,7 @@ class UserDeleted implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return [
-            $this->user->getAttributes()
-        ];
+        return $this->user->getAttributes();
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -3,8 +3,10 @@
 namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
+use ProcessMaker\Events\ProcessCreated;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\TemplateCollection;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Models\Template;
 
 class TemplateController extends Controller
@@ -116,8 +118,14 @@ class TemplateController extends Controller
     public function create(string $type, Request $request)
     {
         $request->validate(Template::rules($request->id, $this->types[$type][4]));
+        $response = $this->template->create($type, $request);
+        if (isset($response->getData()->processId) && $type === 'process') {
+            $process = Process::find($response->getData()->processId);
+            // Register the Event
+            ProcessCreated::dispatch($process, ProcessCreated::TEMPLATE_CREATION);
+        }
 
-        return $this->template->create($type, $request);
+        return $response;
     }
 
     /**

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -57,6 +57,18 @@ class EventServiceProvider extends ServiceProvider
         'ProcessMaker\Events\GroupUsersUpdated' => [
             'ProcessMaker\Listeners\SecurityLogger',
         ],
+        'ProcessMaker\Events\ProcessCreated' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
+        'ProcessMaker\Events\ProcessArchived' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
+        'ProcessMaker\Events\ProcessPublished' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
+        'ProcessMaker\Events\ProcessRestored' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
         'ProcessMaker\Events\ProcessUpdated' => [
             'ProcessMaker\Listeners\SecurityLogger',
         ],


### PR DESCRIPTION
## Issue & Reproduction Steps
Register some events related to user activity events according to the [PRD](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3084320783/User+Activity+Logging).
Related to the Log creation, update, publish, archive, or unarchive of a process

## Solution
- Improve the tickets definition

## How to Test
Needs to make the following actions:
- Create Process
- Update/Publish Process
- Archive Process
- UnArchive Process

## Related Tickets & Packages
- [FOUR-8244](https://processmaker.atlassian.net/browse/FOUR-8244)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
## Environment
ci:deploy

[FOUR-8244]: https://processmaker.atlassian.net/browse/FOUR-8244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ