### PR TITLE
Rollback a failed process request

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -431,7 +431,7 @@ class TaskController extends Controller
 
     public function rollbackTask(Request $request, ProcessRequestToken $task)
     {
-        $processDefinitions = $task->processRequest->getVersionDefinitions();
+        $processDefinitions = $task->process->getDefinitions();
         $newTask = RollbackProcessRequest::rollback($task, $processDefinitions);
 
         return new Resource($newTask);

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Http\Controllers\Api;
 
 use Carbon\Carbon;
+use Facades\ProcessMaker\RollbackProcessRequest;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -416,5 +417,23 @@ class TaskController extends Controller
     {
         // Authorized in policy
         return new ApiResource($screen->versionFor($task->processRequest));
+    }
+
+    public function eligibleRollbackTask(Request $request, ProcessRequestToken $task)
+    {
+        $eligibleTask = RollbackProcessRequest::eligibleRollbackTask($task);
+        if (!$eligibleTask) {
+            return ['message' => __('Task can not be rolled back')];
+        }
+
+        return new Resource($eligibleTask);
+    }
+
+    public function rollbackTask(Request $request, ProcessRequestToken $task)
+    {
+        $processDefinitions = $task->processRequest->getVersionDefinitions();
+        $newTask = RollbackProcessRequest::rollback($task, $processDefinitions);
+
+        return new Resource($newTask);
     }
 }

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -153,7 +153,8 @@ class RequestController extends Controller
             'screenRequested',
             'addons',
             'isProcessManager',
-            'eligibleRollbackTask'
+            'eligibleRollbackTask',
+            'errorTask',
         ));
     }
 

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Http\Controllers;
 
+use Facades\ProcessMaker\RollbackProcessRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
@@ -134,6 +135,12 @@ class RequestController extends Controller
 
         $isProcessManager = $request->process?->manager_id === Auth::user()->id;
 
+        $eligibleRollbackTask = null;
+        $errorTask = RollbackProcessRequest::getErrorTask($request);
+        if ($errorTask) {
+            $eligibleRollbackTask = RollbackProcessRequest::eligibleRollbackTask($errorTask);
+        }
+
         return view('requests.show', compact(
             'request',
             'files',
@@ -145,7 +152,8 @@ class RequestController extends Controller
             'canPrintScreens',
             'screenRequested',
             'addons',
-            'isProcessManager'
+            'isProcessManager',
+            'eligibleRollbackTask'
         ));
     }
 

--- a/ProcessMaker/Policies/ProcessRequestTokenPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestTokenPolicy.php
@@ -93,7 +93,7 @@ class ProcessRequestTokenPolicy
      * Determine if a user can rollback the process request.
      *
      * @param  \ProcessMaker\Models\User  $user
-     * @param  \ProcessMaker\Models\ProcessRequest  $processRequest
+     * @param  \ProcessMaker\Models\ProcessRequestToken  $processRequestToken
      *
      * @return bool
      */

--- a/ProcessMaker/Policies/ProcessRequestTokenPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestTokenPolicy.php
@@ -88,4 +88,18 @@ class ProcessRequestTokenPolicy
 
         return true;
     }
+
+    /**
+     * Determine if a user can rollback the process request.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @param  \ProcessMaker\Models\ProcessRequest  $processRequest
+     *
+     * @return bool
+     */
+    public function rollback(User $user, ProcessRequestToken $task)
+    {
+        // For now, only the process manager can rollback the request
+        return $user->id === $task->process->managerId;
+    }
 }

--- a/ProcessMaker/RollbackProcessRequest.php
+++ b/ProcessMaker/RollbackProcessRequest.php
@@ -58,7 +58,17 @@ class RollbackProcessRequest
     public function getErrorTask(ProcessRequest $processRequest) : ?ProcessRequestToken
     {
         $lastTask = $processRequest->tokens()->orderBy('id', 'desc')->first();
+
         if ($lastTask->status === 'FAILING') {
+            return $lastTask;
+        }
+
+        // Allow for gateway tasks
+        if (
+            $lastTask->element_type === 'gateway' &&
+            $lastTask->status === 'CLOSED' &&
+            $processRequest->status === 'ERROR'
+        ) {
             return $lastTask;
         }
 

--- a/ProcessMaker/RollbackProcessRequest.php
+++ b/ProcessMaker/RollbackProcessRequest.php
@@ -59,6 +59,10 @@ class RollbackProcessRequest
     {
         $lastTask = $processRequest->tokens()->orderBy('id', 'desc')->first();
 
+        if (!$lastTask) {
+            return null;
+        }
+
         if ($lastTask->status === 'FAILING') {
             return $lastTask;
         }

--- a/ProcessMaker/RollbackProcessRequest.php
+++ b/ProcessMaker/RollbackProcessRequest.php
@@ -115,7 +115,11 @@ class RollbackProcessRequest
 
         $processRequest = $this->newTask->processRequest;
         $processRequest->status = 'ACTIVE';
+        $processRequest->process_version_id = $processRequest->process->getLatestVersion()->id;
         $processRequest->saveOrFail();
+
+        $currentTask->status = 'CLOSED';
+        $currentTask->saveOrFail();
 
         return $this->newTask;
     }
@@ -139,6 +143,17 @@ class RollbackProcessRequest
         $bpmnTask = $this->processDefinitions->getEvent($this->newTask->element_id);
 
         WorkflowManager::runScripTask($bpmnTask, $this->newTask);
+
+        $this->addComment();
+    }
+
+    private function rollbackToServiceTask()
+    {
+        $this->copyTask();
+
+        $bpmnTask = $this->processDefinitions->getEvent($this->newTask->element_id);
+
+        WorkflowManager::runServiceTask($bpmnTask, $this->newTask);
 
         $this->addComment();
     }

--- a/ProcessMaker/RollbackProcessRequest.php
+++ b/ProcessMaker/RollbackProcessRequest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace ProcessMaker;
+
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Events\ActivityAssigned;
+use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Models\Comment;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Repositories\BpmnDocument;
+
+class RollbackProcessRequest
+{
+    /**
+     * Element types that can be rolled-back to
+     *
+     * @var array
+     */
+    private $eligibleTypes = ['task', 'scriptTask', 'serviceTask'];
+
+    /**
+     * The current task (that is presumably failing or has some problem)\
+     *
+     * @var ProcessRequestToken
+     */
+    private $currentTask;
+
+    /**
+     * A previously completed task that we want to rollback to.
+     *
+     * @var ProcessRequestToken
+     */
+    private $rollbackToTask;
+
+    /**
+     * A copy of the rollbackToTask that will be the new active task.
+     *
+     * @var ProcessRequestToken
+     */
+    private $newTask;
+
+    /**
+     * BPMN Definitions for the process
+     *
+     * @var ProcessMaker\Repositories\BpmnDocument
+     */
+    private $processDefinitions;
+
+    /**
+     * Find an element in the request that can be rolled-back to.
+     * Return null if none are eligible.
+     *
+     * @return ProcessRequestToken|null
+     */
+    public function eligibleRollbackTask() : ?ProcessRequestToken
+    {
+        $processRequest = $this->currentTask->processRequest;
+
+        return $processRequest->tokens()
+            ->where('status', 'CLOSED')
+            ->where('id', '<', $this->currentTask->id)
+            ->where('element_id', '!=', $this->currentTask->element_id)
+            ->whereIn('element_type', $this->eligibleTypes)
+            ->orderBy('id', 'desc')
+            ->first();
+    }
+
+    /**
+     * Rollback a token to the previous token and reset the request status.
+     *
+     * @param ProcessRequestToken $task
+     * @return ProcessRequestToken
+     */
+    public function rollback(
+        ProcessRequestToken $currentTask,
+        BpmnDocument $processDefinitions
+        ) : ProcessRequestToken {
+        $this->currentTask = $currentTask;
+        $this->processDefinitions = $processDefinitions;
+        $this->rollbackToTask = $rollbackToTask = $this->eligibleRollbackTask();
+        if (!$this->rollbackToTask) {
+            throw new \Exception('No eligible rollback task found');
+        }
+
+        switch ($this->rollbackToTask->element_type) {
+            case 'scriptTask':
+                $this->rollbackToScriptTask();
+                break;
+            case 'serviceTask':
+                $this->rollbackToServiceTask();
+                break;
+            case 'task':
+                $this->rollbackToTask();
+                break;
+        }
+
+        $processRequest = $this->newTask->processRequest;
+        $processRequest->status = 'ACTIVE';
+        $processRequest->saveOrFail();
+
+        return $this->newTask;
+    }
+
+    private function rollbackToTask()
+    {
+        $this->copyTask();
+
+        if ($this->newTask->user_id) {
+            $this->newTask->sendActivityActivatedNotifications();
+        }
+        event(new ActivityAssigned($this->newTask));
+
+        $this->addComment();
+    }
+
+    private function rollbackToScriptTask()
+    {
+        $this->copyTask();
+
+        $bpmnTask = $this->processDefinitions->getEvent($this->newTask->element_id);
+
+        WorkflowManager::runScripTask($bpmnTask, $this->newTask);
+    }
+
+    private function copyTask()
+    {
+        $newTask = $this->rollbackToTask->replicate();
+        $newTask->uuid = null;
+        $newTask->status = 'ACTIVE';
+        $newTask->saveOrFail();
+        $this->newTask = $newTask;
+    }
+
+    /**
+     * Add a comment that the task was rolled back.
+     *
+     * @return void
+     */
+    private function addComment() : void
+    {
+        $user = Auth::user();
+        $userName = $user ? $user->name : __('The System');
+        Comment::create([
+            'type' => 'LOG',
+            'user_id' => $user ? $user->id : null,
+            'commentable_type' => ProcessRequest::class,
+            'commentable_id' => $this->currentTask->process_request_id,
+            'subject' => 'Rollback',
+            'body' => __(':user rolled back :failed_task_name to :new_task_name', [
+                'user' => $userName,
+                'failed_task_name' => $this->currentTask->element_name,
+                'new_task_name' => $this->newTask->element_name,
+            ]),
+        ]);
+    }
+}

--- a/resources/js/components/Timeline.vue
+++ b/resources/js/components/Timeline.vue
@@ -30,6 +30,7 @@
 const SubjectIcons = {
   'Task Complete': 'far fa-square',
   'Gateway': 'far fa-square fa-rotate-45',
+  'Rollback': 'fa fa-undo',
 };
 export default {
   props: ["commentable_id", 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1773,5 +1773,11 @@
   "Seconds to wait before retrying. Leave empty to use script default. Set to 0 for no retry wait time. This setting is only used when running a script task in a process.": "Seconds to wait before retrying. Leave empty to use script default. Set to 0 for no retry wait time. This setting is only used when running a script task in a process.",
   "Number of times to retry. Leave empty to use script default. Set to 0 for no retry attempts. This setting is only used when running a script task in a process.": "Number of times to retry. Leave empty to use script default. Set to 0 for no retry attempts. This setting is only used when running a script task in a process.",
   "View Request": "View Request",
-  "Execution Error": "Execution Error"
+  "Execution Error": "Execution Error",
+  "Task can not be rolled back": "Task can not be rolled back",
+  ":user rolled back :failed_task_name to :new_task_name": ":user rolled back :failed_task_name to :new_task_name",
+  "Rollback Request": "Rollback Request",
+  "Rollback": "Rollback",
+  "Rollback to task" : "Rollback to task",
+  "Are you sure you want to rollback to the task @{{name}}? Warning! This request will continue as the current published process version.": "Are you sure you want to rollback to the task @{{name}}? Warning! This request will continue as the current published process version."
 }

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -313,6 +313,18 @@
                     </button>
                   </li>
                 @endif
+                @if ($eligibleRollbackTask)
+                  @can('update', $request)
+                    <li class="list-group-item">
+                      <h5>{{ __('Rollback Request') }}</h5>
+                      <button id="retryRequestButton" type="button" class="btn btn-outline-info btn-block"
+                        data-toggle="modal" @click="rollback('{{ $eligibleRollbackTask->element_name }}')">
+                        <i class="fas fa-undo"></i> {{ __('Rollback') }}
+                      </button>
+                      <small>{{ __('Rollback to task') }}: <b>{{ $eligibleRollbackTask->element_name }}</b> ({{ $eligibleRollbackTask->element_id }})</small>
+                    </li>
+                  @endcan
+                @endif
                 @if ($request->parentRequest)
                   <li class="list-group-item">
                     <h5>{{ __('Parent Request') }}</h5>
@@ -700,6 +712,14 @@
             'default',
             apiRequest
           );
+        },
+        rollback(name) {
+          ProcessMaker.confirmModal(
+            this.$t('Confirm'),
+            this.$t('Are you sure you want to rollback to the task: ')  + name,
+            'default',
+            () => { console.log("foo") } 
+          )
         },
         getConfigurationComments() {
           if (this.canViewComments) {

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -314,7 +314,7 @@
                   </li>
                 @endif
                 @if ($eligibleRollbackTask)
-                  @can('update', $request)
+                  @can('rollback', $errorTask)
                     <li class="list-group-item">
                       <h5>{{ __('Rollback Request') }}</h5>
                       <button id="retryRequestButton" type="button" class="btn btn-outline-info btn-block"

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -318,7 +318,7 @@
                     <li class="list-group-item">
                       <h5>{{ __('Rollback Request') }}</h5>
                       <button id="retryRequestButton" type="button" class="btn btn-outline-info btn-block"
-                        data-toggle="modal" @click="rollback('{{ $eligibleRollbackTask->element_name }}')">
+                        data-toggle="modal" @click="rollback({{ $errorTask->id }}, '{{ $eligibleRollbackTask->element_name }}')">
                         <i class="fas fa-undo"></i> {{ __('Rollback') }}
                       </button>
                       <small>{{ __('Rollback to task') }}: <b>{{ $eligibleRollbackTask->element_name }}</b> ({{ $eligibleRollbackTask->element_id }})</small>
@@ -713,12 +713,16 @@
             apiRequest
           );
         },
-        rollback(name) {
+        rollback(errorTaskId, rollbackToName) {
           ProcessMaker.confirmModal(
             this.$t('Confirm'),
-            this.$t('Are you sure you want to rollback to the task: ')  + name,
+            this.$t('Are you sure you want to rollback to the task @{{name}}? Warning! This request will continue as the current published process version.', { name: rollbackToName }),
             'default',
-            () => { console.log("foo") } 
+            () => {
+              ProcessMaker.apiClient.post(`tasks/${errorTaskId}/rollback`).then(response => {
+                location.reload();
+              });
+            } 
           )
         },
         getConfigurationComments() {

--- a/routes/api.php
+++ b/routes/api.php
@@ -149,8 +149,8 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('tasks', [TaskController::class, 'index'])->name('tasks.index'); // Already filtered in controller
     Route::get('tasks/{task}', [TaskController::class, 'show'])->name('tasks.show')->middleware('can:view,task');
     Route::get('tasks/{task}/screens/{screen}', [TaskController::class, 'getScreen'])->name('tasks.get_screen')->middleware('can:viewScreen,task,screen');
-    Route::get('tasks/{task}/eligibleRollbackTask', [TaskController::class, 'eligibleRollbackTask'])->name('tasks.eligible_rollback_task')->middleware('can:update,task');
-    Route::post('tasks/{task}/rollback', [TaskController::class, 'rollbackTask'])->name('tasks.rollback_task')->middleware('can:update,task');
+    Route::get('tasks/{task}/eligibleRollbackTask', [TaskController::class, 'eligibleRollbackTask'])->name('tasks.eligible_rollback_task')->middleware('can:rollback,task');
+    Route::post('tasks/{task}/rollback', [TaskController::class, 'rollbackTask'])->name('tasks.rollback_task')->middleware('can:rollback,task');
 
     // Requests
     Route::get('requests', [ProcessRequestController::class, 'index'])->name('requests.index'); // Already filtered in controller

--- a/routes/api.php
+++ b/routes/api.php
@@ -149,6 +149,8 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('tasks', [TaskController::class, 'index'])->name('tasks.index'); // Already filtered in controller
     Route::get('tasks/{task}', [TaskController::class, 'show'])->name('tasks.show')->middleware('can:view,task');
     Route::get('tasks/{task}/screens/{screen}', [TaskController::class, 'getScreen'])->name('tasks.get_screen')->middleware('can:viewScreen,task,screen');
+    Route::get('tasks/{task}/eligibleRollbackTask', [TaskController::class, 'eligibleRollbackTask'])->name('tasks.eligible_rollback_task')->middleware('can:update,task');
+    Route::post('tasks/{task}/rollback', [TaskController::class, 'rollbackTask'])->name('tasks.rollback_task')->middleware('can:update,task');
 
     // Requests
     Route::get('requests', [ProcessRequestController::class, 'index'])->name('requests.index'); // Already filtered in controller

--- a/tests/Fixtures/rollback_test.bpmn
+++ b/tests/Fixtures/rollback_test.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="false" pm:config="{&#34;web_entry&#34;:null}">
+      <bpmn:outgoing>node_270</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="node_206" name="End Event">
+      <bpmn:incoming>node_283</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="node_255" name="Form Task" pm:screenRef="13" pm:allowInterstitial="false" pm:assignment="user_group" pm:assignedUsers="[task_user_id]" pm:assignedGroups="" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;reactions&#34;:false,&#34;voting&#34;:false,&#34;edit_comments&#34;:false,&#34;remove_comments&#34;:false,&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+      <bpmn:incoming>node_270</bpmn:incoming>
+      <bpmn:outgoing>node_281</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_270" name="" sourceRef="node_1" targetRef="node_255" />
+    <bpmn:task id="node_272" name="Bad Assignment" pm:screenRef="13" pm:allowInterstitial="false" pm:assignment="rule_expression" pm:assignedUsers="" pm:assignedGroups="" pm:assignmentLock="false" pm:allowReassignment="false" pm:assignmentRules="[{&#34;type&#34;:&#34;user&#34;,&#34;assignee&#34;:[task_user_id],&#34;expression&#34;:&#34;foo == 123&#34;,&#34;assignmentName&#34;:&#34;Admin User (admin)&#34;}]" pm:config="{&#34;reactions&#34;:false,&#34;voting&#34;:false,&#34;edit_comments&#34;:false,&#34;remove_comments&#34;:false,&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+      <bpmn:incoming>node_281</bpmn:incoming>
+      <bpmn:outgoing>node_283</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_281" name="" sourceRef="node_255" targetRef="node_272" />
+    <bpmn:sequenceFlow id="node_283" name="" sourceRef="node_272" targetRef="node_206" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="204" y="242.5" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_206_di" bpmnElement="node_206">
+        <dc:Bounds x="698" y="243.5" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_255_di" bpmnElement="node_255">
+        <dc:Bounds x="332" y="223" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_270_di" bpmnElement="node_270">
+        <di:waypoint x="222" y="260.5" />
+        <di:waypoint x="390" y="261" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_272_di" bpmnElement="node_272">
+        <dc:Bounds x="497" y="224" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_281_di" bpmnElement="node_281">
+        <di:waypoint x="390" y="261" />
+        <di:waypoint x="555" y="262" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_283_di" bpmnElement="node_283">
+        <di:waypoint x="555" y="262" />
+        <di:waypoint x="716" y="261.5" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/unit/ProcessMaker/RollbackProcessRequestTest.php
+++ b/tests/unit/ProcessMaker/RollbackProcessRequestTest.php
@@ -6,7 +6,6 @@ use Facades\ProcessMaker\RollbackProcessRequest;
 use Illuminate\Support\Facades\Auth;
 use Mockery;
 use ProcessMaker\Facades\WorkflowManager;
-use ProcessMaker\ImportExport\Psudomodels\Psudomodel;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
@@ -14,79 +13,11 @@ use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\ProcessTaskAssignment;
 use ProcessMaker\Models\Script;
 use ProcessMaker\Models\User;
-use ProcessMaker\Nayra\Contracts\Bpmn\EventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
-use ProcessMaker\Nayra\Contracts\Storage\BpmnDocumentInterface;
 use ProcessMaker\Repositories\BpmnDocument;
 
 class RollbackProcessRequestTest extends TestCase
 {
-    private $process;
-
-    private $processRequest;
-
-    private $user;
-
-    public function setUpProcessRequest()
-    {
-        return;
-
-        $this->user = User::factory()->create();
-        Auth::login($this->user);
-
-        $bpmn = file_get_contents(__DIR__ . '/../../Fixtures/rollback_test.bpmn');
-
-        $workingScript = Script::factory()->create(['code' => '<?php return ["success" => 1]; ']);
-        $workingServiceTask = Script::factory()->create([
-            'key' => 'test/foo',
-            'code' => '<?php return ["success" => 1]; ',
-        ]);
-        $errorScript = Script::factory()->create(['code' => '<?php throw new \Exception("an error");']);
-        $bpmn = str_replace('[working_script_id]', $workingScript->id, $bpmn);
-        $bpmn = str_replace('[error_script_id]', $errorScript->id, $bpmn);
-
-        $this->process = Process::factory()->create([
-            'bpmn' => $bpmn,
-        ]);
-        $this->processRequest = ProcessRequest::factory()->create([
-            'process_id' => $this->process->id,
-        ]);
-        ProcessTaskAssignment::factory()->create([
-            'process_id' => $this->process->id,
-            'process_task_id' => 'node_45',
-            'assignment_id' => $this->user->id,
-            'assignment_type' => 'user',
-        ]);
-    }
-
-    // public function testRollbackToFormTask()
-    // {
-    //     $definitions = $this->process->getDefinitions();
-    //     $startEvent = $definitions->getEvent('node_1');
-    //     $request = WorkflowManager::triggerStartEvent($this->process, $startEvent, []);
-    //     $workingFormTask = $request->tokens()->where('element_id', 'node_45')->first();
-    //     WorkflowManager::completeTask($this->process, $request, $workingFormTask, []);
-
-    //     $failedTask = $request->tokens()->where('element_id', 'node_145')->first();
-    //     $newTask = RollbackProcessRequest::rollback($failedTask);
-
-    //     $this->assertEquals('node_45', $newTask->element_id);
-    //     $this->assertEquals('ACTIVE', $newTask->status);
-    // }
-
-    // public function testRollbackToScriptTask()
-    // {
-    //     $definitions = $this->process->getDefinitions();
-    //     $startEvent = $definitions->getEvent('node_1');
-    //     $request = WorkflowManager::triggerStartEvent($this->process, $startEvent, []);
-
-    //     $failedTask = $request->tokens()->where('element_id', 'node_145')->orderBy('id', 'desc')->first();
-    //     $newTask = RollbackProcessRequest::rollback($failedTask);
-
-    //     $this->assertEquals('node_2', $newTask->element_id);
-    //     $this->assertEquals('ACTIVE', $newTask->status);
-    // }
-
     public function testRollbackToFormTask()
     {
         $processRequest = ProcessRequest::factory()->create(['status' => 'ERROR']);
@@ -109,7 +40,9 @@ class RollbackProcessRequestTest extends TestCase
             'element_type' => 'scriptTask',
         ]);
 
-        $newTask = RollbackProcessRequest::rollback($task3);
+        $mockProcessDefinitions = $this->mockWorkflowManager();
+
+        $newTask = RollbackProcessRequest::rollback($task3, $mockProcessDefinitions);
         $this->assertEquals('node_5', $newTask->element_id);
         $this->assertEquals('ACTIVE', $newTask->status);
 
@@ -139,18 +72,26 @@ class RollbackProcessRequestTest extends TestCase
             'element_type' => 'scriptTask',
         ]);
 
+        $mockProcessDefinitions = $this->mockWorkflowManager();
+
+        $newTask = RollbackProcessRequest::rollback($task3, $mockProcessDefinitions);
+        $this->assertEquals('node_5', $newTask->element_id);
+        $this->assertEquals('ACTIVE', $newTask->status);
+    }
+
+    private function mockWorkflowManager()
+    {
         $mocksScriptTask = Mockery::mock(ScriptTaskInterface::class);
         $mockProcessDefinitions = Mockery::mock(BpmnDocument::class);
         $mockProcessDefinitions->shouldReceive('getEvent')
             ->with('node_5')
             ->andReturn($mocksScriptTask);
         WorkflowManager::shouldReceive('runScripTask')
+            ->zeroOrMoreTimes()
             ->withArgs(function ($scriptTask, $task) use ($mocksScriptTask) {
                 return $scriptTask === $mocksScriptTask && $task->element_id = 'node_5';
             });
 
-        $newTask = RollbackProcessRequest::rollback($task3, $mockProcessDefinitions);
-        $this->assertEquals('node_5', $newTask->element_id);
-        $this->assertEquals('ACTIVE', $newTask->status);
+        return $mockProcessDefinitions;
     }
 }

--- a/tests/unit/ProcessMaker/RollbackProcessRequestTest.php
+++ b/tests/unit/ProcessMaker/RollbackProcessRequestTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests;
+
+use Facades\ProcessMaker\RollbackProcessRequest;
+use Illuminate\Support\Facades\Auth;
+use Mockery;
+use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\ImportExport\Psudomodels\Psudomodel;
+use ProcessMaker\Models\Comment;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\ProcessTaskAssignment;
+use ProcessMaker\Models\Script;
+use ProcessMaker\Models\User;
+use ProcessMaker\Nayra\Contracts\Bpmn\EventInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
+use ProcessMaker\Nayra\Contracts\Storage\BpmnDocumentInterface;
+use ProcessMaker\Repositories\BpmnDocument;
+
+class RollbackProcessRequestTest extends TestCase
+{
+    private $process;
+
+    private $processRequest;
+
+    private $user;
+
+    public function setUpProcessRequest()
+    {
+        return;
+
+        $this->user = User::factory()->create();
+        Auth::login($this->user);
+
+        $bpmn = file_get_contents(__DIR__ . '/../../Fixtures/rollback_test.bpmn');
+
+        $workingScript = Script::factory()->create(['code' => '<?php return ["success" => 1]; ']);
+        $workingServiceTask = Script::factory()->create([
+            'key' => 'test/foo',
+            'code' => '<?php return ["success" => 1]; ',
+        ]);
+        $errorScript = Script::factory()->create(['code' => '<?php throw new \Exception("an error");']);
+        $bpmn = str_replace('[working_script_id]', $workingScript->id, $bpmn);
+        $bpmn = str_replace('[error_script_id]', $errorScript->id, $bpmn);
+
+        $this->process = Process::factory()->create([
+            'bpmn' => $bpmn,
+        ]);
+        $this->processRequest = ProcessRequest::factory()->create([
+            'process_id' => $this->process->id,
+        ]);
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $this->process->id,
+            'process_task_id' => 'node_45',
+            'assignment_id' => $this->user->id,
+            'assignment_type' => 'user',
+        ]);
+    }
+
+    // public function testRollbackToFormTask()
+    // {
+    //     $definitions = $this->process->getDefinitions();
+    //     $startEvent = $definitions->getEvent('node_1');
+    //     $request = WorkflowManager::triggerStartEvent($this->process, $startEvent, []);
+    //     $workingFormTask = $request->tokens()->where('element_id', 'node_45')->first();
+    //     WorkflowManager::completeTask($this->process, $request, $workingFormTask, []);
+
+    //     $failedTask = $request->tokens()->where('element_id', 'node_145')->first();
+    //     $newTask = RollbackProcessRequest::rollback($failedTask);
+
+    //     $this->assertEquals('node_45', $newTask->element_id);
+    //     $this->assertEquals('ACTIVE', $newTask->status);
+    // }
+
+    // public function testRollbackToScriptTask()
+    // {
+    //     $definitions = $this->process->getDefinitions();
+    //     $startEvent = $definitions->getEvent('node_1');
+    //     $request = WorkflowManager::triggerStartEvent($this->process, $startEvent, []);
+
+    //     $failedTask = $request->tokens()->where('element_id', 'node_145')->orderBy('id', 'desc')->first();
+    //     $newTask = RollbackProcessRequest::rollback($failedTask);
+
+    //     $this->assertEquals('node_2', $newTask->element_id);
+    //     $this->assertEquals('ACTIVE', $newTask->status);
+    // }
+
+    public function testRollbackToFormTask()
+    {
+        $processRequest = ProcessRequest::factory()->create(['status' => 'ERROR']);
+        $task1 = ProcessRequestToken::factory()->create([
+            'status' => 'CLOSED',
+            'process_request_id' => $processRequest->id,
+            'element_id' => 'node_5',
+            'element_type' => 'task',
+        ]);
+        $task2 = ProcessRequestToken::factory()->create([
+            'status' => 'CLOSED',
+            'process_request_id' => $processRequest->id,
+            'element_id' => 'node_6',
+            'element_type' => 'gateway',
+        ]);
+        $task3 = ProcessRequestToken::factory()->create([
+            'status' => 'FAILING',
+            'process_request_id' => $processRequest->id,
+            'element_id' => 'node_7',
+            'element_type' => 'scriptTask',
+        ]);
+
+        $newTask = RollbackProcessRequest::rollback($task3);
+        $this->assertEquals('node_5', $newTask->element_id);
+        $this->assertEquals('ACTIVE', $newTask->status);
+
+        $comment = Comment::orderBy('id', 'desc')->first();
+        $this->assertEquals($comment->body, "The System rolled back {$task3->element_name} to {$newTask->element_name}");
+    }
+
+    public function testRollbackToScriptTask()
+    {
+        $processRequest = ProcessRequest::factory()->create(['status' => 'ERROR']);
+        $task1 = ProcessRequestToken::factory()->create([
+            'status' => 'CLOSED',
+            'process_request_id' => $processRequest->id,
+            'element_id' => 'node_5',
+            'element_type' => 'scriptTask',
+        ]);
+        $task2 = ProcessRequestToken::factory()->create([
+            'status' => 'CLOSED',
+            'process_request_id' => $processRequest->id,
+            'element_id' => 'node_6',
+            'element_type' => 'gateway',
+        ]);
+        $task3 = ProcessRequestToken::factory()->create([
+            'status' => 'FAILING',
+            'process_request_id' => $processRequest->id,
+            'element_id' => 'node_7',
+            'element_type' => 'scriptTask',
+        ]);
+
+        $mocksScriptTask = Mockery::mock(ScriptTaskInterface::class);
+        $mockProcessDefinitions = Mockery::mock(BpmnDocument::class);
+        $mockProcessDefinitions->shouldReceive('getEvent')
+            ->with('node_5')
+            ->andReturn($mocksScriptTask);
+        WorkflowManager::shouldReceive('runScripTask')
+            ->withArgs(function ($scriptTask, $task) use ($mocksScriptTask) {
+                return $scriptTask === $mocksScriptTask && $task->element_id = 'node_5';
+            });
+
+        $newTask = RollbackProcessRequest::rollback($task3, $mockProcessDefinitions);
+        $this->assertEquals('node_5', $newTask->element_id);
+        $this->assertEquals('ACTIVE', $newTask->status);
+    }
+}


### PR DESCRIPTION
Allows the user to rollback a request to a previous task so they can fix issues and try again.

ci:deploy

## How to Test
See the examples in the comments in the PRD https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3081732111/Error+Handling?focusedCommentId=3124789249

Jose said the the first and second examples are the most important. To trigger an error on a form task, assign the task by "rule expression" and give an invalid expression

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9083

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
