### PR TITLE
Add missing closing curly brace "}"

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -963,3 +963,4 @@ nav {
   display: inline-block;
   width: 400px;
 }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Missing an closing '}' at the end of the app.scss file. This is causing compile errors when running `npm run watch`

```
ERROR in ./resources/sass/app.scss
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: expected "}".
    ╷
965 │ }
    │  ^
    ╵
  resources/sass/app.scss 965:2  root stylesheet
```

## Solution
- Add missing closing curly brace '}'

## How to Test
Run `npm run watch` in your local env.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
