### PR TITLE
Add message when missing nested screen's screen

### DIFF
--- a/ProcessMaker/Assets/ScreensInScreen.php
+++ b/ProcessMaker/Assets/ScreensInScreen.php
@@ -65,17 +65,32 @@ class ScreensInScreen
      *
      * @param Screen $process
      * @param array $references
+     * @param ExportManager $exportManager
      *
      * @return void
      */
-    public function updateReferences(Screen $screen, array $references = [])
+    public function updateReferences(Screen $screen, array $references, ExportManager $exportManager)
     {
         $config = $screen->config;
         if (is_array($config)) {
-            $this->findInArray($config, function ($item, $key) use ($references, &$config) {
+            $this->findInArray($config, function ($item, $key) use ($references, &$config, $exportManager) {
                 if (is_array($item) && isset($item['component']) && $item['component'] === 'FormNestedScreen' && !empty($item['config']['screen'])) {
                     $oldRef = $item['config']['screen'];
-                    $newRef = $references[Screen::class][$oldRef]->getKey();
+                    if ((array_key_exists($oldRef, $references[Screen::class]))) {
+                        $newRef = $references[Screen::class][$oldRef]->getKey();
+                        
+                    } else {
+                        $newRef = null;
+                        $exportManager->addLogMessage(
+                            'ScreensInScreen:references',
+                            __(
+                                'Imported file does not contain the screen #:screen assigned to a nested screen',
+                                ['screen' => $oldRef]
+                            ),
+                            false,
+                            __("Missing Nested Screen's screen")
+                        );
+                    }
                     Arr::set($config, "$key.config.screen", $newRef);
                 }
             });


### PR DESCRIPTION
## Issue & Reproduction Steps
In the file to import not exists a screen, this screen refers to a nested screen.

## Solution
- Add validation when the reference of the NestedSscreen's screen not exists.
- add a log message

## How to Test
Import process and review the message, the process was imported but without a screen reference
![image](https://github.com/ProcessMaker/processmaker/assets/1747025/77e0dc43-b709-444c-90ec-cd21cf617617)

## Related Tickets & Packages
[FOUR-7247](https://processmaker.atlassian.net/browse/FOUR-7247)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-7247]: https://processmaker.atlassian.net/browse/FOUR-7247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ