### PR TITLE
Screens aren't listed in the screen list in Oakstar Bank Development server with PM4 v4.6.1

### DIFF
--- a/ProcessMaker/Console/Commands/ReviewCategoryNull.php
+++ b/ProcessMaker/Console/Commands/ReviewCategoryNull.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use ProcessMaker\Models\Screen;
+
+class ReviewCategoryNull extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'category:review-category-assign';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check the category_id column for null values.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $table = 'screens';
+        $field = 'screen_category_id';
+        $class = Screen::class;
+        $default = DB::table('screen_categories')->where('name', 'Uncategorized')->pluck('id')->first();
+
+        DB::table($table)->select('id', 'title')
+            ->whereNull($field)
+            ->whereNull('key')
+            ->orderBy('id', 'DESC')->chunk(100, function (Collection $items) use ($table, $field, $class, $default) {
+            foreach ($items as $item) {
+                //$this->info('title: ' . $item->id);
+                $category = DB::table('category_assignments')
+                    ->select('category_id')
+                    ->where([
+                        ['assignable_type', '=', $class],
+                        ['assignable_id', '=', $item->id],
+                    ])->first();
+                
+                $categoryId = $default;
+                if ($category) {
+                    $categoryId = $category->category_id;
+                }
+
+                DB::table($table)
+                    ->where('id', $item->id)
+                    ->update([$field => $categoryId]);
+                
+                $this->info('- ' . $item->title . '   ==>   Category: ' . $categoryId);
+                
+            }
+        });
+    }
+}

--- a/ProcessMaker/Console/Commands/ReviewCategoryNull.php
+++ b/ProcessMaker/Console/Commands/ReviewCategoryNull.php
@@ -46,11 +46,9 @@ class ReviewCategoryNull extends Command
         $default = DB::table('screen_categories')->where('name', 'Uncategorized')->pluck('id')->first();
 
         DB::table($table)->select('id', 'title')
-            ->whereNull($field)
-            ->whereNull('key')
-            ->orderBy('id', 'DESC')->chunk(100, function (Collection $items) use ($table, $field, $class, $default) {
+            ->whereNull([$field, 'key'])
+            ->orderBy('id', 'DESC')->chunkById(100, function (Collection $items) use ($table, $field, $class, $default) {
             foreach ($items as $item) {
-                //$this->info('title: ' . $item->id);
                 $category = DB::table('category_assignments')
                     ->select('category_id')
                     ->where([

--- a/upgrades/2023_06_16_131342_review_categories_null.php
+++ b/upgrades/2023_06_16_131342_review_categories_null.php
@@ -1,0 +1,28 @@
+<?php
+
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class ReviewCategoriesNull extends Upgrade
+{
+    public $to = '4.6.2';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Artisan::call('category:review-category-assign');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
_Based on [original PR](https://github.com/ProcessMaker/processmaker/pull/4897) for v4.6.2 by @marcoAntonioNina._

----

## Issue & Reproduction Steps
It can be seen that there are several screens with the screen_category_id column null, which could be seen in versions prior to 4.6.0, but currently, they are not displayed in the list of screens since they need to have a category assigned, in addition to having a system category.

## Solution
- An artisan php command was created, to review all screens with null category

## How to Test

- have screens with field category null, but with assignments in the category_asgments table.
- these screens are not shown in the list of screens.
- run the `php artisan category:review-category-assign` command

## Related Tickets & Packages
- [FOUR-8788](https://processmaker.atlassian.net/browse/FOUR-8788)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8788]: https://processmaker.atlassian.net/browse/FOUR-8788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy