### PR TITLE
Bugfix/FOUR-9301: Error server displayed after import a translation

### DIFF
--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -590,6 +590,10 @@ class ProcessTranslation
                     foreach ($screenTranslations as $language => $translations) {
                         if ($language === $languageCode) {
                             $screenTranslations[$languageCode]['strings'] = $newTranslations;
+                            if (!array_key_exists('created_at', $screenTranslations[$languageCode])) {
+                                $screenTranslations[$languageCode]['created_at'] = Carbon::now();
+                            }
+                            $screenTranslations[$languageCode]['updated_at'] = Carbon::now();
                         }
                     }
                 }

--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -541,8 +541,9 @@ class ProcessTranslation
                 $availableStrings,
                 $newScreenTranslations[$languageCode]['strings'] ?? []
             );
+            $createdAt = $newScreenTranslations[$languageCode]['created_at'] ?? Carbon::now();
             $newScreenTranslations[$languageCode]['updated_at'] = Carbon::now();
-            $newScreenTranslations[$languageCode]['created_at'] = $newScreenTranslations[$languageCode]['created_at'] ?? Carbon::now();
+            $newScreenTranslations[$languageCode]['created_at'] = $createdAt;
         }
 
         return $newScreenTranslations;

--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -522,84 +522,59 @@ class ProcessTranslation
 
     public function importTranslations($payload)
     {
-        $screens = [];
         foreach ($payload as $screenUuid => $value) {
             $screen = Screen::where('uuid', $screenUuid)->first();
-            $newScreenTranslations = [];
             if ($screen) {
-                $screenTranslations = $screen->translations;
-                $availableStrings = $this->getStringsInScreen($screen);
-
-                foreach ($value as $languageCode => $translations) {
-                    if (!array_key_exists($languageCode, $screenTranslations)) {
-                        $screenTranslations[$languageCode]['strings'] = [];
-                    }
-
-                    $newTranslations = [];
-                    // For each of the available elements in the screens
-                    foreach ($availableStrings as $availableString) {
-                        // We need to check if there are current translations in the translation
-                        // column (old translations) for that available string
-                        $foundOld = false;
-                        foreach ($screenTranslations[$languageCode]['strings'] as $inDbTranslation) {
-                            if ($availableString === $inDbTranslation['key']) {
-                                $foundOld = true;
-                                $oldTranslation = [
-                                    'key' => $inDbTranslation['key'],
-                                    'string' => $inDbTranslation['string'],
-                                ];
-                            }
-                        }
-
-                        // We need to check if there are some translation in the translation file
-                        // for that available string
-                        $foundInFile = false;
-                        foreach ($translations as $importedTranslation) {
-                            if ($availableString === $importedTranslation['key']) {
-                                $foundInFile = true;
-                                $inFileTranslation = [
-                                    'key' => $importedTranslation['key'],
-                                    'string' => $importedTranslation['string'],
-                                ];
-                            }
-                        }
-
-                        if ($foundOld && !$foundInFile) {
-                            $newTranslations[] = $oldTranslation;
-                        }
-
-                        if (!$foundOld && $foundInFile) {
-                            $newTranslations[] = $inFileTranslation;
-                        }
-
-                        if ($foundOld && $foundInFile && $inFileTranslation['string'] === '') {
-                            $newTranslations[] = $inFileTranslation;
-                        }
-
-                        if ($foundOld && $foundInFile && $inFileTranslation['string'] === null) {
-                            $newTranslations[] = $oldTranslation;
-                        }
-
-                        if ($foundOld && $foundInFile && $inFileTranslation['string'] && $inFileTranslation['string'] !== '') {
-                            $newTranslations[] = $inFileTranslation;
-                        }
-                    }
-
-                    // Assign new translations to language in screen
-                    // $newScreenTranslations[$languageCode]['strings'] = $newTranslations;
-                    foreach ($screenTranslations as $language => $translations) {
-                        if ($language === $languageCode) {
-                            $screenTranslations[$languageCode]['strings'] = $newTranslations;
-                            if (!array_key_exists('created_at', $screenTranslations[$languageCode])) {
-                                $screenTranslations[$languageCode]['created_at'] = Carbon::now();
-                            }
-                            $screenTranslations[$languageCode]['updated_at'] = Carbon::now();
-                        }
-                    }
-                }
-                $screen->translations = $screenTranslations;
+                $screen->translations = $this->generateNewTranslations($value, $screen);
                 $screen->save();
             }
         }
+    }
+
+    protected function generateNewTranslations($value, $screen)
+    {
+        $newScreenTranslations = $screen->translations;
+        $availableStrings = $this->getStringsInScreen($screen);
+        foreach ($value as $languageCode => $translations) {
+            $newScreenTranslations[$languageCode]['strings'] = $this->generateNewLanguageTranslations(
+                $translations,
+                $availableStrings,
+                $newScreenTranslations[$languageCode]['strings'] ?? []
+            );
+            $newScreenTranslations[$languageCode]['updated_at'] = Carbon::now();
+            $newScreenTranslations[$languageCode]['created_at'] = $newScreenTranslations[$languageCode]['created_at'] ?? Carbon::now();
+        }
+
+        return $newScreenTranslations;
+    }
+
+    protected function generateNewLanguageTranslations($translations, $availableStrings, $existingTranslations)
+    {
+        $newTranslations = [];
+        foreach ($availableStrings as $availableString) {
+            $oldTranslation = $this->getTranslation($availableString, $existingTranslations);
+            $inFileTranslation = $this->getTranslation($availableString, $translations);
+            if (($oldTranslation !== null && $inFileTranslation === null)
+                || ($oldTranslation !== null && $inFileTranslation !== null && $inFileTranslation['string'] === null)) {
+                $newTranslations[] = $oldTranslation;
+            }
+            if ($inFileTranslation !== null
+                && ($oldTranslation === null || $oldTranslation !== null && $inFileTranslation !== null)) {
+                $newTranslations[] = $inFileTranslation;
+            }
+        }
+
+        return $newTranslations;
+    }
+
+    protected function getTranslation($key, $translationArray)
+    {
+        foreach ($translationArray as $translation) {
+            if ($key === $translation['key']) {
+                return $translation;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduce:**
- Login as admin
- Import a process
- Go to Configure > Translations
- Create a translation
- Export the translation
- **Delete the translation**
- Import the translation

**Current behavior:**
After completing the translation a Server Error message is displayed, the list of translations is not displayed and when trying to create a new translation, the dropdown with the languages does not display

**Expected behavior:**
The translation should be imported with no issues

## Solution
- When no translations in the DB, the fields created_at and updated_at for the translation doesn't exists. Added the fields created_at and updated_at when importing into an empty translations column.

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-9301](https://processmaker.atlassian.net/browse/FOUR-9301)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy

.


[FOUR-9301]: https://processmaker.atlassian.net/browse/FOUR-9301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ