### PR TITLE
FOUR-8554

### DIFF
--- a/ProcessMaker/Console/Commands/Consumer.php
+++ b/ProcessMaker/Console/Commands/Consumer.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Console\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
 use ProcessMaker\Facades\MessageBrokerService;
 
 class Consumer extends Command
@@ -40,7 +41,8 @@ class Consumer extends Command
         try {
             MessageBrokerService::worker();
         } catch (Exception $e) {
-            $this->warn($e->getMessage());
+            Log::error($e->getMessage());
+            Log::error($e->getTraceAsString());
         }
     }
 }

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -907,4 +907,18 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     {
         return \ProcessMaker\Models\Media::getFilesRequest($this);
     }
+
+    public function getErrors()
+    {
+        if ($this->errors) {
+            return $this->errors;
+        }
+        // select tokens with errors
+        return $this->tokens()
+            ->select('token_properties->error as message', 'created_at', 'element_name')
+            ->where('status', '=', ActivityInterface::TOKEN_STATE_FAILING)
+            ->limit(10)
+            ->get()
+            ->toArray();
+    }
 }

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -823,7 +823,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
 
     public function updateTokenProperties()
     {
-        $allowed = ['conditionals', 'loopCharacteristics', 'data'];
+        $allowed = ['conditionals', 'loopCharacteristics', 'data', 'error'];
         $this->token_properties = array_filter(
             $this->getProperties(),
             function ($key) use ($allowed) {

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -480,17 +480,25 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
             $tokensRows = [];
             $tokens = $request->tokens()->where('status', '!=', 'CLOSED')->where('status', '!=', 'TRIGGERED')->get();
             foreach ($tokens as $token) {
-                $tokensRows[] = array_merge($token->token_properties ?: [], [
+                $tokenRow = array_merge($token->token_properties ?: [], [
                     'id' => $token->uuid,
                     'status' => $token->status,
                     'index' => $token->element_index,
                     'element_id' => $token->element_id,
                     'created_at' => $token->created_at->getTimestamp(),
                 ]);
+                if ($token->subprocess_request_id) {
+                    $subRequest = ProcessRequest::select(['process_version_id', 'uuid'])
+                        ->find($token->subprocess_request_id);
+                    $tokenRow['subprocess_request_id'] = $subRequest->uuid;
+                    $tokenRow['subprocess_request_version'] = $subRequest->process_version_id;
+                }
+                $tokensRows[] = $tokenRow;
             }
 
             return [
                 'id' => $request->uuid,
+                'process_version_id' => $request->process_version_id,
                 'callable_id' => $request->callable_id,
                 'collaboration_uuid' => $request->collaboration_uuid,
                 'data' => $request->data,

--- a/ProcessMaker/Nayra/Repositories/Deserializer.php
+++ b/ProcessMaker/Nayra/Repositories/Deserializer.php
@@ -12,6 +12,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\EntityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+use ProcessMaker\Nayra\Contracts\Storage\BpmnDocumentInterface;
 use ProcessMaker\Repositories\BpmnDocument;
 use ProcessMaker\Repositories\DefinitionsRepository;
 use ProcessMaker\Repositories\ExecutionInstanceRepository;
@@ -56,7 +57,7 @@ class Deserializer
             $version = ProcessVersion::find($modelId);
             $model = $version->process;
 
-            $definition = new BpmnDocument($model);
+            $definition = app(BpmnDocumentInterface::class, ['process' => $model]);
             $definition->setFactory($this->factory);
             $definition->loadXML($version->bpmn);
 

--- a/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
@@ -116,6 +116,9 @@ class PersistenceHandler
                 case 'instance_updated':
                     $this->persistInstanceUpdated($transaction);
                     break;
+                case 'call_activity_activated':
+                    $this->persistCallActivityActivated($transaction);
+                    break;
                 case 'schedule_date':
                     $this->persistScheduleDate($transaction);
                     break;
@@ -139,7 +142,8 @@ class PersistenceHandler
             }
         } catch (Exception $error) {
             Log::error($error->getMessage());
-            if ($transaction['token']) {
+            Log::error($error->getTraceAsString());
+            if (!empty($transaction['token'])) {
                 $token = $this->deserializer->unserializeToken($transaction['token']);
                 $request = $token->getInstance();
                 if ($request && $request instanceof ProcessRequest) {

--- a/ProcessMaker/Nayra/Repositories/PersistenceTokenTrait.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceTokenTrait.php
@@ -2,8 +2,12 @@
 
 namespace ProcessMaker\Nayra\Repositories;
 
+use ProcessMaker\Repositories\TokenRepository;
+
 trait PersistenceTokenTrait
 {
+    protected TokenRepository $tokenRepository;
+
     /**
      * Persists instance and token data when a token arrives to an activity
      *
@@ -207,5 +211,18 @@ trait PersistenceTokenTrait
         $passedToken = $this->deserializer->unserializeToken($transaction['passed_token']);
         $consumedTokens = $this->deserializer->unserializeTokensCollection($transaction['consumed_tokens']);
         $this->tokenRepository->persistEventBasedGatewayActivated($gateway, $passedToken, $consumedTokens);
+    }
+
+    /**
+     * Persists a Call Activity Activated
+     *
+     * @param array $transaction
+     */
+    public function persistCallActivityActivated(array $transaction)
+    {
+        $token = $this->deserializer->unserializeToken($transaction['token']);
+        $subprocessInstance = $this->deserializer->unserializeInstance($transaction['subprocess']);
+        $startId = $transaction['start_id'];
+        $this->tokenRepository->persistCallActivityActivated($token, $subprocessInstance, $startId);
     }
 }

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 use ProcessMaker\Models\ProcessCollaboration;
 use ProcessMaker\Models\ProcessRequest as Instance;
 use ProcessMaker\Models\ProcessRequestToken as Token;
+use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\User;
 use ProcessMaker\Nayra\Bpmn\Collection;
 use ProcessMaker\Nayra\Bpmn\Models\EndEvent;
@@ -201,7 +202,7 @@ class TokenRepository implements TokenRepositoryInterface
      * Persists instance and token data when a token within an activity change to error state
      *
      * @param ActivityInterface $activity
-     * @param TokenInterface $token
+     * @param TokenInterface|ProcessRequestToken $token
      *
      * @return mixed
      */

--- a/resources/js/requests/components/RequestErrors.vue
+++ b/resources/js/requests/components/RequestErrors.vue
@@ -63,7 +63,7 @@
 <style lang="scss" scoped>
     .error-body {
       word-break: break-word;
-      overflow-x: scroll;
+      overflow-x: auto;
       font-size: 87.5%;
       max-width: 992px; // Not a fan of hard-coding this value, but it's equivalent to $screen-md-max
     }

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -398,7 +398,7 @@
           canViewPrint: @json($canPrintScreens),
           status: 'ACTIVE',
           userRequested: [],
-          errorLogs: @json(['data' => $request->errors]),
+          errorLogs: @json(['data' => $request->getErrors()]),
           disabled: false,
           retryDisabled: false,
           packages: [],

--- a/upgrades/2023_06_29_110455_populate_process_requests_collaboration_uuid.php
+++ b/upgrades/2023_06_29_110455_populate_process_requests_collaboration_uuid.php
@@ -30,7 +30,7 @@ class PopulateProcessRequestsCollaborationUuid extends Upgrade
                     } else {
                         $request->collaboration_uuid = ProcessCollaboration::generateUuid();
                     }
-                    $request->save();
+                    ProcessRequest::where('id', $request->id)->update(['collaboration_uuid' => $request->collaboration_uuid]);
                 }
             });
     }


### PR DESCRIPTION
## Solution
This PR refactors the callProcess function to use the Nayra BPMN engine. This improves reliability, enables process calls by ID using a CallProcess event, and includes thorough testing for error handling.

## How to Test
Run a process with SubProcesses. (See the attached file)

### Scenario 1
- In the attached file there are a Parent Process and a Child process
- Run the parent process
- In the form task of the sub process fill a value in the input text
- Complete the task
- It will complete the child and the parent process

### Scenario 2
- In the attached file there are a Parent Process and a Child process
- Run the parent process
- In the form task of the sub process fill "error" in the input text
- Complete the task
- It will complete the child and the parent process will go to ERROR state in the element "Sub Process"

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8554

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
