### PR TITLE
FOUR-9706: (QA Observation) Full Set of Categories Updated in ProcessUpdated is Not Completed Shown

### DIFF
--- a/ProcessMaker/Events/ProcessPublished.php
+++ b/ProcessMaker/Events/ProcessPublished.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
+use ProcessMaker\Helpers\ArrayHelper;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
@@ -22,6 +23,10 @@ class ProcessPublished implements SecurityLogEventInterface
         'signal_events',
         'conditional_events',
         'properties',
+    ];
+    public const REMOVE_KEYS_AUX = [
+        'tmp_process_category_id',
+        'process_category_id',
     ];
 
     private Process $process;
@@ -46,8 +51,11 @@ class ProcessPublished implements SecurityLogEventInterface
         ? ProcessCategory::getNamesByIds($this->original['process_category_id']) : '';
         unset($this->original['process_category_id']);
         $this->changes['process_category'] = isset($changes['process_category_id'])
-        ? ProcessCategory::getNamesByIds($this->changes['process_category_id']) : '';
-        unset($this->changes['process_category_id']);
+        ? ProcessCategory::getNamesByIds($this->changes['tmp_process_category_id']) : '';
+        $this->changes = array_diff_key($this->changes, array_flip($this::REMOVE_KEYS_AUX));
+        if (empty($this->changes['process_category'])) {
+            unset($this->changes['process_category']);
+        }
     }
 
     /**
@@ -65,7 +73,7 @@ class ProcessPublished implements SecurityLogEventInterface
             'category' => $this->process->category ? $this->process->category->name : null,
             'action' => $this->process->getAttribute('status'),
             'last_modified' => $this->process->getAttribute('updated_at'),
-        ], $this->formatChanges($this->changes, $this->original));
+        ], ArrayHelper::getArrayDifferencesWithFormat($this->changes, $this->original));
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -389,6 +389,7 @@ class ProcessController extends Controller
             );
         }
         $changes = $process->getChanges();
+        $changes['tmp_process_category_id'] = $request->input('process_category_id');
 
         // Register the Event
         ProcessPublished::dispatch($process->refresh(), $changes, $original);


### PR DESCRIPTION
Full Set of Categories Updated in ProcessUpdated is Not Completed Shown

## Related Tickets & Packages
- FOUR-9706

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
