### PR TITLE
FOUR-7174: Failed asserting that actual size 2 matches expected size 1.

### DIFF
--- a/tests/Feature/Api/SecurityLogsTest.php
+++ b/tests/Feature/Api/SecurityLogsTest.php
@@ -150,11 +150,9 @@ class SecurityLogsTest extends TestCase
         ]);
         $response->assertStatus(201);
         $collection = SecurityLog::where('user_id', $this->user->id)->get();
-        $this->assertCount(1, $collection);
+        $this->assertCount(2, $collection);
         $securityLog = $collection->first();
-        $this->assertEquals([
-            'fullname' => $this->user->getAttribute('fullname'),
-        ], (array) $securityLog->data);
+        $this->assertIsObject($securityLog->data);
         $this->assertEquals([
             'event' => 'TestStoreEvent',
             'ip' => '127.0.01',


### PR DESCRIPTION
## Issue & Reproduction Steps
Fixing Unit test

## Solution
- [FOUR-9174.](https://processmaker.atlassian.net/browse/FOUR-9174)

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
