### PR TITLE
Bugfix/FOUR-9016:

### DIFF
--- a/ProcessMaker/Assets/ScreensInScreen.php
+++ b/ProcessMaker/Assets/ScreensInScreen.php
@@ -44,9 +44,13 @@ class ScreensInScreen
                 if (is_array($item) && isset($item['component']) && $item['component'] === 'FormNestedScreen' && !empty($item['config']['screen'])) {
                     $screens[] = [Screen::class, $item['config']['screen']];
                     if ($recursive) {
-                        $screen = app(Screen::class)->findOrFail($item['config']['screen']);
+                        $screen = app(Screen::class)->find($item['config']['screen']);
                         $this->recursion++;
-                        $screens = $this->referencesToExport($screen, $screens, $manager, $recursive);
+
+                        if ($screen) {
+                            $screens = $this->referencesToExport($screen, $screens, $manager, $recursive);
+                        }
+
                         $this->recursion--;
                     }
                 }

--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -52,8 +52,11 @@ class ProcessTranslation
         }
 
         $nestedScreens = [];
-        foreach ($screensInProcess as $screen) {
-            $nestedScreens = array_merge($nestedScreens, Screen::findOrFail($screen)->nestedScreenIds());
+        foreach ($screensInProcess as $screenId) {
+            $screen = Screen::find($screenId);
+            if ($screen) {
+                $nestedScreens = array_merge($nestedScreens, $screen->nestedScreenIds());
+            }
         }
 
         $screensInProcess = collect(array_merge($screensInProcess, $nestedScreens))->unique();
@@ -186,7 +189,9 @@ class ProcessTranslation
                 if ($item['component'] === 'FormSelectList') {
                     if (isset($item['config']) && isset($item['config']['options']) && isset($item['config']['options']['optionsList'])) {
                         foreach ($item['config']['options']['optionsList'] as $option) {
-                            $elements[] = $option['content'];
+                            if (array_key_exists('content', $option)) {
+                                $elements[] = $option['content'];
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to Reproduce:**
- Import the attached process and be sure you don’t have a screen with id 25 in your instance
- Go to process > configure

[Steps_test.json.zip](https://github.com/ProcessMaker/processmaker/files/11839333/Steps_test.json.zip)


## Solution
- Replace **findOrFail** with **find**. Verify screen exists. Added a check also for the key **content** in select lists

## How to Test
Follow steps above

## Related Tickets & Packages
- [FOUR-9016](https://processmaker.atlassian.net/browse/FOUR-9016)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9016]: https://processmaker.atlassian.net/browse/FOUR-9016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ