### PR TITLE
FOUR-9310 Information about a Task without participating is not displayed in the legend

### DIFF
--- a/resources/views/processes/modeler/partials/map-legend.blade.php
+++ b/resources/views/processes/modeler/partials/map-legend.blade.php
@@ -8,6 +8,10 @@
       <span class="line completed-line"></span>
       {{ __('Completed') }}
     </p>
+    <p class="map-legend-label map-legend-label-margin">
+      <span class="line idle-line"></span>
+      {{ __('Pending / Not Executed') }}
+    </p>
   </div>
 </div>
 
@@ -17,6 +21,7 @@
     :root {
       --color-line-in-progress: #3FA6FF;
       --color-line-completed: #00BA7C;
+      --color-line-idle: #CCCCCC;
     }
 
     #map-legend.map-legend-card {
@@ -57,5 +62,10 @@
       border-right-style: solid;
       border-right-color: var(--color-line-completed);
     }
+    .idle-line {
+      border-right-style: solid;
+      border-right-color: var(--color-line-idle);
+    }
+
   </style>
 @endsection


### PR DESCRIPTION
Add the process map legend: Pending / Not Executed

## Issue & Reproduction Steps
The legend only displays information for Task with completed or in progress status. However, when a user had not participated in a Task (gray color),  that information is not displayed in the legend.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9310

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
