### PR TITLE
Bugfix/FOUR-8963: Translation does not reconice apostrophes

### DIFF
--- a/ProcessMaker/Jobs/ExecuteTranslationRequest.php
+++ b/ProcessMaker/Jobs/ExecuteTranslationRequest.php
@@ -80,7 +80,7 @@ class ExecuteTranslationRequest implements ShouldQueue
 
         $this->handler->generatePrompt(
             $this->type,
-            json_encode($this->chunk, JSON_UNESCAPED_SLASHES)
+            json_encode($this->chunk, JSON_HEX_APOS | JSON_HEX_AMP)
         );
 
         [$response, $usage, $targetLanguage] = $this->handler->execute();

--- a/ProcessMaker/ProcessTranslations/BatchesJobHandler.php
+++ b/ProcessMaker/ProcessTranslations/BatchesJobHandler.php
@@ -106,7 +106,7 @@ class BatchesJobHandler
         // Chunk max size should be near 1800.
         // In handler max_token for response is 1200.
         // Total sum is 3000. Under 4096 allowed for text-davinci-003
-        $maxChunkSize = 1500;
+        $maxChunkSize = 1300;
         $handler->generatePrompt('html', '');
         $config = $handler->getConfig();
 


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduce:**
- Login as admin
- Create a simple process
- Create a simple screen with two inputs
- Set one of the labels with an apostrophe
- assign the screen on the process
- Go to Configure of the process and create a translation
- Open the translations once finish

**Current behavior:**
The label with the apostrophe is not translated

**Expected behavior:**
The translation should be considered

## Solution
- Fix encoding

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/9a4feb60-f261-41f6-9393-e39732f8714a


## How to Test
Follow steps above

## Related Tickets & Packages
- [FOUR-8963](https://processmaker.atlassian.net/browse/FOUR-8963)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8963]: https://processmaker.atlassian.net/browse/FOUR-8963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
