### PR TITLE
FOUR-9398 - Hide Scripts and DataSources of PM Blocks

### DIFF
--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -11,7 +11,11 @@ use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\ProcessTemplates;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
+use ProcessMaker\Models\Script;
+use ProcessMaker\Models\ScriptCategory;
 use ProcessMaker\Models\User;
+use ProcessMaker\Packages\Connectors\DataSources\Models\DataSource;
+use ProcessMaker\Packages\Connectors\DataSources\Models\DataSourceCategory;
 
 trait HideSystemResources
 {
@@ -68,6 +72,22 @@ trait HideSystemResources
             return $query->whereNotIn('screen_category_id', $systemCategory)
                     ->where('is_template', false)
                     ->when(Schema::hasColumn('screens', 'asset_type'), function ($query) {
+                        return $query->whereNull('asset_type');
+                    });
+        } elseif (static::class === Script::class) {
+            $systemCategory = ScriptCategory::where('is_system', true)->pluck('id');
+
+            return $query->whereNotIn('script_category_id', $systemCategory)
+                    ->where('is_template', false)
+                    ->when(Schema::hasColumn('scripts', 'asset_type'), function ($query) {
+                        return $query->whereNull('asset_type');
+                    });
+        } elseif (static::class === DataSource::class) {
+            $systemCategory = DataSourceCategory::where('is_system', true)->pluck('id');
+
+            return $query->whereNotIn('data_source_category_id', $systemCategory)
+                    ->where('is_template', false)
+                    ->when(Schema::hasColumn('data_sources', 'asset_type'), function ($query) {
                         return $query->whereNull('asset_type');
                     });
         } elseif (static::class == ProcessRequest::class) {


### PR DESCRIPTION
## Issue & Reproduction Steps
When we create a PM Block, we need to hide all the assets linked to the PM Block. At the moment we're only hiding the Screens. 
1. Create a Process with the following: Screen, Scripts, DataSouces.
2. Create a Pm Block from the Process.
3. The Scripts and DataSouces created based on the Pm Block are still showing on the page related to each asset.

## Solution
- Added Scripts, DataSouces to HideSystemResources.php 

## How to Test
Follow the reproduction steps and check if the Screen and Scripts related to the PM Block are hidden from the page related to the asset.

## Related Tickets & Packages
- Ticket [FOUR-9398](https://processmaker.atlassian.net/browse/FOUR-9398)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9398]: https://processmaker.atlassian.net/browse/FOUR-9398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ