### PR TITLE
FOUR-9440 - Disable Publish PmBlock button at each request

### DIFF
--- a/resources/js/components/pm-blocks/CreatePmBlockModal.vue
+++ b/resources/js/components/pm-blocks/CreatePmBlockModal.vue
@@ -216,6 +216,7 @@ export default {
         formData.append("user_id", this.currentUserId);
         formData.append("pm_block_category_id", this.pm_block_category_id);
         formData.append("meta", JSON.stringify(this.meta));
+        this.customModalButtons[1].disabled = true;
         ProcessMaker.apiClient.post("pm-blocks", formData)
         .then(response => {
           ProcessMaker.alert(this.$t("PM Block successfully created"), "success");
@@ -225,6 +226,7 @@ export default {
           this.close();
         }).catch(error => {
           this.errors = error.response?.data;
+          this.customModalButtons[1].disabled = false;
           if (this.errors.hasOwnProperty('errors')) {
             this.errors = this.errors?.errors;
           } else {


### PR DESCRIPTION
## Issue & Reproduction Steps
When creating a PM Block from a Process, the Publish button will create multiple PM blocks when you click on Publish several times in the same request.

1. Click on Process or create a process
2. Click on the ellipsis menu
3. Click on Save as PM Block
4. Add the Pm Block info in the Create Modal
5. Click on Publish MULTIPLE times

You will notice that multiple PM Blocks will be created a the same time.

## Solution
- Disabled Publish button at each Post request.

## How to Test
Follow the reproduction steps and you will notice that the Publish button will be disabled and only one POST request will be sent.


## Related Tickets & Packages
- Ticket [FOUR-9440](https://processmaker.atlassian.net/browse/FOUR-9440)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9440]: https://processmaker.atlassian.net/browse/FOUR-9440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ