### PR TITLE
FOUR-9389: (QA Observation) ScriptUpdated is automatically created after ScriptCreated

### DIFF
--- a/ProcessMaker/Events/ScriptUpdated.php
+++ b/ProcessMaker/Events/ScriptUpdated.php
@@ -45,6 +45,9 @@ class ScriptUpdated implements SecurityLogEventInterface
         ? ScriptCategory::getNamesByIds($this->changes['tmp_script_category_id']) : '';
         $this->changes = array_diff_key($this->changes, array_flip($this::REMOVE_KEYS));
         $this->original = array_diff_key($this->original, array_flip($this::REMOVE_KEYS));
+        if (empty($this->changes['script_category'])) {
+            $this->original['script_category'] = '';
+        }
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
(QA Observation) ScriptUpdated is automatically created after ScriptCreated

## Related Tickets & Packages
- FOUR-9389

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
