### PR TITLE
Do not fail token until all attempts have been run

### DIFF
--- a/ProcessMaker/Jobs/ErrorHandling.php
+++ b/ProcessMaker/Jobs/ErrorHandling.php
@@ -43,13 +43,16 @@ class ErrorHandling
     public function handleRetries($job, $exception)
     {
         $message = $exception->getMessage();
+        $finalAttempt = true;
 
         if ($this->retryAttempts() > 0) {
             if ($job->attemptNum <= $this->retryAttempts()) {
                 Log::info('Retry the job process. Attempt ' . $job->attemptNum . ' of ' . $this->retryAttempts() . ', Wait time: ' . $this->retryWaitTime());
                 $this->requeue($job);
 
-                return $message;
+                $finalAttempt = false;
+
+                return [$message, $finalAttempt];
             }
 
             $message = __('Job failed after :attempts total attempts', ['attempts' => $job->attemptNum]) . "\n" . $message;
@@ -59,7 +62,7 @@ class ErrorHandling
             $this->sendExecutionErrorNotification($message);
         }
 
-        return $message;
+        return [$message, $finalAttempt];
     }
 
     private function requeue($job)

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -109,11 +109,14 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
                 $this->instance = $instance;
             });
         } catch (Throwable $exception) {
-            $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
-
             $message = $exception->getMessage();
+            $finalAttempt = true;
             if ($errorHandling) {
-                $message = $errorHandling->handleRetries($this, $exception);
+                [$message, $finalAttempt] = $errorHandling->handleRetries($this, $exception);
+            }
+
+            if ($finalAttempt) {
+                $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
             }
 
             $error = $element->getRepository()->createError();


### PR DESCRIPTION
Fix for an issue that @caleeli found for boundary error events when retrying script and service tasks

Might need RunNayra* updates too

Related to https://processmaker.atlassian.net/browse/FOUR-8993