### PR TITLE
FOUR-9412 Fix retry script task

### DIFF
--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -237,7 +237,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
         $version = $instance->process_version_id;
         $userId = $this->getCurrentUserId();
         $state = $this->serializeState($instance);
-\Log::info(json_encode($state));
+
         // Dispatch complete task action
         $this->dispatchAction([
             'bpmn' => $version,

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -631,6 +631,8 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
      * Send payload
      *
      * @param array $action
+     * @param string $subject
+     * @return void
      */
     private function dispatchAction(array $action, $subject = 'requests'): void
     {

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -237,7 +237,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
         $version = $instance->process_version_id;
         $userId = $this->getCurrentUserId();
         $state = $this->serializeState($instance);
-
+\Log::info(json_encode($state));
         // Dispatch complete task action
         $this->dispatchAction([
             'bpmn' => $version,

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -243,7 +243,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
             'bpmn' => $version,
             'action' => self::ACTION_RUN_SCRIPT,
             'params' => [
-                'request_id' => $token->process_request_id,
+                'instance_id' => $instance->uuid,
                 'token_id' => $token->uuid,
                 'element_id' => $token->element_id,
                 'data' => [],
@@ -252,7 +252,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
             'session' => [
                 'user_id' => $userId,
             ],
-        ]);
+        ], 'scripts');
     }
 
     /**
@@ -632,12 +632,11 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
      *
      * @param array $action
      */
-    private function dispatchAction(array $action): void
+    private function dispatchAction(array $action, $subject = 'requests'): void
     {
         // add environment variables to session
         $environmentVariables = $this->getEnvironmentVariables();
         $action['session']['env'] = $environmentVariables;
-        $subject = 'requests';
         $thread = $action['collaboration_id'] ?? 0;
         MessageBrokerService::sendMessage($subject, $thread, $action);
     }

--- a/ProcessMaker/Nayra/MessageBrokers/ServiceRabbitMq.php
+++ b/ProcessMaker/Nayra/MessageBrokers/ServiceRabbitMq.php
@@ -69,10 +69,15 @@ class ServiceRabbitMq
         }
 
         // Prepare the message to send
-        $message = new AMQPMessage(json_encode(['data' => $body, 'collaboration_id' => $collaborationId]));
+        if ($subject === 'scripts') {
+            $payload = json_encode($body);
+        } else {
+            $payload = json_encode(['data' => $body, 'collaboration_id' => $collaborationId]);
+        }
+        $message = new AMQPMessage($payload);
 
         // Publish the message
-        $this->channel->basic_publish($message, '', self::QUEUE_NAME_PUBLISH);
+        $this->channel->basic_publish($message, '', $subject);
     }
 
     /**

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -237,6 +237,9 @@ class TokenRepository implements TokenRepositoryInterface
      */
     public function persistActivityCompleted(ActivityInterface $activity, TokenInterface $token)
     {
+        if ($token->getInstance()->status === 'ERROR') {
+            $token->getInstance()->status = 'ACTIVE';
+        }
         $process = $token->getInstance()->getProcess();
         if ($process->isNonPersistent()) {
             return;

--- a/ProcessMaker/RetryProcessRequest.php
+++ b/ProcessMaker/RetryProcessRequest.php
@@ -83,7 +83,8 @@ class RetryProcessRequest
 
         $this->unlockProcessRequest();
 
-        $this->reactivateRequest();
+        // disable the next line: Rerun the task will move the task to the proper state
+        // $this->reactivateRequest();
 
         $this->getRetriableTasks()->each(function (ProcessRequestToken $token) {
             // Load the token instance

--- a/ProcessMaker/RetryProcessRequest.php
+++ b/ProcessMaker/RetryProcessRequest.php
@@ -83,9 +83,6 @@ class RetryProcessRequest
 
         $this->unlockProcessRequest();
 
-        // disable the next line: Rerun the task will move the task to the proper state
-        // $this->reactivateRequest();
-
         $this->getRetriableTasks()->each(function (ProcessRequestToken $token) {
             // Load the token instance
             $token = $token->loadTokenInstance();


### PR DESCRIPTION
## Issue & Reproduction Steps
During the retry test, a failed script task that was not fixed, changed the process state to ACTIVE when the user pressed "RETRY" instead of remaining in ERROR as intended.

## Solution
- Change to ACTIVE only when the script task is completed successfully.

## How to Test
- Create a script task with a throw exception
- Add the script to a process
- Run the process
- The task fails, then try RETRY, the request should keep in ERROR status
- Fix the script
- try RETRY again
- The request should continue (to ACTIVE if there is a next task or COMPLETED if it is the last)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9412

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
