### PR TITLE
FOUR-9018: Define a variable in ENV to turn off the security Logs

### DIFF
--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -3,6 +3,54 @@
 namespace ProcessMaker\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use ProcessMaker\Events\ActivityReassignment;
+use ProcessMaker\Events\AuthClientCreated;
+use ProcessMaker\Events\AuthClientDeleted;
+use ProcessMaker\Events\AuthClientUpdated;
+use ProcessMaker\Events\CategoryCreated;
+use ProcessMaker\Events\CategoryDeleted;
+use ProcessMaker\Events\CategoryUpdated;
+use ProcessMaker\Events\CustomizeUiUpdated;
+use ProcessMaker\Events\EnvironmentVariablesUpdated;
+use ProcessMaker\Events\EnvironmentVariablesCreated;
+use ProcessMaker\Events\EnvironmentVariablesDeleted;
+use ProcessMaker\Events\FilesCreated;
+use ProcessMaker\Events\FilesDeleted;
+use ProcessMaker\Events\FilesUpdated;
+use ProcessMaker\Events\GroupCreated;
+use ProcessMaker\Events\GroupDeleted;
+use ProcessMaker\Events\GroupUpdated;
+use ProcessMaker\Events\GroupUsersUpdated;
+use ProcessMaker\Events\PermissionUpdated;
+use ProcessMaker\Events\ProcessArchived;
+use ProcessMaker\Events\ProcessCreated;
+use ProcessMaker\Events\ProcessPublished;
+use ProcessMaker\Events\ProcessRestored;
+use ProcessMaker\Events\ProcessUpdated;
+use ProcessMaker\Events\RequestAction;
+use ProcessMaker\Events\RequestError;
+use ProcessMaker\Events\ScreenCreated;
+use ProcessMaker\Events\ScreenDeleted;
+use ProcessMaker\Events\ScreenUpdated;
+use ProcessMaker\Events\ScriptCreated;
+use ProcessMaker\Events\ScriptDeleted;
+use ProcessMaker\Events\ScriptDuplicated;
+use ProcessMaker\Events\ScriptExecutorCreated;
+use ProcessMaker\Events\ScriptExecutorDeleted;
+use ProcessMaker\Events\ScriptExecutorUpdated;
+use ProcessMaker\Events\ScriptUpdated;
+use ProcessMaker\Events\SettingsUpdated;
+use ProcessMaker\Events\TemplateCreated;
+use ProcessMaker\Events\TemplateDeleted;
+use ProcessMaker\Events\TemplateUpdated;
+use ProcessMaker\Events\TokenCreated;
+use ProcessMaker\Events\TokenDeleted;
+use ProcessMaker\Events\UnauthorizedAccessAttempt;
+use ProcessMaker\Events\UserCreated;
+use ProcessMaker\Events\UserDeleted;
+use ProcessMaker\Events\UserGroupMembershipUpdated;
+use ProcessMaker\Events\UserUpdated;
+use ProcessMaker\Listeners\SecurityLogger;
 
 /**
  * Register our Events and their Listeners
@@ -27,151 +75,9 @@ class EventServiceProvider extends ServiceProvider
         'Illuminate\Database\Events\MigrationsEnded' => [
             'ProcessMaker\Listeners\UpdateDataLakeViews',
         ],
-        'ProcessMaker\Events\ActivityReassignment' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\AuthClientUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\AuthClientCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\AuthClientDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\CategoryCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\CategoryDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\CategoryUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\CustomizeUiUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\EnvironmentVariablesCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\EnvironmentVariablesDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\EnvironmentVariablesUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\FilesCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\FilesDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\FilesUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\GroupCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\GroupDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\GroupUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\GroupUsersUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\PermissionUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ProcessCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ProcessArchived' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ProcessPublished' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ProcessRestored' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ProcessUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\RequestError' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\RequestAction' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScreenCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScreenDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScreenUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScriptUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScriptCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScriptDuplicated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScriptDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScriptExecutorCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScriptExecutorDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\ScriptExecutorUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
         'ProcessMaker\Events\SessionStarted' => [
             'ProcessMaker\Listeners\ActiveUserListener',
         ],
-        'ProcessMaker\Events\SettingsUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\TemplateCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\TemplateDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\TemplateUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\TokenCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\TokenDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\UnauthorizedAccessAttempt' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\UserCreated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\UserDeleted' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\UserGroupMembershipUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-        'ProcessMaker\Events\UserUpdated' => [
-            'ProcessMaker\Listeners\SecurityLogger',
-        ],
-
     ];
 
     /**
@@ -181,5 +87,56 @@ class EventServiceProvider extends ServiceProvider
     public function boot()
     {
         parent::boot();
+
+        // Check if the variable security_log is enable
+        if (config('app.security_log')) {
+            $this->app['events']->listen(ActivityReassignment::class, SecurityLogger::class);
+            $this->app['events']->listen(AuthClientUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(AuthClientCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(AuthClientDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(CategoryCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(CategoryDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(CategoryUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(CustomizeUiUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(EnvironmentVariablesCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(EnvironmentVariablesDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(EnvironmentVariablesUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(FilesCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(FilesDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(FilesUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(GroupCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(GroupDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(GroupUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(GroupUsersUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(PermissionUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(ProcessCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(ProcessArchived::class, SecurityLogger::class);
+            $this->app['events']->listen(ProcessPublished::class, SecurityLogger::class);
+            $this->app['events']->listen(ProcessRestored::class, SecurityLogger::class);
+            $this->app['events']->listen(ProcessUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(RequestError::class, SecurityLogger::class);
+            $this->app['events']->listen(RequestAction::class, SecurityLogger::class);
+            $this->app['events']->listen(ScreenCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(ScreenDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(ScreenUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(ScriptCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(ScriptDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(ScriptDuplicated::class, SecurityLogger::class);
+            $this->app['events']->listen(ScriptExecutorCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(ScriptExecutorDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(ScriptExecutorUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(ScriptUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(SettingsUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(TemplateCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(TemplateDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(TemplateUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(TokenCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(TokenDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(UnauthorizedAccessAttempt::class, SecurityLogger::class);
+            $this->app['events']->listen(UserCreated::class, SecurityLogger::class);
+            $this->app['events']->listen(UserDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(UserGroupMembershipUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(UserUpdated::class, SecurityLogger::class);
+        }
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -85,9 +85,14 @@ return [
     'bpmn_actions_lock_check_interval' => (int) env('BPMN_ACTIONS_LOCK_CHECK_INTERVAL', 1000),
 
     // The url of our host from inside the docker
-    'docker_host_url' => env('DOCKER_HOST_URL',
-        preg_replace('/(\w+):\/\/([^:\/]+)(\:\d+)?/', '$1://172.17.0.1$3',
-            env('APP_URL', 'http://localhost'))),
+    'docker_host_url' => env(
+        'DOCKER_HOST_URL',
+        preg_replace(
+            '/(\w+):\/\/([^:\/]+)(\:\d+)?/',
+            '$1://172.17.0.1$3',
+            env('APP_URL', 'http://localhost')
+        )
+    ),
 
     // Allows our script executors to ignore invalid SSL. This should only be set to false for development.
     'api_ssl_verify' => env('API_SSL_VERIFY', 'true'),
@@ -100,6 +105,9 @@ return [
 
     // Microservice AI Host
     'ai_microservice_host' => env('AI_MICROSERVICE_HOST'),
+
+    // Security log
+    'security_log' => env('SECURITY_LOG', 'true'),
 
     // Message broker driver to use in Workflow Manager
     'message_broker_driver' => env('MESSAGE_BROKER_DRIVER', 'default'),

--- a/tests/Feature/Api/SecurityLogsTest.php
+++ b/tests/Feature/Api/SecurityLogsTest.php
@@ -150,8 +150,8 @@ class SecurityLogsTest extends TestCase
         ]);
         $response->assertStatus(201);
         $collection = SecurityLog::where('user_id', $this->user->id)->get();
-        $this->assertCount(2, $collection);
-        $securityLog = $collection->skip(1)->first();
+        $this->assertCount(1, $collection);
+        $securityLog = $collection->first();
         $this->assertEquals([
             'fullname' => $this->user->getAttribute('fullname'),
         ], (array) $securityLog->data);
@@ -180,10 +180,14 @@ class SecurityLogsTest extends TestCase
         $original = array_intersect_key($setting->getOriginal(), $setting->getDirty());
         $setting->save();
         SettingsUpdated::dispatch($setting, $setting->getChanges(), $original);
-
         $collection = SecurityLog::get();
-        $this->assertCount(1, $collection);
-        $securityLog = $collection->first();
-        $this->assertEquals('SettingsUpdated', $securityLog->getAttribute('event'));
+        // Check if the variable security_log is enable
+        if (config('app.security_log')) {
+            $this->assertCount(1, $collection);
+            $securityLog = $collection->first();
+            $this->assertEquals('SettingsUpdated', $securityLog->getAttribute('event'));
+        } else {
+            $this->assertCount(0, $collection);
+        }
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Register some events related to user activity events according to the [PRD](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3084320783/User+Activity+Logging).
Define a variable in ENV to turn off the security Logs

## Solution
- Improve the tickets definition

## How to Test
if the user needs to disable the security log needs to define in the ENV
```
SECURITY_LOG = false;
```

## Related Tickets & Packages
- [FOUR-9018](https://processmaker.atlassian.net/browse/FOUR-9018)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy


[FOUR-9018]: https://processmaker.atlassian.net/browse/FOUR-9018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ