### PR TITLE
FOUR-8942: When Creating a Process with Bpmn and Super Admin as Process Manager, Registry is Wrong

### DIFF
--- a/ProcessMaker/Events/ProcessCreated.php
+++ b/ProcessMaker/Events/ProcessCreated.php
@@ -18,6 +18,8 @@ class ProcessCreated implements SecurityLogEventInterface
 
     public const TEMPLATE_CREATION = 'TEMPLATE';
 
+    public const BPMN_CREATION = 'BPMN';
+
     /**
      * Create a new event instance.
      *

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -224,7 +224,7 @@ class ProcessController extends Controller
     {
         $request->validate(Process::rules());
         $data = $request->all();
-
+        $processCreated = ProcessCreated::BLANK_CREATION;
         // If bpmn exists (from Generative AI)
         if ($request->input('bpmn')) {
             $data['bpmn'] = $request->input('bpmn');
@@ -236,6 +236,7 @@ class ProcessController extends Controller
             $request->request->add(['bpmn' => $data['bpmn']]);
             $request->request->remove('file');
             unset($data['file']);
+            $processCreated = ProcessCreated::BPMN_CREATION;
         }
 
         if ($schemaErrors = $this->validateBpmn($request)) {
@@ -278,7 +279,7 @@ class ProcessController extends Controller
             );
         }
         // Register the Event
-        ProcessCreated::dispatch($process->refresh(), ProcessCreated::BLANK_CREATION);
+        ProcessCreated::dispatch($process->refresh(), $processCreated);
 
         return new Resource($process->refresh());
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
When Creating a Process with Bpmn and Super Admin as Process Manager, Registry is Wrong

## Related Tickets & Packages
Tickets from QA
- FOUR-8942

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
