### PR TITLE
FOUR-9471 - Prevent Editing of Locked PM Blocks in Modeler

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -18,7 +18,6 @@ use ProcessMaker\Exception\InvalidUserAssignmentException;
 use ProcessMaker\Exception\TaskDoesNotHaveRequesterException;
 use ProcessMaker\Exception\TaskDoesNotHaveUsersException;
 use ProcessMaker\Exception\ThereIsNoProcessManagerAssignedException;
-use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Facades\WorkflowUserManager;
 use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Nayra\Bpmn\Models\Activity;
@@ -1639,5 +1638,13 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         });
 
         return $query;
+    }
+
+    /**
+     * Define the "belongsTo" relationship between the Process model and the PmBlock model.
+     */
+    public function pmBlock()
+    {
+        return $this->belongsTo('ProcessMaker\Package\PackagePmBlocks\Models\PmBlock', 'id', 'editing_process_id');
     }
 }

--- a/ProcessMaker/Policies/ProcessPolicy.php
+++ b/ProcessMaker/Policies/ProcessPolicy.php
@@ -28,6 +28,15 @@ class ProcessPolicy
         }
     }
 
+    public function edit(User $user, Process $process)
+    {
+        if ($process->pmBlock?->is_imported_locked) {
+            return false;
+        }
+
+        return $user->can('edit-processes');
+    }
+
     /**
      * Determine whether the user can start the process.
      *

--- a/routes/web.php
+++ b/routes/web.php
@@ -106,7 +106,7 @@ Route::middleware('auth', 'sanitize', 'external.connection', 'force_change_passw
     Route::get('profile/edit', [ProfileController::class, 'edit'])->name('profile.edit')->middleware('can:edit-personal-profile');
     Route::get('profile/{id}', [ProfileController::class, 'show'])->name('profile.show');
     // Ensure our modeler loads at a distinct url
-    Route::get('modeler/{process}', [ModelerController::class, 'show'])->name('modeler.show')->middleware('can:edit-processes');
+    Route::get('modeler/{process}', [ModelerController::class, 'show'])->name('modeler.show')->middleware('can:edit,process');
     Route::get('modeler/{process}/inflight/{request?}', [ModelerController::class, 'inflight'])->name('modeler.inflight')->middleware('can:view,request');
 
     Route::get('/', [HomeController::class, 'index'])->name('home');


### PR DESCRIPTION
## Issue & Reproduction Steps

As of the current implementation, when a PM block is locked and imported, users retain the ability to edit the PM Block within the modeler. To ensure data integrity and avoid inadvertent modifications, we need to enhance the system behavior.

1. Import a PM Block that is locked.
2. Navigate to the PM Block listing page.
3. Observe that the 'Edit PM Block' action is still visible in the Ellipsis menu.
4. Confirm that attempting to edit a locked PM Block does not prevent modifications in the modeler.

## Solution
- Updated Process Policy to prevent changes when the user manually accesses `/modeler/{id}` route of a Locked PM Block.

## Related Tickets & Packages
- [FOUR-9471](https://processmaker.atlassian.net/browse/FOUR-9471)
- [PM Block PR](https://github.com/ProcessMaker/package-pm-blocks/pull/58)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9471]: https://processmaker.atlassian.net/browse/FOUR-9471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ