### PR TITLE
Bugfix/FOUR-9437: Change cancel button text to close in modal

### DIFF
--- a/resources/js/components/shared/Modal.vue
+++ b/resources/js/components/shared/Modal.vue
@@ -70,7 +70,8 @@
     </template>
     <slot></slot>
     <template v-if="setCustomButtons" #modal-footer>
-      <div class="d-flex justify-content-end align-items-center w-100">
+      <div class="d-flex align-items-center w-100"
+        :class="{'justify-content-end': !showAiSlogan, 'justify-content-between': showAiSlogan}">
         <div v-if="showAiSlogan" class="slogan">
           <img src="/img/favicon.svg"> {{ $t("Powered by ProcessMaker AI") }}
         </div>

--- a/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
+++ b/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
@@ -159,7 +159,7 @@ export default {
         {'content': '< Back', 'action': 'showSelectTargetLanguage', 'variant': 'link', 'disabled': false, 'hidden': true, 'ariaLabel': 'Back to select language'},
       ],
       customModalButtons: [
-        {'content': 'Cancel', 'action': 'hide()', 'variant': 'outline-secondary', 'disabled': false, 'hidden': false},
+        {'content': 'Close', 'action': 'hide()', 'variant': 'outline-secondary', 'disabled': false, 'hidden': false},
         {'content': 'Translate Process', 'action': 'translate', 'variant': 'secondary', 'disabled': true, 'hidden': false, 'dataTest': 'translation-translate-process'},
         {'content': 'Save Translation', 'action': 'saveTranslations', 'variant': 'secondary', 'disabled': false, 'hidden': true, 'dataTest': 'translation-save-translation-button'},
       ],


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduce:**
- Create a process
- Go to process > configure
- Click on translations tab
- Click on + translation button

**Current behavior:**
The button to close the modal shows **Cancel** instead **Close**

**Expected behavior:**
The button should show Close

## Solution
- Change cancel text to close. Fix alignment.

**Working screenshot**

<img width="1512" alt="Screenshot 2023-07-20 at 09 14 44" src="https://github.com/ProcessMaker/processmaker/assets/90727999/534ec6c0-cd8a-4762-9cf6-a19ff61e4504">


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-9437](https://processmaker.atlassian.net/browse/FOUR-9437)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9437]: https://processmaker.atlassian.net/browse/FOUR-9437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ