### PR TITLE
Changing the download format validation

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
+++ b/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
@@ -140,7 +140,7 @@ class SecurityLogController extends Controller
     private function download(Request $request, User $user = null)
     {
         $request->validate([
-            'format' => 'required|string|in:xml,text'
+            'format' => 'required|string|in:xml,csv'
         ]);
         sleep(1);
         $sessionUser = Auth::user();

--- a/ProcessMaker/Jobs/DownloadSecurityLog.php
+++ b/ProcessMaker/Jobs/DownloadSecurityLog.php
@@ -41,7 +41,7 @@ class DownloadSecurityLog implements ShouldQueue
     public function handle()
     {
         //1. Get all data from security_logs table
-        //2. Create a file in specified format: text or xml
+        //2. Create a file in specified format: csv or xml
         //3. Zip this file
         //4. Store in S3, with private visibility, with 24h of lifecycle
         //5. Send email to user with the link or error message


### PR DESCRIPTION
## Issue & Reproduction Steps
This is a mock response from the asynchronous download.
The goal is to speed up frontend development.

## How to Test
1. Run `php artisan horizon` and `npx laravel-echo-server start`
2. Access the link: `/admin/security-logs/download/all?format=text`
3. In 5 seconds the frontend should receive a message in the websocket
```
0:"SecurityLogDownloadJobCompleted"
1:"private-ProcessMaker.Models.User.1"
2:{success: true|false, link:"...", message: "..."}
```

## Related Tickets & Packages
- [FOUR-8720](https://processmaker.atlassian.net/browse/FOUR-8720)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8720]: https://processmaker.atlassian.net/browse/FOUR-8720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ