### PR TITLE
FOUR-9671: Failed asserting in security logs expected size 1.

### DIFF
--- a/tests/Feature/Api/SecurityLogsTest.php
+++ b/tests/Feature/Api/SecurityLogsTest.php
@@ -90,6 +90,14 @@ class SecurityLogsTest extends TestCase
     }
 
     /**
+     * @before
+     */
+    public function setupCleanSomeTables(): void
+    {
+        SecurityLog::query()->delete();
+    }
+
+    /**
      * Attempt to access security logs
      */
     public function testAccessSecurityLogsApi()


### PR DESCRIPTION
## Issue & Reproduction Steps
Failed asserting in security logs expected size 1

## Related Tickets & Packages
- FOUR-9671

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
