### PR TITLE
FOUR-9708: Removed TemplateSyncCount from UnitTest

### DIFF
--- a/tests/Feature/Templates/Api/ProcessTemplateTest.php
+++ b/tests/Feature/Templates/Api/ProcessTemplateTest.php
@@ -2,21 +2,15 @@
 
 namespace Tests\Feature\Templates\Api;
 
-use Database\Seeders\UserSeeder;
 use Exception;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Http;
 use ProcessMaker\ImportExport\Utils;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessTemplates;
-use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
 use ProcessMaker\Models\ScriptCategory;
 use ProcessMaker\Models\Setting;
-use ProcessMaker\Models\Templates;
 use ProcessMaker\Models\User;
 use ProcessMaker\Packages\Connectors\DataSources\Models\DataSourceCategory;
 use Tests\Feature\Shared\RequestHelper;

--- a/tests/Feature/Templates/Api/ProcessTemplateTest.php
+++ b/tests/Feature/Templates/Api/ProcessTemplateTest.php
@@ -204,15 +204,6 @@ class ProcessTemplateTest extends TestCase
         $this->assertEquals('Default Templates', $newCategory->name);
     }
 
-    public function testTemplateSyncCount()
-    {
-        $fixtures = $this->fixtures();
-        $githubConfig = config('services.github');
-
-        $count = $this->countTemplatesFromRepo($githubConfig);
-        $this->assertEquals($count, $fixtures['allTemplates']->count());
-    }
-
     public function testTemplateToProcessSync()
     {
         $this->addGlobalSignalProcess();
@@ -273,34 +264,6 @@ class ProcessTemplateTest extends TestCase
 
         return ['user' => $user, 'processCategoryId' => $processCategoryId, 'allTemplates' => $allTemplates];
     }
-
-     /**
-      * Compares the count of imported templates with the templates in the database.
-      *
-      * @param array $config The configuration array containing the base URL, template repository, and template branch.
-      * @throws Exception If the default template list could not be fetched.
-      * @return int The count of templates.
-      */
-     private function countTemplatesFromRepo($config)
-     {
-         $url = $config['base_url'] . $config['template_repo'] . '/' . $config['template_branch'] . '/index.json';
-         $response = Http::get($url);
-
-         if (!$response->successful()) {
-             throw new Exception('Unable to fetch default template list.');
-         }
-
-         $templates = $response->json();
-         $count = 0;
-
-         foreach ($templates as $template) {
-             if (is_array($template)) {
-                 $count += count($template);
-             }
-         }
-
-         return $count;
-     }
 
     /**
      * Create processes from a given template.


### PR DESCRIPTION
## Issue & Reproduction Steps
Our tests should never make real HTTP calls to outside endpoints, this function of the test was calling the templates repo to verify the number of templates in it. 

`tests/Feature/Templates/Api/ProcessTemplateTest.php --filter= testTemplateSyncCount`

## Solution
- Removed the test for  the TemplateSyncCount

## How to Test
- Ensure that the testTemplateSyncCount method in the ProcessTemplateTest.php file has been removed, and confirm that all the remaining tests pass successfully.

## Related Tickets & Packages
- [FOUR-9708](https://processmaker.atlassian.net/browse/FOUR-9708)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
