### PR TITLE
FOUR-9240: (QA Observation)When Creating Files After Folder Creation, the Link for FilesCreated for the File is Incorrect

### DIFF
--- a/ProcessMaker/Events/FilesCreated.php
+++ b/ProcessMaker/Events/FilesCreated.php
@@ -37,7 +37,7 @@ class FilesCreated implements SecurityLogEventInterface
             // Link to file in the package
             $this->name = [
                 'label' => $this->media['name'],
-                'link' => route('file-manager.index', ['public/' . $this->media['name']]),
+                'link' => route('file-manager.index', ['public/' . $this->media['file_name']]),
             ];
         } else {
             $this->processName = $data->getAttribute('name');


### PR DESCRIPTION
## Issue & Reproduction Steps

- Have package files installed
- Create a folder
- Inside the folder, create a file
- Verify Security Logs

## Solution
- I added the file_name instead of name

## How to Test

- Upload a File
- Go to Security Logs
- Review the event Files Created
- Click in the URL and check if the route is correct

## Related Tickets & Packages
- [FOUR-9240](https://processmaker.atlassian.net/browse/FOUR-9240)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9240]: https://processmaker.atlassian.net/browse/FOUR-9240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ