### PR TITLE
Fix process translations redirects to translations tab

### DIFF
--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -47,7 +47,7 @@
                     <div class="tab-content" id="nav-tabContent">
 
                         {{-- Configuration --}}
-                        <div class="tab-pane fade show active" id="nav-config" role="tabpanel"
+                        <div class="tab-pane fade show" :class="{'active': activeTab === ''}" id="nav-config" role="tabpanel"
                              aria-labelledby="nav-config-tab">
                             <required></required>
                             <div class="form-group">
@@ -172,7 +172,7 @@
 
                         {{-- Translations --}}
                         @can('view-process-translations')
-                            <div class="tab-pane fade show" id="nav-translations" role="tabpanel"
+                            <div class="tab-pane fade show" :class="{'active': activeTab === 'nav-translations'}" id="nav-translations" ref="nav-translations" role="tabpanel"
                                 aria-labelledby="nav-translations-tab">
                                 
                                 <div class="page-content mb-0" id="processTranslationIndex">
@@ -402,12 +402,22 @@
             manager: @json($process->manager),
             translatedLanguages: [],
             editTranslation: null,
+            activeTab: "",
           }
         },
         mounted() {
+            this.activeTab = "";
             if (_.get(this.formData, 'properties.manager_can_cancel_request')) {
                 this.canCancel.push(this.processManagerOption());
             }
+            
+            let path = new URL(location.href).href;
+            let target = path.split('#');
+
+            if (target[1] !== undefined) {
+                this.activeTab = target[1];
+            }
+            
         },
         computed: {
             activeUsersAndGroupsWithManager() {

--- a/resources/views/processes/translations/export.blade.php
+++ b/resources/views/processes/translations/export.blade.php
@@ -12,7 +12,7 @@
     @include('shared.breadcrumbs', ['routes' => [
         __('Designer') => route('processes.index'),
         __('Processes') => route('processes.index'),
-        __('Translations') => route('processes.edit', ['process' => $process->id]),
+        __('Translations') => '/processes/'.$process->id.'/edit#nav-translations',
         __('Export' . ' ' . $process->name . ' - ' . $language['humanLanguage']) => null,
     ]])
 @endsection
@@ -55,7 +55,7 @@
         },
         methods: {
           onCancel() {
-            window.location = `/processes/${this.processId}/edit`;
+            window.location = `/processes/${this.processId}/edit/#nav-translations`;
           },
           onExport() {
             ProcessMaker.apiClient({

--- a/resources/views/processes/translations/import.blade.php
+++ b/resources/views/processes/translations/import.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.layout')
 
 @section('title')
-    {{__('Import Screen')}}
+    {{__('Import Translation')}}
 @endsection
 
 @section('sidebar')
@@ -12,7 +12,7 @@
     @include('shared.breadcrumbs', ['routes' => [
       __('Designer') => route('processes.index'),
       __('Processes') => route('processes.index'),
-      __('Translations') => route('processes.edit', ['process' => $process->id]),
+      __('Translations') => '/processes/'.$process->id.'/edit#nav-translations',
       __('Import') => null,
     ]])
 @endsection
@@ -125,7 +125,7 @@
 
           },
           onCancel() {
-            window.location = `/processes/${$processId}/edit`;
+            window.location = `/processes/${this.process.id}/edit#nav-translations`;
           },
           onImport() {
             let formData = new FormData();
@@ -147,7 +147,7 @@
               let message = this.$t('The process translation was imported correctly.');
               let variant = 'success';
               ProcessMaker.alert(message, variant);
-              window.location.href = `/processes/${this.process.id}/edit`;
+              window.location.href = `/processes/${this.process.id}/edit#nav-translations`;
             })
             .catch((error) => {
               this.submitted = false;


### PR DESCRIPTION
## Issue & Reproduction Steps
Redirects to translations needs to be fixed:

Descripción

- When user is in export view for process translations and click the cancel button, should redirect to Process Translations tab
- When user is in import view for process translations and click the cancel button, should redirect to Process Translations tab
- When user imports a process translations, should redirect to Process Translations tab
- When user is in export view for process translations and click the Translations breadcrumb, should redirect to Process Translations tab
- When user is in import view for process translations and click the Translations breadcrumb, should redirect to Process Translations tab

## Solution
- Added fixes for each of the item listed above.

## Related Tickets & Packages
- [FOUR-9135](https://processmaker.atlassian.net/browse/FOUR-9135)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9135]: https://processmaker.atlassian.net/browse/FOUR-9135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ