### PR TITLE
Bugfix/FOUR-9133: Retry Empty Translations button words are not capitalized

### DIFF
--- a/resources/js/processes/translations/components/ProcessTranslationListing.vue
+++ b/resources/js/processes/translations/components/ProcessTranslationListing.vue
@@ -108,7 +108,7 @@ export default {
         },
         {
           value: "retry-translation",
-          content: "Retry empty translations",
+          content: "Retry Empty Translations",
           permission: "edit-process-translations",
           dataTest: "translation-option-retry",
           icon: "fas fa-redo",


### PR DESCRIPTION
## Issue & Reproduction Steps
Words in Retry Empty Translations button are not capitalized

![Screenshot 2023-06-27 at 11 39 53](https://github.com/ProcessMaker/processmaker/assets/90727999/de0bc783-01c3-4c16-80cb-26e3cb868829)


## Solution
- Capitalize words for retry empty translations button.

## Related Tickets & Packages
- [FOUR-9133](https://processmaker.atlassian.net/browse/FOUR-9133)

[FOUR-9133]: https://processmaker.atlassian.net/browse/FOUR-9133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ