### PR TITLE
FOUR-7965 add device preview behavior

### DIFF
--- a/resources/js/components/Menu.vue
+++ b/resources/js/components/Menu.vue
@@ -168,7 +168,16 @@ export default {
       return item.items.filter((button) => button.hide !== true);
     },
     isVisible(item, type) {
-      return item.type === type && item.hide !== true;
+      if (item.type === type && item.hide !== true) {
+        if (item.displayCondition) {
+        // eslint-disable-next-line no-eval
+          return eval(`this.environment.${item.displayCondition}`);
+        }
+
+        return true;
+      }
+
+      return false;
     },
     changeItem(id, value) {
       this.changeItems[id] = value;

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -41,7 +41,7 @@
           id="preview"
           class="h-100 m-0"
         >
-          <b-col class="overflow-auto h-100">
+          <b-col class="d-flex overflow-auto h-100">
             <vue-form-renderer
               v-if="renderComponent === 'task-screen'"
               ref="renderer"
@@ -55,6 +55,7 @@
               :watchers="preview.watchers"
               :show-errors="true"
               :mock-magic-variables="mockMagicVariables"
+              :device-screen="deviceScreen"
               @submit="previewSubmit"
               @update="onUpdate"
               @css-errors="cssErrors = $event"
@@ -373,6 +374,30 @@ export default {
         ],
       },
       {
+        id: "group_preview",
+        type: "group",
+        section: "left",
+        displayCondition: "displayPreview",
+        items: [
+          {
+            id: "button_preview_desktop",
+            type: "button",
+            title: this.$t("Preview Desktop"),
+            variant: "secondary",
+            icon: "fas fa-desktop",
+            action: "changeDeviceScreen(\"desktop\")",
+          },
+          {
+            id: "button_preview_mobile",
+            type: "button",
+            title: this.$t("Preview Mobile"),
+            variant: "outline-secondary",
+            icon: "fas fa-mobile pr-1",
+            action: "changeDeviceScreen(\"mobile\")",
+          },
+        ],
+      },
+      {
         id: "group_properties",
         type: "group",
         section: "right",
@@ -454,6 +479,7 @@ export default {
       },
       type: formTypes.form,
       mode: "editor",
+      deviceScreen: "desktop",
       // Computed properties
       computed: [],
       // Watchers
@@ -770,6 +796,16 @@ export default {
       } else {
         this.$refs.builder.refreshContent();
       }
+    },
+    changeDeviceScreen(deviceScreen) {
+      this.$refs.menuScreen.changeItem("button_preview_desktop", {
+        variant: deviceScreen === "desktop" ? "secondary" : "outline-secondary",
+      });
+      this.$refs.menuScreen.changeItem("button_preview_mobile", {
+        variant: deviceScreen === "mobile" ? "secondary" : "outline-secondary",
+      });
+
+      this.deviceScreen = deviceScreen;
     },
     onUpdate(data) {
       this.updateDataPreview();

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -637,6 +637,8 @@
   "Preview Screen was Submitted": "Preview Screen was Submitted",
   "Preview": "Preview",
   "Preview Screen": "Preview Screen",
+  "Preview Desktop": "Preview Desktop",
+  "Preview Mobile": "Preview Mobile",
   "Previous Task Assignee": "Previous Task Assignee",
   "primary": "primary",
   "Print": "Print",


### PR DESCRIPTION
## Issue & Reproduction Steps
Preview the screen in desktop and mobile resolutions

## Solution
Add a desktop and mobile preview button next to the PREVIEW button

## How to Test
1. Switch to feature/FOUR-7965 branch in the projects processmaker and screen-builder
2. Build the assets
3. Open the PM Core
4. Open an existing Screen or create a new one
5. Press on Preview button
6. The new device preview buttons must be displayed
7. Press on mobile preview button
8. The screen must be displayed in mobile resolution

## Related Tickets & Packages
[FOUR-7965](https://processmaker.atlassian.net/browse/FOUR-7965)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-7965]: https://processmaker.atlassian.net/browse/FOUR-7965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ