### PR TITLE
Feature/process-translations-data-test

### DIFF
--- a/resources/js/components/SelectLanguage.vue
+++ b/resources/js/components/SelectLanguage.vue
@@ -12,6 +12,7 @@
     label="humanLanguage"
     class="assignable-input"
     @input="change"
+    data-test="translation-select-language"
   >
     <template slot="noResult">
       <slot name="noResult">

--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -27,6 +27,7 @@
         :key="action.value"
         :href="action.link ? itemLink(action, data) : null"
         class="ellipsis-dropdown-item mx-auto"
+        :data-test="action.dataTest"
         @click="!action.link ? onClick(action, data) : null"
       >
         <div class="ellipsis-dropdown-content">

--- a/resources/js/components/shared/Modal.vue
+++ b/resources/js/components/shared/Modal.vue
@@ -81,6 +81,7 @@
             :variant="button.variant" 
             :disabled="button.disabled"
             :hidden="button.hidden"
+            :data-test="button.dataTest"
             class="ml-2"
           >
             {{ button.content }}

--- a/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
+++ b/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
@@ -36,7 +36,7 @@
         </div>
         <div class="mt-3">
           <div class="form-group">
-            <b-form-checkbox v-model="manualTranslation">
+            <b-form-checkbox v-model="manualTranslation" data-test="translation-manual-option">
               <div>{{ $t("Manual translation") }}</div>
               <small class="text-muted">{{ $t("Disables auto translate and manually translate screen content.") }}</small>
             </b-form-checkbox>
@@ -64,6 +64,7 @@
             :multiple="false"
             :aria-label="$t('Select a screen')"
             class="w-50"
+            data-test="translation-screen-option"
           />
           <small class="text-muted">{{ $t("Select a screen from the process to review and perform translations.") }}</small>
         </div>
@@ -85,7 +86,9 @@
             </div>
           </div>
 
-          <table v-if="stringsWithTranslations && Object.keys(stringsWithTranslations).length !== 0" class="table table-responsive-lg mb-0">
+          <table v-if="stringsWithTranslations && Object.keys(stringsWithTranslations).length !== 0" 
+            class="table table-responsive-lg mb-0"
+            data-test="translation-string-list">
             <thead>
               <tr>
                   <th class="col-6">{{ $t('String') }}</th>
@@ -157,8 +160,8 @@ export default {
       ],
       customModalButtons: [
         {'content': 'Cancel', 'action': 'hide()', 'variant': 'outline-secondary', 'disabled': false, 'hidden': false},
-        {'content': 'Translate Process', 'action': 'translate', 'variant': 'secondary', 'disabled': true, 'hidden': false},
-        {'content': 'Save Translation', 'action': 'saveTranslations', 'variant': 'secondary', 'disabled': false, 'hidden': true},
+        {'content': 'Translate Process', 'action': 'translate', 'variant': 'secondary', 'disabled': true, 'hidden': false, 'dataTest': 'translation-translate-process'},
+        {'content': 'Save Translation', 'action': 'saveTranslations', 'variant': 'secondary', 'disabled': false, 'hidden': true, 'dataTest': 'translation-save-translation-button'},
       ],
     };
   },

--- a/resources/js/processes/translations/components/ProcessTranslationListing.vue
+++ b/resources/js/processes/translations/components/ProcessTranslationListing.vue
@@ -11,7 +11,10 @@
       </div>
     </div>
 
-    <table v-if="!loading && ((translatedLanguages && translatedLanguages.length) || (translatingLanguages && translatingLanguages.length))" id="table-translations" class="table table-hover table-responsive-lg ">
+    <table v-if="!loading && ((translatedLanguages && translatedLanguages.length) || (translatingLanguages && translatingLanguages.length))"
+      id="table-translations"
+      class="table table-hover table-responsive-lg "
+      data-test="translation-list">
       <thead>
         <tr>
             <th class="notify">{{ $t('Target Language') }}</th>
@@ -92,12 +95,14 @@ export default {
           content: "Edit Translation",
           permission: "edit-process-translations",
           icon: "fas fa-edit",
+          dataTest: "translation-list-editfield",
         },
         {
           value: "export-translation",
           content: "Export Translation",
           permission: "export-process-translations",
           icon: "fas fa-file-export",
+          dataTest: "translation-export",
           link: true,
           href: "/processes/{{processId}}/export/translation/{{language}}",
         },
@@ -105,21 +110,31 @@ export default {
           value: "retry-translation",
           content: "Retry empty translations",
           permission: "edit-process-translations",
+          dataTest: "translation-option-retry",
           icon: "fas fa-redo",
         },
         {
           value: "delete-translation",
           content: "Delete Translation",
+          dataTest: "translation-option-delete",
           permission: "delete-process-translations",
           icon: "fas fa-trash",
         },
       ],
       actionsInProgress: [
         {
-          value: "cancel-translation", content: "Cancel Translation", permission: "cancel-process-translations", icon: "fas fa-stop-circle",
+          value: "cancel-translation",
+          content: "Cancel Translation",
+          permission: "cancel-process-translations",
+          icon: "fas fa-stop-circle",
+          dataTest: "translation-option-cancel",
         },
         {
-          value: "delete-translation", content: "Delete Translation", permission: "delete-process-translations", icon: "fas fa-trash",
+          value: "delete-translation",
+          content: "Delete Translation",
+          permission: "delete-process-translations",
+          icon: "fas fa-trash",
+          dataTest: "translation-option-delete",
         },
       ],
       inProgressButton: {

--- a/resources/js/processes/translations/components/TranslateOptionsPopup.vue
+++ b/resources/js/processes/translations/components/TranslateOptionsPopup.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <div class="position-relative">
-      <button ref="optionsButton" class="btn btn-outline-secondary mr-1 mt-3 d-flex align-items-center" @click="toggleOptionsPopup">
+      <button
+        ref="optionsButton"
+        class="btn btn-outline-secondary mr-1 mt-3 d-flex align-items-center"
+        @click="toggleOptionsPopup"
+        data-test="translation-translate-option">
         <font-awesome-icon :icon="['fpm', 'fa-translations']" class="mr-1" />
         <span class="text-capitalize">{{$t('Translation Options')}}</span>
       </button>
@@ -14,6 +18,7 @@
               :key="'all'"
               value="all"
               :disabled="false"
+              data-test="translation-auto-all"
             >
               <span class="fw-medium">{{ $t('Auto Translate') }} <strong>{{ $t('All') }}</strong></span>
               <div>
@@ -28,6 +33,7 @@
               :key="'empty'"
               value="empty"
               :disabled="false"
+              data-test="translation-auto-empty"
             >
               <span class="fw-medium">{{ $t('Auto Translate') }} <strong>{{ $t('Empty') }}</strong></span>
               <div>
@@ -40,7 +46,7 @@
         </div>
         <div class="card-footer bg-white text-right">
           <button class="btn btn-white btn-sm" @click="toggleOptionsPopup">Cancel</button>
-          <button class="btn btn-primary btn-sm" @click="reTranslate">Translate</button>
+          <button class="btn btn-primary btn-sm" @click="reTranslate" data-test="translation-translate-button">Translate</button>
         </div>
       </div>
     </div>

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -28,6 +28,7 @@
                         @can('view-process-translations')
                             <a class="nav-item nav-link" id="nav-groups-tab" data-toggle="tab" href="#nav-translations"
                                 role="tab"
+                                data-test="translation-tab"
                                 aria-controls="nav-translations" aria-selected="true">{{__('Translations')}}</a>
                         @endcan
                         <a class="nav-item nav-link" id="nav-groups-tab" data-toggle="tab" href="#nav-notifications"
@@ -193,14 +194,19 @@
                                                 <div class="d-flex ml-md-0 flex-column flex-md-row">
                                                     @can('import-process-translations')
                                                         <div class="mb-3 mb-md-0 ml-md-2">
-                                                            <a href="#" aria-label="{{ __('Import Translation') }}" id="import_translation" class="btn btn-outline-secondary w-100" @click="importTranslation">
+                                                            <a href="#" aria-label="{{ __('Import Translation') }}" id="import_translation" class="btn btn-outline-secondary w-100" @click="importTranslation" data-test="translation-import">
                                                                 <i class="fas fa-file-import"></i> {{__('Import')}}
                                                             </a>
                                                         </div>
                                                     @endcan
                                                     @can('create-process-translations')
                                                         <div class="mb-3 mb-md-0 ml-md-2">
-                                                            <a href="#" aria-label="{{ __('New Translation') }}" id="new_translation" class="btn btn-primary w-100" @click="newTranslation">
+                                                            <a href="#" 
+                                                                aria-label="{{ __('New Translation') }}" 
+                                                                id="new_translation" 
+                                                                class="btn btn-primary w-100" 
+                                                                @click="newTranslation"
+                                                                data-test="translation-create-button">
                                                                 {{__('+ Translation')}}
                                                             </a>
                                                         </div>


### PR DESCRIPTION
## Issue & Reproduction Steps
Add data test attributes for automation

```
data-test="translation-tab"
data-test="translation-create-button"
data-test="translation-select-language"
data-test="translation-manual-option"
data-test="translation-translate-process"
data-test="translation-screen-option"
data-test="translation-translate-option"
data-test="translation-auto-all"
data-test="translation-auto-empty"
data-test="translation-translate-button"
data-test="translation-list"
data-test="translation-list-editfield"
data-test="translation-save-translation-button"
data-test="translation-option-retry"
data-test="translation-delete"
data-test="translation-string-list"
data-test="translation-export"
data-test="translation-import"
```
