### PR TITLE
Do not consider null values duplicates when importing

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -382,12 +382,15 @@ abstract class ExporterBase implements ExporterInterface
         foreach ($this->handleDuplicateAttributes() as $attribute => $handler) {
             $value = $this->model->$attribute;
             $i = 0;
-            while ($value !== null && $this->duplicateExists($attribute, $value)) {
+            while ($this->duplicateExists($attribute, $value)) {
                 if ($i > 100) {
                     throw new \Exception('Can not fix duplicate attribute after 100 iterations');
                 }
                 $i++;
                 $value = $handler($value);
+                if ($value === null) {
+                    break;
+                }
             }
             $this->model->$attribute = $value;
         }

--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -382,7 +382,7 @@ abstract class ExporterBase implements ExporterInterface
         foreach ($this->handleDuplicateAttributes() as $attribute => $handler) {
             $value = $this->model->$attribute;
             $i = 0;
-            while ($this->duplicateExists($attribute, $value)) {
+            while ($value !== null && $this->duplicateExists($attribute, $value)) {
                 if ($i > 100) {
                     throw new \Exception('Can not fix duplicate attribute after 100 iterations');
                 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Required for https://github.com/ProcessMaker/package-data-sources/pull/307

Occasionally we need to temporarily set a foreign key to null until all the models are saved and we have a new key for it. To support this, we should not consider null values duplicates.

## Solution
- Skip checking duplicates if the value is null

## How to Test
- See jira issue

## Related Tickets & Packages
- https://github.com/ProcessMaker/package-data-sources/pull/307
- https://processmaker.atlassian.net/browse/FOUR-9646

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-data-sources:bugfix/FOUR-9646