### PR TITLE
FOUR-9331: Disable buttons in Forms Tab

### DIFF
--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -21,7 +21,7 @@
       </button>
     </div>
     <div v-for="page in printablePages" :key="page" class="card">
-      <div class="card-body h-100" :style="styles">
+      <div class="card-body h-100" :style="cardStyles">
         <component
           ref="print"
           :is="component"
@@ -86,7 +86,7 @@
         opacity: 0.85,
         blur: '2px',
         isPhotoVideo: false,
-        styles: '',
+        cardStyles: 'pointer-events: none;',
       }
     },
     computed: {
@@ -216,7 +216,7 @@
         }
       },
       isPhotoVideo() {
-        this.styles = this.isPhotoVideo ? 'pointer-events : all' : 'pointer-events : none';
+        this.cardStyles = this.isPhotoVideo ? 'pointer-events : all' : 'pointer-events : none';
       }
     }
   }


### PR DESCRIPTION
## Issue & Reproduction Steps

The buttons are enabled in the Request - Forms tab.

1. Create a screen
2. Add a loop check in Allow additional loops
3. inside the loop add any control
4. Create a simple process and add the previously created screen
5. create a request and complete it
6. go to the tab form and click on Details

## Solution
- Previously, in the form tabs, the CSS rule `pointer-events: none` was used, that rule has been set back as the default.
  - Related commit: [https://github.com/ProcessMaker/processmaker/pull/4798/commits/93f47a4d2d71e1d4debedd7567ec9601385c0330](https://github.com/ProcessMaker/processmaker/pull/4798/commits/93f47a4d2d71e1d4debedd7567ec9601385c0330)
  - This change is compatible with the previous JIRA ticket ([FOUR-8608](https://processmaker.atlassian.net/browse/FOUR-8608)).

## How to Test
- Follow the reproduction steps of above.

## Related Tickets & Packages
- [FOUR-9331](https://processmaker.atlassian.net/browse/FOUR-9331)
- [FOUR-9405](https://processmaker.atlassian.net/browse/FOUR-9405)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy


[FOUR-8608]: https://processmaker.atlassian.net/browse/FOUR-8608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-9331]: https://processmaker.atlassian.net/browse/FOUR-9331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-9405]: https://processmaker.atlassian.net/browse/FOUR-9405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ