### PR TITLE
Change default process template categories

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -38,6 +38,6 @@ return [
         'base_url' => 'https://raw.githubusercontent.com/processmaker/',
         'template_repo' => env('DEFAULT_TEMPLATE_REPO', 'process-templates'),
         'template_branch' => env('DEFAULT_TEMPLATE_BRANCH', 'main'),
-        'template_categories' => env('DEFAULT_TEMPLATE_CATEGORIES', 'all'),
+        'template_categories' => env('DEFAULT_TEMPLATE_CATEGORIES', 'accounting-and-finance,customer-success,human-resources,marketing-and-sales,operations,it'),
     ],
 ];


### PR DESCRIPTION
## Issue & Reproduction Steps
Set the default process template categories to the following:
- accounting-and-finance
- customer-success
- human-resources
- marketing-and-sales
- operations
- it

## Solution
- Change the default templates in the configuration

ci:deploy
ci:db:clean