### PR TITLE
Bugfix/FOUR-8976: Notifications with no valuable information and twice

### DIFF
--- a/ProcessMaker/Notifications/ProcessTranslationReady.php
+++ b/ProcessMaker/Notifications/ProcessTranslationReady.php
@@ -51,7 +51,7 @@ class ProcessTranslationReady extends Notification
             'code' => $this->code,
             'name' => __('Process translated'),
             'processId' => $this->process->id ?? '',
-            'processName' => $this->process->name ?? '',
+            'processName' => $this->process->name . ' to ' . $this->targetLanguage['humanLanguage'] ?? '',
             'targetLanguage' => $this->targetLanguage ?? '',
         ];
     }

--- a/ProcessMaker/ProcessTranslations/BatchesJobHandler.php
+++ b/ProcessMaker/ProcessTranslations/BatchesJobHandler.php
@@ -60,6 +60,8 @@ class BatchesJobHandler
             ->then(function (Batch $batch) {
                 \Log::info('All jobs in batch completed');
                 $this->notifyProgress($batch);
+                // Broadcast response
+                $this->broadcastResponse();
             })->catch(function (Batch $batch, Throwable $e) {
                 // First batch job failure detected...
                 \Log::info('Batch error');
@@ -97,8 +99,6 @@ class BatchesJobHandler
     {
         event(new ProcessTranslationChunkProgressEvent($this->process->id, $this->targetLanguage['language'], $batch));
         $delete = ProcessTranslationToken::where('token', $batch->id)->delete();
-        // Broadcast response
-        $this->broadcastResponse();
     }
 
     public function prepareData($screens, $handler)


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduce:**
- Login as banker
- Create a simple process
- Open the Configure > Translations of the process
- Create a translation

**Current behavior:**
After the translation is completed a notification is displayed twice and with no additional information

**Expected behavior:**
The notification should be only one and provide more information about the translation

## Solution
- Broadcast response only once when translation completed.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/43611c0f-3223-43ae-b6fd-908053c3d96a

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-8976](https://processmaker.atlassian.net/browse/FOUR-8976)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8976]: https://processmaker.atlassian.net/browse/FOUR-8976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ