### PR TITLE
FOUR-8235: Create and Update to any files

### DIFF
--- a/ProcessMaker/Events/FilesCreated.php
+++ b/ProcessMaker/Events/FilesCreated.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use ProcessMaker\Contracts\SecurityLogEventInterface;
+use ProcessMaker\Models\Media;
+use ProcessMaker\Traits\FormatSecurityLogChanges;
+
+class FilesCreated implements SecurityLogEventInterface
+{
+    use Dispatchable;
+    use FormatSecurityLogChanges;
+
+    private array $media;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(int $fileId)
+    {
+        $this->media = Media::find(['id' => $fileId])->toArray();
+        $this->media = head($this->media);
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getData(): array
+    {
+        return [
+            'file_name' => [
+                'label' => $this->media['name'],
+                'link' => route('file-manager.index', ['public/' . $this->media['file_name']]),
+            ],
+            'created_at' => $this->media['created_at'],
+        ];
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getChanges(): array
+    {
+        return [
+            'id' => $this->media['id']
+        ];
+    }
+
+    /**
+     * Get the Event name
+     *
+     * @return string
+     */
+    public function getEventName(): string
+    {
+        return 'FilesCreated';
+    }
+}

--- a/ProcessMaker/Events/FilesDeleted.php
+++ b/ProcessMaker/Events/FilesDeleted.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Events\Dispatchable;
+use ProcessMaker\Contracts\SecurityLogEventInterface;
+use ProcessMaker\Traits\FormatSecurityLogChanges;
+
+class FilesDeleted implements SecurityLogEventInterface
+{
+    use Dispatchable;
+    use FormatSecurityLogChanges;
+
+    private int $fileId;
+    private string $fileName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(int $id, string $name)
+    {
+        $this->fileId = $id;
+        $this->fileName = $name;
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getData(): array
+    {
+        return [
+            'file_name' => $this->fileName,
+            'deleted_at' => Carbon::now(),
+        ];
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getChanges(): array
+    {
+        return [
+            'id' => $this->fileId
+        ];
+    }
+
+    /**
+     * Get the Event name
+     *
+     * @return string
+     */
+    public function getEventName(): string
+    {
+        return 'FilesDeleted';
+    }
+}

--- a/ProcessMaker/Events/FilesUpdated.php
+++ b/ProcessMaker/Events/FilesUpdated.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use ProcessMaker\Contracts\SecurityLogEventInterface;
+use ProcessMaker\Models\Media;
+use ProcessMaker\Traits\FormatSecurityLogChanges;
+
+class FilesUpdated implements SecurityLogEventInterface
+{
+    use Dispatchable;
+    use FormatSecurityLogChanges;
+
+    private Media $media;
+
+    private array $changes;
+    private array $original;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Media $data, array $changes, array $original)
+    {
+        $this->media = $data;
+        $this->changes = $changes;
+        $this->original = $original;
+        unset($this->changes['name']);
+        unset($this->original['name']);
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getData(): array
+    {
+        return array_merge([
+            'name' => $this->media->getAttribute('name'),
+            'updated_at' => $this->media->getAttribute('updated_at'),
+        ], $this->formatChanges($this->changes, $this->original));
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getChanges(): array
+    {
+        return [
+            'id' => $this->media->getAttribute('id')
+        ];
+    }
+
+    /**
+     * Get the Event name
+     *
+     * @return string
+     */
+    public function getEventName(): string
+    {
+        return 'FilesUpdated';
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use ProcessMaker\Events\FilesDeleted;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
@@ -338,6 +339,9 @@ class FileController extends Controller
         $model = $modelType::find($modelId);
 
         $model->deleteMedia($file->id);
+
+        // Register the Event
+        FilesDeleted::dispatch($file->id, $file->file_name);
 
         return response([], 204);
     }

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -14,6 +14,8 @@ use Pion\Laravel\ChunkUpload\Exceptions\UploadMissingFileException;
 use Pion\Laravel\ChunkUpload\Handler\AbstractHandler;
 use Pion\Laravel\ChunkUpload\Handler\HandlerFactory;
 use Pion\Laravel\ChunkUpload\Receiver\FileReceiver;
+use ProcessMaker\Events\FilesCreated;
+use ProcessMaker\Events\FilesDeleted;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
@@ -305,6 +307,9 @@ class ProcessRequestFileController extends Controller
             ])
             ->toMediaCollection();
 
+        // Register the Event
+        FilesCreated::dispatch($media->id);
+
         return new JsonResponse(['message' => 'The file was uploaded.', 'fileUploadId' => $media->id], 200);
     }
 
@@ -355,6 +360,9 @@ class ProcessRequestFileController extends Controller
         }
 
         $file->delete();
+
+        // Register the Event
+        FilesDeleted::dispatch($fileId, $file->file_name);
 
         return response([], 204);
     }

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -57,6 +57,15 @@ class EventServiceProvider extends ServiceProvider
         'ProcessMaker\Events\EnvironmentVariablesUpdated' => [
             'ProcessMaker\Listeners\SecurityLogger',
         ],
+        'ProcessMaker\Events\FilesCreated' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
+        'ProcessMaker\Events\FilesDeleted' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
+        'ProcessMaker\Events\FilesUpdated' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
         'ProcessMaker\Events\GroupCreated' => [
             'ProcessMaker\Listeners\SecurityLogger',
         ],


### PR DESCRIPTION
## Issue & Reproduction Steps
Register some events related to user activity events according to the [PRD](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3084320783/User+Activity+Logging).
Related to the Log Access to any files -> File manager

## Solution
- Improve the tickets definition

## How to Test
Needs to make the following actions:
- Create Files / Folder
- Update Files / Folder

## Related Tickets & Packages
- [FOUR-8235](https://processmaker.atlassian.net/browse/FOUR-8235)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
## enviroment
ci:deploy
ci:package-files:feature/FOUR-8235

[FOUR-8235]: https://processmaker.atlassian.net/browse/FOUR-8235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ