### PR TITLE
FOUR-9348: Download Link and the Link Sepated are Shown when Downloading in Logs Admin/Users

### DIFF
--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -28,7 +28,7 @@
             <b-alert v-for="(item, index) in alerts" :key="index" class="d-none d-lg-block alertBox" :show="item.alertShow" :variant="item.alertVariant" dismissible fade @dismissed="alertDismissed(item)" @dismiss-count-down="alertDownChanged($event, item)" style="white-space:pre-line">
               <span v-if="item.showLoader" class="spinner-border spinner-border-sm mb-1 mr-2"></span>
               <span>@{{item.alertText}}</span>
-              <span v-if="item.alertLink"><a :href="item.alertLink">@{{item.alertLink}}</a></span>
+              <span v-if="item.alertLink"><a :href="item.alertLink">{{ __('Download') }}</a></span>
             </b-alert>
         </div>
         @php


### PR DESCRIPTION
## Issue & Reproduction Steps
Download Link and the Link Sepated are Shown when Downloading in Logs Admin/Users

## Related Tickets & Packages
Tickets from QA
- FOUR-9348

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy