### PR TITLE
Add error notification setting for process request

### DIFF
--- a/ProcessMaker/Listeners/BpmnSubscriber.php
+++ b/ProcessMaker/Listeners/BpmnSubscriber.php
@@ -166,6 +166,7 @@ class BpmnSubscriber
     public function onActivityException(ActivityInterface $activity, ProcessRequestToken $token)
     {
         $error = $token->getProperty('error');
+        $msg = '';
         if ($error instanceof ErrorInterface) {
             $msg = $error->getName();
             $token->logError(new Exception($msg), $activity);

--- a/ProcessMaker/Listeners/BpmnSubscriber.php
+++ b/ProcessMaker/Listeners/BpmnSubscriber.php
@@ -33,6 +33,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TransitionInterface;
 use ProcessMaker\Notifications\ActivityActivatedNotification;
 use ProcessMaker\Notifications\ActivityCompletedNotification;
+use ProcessMaker\Notifications\ErrorExecutionNotification;
 use ProcessMaker\Notifications\ProcessCompletedNotification;
 use ProcessMaker\Notifications\ProcessCreatedNotification;
 
@@ -172,6 +173,12 @@ class BpmnSubscriber
             $msg = "$error";
             $token->logError(new Exception($msg), $activity);
         }
+
+        $notifiables = $token->getInstance()->getNotifiables('error');
+        Notification::send($notifiables, new ErrorExecutionNotification($token, $msg, [
+            'email_notification' => true,
+            'inapp_notification' => true,
+        ]));
     }
 
     /**

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -199,6 +199,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         'started',
         'canceled',
         'completed',
+        'error',
     ];
 
     public $taskNotifiableTypes = [

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -704,6 +704,7 @@
   "Request All": "Request All",
   "Request Canceled": "Request Canceled",
   "Request Completed": "Request Completed",
+  "Request Error": "Request Error",
   "Request Detail Screen": "Request Detail Screen",
   "Request Detail": "Request Detail",
   "Request In Progress": "Request In Progress",

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -257,6 +257,7 @@
                                         <th class="action">{{__('Request Started')}}</th>
                                         <th class="action">{{__('Request Canceled')}}</th>
                                         <th class="action">{{__('Request Completed')}}</th>
+                                        <th class="action">{{__('Request Error')}}</th>
                                     </tr>
                                     </thead>
                                     <tbody>
@@ -289,6 +290,15 @@
                                                            for="notify-manager-completed"></label>
                                                 </div>
                                             </td>
+                                            <td class="action">
+                                                <div class="custom-control custom-switch">
+                                                    <input id="notify-manager-error" type="checkbox"
+                                                           v-model="formData.notifications.manager.error"
+                                                           class="custom-control-input">
+                                                    <label class="custom-control-label"
+                                                           for="notify-manager-error"></label>
+                                                </div>
+                                            </td>
                                         </tr>
                                         <tr>
                                             <td class="notify">{{__('Notify Requester')}}</td>
@@ -310,7 +320,7 @@
                                                            for="notify-requester-canceled"></label>
                                                 </div>
                                             </td>
-                                            <td class="action">
+                                            <td class="action" colspan="2">
                                                 <div class="custom-control custom-switch">
                                                     <input id="notify-requester-completed" type="checkbox"
                                                            v-model="formData.notifications.requester.completed"
@@ -336,7 +346,7 @@
                                                            for="notify-participants-canceled"></label>
                                                 </div>
                                             </td>
-                                            <td class="action">
+                                            <td class="action" colspan="2">
                                                 <div class="custom-control custom-switch">
                                                     <input id="notify-participants-completed" type="checkbox"
                                                            v-model="formData.notifications.participants.completed"
@@ -549,11 +559,9 @@
         }
 
         #table-notifications td.notify {
-            width: 40%;
         }
 
         #table-notifications td.action {
-            width: 20%;
         }
 
         .inline-input {


### PR DESCRIPTION
## Issue & Reproduction Steps
- Notifications were not being sent to the process manager for failings requests

## Solution
- Add error notification setting for process request

![image](https://github.com/ProcessMaker/processmaker/assets/2546850/72a2da69-db07-4c09-9e79-080865982ae3)


## How to Test
- Create a process and set a process manager
- Configure the process Notification tab to notify the manager on request error
- Add a failing task to the process. For example, a script task that throws an error or a send email task when the email server credentials are wrong
- Verify the process manager gets a notification when the process is run. They should receive both an in-app notification (bell icon) and an email notification (assuming the email server credentials are correct)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8062

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
