### PR TITLE
FOUR-9417 - Rich text-html settings stopped working

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -97,7 +97,7 @@ Route::middleware('auth', 'sanitize', 'external.connection', 'force_change_passw
     Route::put('processes/{process}', [ProcessController::class, 'update'])->name('processes.update')->middleware('can:edit-processes');
     Route::delete('processes/{process}', [ProcessController::class, 'destroy'])->name('processes.destroy')->middleware('can:archive-processes');
 
-    Route::get('process_events/{process}', [ProcessController::class, 'triggerStartEventApi'])->middleware('can:start,process');
+    Route::get('process_events/{process}', [ProcessController::class, 'triggerStartEventApi'])->name('process_events.trigger')->middleware('can:start,process');
     Route::get('processes/{process}/export/translation/{language}', [ProcessTranslationController::class, 'export']);
     Route::get('processes/{process}/import/translation', [ProcessTranslationController::class, 'import']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -97,6 +97,7 @@ Route::middleware('auth', 'sanitize', 'external.connection', 'force_change_passw
     Route::put('processes/{process}', [ProcessController::class, 'update'])->name('processes.update')->middleware('can:edit-processes');
     Route::delete('processes/{process}', [ProcessController::class, 'destroy'])->name('processes.destroy')->middleware('can:archive-processes');
 
+    Route::get('process_events/{process}', [ProcessController::class, 'triggerStartEventApi'])->middleware('can:start,process');
     Route::get('processes/{process}/export/translation/{language}', [ProcessTranslationController::class, 'export']);
     Route::get('processes/{process}/import/translation', [ProcessTranslationController::class, 'import']);
 

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -1190,4 +1190,21 @@ class ProcessTest extends TestCase
         // Assert draft version is deleted.
         $this->assertEquals(0, $process->versions()->draft()->count());
     }
+
+    public function testTriggerStartEventWeb()
+    {
+        $this->withoutExceptionHandling();
+        $process = Process::factory()->create([
+            'bpmn' => Process::getProcessTemplate('SingleTask.bpmn'),
+        ]);
+
+        $route = route('process_events.trigger', [
+            'process' => $process->id,
+            'event' => 'StartEventUID',
+        ]);
+        $response = $this->webCall('GET', $route);
+
+        // Assert redirect status.
+        $response->assertStatus(302);
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The `process_events/{process}` route stopped working.

## Solution
- The mentioned route has been restored, which may have been accidentally deleted in this commit: https://github.com/ProcessMaker/processmaker/commit/9dec5b81044b28f65e7ebecf6442ae0ef5a4d9d9.
- Added unit test to take into account this route in the future.

## How to Test
- Follow the steps mentioned in the JIRA ticket to test its functionality.
- Execute unit test.

## Related Tickets & Packages
- [FOUR-9417](https://processmaker.atlassian.net/browse/FOUR-9417)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9417]: https://processmaker.atlassian.net/browse/FOUR-9417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ