### PR TITLE
FOUR-9341 Start a Process has a large delay because of large media table

### DIFF
--- a/ProcessMaker/Models/EnvironmentVariable.php
+++ b/ProcessMaker/Models/EnvironmentVariable.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Models;
 
+use Exception;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 use ProcessMaker\Traits\Exportable;
@@ -56,9 +57,13 @@ class EnvironmentVariable extends ProcessMakerModel
     {
         try {
             return decrypt($this->attributes['value']);
-        } catch (\Exception $e) {
-            Log::error('EnvironmentVariable: ' . $this->attributes['value']. "\n" . $e->getMessage());
-            Log::error($e->getTraceAsString());
+        } catch (Exception $e) {
+            Log::error(
+                'Can not decrypt environment variable: ' .
+                $this->attributes['name'] .
+                "\n" . $e->getMessage() .
+                "\n" . $e->getTraceAsString()
+            );
             return null;
         }
     }

--- a/database/migrations/2023_07_13_110125_add_index_by_model_id_to_media_table.php
+++ b/database/migrations/2023_07_13_110125_add_index_by_model_id_to_media_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexByModelIdToMediaTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('media', function (Blueprint $table) {
+            // Create index by model_id
+            $table->index('model_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('media', function (Blueprint $table) {
+            // Drop index by model_id
+            $table->dropIndex('media_model_id_index');
+        });
+    }
+}

--- a/upgrades/2023_06_29_110455_populate_process_requests_collaboration_uuid.php
+++ b/upgrades/2023_06_29_110455_populate_process_requests_collaboration_uuid.php
@@ -30,7 +30,7 @@ class PopulateProcessRequestsCollaborationUuid extends Upgrade
                     } else {
                         $request->collaboration_uuid = ProcessCollaboration::generateUuid();
                     }
-                    $request->save();
+                    ProcessRequest::where('id', $request->id)->update(['collaboration_uuid' => $request->collaboration_uuid]);
                 }
             });
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
During the start of a process, the model  Media is selected by model_id, for example:
```
select * from `media` where `model_id` in (342393);
```
For a large amount of media files this query takes a while.

As a developer I would like to have a index by model_id to improve the performance of the query.

## Solution
- Add an Index by model_id in table media.

## How to Test
Start any process.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9341

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
