### PR TITLE
Bugfix/FOUR-9387: X button is displaced when create 7 templates

### DIFF
--- a/resources/js/components/templates/ButtonCard.vue
+++ b/resources/js/components/templates/ButtonCard.vue
@@ -1,13 +1,13 @@
 <template>
   <div :class="{'d-flex': button.helperEnabled}">
-    <b-card no-body class="button-card" @mouseenter="addHoverClass" @mouseleave="removeHoverClass" @click="$emit('card-button-clicked')">
+    <b-card no-body class="button-card" :class="{'col-6 p-0': button.helperEnabled}" @mouseenter="addHoverClass" @mouseleave="removeHoverClass" @click="$emit('card-button-clicked')">
       <div class="card-body text-center d-flex justify-content-center flex-column">
         <i class="icon mb-1 text-primary" :class="button.icon"></i>
         <h5 class="m-0">{{ button.title }}</h5>
       </div>
     </b-card>
 
-    <div v-if="button.helperEnabled" class="helper-container">
+    <div v-if="button.helperEnabled" class="helper-container col-6 p-0">
       <div class="arrow-left"></div>
       <b-card no-body class="button-card card-helper p-4">
         <div class="card-body card-helper text-center d-flex justify-content-center flex-column">

--- a/resources/js/components/templates/ButtonCard.vue
+++ b/resources/js/components/templates/ButtonCard.vue
@@ -41,7 +41,6 @@ export default {
 
 <style lang="scss" scoped>
 .button-card {
-  width: 292px;
   height: 172px;
   border-radius: 4px;
   padding: 10px 8px 10px 8px;

--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -11,65 +11,68 @@
       </b-input-group>
     </div>
 
-    <b-card-group id="template-options" deck class="d-flex small-deck-margin">
-      <button-card
-        v-show="component === 'template-select-card'"
-        :button="blankProcessButton"
-        @show-details="showDetails($event)"
-        @card-button-clicked="$emit('blank-process-button-clicked')"
-      />
-
-      <div v-if="packageAi">
+    <div class="cards-container">
+      <b-card-group id="template-options" deck class="d-flex small-deck-margin">
         <button-card
-          v-if="component === 'template-select-card'"
-          :button="aiProcessButton"
+          class="col-4 p-0"
+          v-show="component === 'template-select-card'"
+          :button="blankProcessButton"
           @show-details="showDetails($event)"
-          @card-button-clicked="$emit('ai-process-button-clicked')"
+          @card-button-clicked="$emit('blank-process-button-clicked')"
         />
-      </div>
-      <div v-if="component === 'template-select-card'" class="d-flex w-100 align-items-center my-3 card-separator">
-        <small class="mr-2 text-secondary">Templates</small>
-        <div class="flex-grow-1 border-bottom"></div>
-      </div>
 
-    </b-card-group>
-
-    <div class="pb-2 template-container">
-      <template v-if="noResults === true">
-        <div class="no-data-icon d-flex d-block justify-content-center mt-5 pt-5 pb-2">
-          <i class="fas fa-umbrella-beach mt-5 pt-5" />
-        </div>
-        <div class="no-data d-block d-flex justify-content-center">
-          {{ $t('No Data Available') }}
-        </div>
-      </template>
-      <template v-else>
-        <b-card-group id="template-options" deck class="d-flex small-deck-margin">
-          <template-select-card
-            v-show="component === 'template-select-card'"
-            v-for="(template, index) in templates"
-            :key="index"
-            :template="template"
+        <div v-if="packageAi" class="col-8 p-0">
+          <button-card
+            v-if="component === 'template-select-card'"
+            :button="aiProcessButton"
             @show-details="showDetails($event)"
+            @card-button-clicked="$emit('ai-process-button-clicked')"
           />
-        </b-card-group>
-      </template>
-      <template-details v-if="component === 'template-details'" :template="template"></template-details>
-      <template v-else>
-          <b-pagination
-          v-model="currentPage"
-          v-if="templates.length > 0"
-          class="template-modal-pagination"
-          :total-rows="totalRow"
-          :per-page="perPage"
-          :limit="limit"
-          prev-class="caretBtn prevBtn"
-          next-class="caretBtn nextBtn"
-          size="sm"
-          last-number
-          first-number
-        ></b-pagination>
-      </template>
+        </div>
+        <div v-if="component === 'template-select-card'" class="d-flex w-100 align-items-center my-3 card-separator">
+          <small class="mr-2 text-secondary">Templates</small>
+          <div class="flex-grow-1 border-bottom"></div>
+        </div>
+
+      </b-card-group>
+
+      <div class="pb-2 template-container">
+        <template v-if="noResults === true">
+          <div class="no-data-icon d-flex d-block justify-content-center mt-5 pt-5 pb-2">
+            <i class="fas fa-umbrella-beach mt-5 pt-5" />
+          </div>
+          <div class="no-data d-block d-flex justify-content-center">
+            {{ $t('No Data Available') }}
+          </div>
+        </template>
+        <template v-else>
+          <b-card-group id="template-options" deck class="d-flex small-deck-margin">
+            <template-select-card
+              v-show="component === 'template-select-card'"
+              v-for="(template, index) in templates"
+              :key="index"
+              :template="template"
+              @show-details="showDetails($event)"
+            />
+          </b-card-group>
+        </template>
+        <template-details v-if="component === 'template-details'" :template="template"></template-details>
+        <template v-else>
+            <b-pagination
+            v-model="currentPage"
+            v-if="templates.length > 0"
+            class="template-modal-pagination"
+            :total-rows="totalRow"
+            :per-page="perPage"
+            :limit="limit"
+            prev-class="caretBtn prevBtn"
+            next-class="caretBtn nextBtn"
+            size="sm"
+            last-number
+            first-number
+          ></b-pagination>
+        </template>
+      </div>
     </div>
   </div>
 </template>
@@ -211,5 +214,10 @@ export default {
 .card-separator {
   margin-left: 0.7rem;
   margin-right: 0.7rem;
+}
+.cards-container {
+  overflow-y: auto;
+  overflow-x: hidden;
+  height: 400px;
 }
 </style>

--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -46,7 +46,7 @@
           </div>
         </template>
         <template v-else>
-          <b-card-group id="template-options" deck class="d-flex small-deck-margin">
+          <b-card-group id="template-options" deck class="d-flex small-deck-margin template-options">
             <template-select-card
               v-show="component === 'template-select-card'"
               v-for="(template, index) in templates"
@@ -57,23 +57,23 @@
           </b-card-group>
         </template>
         <template-details v-if="component === 'template-details'" :template="template"></template-details>
-        <template v-else>
-            <b-pagination
-            v-model="currentPage"
-            v-if="templates.length > 0"
-            class="template-modal-pagination"
-            :total-rows="totalRow"
-            :per-page="perPage"
-            :limit="limit"
-            prev-class="caretBtn prevBtn"
-            next-class="caretBtn nextBtn"
-            size="sm"
-            last-number
-            first-number
-          ></b-pagination>
-        </template>
       </div>
     </div>
+    <template v-if="component !== 'template-details'">
+        <b-pagination
+        v-model="currentPage"
+        v-if="templates.length > 0"
+        class="template-modal-pagination"
+        :total-rows="totalRow"
+        :per-page="perPage"
+        :limit="limit"
+        prev-class="caretBtn prevBtn"
+        next-class="caretBtn nextBtn"
+        size="sm"
+        last-number
+        first-number
+      ></b-pagination>
+    </template>
   </div>
 </template>
 
@@ -218,6 +218,11 @@ export default {
 .cards-container {
   overflow-y: auto;
   overflow-x: hidden;
-  height: 400px;
+  height: 415px;
+}
+.template-options {
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 0;
 }
 </style>

--- a/resources/js/components/templates/TemplateSelectCard.vue
+++ b/resources/js/components/templates/TemplateSelectCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="pb-2">
+  <div class="pb-2 template-select-card-container">
     <b-card no-body class="template-select-card" @click="showDetails()" @mouseenter="addHoverClass" @mouseleave="removeHoverClass">
       <b-card-body :title="template.name | str_limit(30)" class="card-body">
         <b-card-text class="mb-2">
@@ -63,8 +63,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.template-select-card-container {
+  flex: 0 0 33.333333%;
+}
 .template-select-card {
-  width: 292px;
+  // width: 292px;
   height: 172px;
   border-radius: 4px;
   padding: 10px 8px 10px 8px;


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduce:**
- Login as admin
- Create a process
- Save the process as template
- Repeat the process three more times

**Current behavior:**
When there are seven templates saved the window displayed is too big and the X button is overlaped with the top of the browser

**Expected behavior:**
The window should not reach that size and display a scroll bar in order to prevent this issue

## Solution
- Added a cards container with height and overflow.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/42ae060d-7db4-40f7-9e76-20cf19fc80b2



## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-9387](https://processmaker.atlassian.net/browse/FOUR-9387)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy


[FOUR-9387]: https://processmaker.atlassian.net/browse/FOUR-9387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ