### PR TITLE
FOUR-8697: Deleting Authentication Client Details are not shown in Security Logs

### DIFF
--- a/ProcessMaker/Events/AuthClientDeleted.php
+++ b/ProcessMaker/Events/AuthClientDeleted.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Events;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
 
@@ -18,10 +19,9 @@ class AuthClientDeleted implements SecurityLogEventInterface
      *
      * @return void
      */
-    public function __construct(array $deleted_values)
+    public function __construct(array $values)
     {
-        $this->data = ['auth_client_id' => $deleted_values['id']];
-        $this->changes = $deleted_values;
+        $this->changes = $values;
     }
 
     /**
@@ -29,7 +29,11 @@ class AuthClientDeleted implements SecurityLogEventInterface
      */
     public function getData(): array
     {
-        return $this->data;
+        return [
+            'auth_client_id' => $this->changes['id'] ?? 0,
+            'name' => $this->changes['name'] ?? 0,
+            'deleted_at' => Carbon::now()
+        ];
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- Deleting Authentication Client Details are not shown in Security Logs

## How to Test
Create a Authentication Client
Delete Authentication Client

## Related Tickets & Packages
- [FOUR-8697](https://processmaker.atlassian.net/browse/FOUR-8697)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
'
ci:deploy

[FOUR-8697]: https://processmaker.atlassian.net/browse/FOUR-8697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ