### PR TITLE
FOUR-9176: Add logging of users actually downloading a file, either through the Files tab or as part of a form task

### DIFF
--- a/ProcessMaker/Events/FilesAccessed.php
+++ b/ProcessMaker/Events/FilesAccessed.php
@@ -2,21 +2,18 @@
 
 namespace ProcessMaker\Events;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
-use ProcessMaker\Models\Media;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
 
-class FilesCreated implements SecurityLogEventInterface
+class FilesAccessed implements SecurityLogEventInterface
 {
     use Dispatchable;
     use FormatSecurityLogChanges;
 
-    public const NAME_PUBLIC_FILES = 'Public Files';
-
-    private array $media;
-    private array $name = [];
+    private array $linkFile = [];
     private string $processName = '';
 
     /**
@@ -24,25 +21,21 @@ class FilesCreated implements SecurityLogEventInterface
      *
      * @return void
      */
-    public function __construct(int $fileId, ProcessRequest $data)
+    public function __construct(string $name, ProcessRequest $data = null)
     {
-        $this->media = Media::find(['id' => $fileId])->toArray();
-        $this->media = head($this->media);
-
-        // Check if the request is related to the package files
-        if (static::NAME_PUBLIC_FILES === $data->getAttribute('name')) {
-            $this->processName = '';
-            // Link to file in the package
-            $this->name = [
-                'label' => $this->media['name'],
-                'link' => route('file-manager.index', ['public/' . $this->media['name']]),
-            ];
-        } else {
+        // Check if the file is related to the request
+        if (!is_null($data)) {
             $this->processName = $data->getAttribute('name');
             // Link to the request
-            $this->name = [
+            $this->linkFile = [
                 'label' => $data->getAttribute('id'),
                 'link' => route('requests.show', $data)
+            ];
+        } else {
+            // Link to file in the package
+            $this->linkFile = [
+                'label' => $name,
+                'link' => route('file-manager.index', ['public/' . $name]),
             ];
         }
     }
@@ -55,9 +48,9 @@ class FilesCreated implements SecurityLogEventInterface
     public function getData(): array
     {
         return [
-            'name' => $this->name,
+            'name' => $this->linkFile,
             'process' => $this->processName,
-            'created_at' => $this->media['created_at'],
+            'accessed_at' => Carbon::now()
         ];
     }
 
@@ -68,9 +61,7 @@ class FilesCreated implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return [
-            'id' => $this->media['id']
-        ];
+        return [];
     }
 
     /**
@@ -80,6 +71,6 @@ class FilesCreated implements SecurityLogEventInterface
      */
     public function getEventName(): string
     {
-        return 'FilesCreated';
+        return 'FilesAccessed';
     }
 }

--- a/ProcessMaker/Events/FilesDownloaded.php
+++ b/ProcessMaker/Events/FilesDownloaded.php
@@ -5,7 +5,7 @@ namespace ProcessMaker\Events;
 use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
-use ProcessMaker\Models\Media;
+use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
 
 class FilesDownloaded implements SecurityLogEventInterface
@@ -13,16 +13,31 @@ class FilesDownloaded implements SecurityLogEventInterface
     use Dispatchable;
     use FormatSecurityLogChanges;
 
-    private Media $media;
+    private array $name = [];
+    private string $processName = '';
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct(Media $data)
+    public function __construct(string $file, ProcessRequest $data = null)
     {
-        $this->media = $data;
+        // Check if the file is related to the request
+        if (!is_null($data)) {
+            $this->processName = $data->getAttribute('name');
+            // Link to the request
+            $this->name = [
+                'label' => $data->getAttribute('id'),
+                'link' => route('requests.show', $data)
+            ];
+        } else {
+            // Link to file in the package
+            $this->name = [
+                'label' => $file,
+                'link' => route('file-manager.index', ['public/' . $file]),
+            ];
+        }
     }
 
     /**
@@ -33,10 +48,8 @@ class FilesDownloaded implements SecurityLogEventInterface
     public function getData(): array
     {
         return [
-            'name' => [
-                'label' => $this->media['name'],
-                'link' => route('file-manager.index', ['public/'. $this->media['file_name']])
-            ],
+            'name' => $this->name,
+            'process' => $this->processName,
             'accessed_at' => Carbon::now()
         ];
     }
@@ -48,9 +61,7 @@ class FilesDownloaded implements SecurityLogEventInterface
      */
     public function getChanges(): array
     {
-        return [
-            'id' => $this->media['id'] ?? ''
-        ];
+        return [];
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -282,8 +282,11 @@ class FileController extends Controller
         $path = Storage::disk('public')->getAdapter()->getPathPrefix() .
                 $file->id . '/' .
                 $file->file_name;
+
         // Register the Event
-        FilesDownloaded::dispatch($file);
+        if (!empty($file->file_name)) {
+            FilesDownloaded::dispatch($file->file_name);
+        }
 
         return response()->download($path);
     }

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use ProcessMaker\Events\FilesDownloaded;
 use ProcessMaker\Events\ScreenBuilderStarting;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Managers\DataManager;
@@ -134,7 +135,17 @@ class RequestController extends Controller
         $isProcessManager = $request->process?->manager_id === Auth::user()->id;
 
         return view('requests.show', compact(
-            'request', 'files', 'canCancel', 'canViewComments', 'canManuallyComplete', 'canRetry', 'manager', 'canPrintScreens', 'screenRequested', 'addons', 'isProcessManager'
+            'request',
+            'files',
+            'canCancel',
+            'canViewComments',
+            'canManuallyComplete',
+            'canRetry',
+            'manager',
+            'canPrintScreens',
+            'screenRequested',
+            'addons',
+            'isProcessManager'
         ));
     }
 
@@ -186,6 +197,9 @@ class RequestController extends Controller
         $file = $request->downloadFile($media);
 
         if ($file) {
+            // Register the Event
+            FilesDownloaded::dispatch(basename($file), $request);
+
             return response()->download($file);
         }
 

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -14,6 +14,7 @@ use ProcessMaker\Events\CustomizeUiUpdated;
 use ProcessMaker\Events\EnvironmentVariablesUpdated;
 use ProcessMaker\Events\EnvironmentVariablesCreated;
 use ProcessMaker\Events\EnvironmentVariablesDeleted;
+use ProcessMaker\Events\FilesAccessed;
 use ProcessMaker\Events\FilesCreated;
 use ProcessMaker\Events\FilesDeleted;
 use ProcessMaker\Events\FilesDownloaded;
@@ -102,6 +103,7 @@ class EventServiceProvider extends ServiceProvider
             $this->app['events']->listen(EnvironmentVariablesCreated::class, SecurityLogger::class);
             $this->app['events']->listen(EnvironmentVariablesDeleted::class, SecurityLogger::class);
             $this->app['events']->listen(EnvironmentVariablesUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(FilesAccessed::class, SecurityLogger::class);
             $this->app['events']->listen(FilesCreated::class, SecurityLogger::class);
             $this->app['events']->listen(FilesDeleted::class, SecurityLogger::class);
             $this->app['events']->listen(FilesDownloaded::class, SecurityLogger::class);


### PR DESCRIPTION
## Issue & Reproduction Steps
Register some events related to user activity events according to the [PRD](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3084320783/User+Activity+Logging).
Add logging of users actually downloading a file, either through the Files tab or as part of a form task

## Solution
- Improve the tickets definition

## How to Test
- Go to Request, and check opens file, downloads

## Related Tickets & Packages
- [FOUR-9176](https://processmaker.atlassian.net/browse/FOUR-9176)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:package-files:feature/FOUR-9176

[FOUR-9176]: https://processmaker.atlassian.net/browse/FOUR-9176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ