### PR TITLE
FOUR-9662: remove User_id is present in AuthClientCreated

### DIFF
--- a/ProcessMaker/Events/AuthClientCreated.php
+++ b/ProcessMaker/Events/AuthClientCreated.php
@@ -33,8 +33,6 @@ class AuthClientCreated implements SecurityLogEventInterface
                 'label' => $this->data['name'],
                 'link' => route('auth-clients.index'),
             ],
-            'auth_client_id' => $this->data['id'] ?? '',
-            'user_id' => $this->data['user_id'] ?? '',
             'revoked' => $this->data['revoked'] ?? '',
             'provider' => $this->data['provider'] ?? '',
             'redirect' => $this->data['redirect'] ?? '',
@@ -50,6 +48,7 @@ class AuthClientCreated implements SecurityLogEventInterface
     {
         return [
             'id' => $this->data['id'],
+            'user_id' => $this->data['user_id'] ?? '',
         ];
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Create an Authenticated Client
Check the User Activity Logging

## Solution
- I will remove some ids does not provide important information to the end user

## How to Test
Create an Authenticated Client
Check the User Activity Logging

## Related Tickets & Packages
- [FOUR-9662](https://processmaker.atlassian.net/browse/FOUR-9662)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9662]: https://processmaker.atlassian.net/browse/FOUR-9662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ