### PR TITLE
FOUR-9363 Fix Error is generated when creating a saved search filtered by process name

### DIFF
--- a/database/migrations/2023_07_14_123928_add_index_by_name_to_process_requests_table.php
+++ b/database/migrations/2023_07_14_123928_add_index_by_name_to_process_requests_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexByNameToProcessRequestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('process_requests', function (Blueprint $table) {
+            // Create index by name
+            $table->index('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('process_requests', function (Blueprint $table) {
+            // Drop index
+            $table->dropIndex(['name']);
+        });
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Filter by process_requests.name is commonly used. In a large DB filter by request name took a long time to complete.

## Solution
- Add index by process_requests.name.

## How to Test
Run a search by process request name.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9363

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
