### PR TITLE
Bugfix/FOUR-8981: List of translations should be sorted

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessTranslationController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessTranslationController.php
@@ -41,8 +41,10 @@ class ProcessTranslationController extends Controller
             }
         }
 
+        $languageList = collect($languageList)->sortBy('humanLanguage');
+
         return response()->json([
-            'translatedLanguages' => $languageList,
+            'translatedLanguages' => array_values($languageList->toArray()),
             'permissions' => [
                 'create'   => $request->user()->can('create-process-translations'),
                 'view' => $request->user()->can('view-process-translations'),
@@ -70,8 +72,10 @@ class ProcessTranslationController extends Controller
             $translatingLanguages[] = $processTranslationToken;
         }
 
+        $processTranslationTokens = collect($processTranslationTokens)->sortBy('humanLanguage');
+
         return response()->json([
-            'translatingLanguages' => $processTranslationTokens,
+            'translatingLanguages' => array_values($processTranslationTokens->toArray()),
         ]);
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
**Story:**
As an administrator, I want to have the list of translations created for a process in alphabetic order or sorted by creation. So I can have more order on the list and a better access to the translations

**Details:**
The list of translations should be sorted

There should be an option to change the type of sort

## Solution
- Sort translations alphabetically.

**Working screenshot**

![Screenshot 2023-06-16 at 16 57 35](https://github.com/ProcessMaker/processmaker/assets/90727999/32a359d3-2e11-493d-8fe4-c35108305cd8)


## How to Test
Create some translations and check if they are correctly ordered. First it will show pending translations ordered and below that the already translated languages

## Related Tickets & Packages
- [FOUR-8981](https://processmaker.atlassian.net/browse/FOUR-8981)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8981]: https://processmaker.atlassian.net/browse/FOUR-8981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ