### PR TITLE
Bugfix/FOUR-9438: Clear history after click the use model button

### DIFF
--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -152,6 +152,10 @@
         this.$emit('resetModal');
       },
       onSubmit () {
+        if (this.generativeProcessData) {
+          this.$emit("clear-ai-history");
+        }
+
         this.errors = Object.assign({}, {
           name: null,
           description: null,


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduce:**
- Go to processes > + process > generative AI
- Generate some processes to get history items
- Click on **use model** button and then save in the modal
- You will be redirected to the modeler with the new process
- Go back to the generative ai screen
- The history should be empty

**Current behavior:**
After click on use model and create a process, the history still there.

**Expected behavior:**
After click on use model and create a process, the history should be cleared.

## Solution
- After click save in the modal emit an event to package-ai to clear the history.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/95e738df-440d-4171-bbb2-8dd5cd07451a


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-9438](https://processmaker.atlassian.net/browse/FOUR-9438)
- [Package AI PR](https://github.com/ProcessMaker/package-ai/pull/7)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-9438]: https://processmaker.atlassian.net/browse/FOUR-9438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ