### PR TITLE
Bugfix/FOUR-9139: Progress still in 0% when a process doesn't have strings to translate

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/OpenAIController.php
+++ b/ProcessMaker/Http/Controllers/Api/OpenAIController.php
@@ -123,7 +123,12 @@ class OpenAIController extends Controller
                 $processTranslationToken->save();
 
                 $translateProcess = new BatchesJobHandler($process, $screensTranslations, $request->input('language'), $code, Auth::id(), $option);
-                $translateProcess->handle();
+                $haveStringsToTranslate = $translateProcess->handle();
+                if (!$haveStringsToTranslate) {
+                    return response()->json([
+                        'error' => __('No strings found to translate'),
+                    ]);
+                }
             } else {
                 return response()->json([
                     'error' => 'Already running a translation for this language in background',

--- a/ProcessMaker/ProcessTranslations/BatchesJobHandler.php
+++ b/ProcessMaker/ProcessTranslations/BatchesJobHandler.php
@@ -55,7 +55,6 @@ class BatchesJobHandler
         [$screensWithChunks, $chunksCount] = $this->prepareData($this->screens, $languageTranslationHandler);
 
         // Execute requests for each regular chunk
-
         $batch = Bus::batch([])
             ->then(function (Batch $batch) {
                 \Log::info('All jobs in batch completed');
@@ -79,6 +78,12 @@ class BatchesJobHandler
         // Update with real batch token ...
         ProcessTranslationToken::where('token', $this->code)->update(['token' => $batch->id]);
 
+        if (!count($screensWithChunks)) {
+            $this->notifyProgress($batch);
+
+            return false;
+        }
+
         foreach ($screensWithChunks as $screenId => $screenWithChunks) {
             foreach ($screenWithChunks as $chunk) {
                 $batch->add(
@@ -93,6 +98,8 @@ class BatchesJobHandler
                 );
             }
         }
+
+        return true;
     }
 
     private function notifyProgress($batch)

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1279,6 +1279,7 @@
   "Validate that an attribute has a valid URL format.": "Validate that an attribute has a valid URL format.",
   "Add Rule": "Add Rule",
   "No validation rule(s)": "No validation rule(s)",
+  "No strings found to translate": "No strings found to translate",
   "New Select List": "New Select List",
   "New Array of Objects": "New Array of Objects",
   "Existing Array": "Existing Array",


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduce**
- Create a process without screens (empty process)
- Go to process configuration
- Click on new translation button
- Select some language
- Try to automatic translate the process

**Current behavior**
The translation never ends, showing 0% of progress

**Expected behavior**
If there are no strings to translate in the process, should not add an item in the pending translations table and should show to the user an error.

## Solution
- Fix issue when no strings to translate in a process.

## How to Test
Follow steps above.

## Related Tickets & Packages
- [FOUR-9139](https://processmaker.atlassian.net/browse/FOUR-9139)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9139]: https://processmaker.atlassian.net/browse/FOUR-9139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ