### PR TITLE
FOUR-8352 Added dynamic import plugin from babel to support modeler d…

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,8 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": [
+    "@babel/preset-env"
+  ],
+  "plugins": [
+    "@babel/plugin-syntax-dynamic-import"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
             },
             "devDependencies": {
                 "@babel/eslint-parser": "^7.15.8",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
                 "accounting": "^0.4.1",
                 "chartjs-plugin-colorschemes": "^0.4.0",
                 "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     },
     "devDependencies": {
         "@babel/eslint-parser": "^7.15.8",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "accounting": "^0.4.1",
         "chartjs-plugin-colorschemes": "^0.4.0",
         "cross-env": "^7.0.3",


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior:
Components should be imported async when needed. For example.
If we are going to use the "Signal End Event" and put it in the paper, as soon as the user puts the icon in the paper, we will trigger an AJAX Call (done automatically by Webpack) to import that component async to alleviate the final build result, resulting in the final build having the necessary to run modeler and "chunks" to be loaded async when needed.

Actual behavior: 
Currently not doing anything async

## Solution
-

## How to Test
Test the steps above
- Open the Chrome Developer Tools, go to the network page
- Clear the Network page
- Open the explorer or an already tabbed element in the bottom rail, lets say the "End Signal event", as soon as you put the element in the paper, you should see the file with a relevant name to the Node we just dragged to the paper being called and the image. For Core purposes, the image is the only one being added

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8352

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:modeler:FOUR-8352
