### PR TITLE
Resolve API Clash and 'getOriginal()' Error When Importing and Updating Process Templates

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -110,7 +110,7 @@ class TemplateController extends Controller
     public function updateTemplateConfigs(string $type, Request $request)
     {
         $request->validate(Template::rules($request->id, $this->types[$type][4]));
-        $proTemplates = ProcessTemplates::select()->find($request->id)->getOriginal();
+        $proTemplates = ProcessTemplates::select()->find($request->id);
         $changes = $request->all();
         $original = array_intersect_key($proTemplates->getOriginal(), $changes);
         $response = $this->template->updateTemplateConfigs($type, $request);

--- a/resources/js/processes/export/DataProvider.js
+++ b/resources/js/processes/export/DataProvider.js
@@ -29,7 +29,7 @@ export default {
     formData.append('file', file);
     formData.append('options', optionsBlob);
     
-    return ProcessMaker.apiClient.post(`/template/do-import/${type}`, formData,
+    return ProcessMaker.apiClient.post(`/template/${type}/do-import`, formData,
     {
         headers: {
             'Content-Type': 'multipart/form-data'

--- a/routes/api.php
+++ b/routes/api.php
@@ -241,6 +241,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
 
     // Templates
     Route::get('templates/{type}', [TemplateController::class, 'index'])->name('template.index')->middleware('template-authorization');
+    Route::post('template/do-import/{type}', [ImportController::class, 'importTemplate'])->name('import.do_importTemplate')->middleware('template-authorization');
     Route::post('template/{type}/{id}', [TemplateController::class, 'store'])->name('template.store')->middleware('template-authorization');
     Route::post('template/create/{type}/{id}', [TemplateController::class, 'create'])->name('template.create')->middleware('template-authorization');
     Route::put('template/{type}/{processId}', [TemplateController::class, 'updateTemplateManifest'])->name('template.update')->middleware('template-authorization');
@@ -248,7 +249,6 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::put('template/settings/{type}/{id}', [TemplateController::class, 'updateTemplateConfigs'])->name('template.settings.update')->middleware('template-authorization');
     Route::delete('template/{type}/{id}', [TemplateController::class, 'delete'])->name('template.delete')->middleware('template-authorization');
     Route::get('modeler/templates/{type}/{id}', [TemplateController::class, 'show'])->name('modeler.template.show')->middleware('template-authorization');
-    Route::post('template/do-import/{type}', [ImportController::class, 'importTemplate'])->name('import.do_importTemplate')->middleware('template-authorization');
     Route::post('templates/{type}/import/validation', [TemplateController::class, 'preImportValidation'])->name('template.preImportValidation')->middleware('template-authorization');
 
     // Process Translations

--- a/routes/api.php
+++ b/routes/api.php
@@ -241,7 +241,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
 
     // Templates
     Route::get('templates/{type}', [TemplateController::class, 'index'])->name('template.index')->middleware('template-authorization');
-    Route::post('template/do-import/{type}', [ImportController::class, 'importTemplate'])->name('import.do_importTemplate')->middleware('template-authorization');
+    Route::post('template/{type}/do-import', [ImportController::class, 'importTemplate'])->name('import.do_importTemplate')->middleware('template-authorization');
     Route::post('template/{type}/{id}', [TemplateController::class, 'store'])->name('template.store')->middleware('template-authorization');
     Route::post('template/create/{type}/{id}', [TemplateController::class, 'create'])->name('template.create')->middleware('template-authorization');
     Route::put('template/{type}/{processId}', [TemplateController::class, 'updateTemplateManifest'])->name('template.update')->middleware('template-authorization');


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses the two issues mentioned in [FOUR-9725](https://processmaker.atlassian.net/browse/FOUR-9725) related to process template import and update errors. The following changes have been made to resolve the problems:

## Solution

**Issue 1: API Clash during Process Template Import**

- Modified the route for importing process templates from template/do-import/{type} to template/{type}/do-import.
- Updated the route order to ensure that the more specific route for importing takes precedence over the generic storing template route.

**Issue 2: 'getOriginal()' Error during Process Template Update**

- Removed the duplicated `getOriginal()` method that was being called on an array.


## How to Test

- Test the import functionality to ensure successful routing and handling of the process templates.

- Confirm the proper functioning of process template updates.


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9725]: https://processmaker.atlassian.net/browse/FOUR-9725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ