### PR TITLE
FOUR-9413 Run reassign process with default engine

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -16,6 +16,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowElementInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\MultiInstanceLoopCharacteristicsInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Managers\WorkflowManagerDefault;
 use ProcessMaker\Notifications\ActivityActivatedNotification;
 use ProcessMaker\Traits\ExtendedPMQL;
 use ProcessMaker\Traits\HasUuids;
@@ -900,7 +901,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         }
         $assignmentProcess = Process::where('name', Process::ASSIGNMENT_PROCESS)->first();
         if ($assignmentProcess) {
-            $res = WorkflowManager::runProcess($assignmentProcess, 'assign', [
+            $res = (new WorkflowManagerDefault)->runProcess($assignmentProcess, 'assign', [
                 'task_id' => $this->id,
                 'user_id' => $userId,
                 'process_id' => $this->process_id,


### PR DESCRIPTION
## Issue & Reproduction Steps
During the tests of logs. An error happens when a task is reassigned.

## Solution
- The internal process reassign user is synchronous an should be executed by the default engine (without kafka).

## How to Test
- Create a process with a form task (see the attached process as example)
- Enable reassign task
- Run the process
- Reassign the task

Attached: process
[logs_in_requests.zip](https://github.com/ProcessMaker/processmaker/files/12098900/logs_in_requests.zip)

![image](https://github.com/ProcessMaker/processmaker/assets/8028650/04c699de-40f9-4cd3-bf31-a9316f617256)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9413

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
