### PR TITLE
Bugfix/FOUR-9292: Show warning message for no PM languages

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessTranslationController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessTranslationController.php
@@ -104,8 +104,21 @@ class ProcessTranslationController extends Controller
             }
         }
 
+        // Available Pm Languages (user settings)
+        $pmLangs = [];
+        foreach (scandir(resource_path('lang')) as $file) {
+            preg_match('/([a-z]{2})\\.json/', $file, $matches);
+            if (!empty($matches)) {
+                $pmLangs[] = $matches[1];
+            }
+        }
+
+        // Our form controls need attribute:value pairs sot we convert the langs array to and associative one
+        $availablePmLanguages = array_combine($pmLangs, $pmLangs);
+
         return response()->json([
             'availableLanguages' => $availableLanguages,
+            'availablePmLanguages' => $availablePmLanguages,
         ]);
     }
 

--- a/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
+++ b/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
@@ -42,6 +42,12 @@
             </b-form-checkbox>
           </div>
         </div>
+
+        <div class="mt-3" v-if="showLanguageWarning">
+          <p class="alert alert-warning m-0">
+            The translations for the selected language are only be applied to anonymous web entry screens.
+          </p>
+        </div>
       </div>
 
       <!-- Processing translations section -->
@@ -143,6 +149,7 @@ export default {
       disabled: false,
       aiLoading: false,
       availableLanguages: [],
+      availablePmLanguages: [],
       selectedLanguage: null,
       selectedScreen: null,
       screensTranslations: [],
@@ -166,6 +173,18 @@ export default {
     };
   },
 
+  computed: {
+    showLanguageWarning() {
+      if (!this.selectedLanguage) {
+        return false;
+      }
+
+      if (this.availablePmLanguages[this.selectedLanguage.language] === undefined) {
+        return true;
+      }
+      return false;
+    },
+  },
   watch: {
     selectedScreen(val) {
       this.currentScreenTranslations = [];
@@ -390,6 +409,7 @@ export default {
       ProcessMaker.apiClient.post("/process/translations/languages", params)
         .then((response) => {
           this.availableLanguages = JSON.parse(JSON.stringify(response.data.availableLanguages));
+          this.availablePmLanguages = JSON.parse(JSON.stringify(response.data.availablePmLanguages));
           this.loading = false;
         });
     },

--- a/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
+++ b/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
@@ -45,7 +45,7 @@
 
         <div class="mt-3" v-if="showLanguageWarning">
           <p class="alert alert-warning m-0">
-            The translations for the selected language are only be applied to anonymous web entry screens.
+            {{ $t("Since there is no interface translation for this language, translations for these screens will only render for anonymous users in web entries.") }}
           </p>
         </div>
       </div>

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1715,6 +1715,7 @@
   "Templates": "Templates",
   "Template Author": "Template Author",
   "Create a new Process": "Create a new Process",
+  "Since there is no interface translation for this language, translations for these screens will only render for anonymous users in web entries.": "Since there is no interface translation for this language, translations for these screens will only render for anonymous users in web entries.",
   "Your word is our command!": "Your word is our command!",
   "Use Artificial Intelligence in any natural language to create complex Processes, just like writing to a person. Even describe your Process in one language, but output your model in another.":"Use Artificial Intelligence in any natural language to create complex Processes, just like writing to a person. Even describe your Process in one language, but output your model in another.",
   "Publish Template": "Publish Template",


### PR DESCRIPTION
## Issue & Reproduction Steps
When you select a language in the process translations list, if that language is not present in the languages list in User > settings, show a warning message.

## Solution
- Add a warning message

## Related Tickets & Packages
- [FOUR-9292](https://processmaker.atlassian.net/browse/FOUR-9292)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9292]: https://processmaker.atlassian.net/browse/FOUR-9292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ