### PR TITLE
feature/FOUR-9155: Add logging of users actually downloading a file, either through the Files tab or as part of a form task

### DIFF
--- a/ProcessMaker/Events/FilesDownloaded.php
+++ b/ProcessMaker/Events/FilesDownloaded.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Events\Dispatchable;
+use ProcessMaker\Contracts\SecurityLogEventInterface;
+use ProcessMaker\Models\Media;
+use ProcessMaker\Traits\FormatSecurityLogChanges;
+
+class FilesDownloaded implements SecurityLogEventInterface
+{
+    use Dispatchable;
+    use FormatSecurityLogChanges;
+
+    private Media $media;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Media $data)
+    {
+        $this->media = $data;
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getData(): array
+    {
+        return [
+            'name' => [
+                'label' => $this->media['name'],
+                'link' => route('file-manager.index', ['public/'. $this->media['file_name']])
+            ],
+            'accessed_at' => Carbon::now()
+        ];
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getChanges(): array
+    {
+        return [
+            'id' => $this->media['id'] ?? ''
+        ];
+    }
+
+    /**
+     * Get the Event name
+     *
+     * @return string
+     */
+    public function getEventName(): string
+    {
+        return 'FilesDownloaded';
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Http\Controllers\Api;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use ProcessMaker\Events\FilesDeleted;
+use ProcessMaker\Events\FilesDownloaded;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
@@ -281,6 +282,8 @@ class FileController extends Controller
         $path = Storage::disk('public')->getAdapter()->getPathPrefix() .
                 $file->id . '/' .
                 $file->file_name;
+        // Register the Event
+        FilesDownloaded::dispatch($file);
 
         return response()->download($path);
     }

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -16,6 +16,7 @@ use ProcessMaker\Events\EnvironmentVariablesCreated;
 use ProcessMaker\Events\EnvironmentVariablesDeleted;
 use ProcessMaker\Events\FilesCreated;
 use ProcessMaker\Events\FilesDeleted;
+use ProcessMaker\Events\FilesDownloaded;
 use ProcessMaker\Events\FilesUpdated;
 use ProcessMaker\Events\GroupCreated;
 use ProcessMaker\Events\GroupDeleted;
@@ -103,6 +104,7 @@ class EventServiceProvider extends ServiceProvider
             $this->app['events']->listen(EnvironmentVariablesUpdated::class, SecurityLogger::class);
             $this->app['events']->listen(FilesCreated::class, SecurityLogger::class);
             $this->app['events']->listen(FilesDeleted::class, SecurityLogger::class);
+            $this->app['events']->listen(FilesDownloaded::class, SecurityLogger::class);
             $this->app['events']->listen(FilesUpdated::class, SecurityLogger::class);
             $this->app['events']->listen(GroupCreated::class, SecurityLogger::class);
             $this->app['events']->listen(GroupDeleted::class, SecurityLogger::class);


### PR DESCRIPTION
## Issue & Reproduction Steps
Register some events related to user activity events according to the [PRD](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3084320783/User+Activity+Logging).
Add logging of users actually downloading a file, either through the Files tab or as part of a form task

## Solution
- Improve the tickets definition

## How to Test
- Go to file tab, opens file, downloads

## Related Tickets & Packages
- [FOUR-9155](https://processmaker.atlassian.net/browse/FOUR-9155)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9155]: https://processmaker.atlassian.net/browse/FOUR-9155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ