### PR TITLE
FOUR-8600 Data Store Table for Saved Search

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -134,10 +134,13 @@ class ProcessRequestController extends Controller
         if (!empty($filter)) {
             $query->filter($filter);
         }
-
+        
+        $query->nonSystem();
+        
         $pmql = $request->input('pmql', '');
         if (!empty($pmql)) {
             try {
+                $query->getModel()->useDataStoreTable($query, $request->input('data_store_table', ''), $request->input('data_store_columns', []));
                 $query->pmql($pmql);
             } catch (SyntaxError $e) {
                 return response(['message' => __('Your PMQL contains invalid syntax.')], 400);
@@ -145,9 +148,6 @@ class ProcessRequestController extends Controller
                 return response(['message' => $e->getMessage(), 'field' => $e->getField()], 400);
             }
         }
-
-        $query->nonSystem();
-
         try {
             if ($getTotal === true) {
                 return $query->count();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-use Exception;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,11 +3,13 @@
 namespace Tests;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use Exception;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Bus;
+use PDOException;
 use ProcessMaker\Jobs\RefreshArtisanCaches;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestLock;
@@ -21,12 +23,15 @@ abstract class TestCase extends BaseTestCase
     use ArraySubsetAsserts;
 
     public $withPermissions = false;
+    protected $skipTeardownPDOException = false;
 
     /**
      * Run additional setUps from traits.
      */
     protected function setUp(): void
     {
+        $this->skipTeardownPDOException = false;
+
         parent::setUp();
 
         $this->disableSetContentMiddleware();
@@ -76,7 +81,13 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown(): void
     {
-        parent::tearDown();
+        try {
+            parent::tearDown();
+        } catch (PDOException $e) {
+            if (!$this->skipTeardownPDOException) {
+                throw $e;
+            }
+        }
         foreach (get_class_methods($this) as $method) {
             $imethod = strtolower($method);
             if (strpos($imethod, 'teardown') === 0 && $imethod !== 'teardown') {


### PR DESCRIPTION
## Issue & Reproduction Steps
The saved searches are using json columns to do the filtering over all the process_request table.

## Solution
- Implement a Data Store Table with the required columns of Saved Search to generate a faster query, avoinding to use json columns for filtering and to traverse all the process_requests table.

## How to Test
- Import the attached process
- Run about 1000 of requests
- Setup a Saved Search with a filter by the specific process request and some varaibles of the process.
   e.g.
   ```
   (request = "Simple Process") AND (status = "In Progress") AND (data.customer_id = 100) AND (data.account.balance > 10000) AND (data.account.balance < 100000) AND (data.transaction.date > NOW -1 day)
   ```
- Test the saved search.
- Check the response time of `/api/1.0/saved-searches/56354/results` is much faster
- Check the sql of the pqml is using the data stored table. (dev)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8600

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
