### PR TITLE
Bugfix/FOUR-8979: Modal remains open when timeout

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessTranslationController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessTranslationController.php
@@ -83,10 +83,16 @@ class ProcessTranslationController extends Controller
 
         $processTranslation = new ProcessTranslation($process);
         $screensTranslations = $processTranslation->getProcessScreensWithTranslations();
-        $languageList = $processTranslation->getLanguageList($screensTranslations);
+        $translatedLanguageList = $processTranslation->getLanguageList($screensTranslations);
+        $translatingLanguageList = ProcessTranslationToken::where('process_id', $processId)->get();
+
+        $availableLanguages = [];
 
         foreach (Languages::ALL as $key => $value) {
-            if (!$this->languageInTranslatedList($key, $languageList)) {
+            if (
+                !$this->languageInTranslatedList($key, $translatedLanguageList)
+                && !$this->languageInTranslatingList($key, $translatingLanguageList)
+            ) {
                 $availableLanguages[] = [
                     'humanLanguage' => $value,
                     'language' => $key,
@@ -99,9 +105,20 @@ class ProcessTranslationController extends Controller
         ]);
     }
 
-    private function languageInTranslatedList($key, $languageList)
+    private function languageInTranslatedList($key, $translatedLanguageList)
     {
-        foreach ($languageList as $value) {
+        foreach ($translatedLanguageList as $value) {
+            if ($value['language'] === $key) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function languageInTranslatingList($key, $pendingLanguageList)
+    {
+        foreach ($pendingLanguageList as $value) {
             if ($value['language'] === $key) {
                 return true;
             }

--- a/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
+++ b/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
@@ -178,6 +178,10 @@ export default {
         return;
       }
 
+      if (!this.selectedLanguage) {
+        return;
+      }
+
       if (this.selectedLanguage.language in val.translations) {
         const translations = val.translations[this.selectedLanguage.language];
 
@@ -262,8 +266,9 @@ export default {
     validateLanguageSelected() {
       if (!this.selectedLanguage) {
         this.customModalButtons[1].disabled = true;
+      } else {
+        this.customModalButtons[1].disabled = false;
       }
-      this.customModalButtons[1].disabled = false;
     },
     show() {
       this.$bvModal.show("createProcessTranslation");
@@ -305,15 +310,18 @@ export default {
             this.$bvModal.hide("createProcessTranslation");
             this.$emit("translating-language");
             this.showSelectTargetLanguage();
+            this.selectedLanguage = null;
+          } else {
+            this.showTranslations();
           }
-
-          this.showTranslations();
+          this.getAvailableLanguages();
         })
         .catch(error => {
           const $errorMsg = this.$t("An error ocurred while calling OpenAI endpoint.");
           window.ProcessMaker.alert($errorMsg, "danger");
           this.endpointErrors = $errorMsg;
           this.aiLoading = false;
+          this.$bvModal.hide("createProcessTranslation");
         });
     },
 
@@ -327,7 +335,6 @@ export default {
         screenId: this.selectedScreen.id,
         option,
       };
-
       ProcessMaker.apiClient.post("/openai/language-translation", params)
         .then((response) => {
           this.screensTranslations = response.data.screensTranslations;
@@ -340,6 +347,7 @@ export default {
           window.ProcessMaker.alert($errorMsg, "danger");
           this.endpointErrors = $errorMsg;
           this.aiLoading = false;
+          this.$bvModal.hide("createProcessTranslation");
         });
     },
 


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduce:**
Login as Admin

Create a process with may fields and labels

Open the Configure > Translations of the process

Create many translations at the same time

**Current behavior:**
A timeout error is displayed and the modal is not closed, it continues loading

**Expected behavior:**
The modal should be closed after a failure

## Solution
- Close modal when endpoint return an exception.
- Fixed button not disabled after translate last 

**Working videos**

https://github.com/ProcessMaker/processmaker/assets/90727999/4fa886c6-ae2a-4154-9ba7-5457a0c377a7

Other fixes

https://github.com/ProcessMaker/processmaker/assets/90727999/ef41b664-30ac-4d79-8493-167d39a0b4b6


## How to Test
Follow steps above.

## Related Tickets & Packages
- [FOUR-8979](https://processmaker.atlassian.net/browse/FOUR-8979)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8979]: https://processmaker.atlassian.net/browse/FOUR-8979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ