### PR TITLE
FOUR-9705: Process Category Link for Name is Not Working

### DIFF
--- a/ProcessMaker/Events/CategoryCreated.php
+++ b/ProcessMaker/Events/CategoryCreated.php
@@ -37,7 +37,7 @@ class CategoryCreated implements SecurityLogEventInterface
         return [
             'name' => [
                 'label' => $this->variable['name'],
-                'link' => route('processes.create', $this->category),
+                'link' => route('processes.index') . '#nav-categories',
             ],
             'created_at' => $this->category->getAttribute('created_at'),
         ];


### PR DESCRIPTION
## Issue & Reproduction Steps
A link name for process category is not working

## How to Test
1. Create a process category process
2. Check the User Activity Logging

## Related Tickets & Packages
[- Link to any related FOUR tickets, PRDs, or packages](https://processmaker.atlassian.net/browse/FOUR-9705)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
