### PR TITLE
FOUR-8972

### DIFF
--- a/ProcessMaker/Events/AuthClientUpdated.php
+++ b/ProcessMaker/Events/AuthClientUpdated.php
@@ -2,13 +2,15 @@
 
 namespace ProcessMaker\Events;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
 
 class AuthClientUpdated implements SecurityLogEventInterface
 {
-    use Dispatchable, FormatSecurityLogChanges;
+    use Dispatchable;
+    use FormatSecurityLogChanges;
 
     private array $original;
     private array $data;
@@ -20,37 +22,32 @@ class AuthClientUpdated implements SecurityLogEventInterface
      *
      * @return void
      */
-    public function __construct(string $clientId, array $original_values, array $changed_values)
+    public function __construct(string $clientId, array $originalValues, array $changedValues)
     {
-        $this->original = $original_values;
-        $this->changes = $changed_values;
+        $this->original = $originalValues;
+        $this->changes = $changedValues;
         $this->clientId = $clientId;
-        $this->buildData();
     }
 
     /**
-     * Building the data
-     */
-    public function buildData() {
-        $this->data = array_merge([
-            'auth_client_id' => $this->clientId
-        ], $this->formatChanges($this->changes, $this->original));
-    }
-    
-    /**
-     * Return event data 
+     * Return event data
      */
     public function getData(): array
     {
-        return $this->data;
+        return array_merge([
+            'auth_client_id' => $this->clientId,
+            'last_modified' => $this->changes['updated_at'] ?? Carbon::now()
+        ], $this->formatChanges($this->changes, $this->original));
     }
-    
+
     /**
-     * Return event changes 
+     * Return event changes
      */
     public function getChanges(): array
     {
-        return $this->changes;
+        return [
+            'auth_client_id' => $this->clientId,
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/CategoryCreated.php
+++ b/ProcessMaker/Events/CategoryCreated.php
@@ -51,7 +51,9 @@ class CategoryCreated implements SecurityLogEventInterface
     public function getChanges(): array
     {
         return [
-            $this->category
+            'id' => $this->category->getAttribute('id'),
+            'name' => $this->category->getAttribute('name'),
+            'status' => $this->category->getAttribute('status')
         ];
     }
 

--- a/ProcessMaker/Events/CategoryUpdated.php
+++ b/ProcessMaker/Events/CategoryUpdated.php
@@ -52,7 +52,9 @@ class CategoryUpdated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return $this->formatChanges($this->changes, $this->original);
+        return [
+            'id' => $this->category->getAttribute('id')
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/CustomizeUiUpdated.php
+++ b/ProcessMaker/Events/CustomizeUiUpdated.php
@@ -8,7 +8,8 @@ use ProcessMaker\Traits\FormatSecurityLogChanges;
 
 class CustomizeUiUpdated implements SecurityLogEventInterface
 {
-    use Dispatchable, FormatSecurityLogChanges;
+    use Dispatchable;
+    use FormatSecurityLogChanges;
 
     private array $data;
     private array $changes;
@@ -28,14 +29,14 @@ class CustomizeUiUpdated implements SecurityLogEventInterface
         $original = array_intersect_key($original, $changes);
         $this->original = $original;
         $this->changes = $changes;
-        $this->changes['update_at'] = $updatedAt;
+        $this->changes['last_modified'] = $updatedAt;
         $this->buildData();
     }
 
     /**
      * Building the data
      */
-    public function buildData() 
+    public function buildData()
     {
         if (isset($this->changes['variables'])) {
             $variables_changes = [];
@@ -48,27 +49,26 @@ class CustomizeUiUpdated implements SecurityLogEventInterface
             }
             $variables_changes = array_diff($variables_changes, $variables_original);
             $variables_original = array_intersect_key($variables_original, $variables_changes);
-            
             $this->changes['variables'] = $variables_changes;
             $this->original['variables'] = $variables_original;
         }
         $this->data = $this->formatChanges($this->changes, $this->original);
     }
-    
+
     /**
-     * Return event data 
+     * Return event data
      */
     public function getData(): array
     {
         return $this->data;
     }
-    
+
     /**
-     * Return event changes 
+     * Return event changes
      */
     public function getChanges(): array
     {
-        return $this->changes;
+        return [];
     }
 
     /**

--- a/ProcessMaker/Events/EnvironmentVariablesCreated.php
+++ b/ProcessMaker/Events/EnvironmentVariablesCreated.php
@@ -13,7 +13,6 @@ class EnvironmentVariablesCreated implements SecurityLogEventInterface
     use FormatSecurityLogChanges;
 
     private EnvironmentVariable $enVariable;
-    private $variable = [];
 
     /**
      * Create a new event instance.
@@ -22,7 +21,6 @@ class EnvironmentVariablesCreated implements SecurityLogEventInterface
      */
     public function __construct(array $data)
     {
-        $this->variable = $data;
         $this->enVariable = EnvironmentVariable::where('name', $data['name'])->first();
     }
 
@@ -35,10 +33,10 @@ class EnvironmentVariablesCreated implements SecurityLogEventInterface
     {
         return [
             'name' => [
-                'label' => $this->variable['name'],
+                'label' => $this->enVariable->getAttribute('name'),
                 'link' => route('environment-variables.edit', $this->enVariable),
             ],
-            'description' => $this->variable['description'],
+            'description' => $this->enVariable->getAttribute('description'),
             'created_at' => $this->enVariable->getAttribute('created_at'),
         ];
     }
@@ -50,7 +48,9 @@ class EnvironmentVariablesCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return $this->enVariable->getAttributes();
+        return [
+            'id' => $this->enVariable->getAttribute('name')
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/EnvironmentVariablesDeleted.php
+++ b/ProcessMaker/Events/EnvironmentVariablesDeleted.php
@@ -46,7 +46,9 @@ class EnvironmentVariablesDeleted implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return $this->enVariable->getAttributes();
+        return [
+            'id' => $this->enVariable->getAttribute('id')
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/FilesUpdated.php
+++ b/ProcessMaker/Events/FilesUpdated.php
@@ -40,7 +40,7 @@ class FilesUpdated implements SecurityLogEventInterface
     {
         return array_merge([
             'name' => $this->media->getAttribute('name'),
-            'updated_at' => $this->media->getAttribute('updated_at'),
+            'last_modified' => $this->media->getAttribute('updated_at'),
         ], $this->formatChanges($this->changes, $this->original));
     }
 

--- a/ProcessMaker/Events/GroupCreated.php
+++ b/ProcessMaker/Events/GroupCreated.php
@@ -47,7 +47,9 @@ class GroupCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return $this->group->getAttributes();
+        return [
+            'id' => $this->group->getAttribute('id')
+        ];
     }
 
     /**
@@ -57,6 +59,6 @@ class GroupCreated implements SecurityLogEventInterface
      */
     public function getEventName(): string
     {
-        return 'CreatedGroup';
+        return 'GroupCreated';
     }
 }

--- a/ProcessMaker/Events/GroupUpdated.php
+++ b/ProcessMaker/Events/GroupUpdated.php
@@ -4,15 +4,15 @@ namespace ProcessMaker\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
-use ProcessMaker\Models\EnvironmentVariable;
+use ProcessMaker\Models\Group;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
 
-class EnvironmentVariablesUpdated implements SecurityLogEventInterface
+class GroupUpdated implements SecurityLogEventInterface
 {
     use Dispatchable;
     use FormatSecurityLogChanges;
 
-    private EnvironmentVariable $enVariable;
+    private Group $group;
 
     private array $changes;
     private array $original;
@@ -22,9 +22,9 @@ class EnvironmentVariablesUpdated implements SecurityLogEventInterface
      *
      * @return void
      */
-    public function __construct(EnvironmentVariable $data, array $changes, array $original)
+    public function __construct(Group $data, array $changes, array $original)
     {
-        $this->enVariable = $data;
+        $this->group = $data;
         $this->changes = $changes;
         $this->original = $original;
     }
@@ -38,10 +38,10 @@ class EnvironmentVariablesUpdated implements SecurityLogEventInterface
     {
         return array_merge([
             'name' => [
-                'label' => $this->enVariable->getAttribute('name'),
-                'link' => route('environment-variables.edit', $this->enVariable),
+                'label' => $this->group->getAttribute('name'),
+                'link' => route('groups.edit', $this->group),
             ],
-            'last_modified' => $this->enVariable->getAttribute('updated_at'),
+            'last_modified' => $this->group->getAttribute('updated_at'),
         ], $this->formatChanges($this->changes, $this->original));
     }
 
@@ -53,7 +53,7 @@ class EnvironmentVariablesUpdated implements SecurityLogEventInterface
     public function getChanges(): array
     {
         return [
-            'id' => $this->enVariable->getAttribute('id')
+            'id' => $this->group->getAttribute('id')
         ];
     }
 
@@ -64,6 +64,6 @@ class EnvironmentVariablesUpdated implements SecurityLogEventInterface
      */
     public function getEventName(): string
     {
-        return 'EnvironmentVariablesUpdated';
+        return 'GroupUpdated';
     }
 }

--- a/ProcessMaker/Events/ProcessArchived.php
+++ b/ProcessMaker/Events/ProcessArchived.php
@@ -37,7 +37,7 @@ class ProcessArchived implements SecurityLogEventInterface
                 'link' => route('modeler.show', $this->process),
             ],
             'action' => $this->process->getAttribute('status'),
-            'updated_at' => $this->process->getAttribute('updated_at'),
+            'last_modified' => $this->process->getAttribute('updated_at'),
         ];
     }
 

--- a/ProcessMaker/Events/ProcessCreated.php
+++ b/ProcessMaker/Events/ProcessCreated.php
@@ -58,10 +58,9 @@ class ProcessCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return array_merge(
-            ['id' => $this->process->getAttribute('id')],
-            $this->getData()
-        );
+        return [
+            'id' => $this->process->getAttribute('id')
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/ProcessPublished.php
+++ b/ProcessMaker/Events/ProcessPublished.php
@@ -53,7 +53,7 @@ class ProcessPublished implements SecurityLogEventInterface
             ],
             'category' => $this->process->category ? $this->process->category->name : null,
             'action' => $this->process->getAttribute('status'),
-            'updated_at' => $this->process->getAttribute('updated_at'),
+            'last_modified' => $this->process->getAttribute('updated_at'),
         ], $this->formatChanges($this->changes, $this->original));
     }
 
@@ -64,10 +64,9 @@ class ProcessPublished implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return array_merge(
-            ['id' => $this->process->getAttribute('id')],
-            $this->getData()
-        );
+        return [
+            'id' => $this->process->getAttribute('id')
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/ProcessRestored.php
+++ b/ProcessMaker/Events/ProcessRestored.php
@@ -37,7 +37,7 @@ class ProcessRestored implements SecurityLogEventInterface
                 'link' => route('modeler.show', $this->process),
             ],
             'action' => $this->process->getAttribute('status'),
-            'updated_at' => $this->process->getAttribute('updated_at'),
+            'last_modified' => $this->process->getAttribute('updated_at'),
         ];
     }
 

--- a/ProcessMaker/Events/ScreenCreated.php
+++ b/ProcessMaker/Events/ScreenCreated.php
@@ -28,10 +28,10 @@ class ScreenCreated implements SecurityLogEventInterface
     public function getData(): array
     {
         return [
-            'name' => $this->newScreen['title'],
-            'description' => $this->newScreen['description'],
-            'type' => $this->newScreen['type'],
-            'screen_category_id' => $this->newScreen['screen_category_id']
+            'name' => $this->newScreen['title'] ?? '',
+            'description' => $this->newScreen['description'] ?? '',
+            'type' => $this->newScreen['type'] ?? '',
+            'screen_category_id' => $this->newScreen['screen_category_id'] ?? ''
         ];
     }
 
@@ -42,7 +42,9 @@ class ScreenCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return $this->getData();
+        return [
+            'id' => $this->newScreen['id'] ?? '',
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/ScreenDeleted.php
+++ b/ProcessMaker/Events/ScreenDeleted.php
@@ -43,10 +43,9 @@ class ScreenDeleted implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return array_merge(
-            ['id' => $this->screen->getAttribute('id')],
-            $this->getData()
-        );
+        return [
+            'id' => $this->screen->getAttribute('id')
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/ScriptCreated.php
+++ b/ProcessMaker/Events/ScriptCreated.php
@@ -35,9 +35,9 @@ class ScriptCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return array_merge([
+        return [
             'script_id' => $this->script->id
-        ], $this->changes);
+        ];
     }
 
     /**
@@ -48,10 +48,10 @@ class ScriptCreated implements SecurityLogEventInterface
     public function getData(): array
     {
         $basic = isset($this->changes['code']) ? [
-            'Name' => $this->script->getAttribute('title'),
-            'Script Last Modified' => $this->script->getAttribute('updated_at'),
+            'name' => $this->script->getAttribute('title'),
+            'created_at' => $this->script->getAttribute('created_at'),
         ] : [
-            'Name' => $this->script->getAttribute('title'),
+            'name' => $this->script->getAttribute('title'),
         ];
         unset($this->changes['code']);
         unset($this->original['code']);

--- a/ProcessMaker/Events/ScriptDeleted.php
+++ b/ProcessMaker/Events/ScriptDeleted.php
@@ -44,7 +44,7 @@ class ScriptDeleted implements SecurityLogEventInterface
     public function getData(): array
     {
         return [
-            'Name' => $this->script->getAttribute('title'),
+            'name' => $this->script->getAttribute('title'),
         ];
     }
 

--- a/ProcessMaker/Events/ScriptExecutorCreated.php
+++ b/ProcessMaker/Events/ScriptExecutorCreated.php
@@ -28,21 +28,21 @@ class ScriptExecutorCreated implements SecurityLogEventInterface
             'config' => $created_values['config']
         ];
     }
-    
+
     /**
-     * Return event data 
+     * Return event data
      */
     public function getData(): array
     {
         return $this->data;
     }
-    
+
     /**
-     * Return event changes 
+     * Return event changes
      */
     public function getChanges(): array
     {
-        return $this->changes;
+        return [];
     }
 
     /**

--- a/ProcessMaker/Events/ScriptExecutorDeleted.php
+++ b/ProcessMaker/Events/ScriptExecutorDeleted.php
@@ -20,27 +20,28 @@ class ScriptExecutorDeleted implements SecurityLogEventInterface
     public function __construct(array $deleted_values)
     {
         $this->changes = $deleted_values;
-        $this->data = [
-            'script_executor_id' => $deleted_values['id'],
-            'title' => $deleted_values['title'],
-            'description' => $deleted_values['description']
-        ];
     }
-    
+
     /**
-     * Return event data 
+     * Return event data
      */
     public function getData(): array
     {
-        return $this->data;
+        return [
+            'script_executor_id' => $this->changes['id'] ?? '',
+            'title' => $this->changes['title'] ?? '',
+            'description' => $this->changes['description'] ?? ''
+        ];
     }
-    
+
     /**
-     * Return event changes 
+     * Return event changes
      */
     public function getChanges(): array
     {
-        return $this->changes;
+        return [
+            'id' => $this->changes['id'] ?? ''
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/ScriptExecutorUpdated.php
+++ b/ProcessMaker/Events/ScriptExecutorUpdated.php
@@ -2,13 +2,15 @@
 
 namespace ProcessMaker\Events;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
 
 class ScriptExecutorUpdated implements SecurityLogEventInterface
 {
-    use Dispatchable, FormatSecurityLogChanges;
+    use Dispatchable;
+    use FormatSecurityLogChanges;
 
     private array $data;
     private array $changes;
@@ -20,37 +22,32 @@ class ScriptExecutorUpdated implements SecurityLogEventInterface
      *
      * @return void
      */
-    public function __construct(int $scriptId, array $original_values, array $changed_values)
+    public function __construct(int $scriptId, array $originalValues, array $changedValues)
     {
-        $this->original = array_intersect_key($original_values, $changed_values);
-        $this->changes = $changed_values;
+        $this->original = array_intersect_key($originalValues, $changedValues);
+        $this->changes = $changedValues;
         $this->scriptId = $scriptId;
-        $this->buildData();
     }
 
     /**
-     * Building the data
-     */
-    public function buildData() {
-        $this->data = array_merge([
-            'script_executor_id' => $this->scriptId
-        ], $this->formatChanges($this->changes, $this->original));
-    }
-    
-    /**
-     * Return event data 
+     * Return event data
      */
     public function getData(): array
     {
-        return $this->data;
+        return array_merge([
+            'script_executor_id' => $this->scriptId,
+            'last_modified' => $this->changes['updated_at'] ?? Carbon::now()
+        ], $this->formatChanges($this->changes, $this->original));
     }
-    
+
     /**
-     * Return event changes 
+     * Return event changes
      */
     public function getChanges(): array
     {
-        return $this->changes;
+        return [
+            'script_executor_id' => $this->scriptId
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/ScriptUpdated.php
+++ b/ProcessMaker/Events/ScriptUpdated.php
@@ -37,9 +37,9 @@ class ScriptUpdated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return array_merge([
+        return [
             'script_id' => $this->script->id
-        ], $this->changes);
+        ];
     }
 
     /**
@@ -52,10 +52,11 @@ class ScriptUpdated implements SecurityLogEventInterface
         $changes = $this->changes;
         $original = $this->original;
         $basic = isset($changes['code']) ? [
-            'Name' => $this->script->getAttribute('title'),
-            'Script Last Modified' => $this->script->getAttribute('updated_at'),
+            'script_name' => $this->script->getAttribute('title'),
+            'last_modified' => $this->script->getAttribute('updated_at'),
         ] : [
-            'Name' => $this->script->getAttribute('title'),
+            'script_name' => $this->script->getAttribute('title'),
+            'last_modified' => $this->script->getAttribute('updated_at'),
         ];
         unset($changes['code']);
         unset($original['code']);

--- a/ProcessMaker/Events/SettingsUpdated.php
+++ b/ProcessMaker/Events/SettingsUpdated.php
@@ -12,9 +12,6 @@ class SettingsUpdated implements SecurityLogEventInterface
 {
     use Dispatchable;
     use FormatSecurityLogChanges;
-    public const SENSITIVE_KEYS = [
-        'password',
-    ];
 
     private Setting $setting;
 
@@ -32,14 +29,6 @@ class SettingsUpdated implements SecurityLogEventInterface
         $this->setting = $setting;
         $this->changes = $changes;
         $this->original = $original;
-        // Some configuration are related to the password
-        $attribute = strtolower($this->setting->getAttribute('name'));
-        if (array_keys($this::SENSITIVE_KEYS, $attribute)) {
-            $this->changes[$attribute] = $this->changes['config'];
-            $this->original[$attribute] = $this->original['config'];
-            unset($this->changes['config']);
-            unset($this->original['config']);
-        }
         // Verify if the config is a sensitive value
         $key = $this->setting->getAttribute('key');
         if (SensitiveDataHelper::isSensitiveKey($key)) {
@@ -55,9 +44,9 @@ class SettingsUpdated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return array_merge([
+        return [
             'setting_id' => $this->setting->id
-        ], $this->changes);
+        ];
     }
 
     /**
@@ -70,6 +59,7 @@ class SettingsUpdated implements SecurityLogEventInterface
         return array_merge([
             'group' => $this->setting->getAttribute('group'),
             'name' => $this->setting->getAttribute('name'),
+            'last_modified' => $this->setting->getAttribute('updated_at'),
         ], $this->formatChanges($this->changes, $this->original));
     }
 

--- a/ProcessMaker/Events/TemplateCreated.php
+++ b/ProcessMaker/Events/TemplateCreated.php
@@ -29,9 +29,9 @@ class TemplateCreated implements SecurityLogEventInterface
     public function getData(): array
     {
         return [
-            'type' => $this->payload['type'],
-            'version' => $this->payload['version'],
-            'name' => $this->payload['name']
+            'type' => $this->payload['type'] ?? '',
+            'version' => $this->payload['version'] ?? '',
+            'name' => $this->payload['name'] ?? ''
         ];
     }
 
@@ -42,10 +42,9 @@ class TemplateCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return array_merge(
-            ['root' => $this->payload['root']],
-            $this->getData()
-        );
+        return [
+            'root' => $this->payload['root'] ?? ''
+        ];
     }
 
     /**

--- a/ProcessMaker/Events/TemplateUpdated.php
+++ b/ProcessMaker/Events/TemplateUpdated.php
@@ -40,7 +40,7 @@ class TemplateUpdated implements SecurityLogEventInterface
                 'name' => [
                     'label' => $this->processType
                 ],
-                'updated_at' => Carbon::now()
+                'last_modified' => $this->changes['updated_at'] ?? Carbon::now()
             ];
         } else {
             $oldData = array_diff_assoc($this->original, $this->changes);
@@ -50,6 +50,7 @@ class TemplateUpdated implements SecurityLogEventInterface
                 'name' => [
                     'label' => $this->processType
                 ],
+                'last_modified' => $this->changes['updated_at'] ?? Carbon::now()
             ], $this->formatChanges($newData, $oldData));
         }
     }

--- a/ProcessMaker/Events/TokenCreated.php
+++ b/ProcessMaker/Events/TokenCreated.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Events;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use Laravel\Passport\Token;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
@@ -21,25 +22,25 @@ class TokenCreated implements SecurityLogEventInterface
     public function __construct(Token $token)
     {
         $this->data = [
-            "token_id" => $token->getKey()
+            'token_id' => $token->getKey(),
+            'created_at' => Carbon::now()
         ];
-        $this->changes = $token->toArray();
     }
-    
+
     /**
-     * Return event data 
+     * Return event data
      */
     public function getData(): array
     {
         return $this->data;
     }
-    
+
     /**
-     * Return event changes 
+     * Return event changes
      */
     public function getChanges(): array
     {
-        return $this->changes;
+        return $this->data;
     }
 
     /**

--- a/ProcessMaker/Events/TokenDeleted.php
+++ b/ProcessMaker/Events/TokenDeleted.php
@@ -22,25 +22,23 @@ class TokenDeleted implements SecurityLogEventInterface
     {
         $this->data = [
             "token_id" => $token->getKey()
-        ];        
-        $this->changes = $token->toArray();
-
+        ];
     }
-    
+
     /**
-     * Return event data 
+     * Return event data
      */
     public function getData(): array
     {
         return $this->data;
     }
-    
+
     /**
-     * Return event changes 
+     * Return event changes
      */
     public function getChanges(): array
     {
-        return $this->changes;
+        return $this->data;
     }
 
     /**

--- a/ProcessMaker/Helpers/SensitiveDataHelper.php
+++ b/ProcessMaker/Helpers/SensitiveDataHelper.php
@@ -4,12 +4,15 @@ namespace ProcessMaker\Helpers;
 
 class SensitiveDataHelper
 {
-    const SENSITIVE_KEYS = [
+    public const SENSITIVE_KEYS = [
         'password',
-        'idp.client_secret'
+        'idp.client_secret',
+        'abe_imap_password',
+        'EMAIL_CONNECTOR_MAIL_PASSWORD',
+        'services.ldap.authentication.password'
     ];
 
-    const MASK = '*';
+    public const MASK = '*';
 
     public static function parseArray(array|object $data)
     {
@@ -17,7 +20,7 @@ class SensitiveDataHelper
             foreach ($data as $key => $value) {
                 if (is_array($value) || is_object($value)) {
                     $data[$key] = static::parseArray($value);
-                } elseif(is_string($value) && static::isSensitiveKey($key)) {
+                } elseif (is_string($value) && static::isSensitiveKey($key)) {
                     $data[$key] = static::parseString($value);
                 } else {
                     $data[$key] = $value;
@@ -27,7 +30,7 @@ class SensitiveDataHelper
             foreach ($data as $key => $value) {
                 if (is_array($value) || is_object($value)) {
                     $data->$key = static::parseArray($value);
-                } elseif(is_string($value) && static::isSensitiveKey($key)) {
+                } elseif (is_string($value) && static::isSensitiveKey($key)) {
                     $data->$key = static::parseString($value);
                 } else {
                     $data->$key = $value;

--- a/ProcessMaker/Http/Controllers/Api/GroupController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Events\GroupCreated;
 use ProcessMaker\Events\GroupDeleted;
+use ProcessMaker\Events\GroupUpdated;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\Groups as GroupResource;
@@ -220,8 +221,12 @@ class GroupController extends Controller
     public function update(Group $group, Request $request)
     {
         $request->validate(Group::rules($group));
+        $original = $group->getOriginal();
         $group->fill($request->input());
         $group->saveOrFail();
+        $changes = $group->getChanges();
+        // Register the Event
+        GroupUpdated::dispatch($group, $changes, $original);
 
         return response([], 204);
     }

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -72,6 +72,9 @@ class EventServiceProvider extends ServiceProvider
         'ProcessMaker\Events\GroupDeleted' => [
             'ProcessMaker\Listeners\SecurityLogger',
         ],
+        'ProcessMaker\Events\GroupUpdated' => [
+            'ProcessMaker\Listeners\SecurityLogger',
+        ],
         'ProcessMaker\Events\GroupUsersUpdated' => [
             'ProcessMaker\Listeners\SecurityLogger',
         ],


### PR DESCRIPTION
## Issue & Reproduction Steps
Register some events related to user activity events according to the [PRD](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3084320783/User+Activity+Logging).
Make some changes related to label and getChanges

## Solution
- Improve the tickets definition

## How to Test
Check the actions related to 
     - CategoryCreated.php
        - CategoryUpdated.php
        - CustomizeUiUpdated.php
        - EnvironmentVariablesCreated.php
        - EnvironmentVariablesDeleted.php
        - EnvironmentVariablesUpdated.php
        - FilesUpdated.php
        - GroupCreated.php
        - ProcessArchived.php
        - ProcessCreated.php
        - ProcessPublished.php
        - ProcessRestored.php
        - ScreenCreated.php
        - ScreenDeleted.php
        - ScriptCreated.php
        - ScriptDeleted.php
        - ScriptExecutorCreated.php
        - ScriptExecutorDeleted.php
        - ScriptExecutorUpdated.php
        - ScriptUpdated.php
        - SettingsUpdated.php
        - TemplateCreated.php
        - TemplateUpdated.php
        - TokenCreated.php
        - TokenDeleted.php

## Related Tickets & Packages
[FOUR-8972](https://processmaker.atlassian.net/browse/FOUR-8972)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

## Enviroment
ci:deploy

[FOUR-8972]: https://processmaker.atlassian.net/browse/FOUR-8972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ