### PR TITLE
FOUR-9462 The summary of a complete request from a process that has a PMBlock shows internal data

### DIFF
--- a/ProcessMaker/Nayra/Repositories/PersistenceRequestTrait.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceRequestTrait.php
@@ -37,6 +37,12 @@ trait PersistenceRequestTrait
     public function persistInstanceCompleted(array $transaction)
     {
         $instance = $this->deserializer->unserializeInstance($transaction['instance']);
+
+        // Remove unnecessary data before complete instance
+        $instance->getDataStore()->removeData('_user');
+        $instance->getDataStore()->removeData('_request');
+
+        // Persist instance
         $this->instanceRepository->persistInstanceCompleted($instance);
 
         // Event


### PR DESCRIPTION
## Issue & Reproduction Steps
When a instance is completed the magic variables "_user" and "_request" still present in the request data

## Solution
- Clean unnecessary data before complete the instance

## How to Test
Set in ".env" file the "MESSAGE_BROKER_DRIVER" value to "rabbitmq" or "kafka" and run a process until complete the flow.

## Related Tickets & Packages
- [FOUR-9482](https://processmaker.atlassian.net/browse/FOUR-9462)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
