### PR TITLE
FOUR-9558 Error Cannot read properties of undefined (reading 'data'),…

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -105,7 +105,7 @@ export default {
             window.ProcessMaker.EventBus.$emit("save-changes");
             this.$set(this, "warnings", response.data.warnings || []);
             if (response.data.warnings && response.data.warnings.length > 0) {
-              this.$refs.validationStatus.autoValidate = true;
+              window.ProcessMaker.EventBus.$emit("save-changes-activate-autovalidate");
             }
             // Set draft status.
             this.setVersionIndicator(true);
@@ -249,7 +249,7 @@ export default {
         window.ProcessMaker.EventBus.$emit("save-changes");
         this.$set(this, "warnings", response.data.warnings || []);
         if (response.data.warnings && response.data.warnings.length > 0) {
-          this.$refs.validationStatus.autoValidate = true;
+          window.ProcessMaker.EventBus.$emit("save-changes-activate-autovalidate");
         }
         if (typeof onSuccess === "function") {
           onSuccess(response);


### PR DESCRIPTION
## Issue & Reproduction Steps
Error Cannot read properties of undefined (reading 'data'), when I want to save a process that has a thread or that is not nested to a thread

when we don't associate a thread with a process in the list , and we save the process, we get an error on the screen: "Cannot read properties of undefined (reading 'data')"

## Solution:
in the spring version, when we save a process with unbound threads, we don't get the error.

## Expected Behavior:
should not show errors when we save a process with threads that does not have an associated process.

## Related pull request
https://github.com/ProcessMaker/modeler/pull/1640
