### PR TITLE
FOUR-9149 | Improve the User Interface in the Global Settings of PM Blocks

### DIFF
--- a/resources/js/components/shared/Modal.vue
+++ b/resources/js/components/shared/Modal.vue
@@ -70,7 +70,7 @@
     </template>
     <slot></slot>
     <template v-if="setCustomButtons" #modal-footer>
-      <div class="d-flex justify-content-between align-items-center w-100">
+      <div class="d-flex justify-content-end align-items-center w-100">
         <div v-if="showAiSlogan" class="slogan">
           <img src="/img/favicon.svg"> {{ $t("Powered by ProcessMaker AI") }}
         </div>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-9149](https://processmaker.atlassian.net/browse/FOUR-9149)

In the Add Field Modal of the PM Blocks Global Settings, the `Add` and `Cancel` buttons should be right-aligned.

# Solution
- In the shared Modal component in core, align custom buttons to the right.
- Note: this change will update all Modals that currently use custom buttons, such as the Create PM Block Modal, Create Template Modal, etc.

# Steps to Reproduce
1. Log in to ProcessMaker.
2. Go to the PM Blocks listing.
3. Have a PM Block created.
4. Go to PM Block Configuration -> Global Settings.
5. Click 'Add Field'.

# How to Test
1. Go to branch `observation/FOUR-9149` in core.
2. Follow the Steps to Reproduce.

# Related Tickets & Packages
- [FOUR-7365](https://processmaker.atlassian.net/browse/FOUR-7365) | PM Blocks

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-9149]: https://processmaker.atlassian.net/browse/FOUR-9149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7365]: https://processmaker.atlassian.net/browse/FOUR-7365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ