### PR TITLE
SecurityLog - Mocking a response for asynchronous download - FOUR-8720

### DIFF
--- a/ProcessMaker/Events/SecurityLogDownloadJobCompleted.php
+++ b/ProcessMaker/Events/SecurityLogDownloadJobCompleted.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Models\User;
+
+class SecurityLogDownloadJobCompleted implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $user;
+    private bool $success;
+    private ?string $link;
+    private ?string $message;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param User $user
+     * @param bool $success
+     * @param string $message
+     * @param string|null $link
+     */
+    public function __construct(User $user, bool $success, string $message, string $link = null)
+    {
+        $this->user = $user;
+        $this->success = $success;
+        $this->message = $message;
+        $this->link = $link;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel("ProcessMaker.Models.User.{$this->user->id}");
+    }
+
+    /**
+     * Set the event name
+     *
+     * @return string
+     */
+    public function broadcastAs()
+    {
+        return 'SecurityLogDownloadJobCompleted';
+    }
+
+    /**
+     * Set the data to broadcast with this event
+     *
+     * @return array
+     */
+    public function broadcastWith()
+    {
+        return [
+            'success' => $this->success,
+            'message' => $this->message,
+            'link' => $this->link
+        ];
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
+++ b/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
@@ -4,12 +4,15 @@ namespace ProcessMaker\Http\Controllers\Api;
 
 use DB;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Helpers\SensitiveDataHelper;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\SecurityLogs;
+use ProcessMaker\Jobs\DownloadSecurityLog;
 use ProcessMaker\Models\SecurityLog;
+use ProcessMaker\Models\User;
 
 class SecurityLogController extends Controller
 {
@@ -132,5 +135,29 @@ class SecurityLogController extends Controller
         $securityLog->saveOrFail();
 
         return new SecurityLogs($securityLog->refresh());
+    }
+
+    private function download(Request $request, User $user = null)
+    {
+        $request->validate([
+            'format' => 'required|string|in:xml,text'
+        ]);
+        sleep(1);
+        $sessionUser = Auth::user();
+        DownloadSecurityLog::dispatch($sessionUser, $request->input('format'), $user ? $user->id : null)
+            ->delay(now()->addSeconds(5));
+        return response()->json([
+            'message' => __('The log file is being prepared and will be sent to your email as soon as it is ready.')
+        ], 200);
+    }
+
+    public function downloadForAllUsers(Request $request)
+    {
+        return $this->download($request);
+    }
+
+    public function downloadForUser(Request $request, User $user)
+    {
+        return $this->download($request, $user);
     }
 }

--- a/ProcessMaker/Jobs/DownloadSecurityLog.php
+++ b/ProcessMaker/Jobs/DownloadSecurityLog.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Events\SecurityLogDownloadJobCompleted;
+use ProcessMaker\Models\User;
+
+class DownloadSecurityLog implements ShouldQueue
+{
+    use Dispatchable,
+        InteractsWithQueue,
+        Queueable,
+        SerializesModels;
+
+    private User $user;
+    private string $format;
+    private ?int $userId;
+
+    /**
+     * @param User $user
+     * @param string $format
+     * @param int|null $userId
+     */
+    public function __construct(User $user, string $format, int $userId = null)
+    {
+        $this->user = $user;
+        $this->format = $format;
+        $this->userId = $userId;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        //1. Get all data from security_logs table
+        //2. Create a file in specified format: text or xml
+        //3. Zip this file
+        //4. Store in S3, with private visibility, with 24h of lifecycle
+        //5. Send email to user with the link or error message
+        if (mt_rand(1, 10) <= 8) {
+            event(new SecurityLogDownloadJobCompleted($this->user, true, __('Click on the link and download the file. This link will be available until midnight tonight.'), 'http://processmaker.com/?download=true'));
+        } else {
+            event (new SecurityLogDownloadJobCompleted($this->user, false, __('Sorry, it was not possible to generate the log file. Please contact the administrator.')));
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -219,6 +219,8 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     // Security logs
     Route::get('security-logs', [SecurityLogController::class, 'index'])->name('security-logs.index')->middleware('can:view-security-logs');
     Route::post('security-logs', [SecurityLogController::class, 'store'])->name('security-logs.index')->middleware('can:create-security-logs');
+    Route::get('security-logs/download/all', [SecurityLogController::class, 'downloadForAllUsers'])->name('security-logs.downloadForAllUsers')->middleware('can:view-security-logs');
+    Route::get('security-logs/download/{user}', [SecurityLogController::class, 'downloadForUser'])->name('security-logs.downloadForUser')->middleware('can:view-security-logs');
     Route::get('security-logs/{securityLog}', [SecurityLogController::class, 'show'])->name('security-logs.show')->middleware('can:view-security-logs');
 
     // Settings

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,6 +52,10 @@ Route::middleware('auth', 'sanitize', 'external.connection', 'force_change_passw
         Route::get('customize-ui/{tab?}', [CssOverrideController::class, 'edit'])->name('customize-ui.edit');
 
         Route::get('script-executors', [ScriptExecutorController::class, 'index'])->name('script-executors.index');
+
+        //temporary, should be removed
+        Route::get('security-logs/download/all', [\ProcessMaker\Http\Controllers\Api\SecurityLogController::class, 'downloadForAllUsers'])->middleware('can:view-security-logs');
+        Route::get('security-logs/download/{user}', [\ProcessMaker\Http\Controllers\Api\SecurityLogController::class, 'downloadForUser'])->middleware('can:view-security-logs');
     });
 
     Route::get('admin', [AdminController::class, 'index'])->name('admin.index');


### PR DESCRIPTION
## Issue & Reproduction Steps
This is a mock response from the asynchronous download.
The goal is to speed up frontend development.

## How to Test
1. Run `php artisan horizon` and `npx laravel-echo-server start`
2. Access the link: `/admin/security-logs/download/all?format=text`
3. In 5 seconds the frontend should receive a message in the websocket
```
0:"SecurityLogDownloadJobCompleted"
1:"private-ProcessMaker.Models.User.1"
2:{success: true|false, link:"...", message: "..."}
```

## Related Tickets & Packages
- [FOUR-8720](https://processmaker.atlassian.net/browse/FOUR-8720)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8720]: https://processmaker.atlassian.net/browse/FOUR-8720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ