### PR TITLE
FOUR-9353 Fix queue connection timeout

### DIFF
--- a/ProcessMaker/Nayra/MessageBrokers/ServiceKafka.php
+++ b/ProcessMaker/Nayra/MessageBrokers/ServiceKafka.php
@@ -62,7 +62,11 @@ class ServiceKafka
     public function worker()
     {
         // Create Kafka consumer
-        $consumer = Kafka::createConsumer([self::QUEUE_NAME])->withHandler(function (KafkaConsumerMessage $message) {
+        $heartbeat = config('kafka.heartbeat_interval_ms', 3000);
+        $consumer = Kafka::createConsumer([self::QUEUE_NAME])
+            ->withOption('heartbeat.interval.ms', $heartbeat)
+            ->withOption('session.timeout.ms', $heartbeat * 10)
+            ->withHandler(function (KafkaConsumerMessage $message) {
             // Get transactions
             $transactions = $message->getBody();
 

--- a/ProcessMaker/Nayra/MessageBrokers/ServiceRabbitMq.php
+++ b/ProcessMaker/Nayra/MessageBrokers/ServiceRabbitMq.php
@@ -29,9 +29,11 @@ class ServiceRabbitMq
         $rabbitMqPort = config('rabbitmq.port');
         $rabbitMqLogin = config('rabbitmq.login');
         $rabbitMqPassword = config('rabbitmq.password');
-
+        $rabbitmqKeepalive = true;
+        $rabbitmqHeartbeat = config('rabbitmq.heartbeat', 60);
+        
         // Create connection
-        $this->connection = new AMQPStreamConnection($rabbitMqHost, $rabbitMqPort, $rabbitMqLogin, $rabbitMqPassword);
+        $this->connection = new AMQPStreamConnection($rabbitMqHost, $rabbitMqPort, $rabbitMqLogin, $rabbitMqPassword, '/', false, 'AMQPLAIN', null, 'en_US', 3, 3, null, $rabbitmqKeepalive, $rabbitmqHeartbeat);
         $this->channel = $this->connection->channel();
 
         // Set channel config

--- a/config/kafka.php
+++ b/config/kafka.php
@@ -55,4 +55,9 @@ return [
      | The sleep time in milliseconds that will be used when retrying flush
      */
     'flush_retry_sleep_in_ms' => 100,
+
+    /*
+     | heartbeat interval in milliseconds
+     */
+    'heartbeat_interval_ms' => intval(env('KAFKA_HEARTBEAT_INTERVAL_MS') ?: 3000),
 ];

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -28,6 +28,7 @@ return [
     'vhost' => env('RABBITMQ_VHOST', '/'),
     'login' => env('RABBITMQ_LOGIN', 'guest'),
     'password' => env('RABBITMQ_PASSWORD', 'guest'),
+    'heartbeat' => intval(env('RABBITMQ_HEARTBEAT') ?: 60),
 
     'queue' => env('RABBITMQ_QUEUE', 'default'),
 


### PR DESCRIPTION
## Issue & Reproduction Steps
When engine is configured with rabbitmq and it is not used for a long time the connection to the message broker times out.

## Solution
- Setup the keepalive and timeout properties for the connection to keep alive the connection.

## How to Test
1. Run a process and wait a couple of days (do not run or complete any action in the server)
2. then check the connection is still alive by running another processes.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9353

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
