### PR TITLE
FOUR-8240: Log Enabling or disabling to User Signals and LDAP

### DIFF
--- a/ProcessMaker/Events/SettingsUpdated.php
+++ b/ProcessMaker/Events/SettingsUpdated.php
@@ -9,7 +9,11 @@ use ProcessMaker\Traits\FormatSecurityLogChanges;
 
 class SettingsUpdated implements SecurityLogEventInterface
 {
-    use Dispatchable, FormatSecurityLogChanges;
+    use Dispatchable;
+    use FormatSecurityLogChanges;
+    public const SENSITIVE_KEYS = [
+        'password',
+    ];
 
     private Setting $setting;
 
@@ -27,8 +31,21 @@ class SettingsUpdated implements SecurityLogEventInterface
         $this->setting = $setting;
         $this->changes = $changes;
         $this->original = $original;
+        // Some configuration are related to the password
+        $attribute = strtolower($this->setting->getAttribute('name'));
+        if (array_keys($this::SENSITIVE_KEYS, $attribute)) {
+            $this->changes[$attribute] = $this->changes['config'];
+            $this->original[$attribute] = $this->original['config'];
+            unset($this->changes['config']);
+            unset($this->original['config']);
+        }
     }
 
+    /**
+     * Get specific changes without format related to the event
+     *
+     * @return array
+     */
     public function getChanges(): array
     {
         return array_merge([
@@ -36,14 +53,24 @@ class SettingsUpdated implements SecurityLogEventInterface
         ], $this->changes);
     }
 
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
     public function getData(): array
     {
         return array_merge([
-            'Group' => $this->setting->getAttribute('group'),
-            'Name' => $this->setting->getAttribute('name'),
+            'group' => $this->setting->getAttribute('group'),
+            'name' => $this->setting->getAttribute('name'),
         ], $this->formatChanges($this->changes, $this->original));
     }
 
+     /**
+     * Get specific changes without format related to the event
+     *
+     * @return array
+     */
     public function getEventName(): string
     {
         return 'SettingsUpdated';

--- a/ProcessMaker/Http/Controllers/Api/SettingController.php
+++ b/ProcessMaker/Http/Controllers/Api/SettingController.php
@@ -211,6 +211,7 @@ class SettingController extends Controller
         $original = array_intersect_key($setting->getOriginal(), $setting->getDirty());
         $setting->save();
 
+        // Register the Event
         SettingsUpdated::dispatch($setting, $setting->getChanges(), $original);
 
         return response([], 204);


### PR DESCRIPTION
## Issue & Reproduction Steps
Register some events related to user activity events according to the [PRD](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3084320783/User+Activity+Logging).
 Log Enabling or disabling to User Signals
## Solution
- Improve the tickets definition

## How to Test
Needs to make the following actions:
- Enabling User Signals
- Disabling User Signals

## Related Tickets & Packages
- [FOUR-8240](https://processmaker.atlassian.net/browse/FOUR-8240)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
## Enviroment
ci:deploy

[FOUR-8240]: https://processmaker.atlassian.net/browse/FOUR-8240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ