### PR TITLE
FOUR-8708: Object data cannot be referenced in assigment rule

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -5,9 +5,11 @@ namespace ProcessMaker\Models;
 use DOMElement;
 use Exception;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Mustache_Engine;
 use ProcessMaker\AssignmentRules\PreviousTaskAssignee;
@@ -645,8 +647,8 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         $dataManager = new DataManager();
         $instanceData = $dataManager->getData($token);
 
-        $assignedUsers = $usersVariable ? $instanceData[$usersVariable] : [];
-        $assignedGroups = $groupsVariable ? $instanceData[$groupsVariable] : [];
+        $assignedUsers = $usersVariable ? Arr::get($instanceData, $usersVariable) : [];
+        $assignedGroups = $groupsVariable ? Arr::get($instanceData, $groupsVariable) : [];
 
         if (!is_array($assignedUsers)) {
             $assignedUsers = [$assignedUsers];


### PR DESCRIPTION
## Issue & Reproduction Steps
Step 1: Create a simple script to have and object as seen below:
$banker = [
       "id"=> 3,
      "name" => "Briana Banker",
      "email" => "solutions+banker@processmaker.com",
      "bankerCoreCode" => "AMR",
      "costCenterCode" => "2000"
];
return ["banker" => $banker];

Step 2: Create a task to use the banker.id as assignment rule:
![image](https://github.com/ProcessMaker/processmaker/assets/14875032/6da8ae82-0613-4634-bc87-b967aabe50ad)

Step 3: You should have a process as shown below then test the process: 
![image](https://github.com/ProcessMaker/processmaker/assets/14875032/d369ccc9-49b0-4b40-a9b9-935d7a8f42ab)


The error below shows:
![image](https://github.com/ProcessMaker/processmaker/assets/14875032/dbe63338-084a-4ce0-8fd9-453e2c07993b)

The expected behavior is that the request will be assigned to the assigned variable banker.id

## Solution
- It was changed the way that the request data is accessed to allow dot notation
- 
## How to Test
Execute the reproduction steps again and the assignment should go to the desired user.

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-8708](https://processmaker.atlassian.net/browse/FOUR-8708)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
