### PR TITLE
Fix issue when pm-blocks-package is not installed

### DIFF
--- a/ProcessMaker/Policies/ProcessPolicy.php
+++ b/ProcessMaker/Policies/ProcessPolicy.php
@@ -3,7 +3,6 @@
 namespace ProcessMaker\Policies;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Illuminate\Http\Request;
 use ProcessMaker\Models\AnonymousUser;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
@@ -30,7 +29,7 @@ class ProcessPolicy
 
     public function edit(User $user, Process $process)
     {
-        if ($process->pmBlock?->is_imported_locked) {
+        if ($this->isPmBlockImportedLocked($process)) {
             return false;
         }
 
@@ -130,5 +129,16 @@ class ProcessPolicy
         }
 
         return false;
+    }
+
+    /**
+     * Check if the PM Block package is installed and if so,
+     * it checks if the related pmBlock of the given Process is imported and locked.
+     */
+    private function isPmBlockImportedLocked(Process $process): bool
+    {
+        $className = 'ProcessMaker\Package\PackagePmBlocks\Models\PmBlock';
+
+        return class_exists($className) && $process->pmBlock?->is_imported_locked;
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

When the PM Block package is not installed and we attempt to access the PM Block associated with a Process, a PHP Fatal error is thrown because the class does not exist.

## Solution
-  An additional check is added to verify that the PM Block package is installed.

## How to Test
- Remove PM Block Package
- Access the route `/modeler/{id}`.

## Related Tickets & Packages
- [FOUR-9471](https://processmaker.atlassian.net/browse/FOUR-9471)


[FOUR-9471]: https://processmaker.atlassian.net/browse/FOUR-9471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ