### PR TITLE
FOUR-9203 Add BpmnAction to process a Failed Task

### DIFF
--- a/ProcessMaker/Facades/WorkflowManager.php
+++ b/ProcessMaker/Facades/WorkflowManager.php
@@ -10,6 +10,8 @@ use ProcessMaker\Bpmn\Process;
  *
  * @method static mixed callProcess($filename, $processId)
  * @method static mixed triggerStartEvent($definitions, $event, array $data)
+ * @method static mixed completeTask(\ProcessMaker\Models\Process $definitions, \ProcessMaker\Nayra\Contracts\Bpmn\ExecutionInstanceInterface $instance, \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface $token, array $data)
+ * @method static mixed taskFailed(\ProcessMaker\Nayra\Contracts\Bpmn\ExecutionInstanceInterface $instance, \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface $token, string $error)
  * @method static mixed runScripTask(\ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface $scriptTask, Token $token)
  * @method static mixed runServiceTask(\ProcessMaker\Nayra\Contracts\Bpmn\ServiceTaskInterface $serviceTask, Token $token)
  * @method static void throwSignalEventDefinition(\ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface $sourceEventDefinition, \ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface $token)

--- a/ProcessMaker/Jobs/RunNayraScriptTask.php
+++ b/ProcessMaker/Jobs/RunNayraScriptTask.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use ProcessMaker\Exception\ScriptException;
+use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Managers\DataManager;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\Script;
+use ProcessMaker\Models\ScriptExecutor;
+use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use Throwable;
+
+/**
+ * This job runs a script task with custom language like nodejs
+ */
+class RunNayraScriptTask implements ShouldQueue
+{
+    use Dispatchable,
+        InteractsWithQueue,
+        Queueable,
+        SerializesModels;
+
+    public $tokenId;
+
+    public $userId;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param \ProcessMaker\Models\ProcessRequestToken $token
+     * @param array $data
+     */
+    public function __construct(TokenInterface $token)
+    {
+        $this->tokenId = $token->getKey();
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Get token
+        $token = ProcessRequestToken::find($this->tokenId);
+        $token->loadTokenProperties();
+        $instance = $token->processRequest;
+        $processModel = $token->process;
+        $instance->loadProcessRequestInstance();
+        $token->setInstance($instance);
+        $element = $token->getDefinition(true);
+
+        // Exit if the task was completed or closed
+        if (!$token || !$element) {
+            return;
+        }
+        $scriptRef = $element->getProperty('scriptRef');
+        $configuration = json_decode($element->getProperty('config'), true);
+        $errorHandling = json_decode($element->getProperty('errorHandling'), true);
+        if ($errorHandling === null) {
+            $errorHandling = [];
+        }
+
+        // Check to see if we've failed parsing.  If so, let's convert to empty array.
+        if ($configuration === null) {
+            $configuration = [];
+        }
+        try {
+            if (empty($scriptRef)) {
+                $code = $element->getScript();
+                if (empty($code)) {
+                    throw new ScriptException(__('No code or script assigned to ":name"', ['name' => $element->getName()]));
+                }
+                $language = Script::scriptFormat2Language($element->getProperty('scriptFormat', 'application/x-php'));
+                $script = new Script([
+                    'code' => $code,
+                    'language' => $language,
+                    'run_as_user_id' => Script::defaultRunAsUser()->id,
+                    'script_executor_id' => ScriptExecutor::initialExecutor($language)->id,
+                ]);
+            } else {
+                $script = Script::findOrFail($scriptRef)->versionFor($instance);
+            }
+
+            $dataManager = new DataManager();
+            $data = $dataManager->getData($token);
+            $response = $script->runScript($data, $configuration, $token->getId(), $errorHandling);
+
+            // Dispatch complete task action
+            WorkflowManager::completeTask($processModel, $instance, $token, $response['output']);
+        } catch (Throwable $exception) {
+            Log::error('Script failed: ' . $scriptRef . ' - ' . $exception->getMessage());
+            Log::error($exception->getTraceAsString());
+            WorkflowManager::taskFailed($instance, $token, $exception->getMessage());
+        }
+    }
+
+    /**
+     * When Job fails
+     */
+    public function failed(Throwable $exception)
+    {
+        if (!$this->tokenId) {
+            Log::error('Script failed: ' . $exception->getMessage());
+
+            return;
+        }
+        Log::error('Script (#' . $this->tokenId . ') failed: ' . $exception->getMessage());
+        $token = ProcessRequestToken::find($this->tokenId);
+        if ($token) {
+            $element = $token->getBpmnDefinition();
+            $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
+            $error = $element->getRepository()->createError();
+            $error->setName($exception->getMessage());
+            $token->setProperty('error', $error);
+            Log::error($exception->getTraceAsString());
+            $token->save();
+        }
+    }
+}

--- a/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Nayra\Repositories;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use ProcessMaker\Jobs\RunNayraScriptTask;
 use ProcessMaker\Listeners\BpmnSubscriber;
 use ProcessMaker\Managers\TaskSchedulerManager;
 use ProcessMaker\Models\ProcessRequest;
@@ -136,6 +137,13 @@ class PersistenceHandler
                     // Trigger service task listener
                     $subscriber = new BpmnSubscriber();
                     $subscriber->onServiceTaskActivated($serviceTask, $token);
+                    break;
+                case 'script_task_executor':
+                    // Get object instances
+                    $token = $this->deserializer->unserializeToken($transaction['token']);
+
+                    // Trigger script task executor
+                    RunNayraScriptTask::dispatch($token)->onQueue('bpmn');
                     break;
                 default:
                     throw new Exception('Unknown transaction type ' . $transaction['type']);


### PR DESCRIPTION
## Issue & Reproduction Steps
In order to properly handle and register Task failures, a new BpmnAction should be implemented.

## Solution
- Implement a BpmnAction TASK_FAILED

## How to Test
- Create a Process with an Script that thorws an exception.
- Run the process

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9203

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
