### PR TITLE
Move data-source logs into its own folder inside storage

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -672,7 +672,7 @@ trait MakeHttpRequests
             $connectorName = StringHelper::friendlyFileName($this->name) . '_(' . $this->id . ')';
             Log::build([
                 'driver' => 'daily',
-                'path' => storage_path("logs/data-sources/$connectorName.log"),
+                'path' => storage_path("data-sources/logs/$connectorName.log"),
                 'days' => env('DATA_SOURCE_CLEAR_LOG', 21),
             ])->info($label . str_replace(["\n", "\t", "\r"], '', $cleanedLog));
         } catch (\Throwable $e) {

--- a/ProcessMaker/WebServices/NativeSoapClient.php
+++ b/ProcessMaker/WebServices/NativeSoapClient.php
@@ -105,7 +105,7 @@ class NativeSoapClient implements SoapClientInterface
             $connectorName = StringHelper::friendlyFileName($this->options['datasource_name']) . '_(' . $this->options['datasource_id'] . ')';
             Log::build([
                 'driver' => 'daily',
-                'path' => storage_path("logs/data-sources/$connectorName.log"),
+                'path' => storage_path("data-sources/logs/$connectorName.log"),
                 'days' => env('DATA_SOURCE_CLEAR_LOG', 21),
             ])->info($label . $doc->saveXML());
         } catch (\Throwable $th) {


### PR DESCRIPTION
The problem is related to the logs folder is missing in the installation. This happens because the logs are redirected to the stderr channel instead of the files.

## Solution
- This PR moves the data-sources logs to `data-sources/logs` which is a shared path and will not have conflict with the stderr configuration.

## How to Test
- Wait for the deploy (should use the STDERR channel for the logs).
- Go to data sources page
- No errors should be displayed

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9668

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
