### PR TITLE
FOUR-8032: Options of Physical Address are not displayed directly under the field but at the bottom of the page

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -29,7 +29,6 @@ html {
   font-weight: 400;
   font-style: normal;
   background-color: $body-bg;
-  overflow-x: hidden;
 }
 
 .fw-medium {


### PR DESCRIPTION
## Issue & Reproduction Steps
## Current behavior
The list of options is displayed on the bottom of the page and not directly under the field, it even moves with the page when scroll down the page 

## Expected behavior
The list should be displayed under the field.

## Solution
- ` overflow-x: hidden` was removed from  **html and body** styles.


https://github.com/ProcessMaker/processmaker/assets/1401911/8e494cc8-a3fc-4828-a0c4-9c3301324c9f

## How to Test

1. Install google places and webentry packages in your pm instances
2. Create a Screen with some controls (Any) to enable the scroll,
3. Add various Google place fields,
4. Add google places inside a nested screen
5. Add google places inside a tables 
6. Create a process with WE 
7. Assign the screen in the WE
8. Create a request
9. Scroll down to Google places
10. Set an address


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8032

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
