### PR TITLE
Bugfix/FOUR-9721: Two filter fields are no longer displayed

### DIFF
--- a/resources/js/components/shared/PmqlInputFilters.vue
+++ b/resources/js/components/shared/PmqlInputFilters.vue
@@ -79,7 +79,7 @@
                 <span class="multiselect__single" v-if="values.length > 1 && !isOpen">{{ values.length }} {{ $t('requesters') }}</span>
             </template>
             <template slot="option" slot-scope="props">
-                <img v-if="props.option.avatar.length > 0" class="option__image"
+                <img v-if="props.option.avatar && props.option.avatar.length > 0" class="option__image"
                     :src="props.option.avatar">
                 <span v-else class="initials bg-warning text-white p-1"> {{getInitials(props.option.firstname, props.option.lastname)}}</span>
                 <span class="ml-1">{{props.option.fullname}}</span>
@@ -109,7 +109,7 @@
                 <span class="multiselect__single" v-if="values.length > 1 && !isOpen">{{ values.length }} {{ $t('requesters') }}</span>
             </template>
             <template slot="option" slot-scope="props">
-                <img v-if="props.option.avatar.length > 0" class="option__image"
+                <img v-if="props.option.avatar && props.option.avatar.length > 0" class="option__image"
                     :src="props.option.avatar">
                 <span v-else class="initials bg-warning text-white p-1"> {{getInitials(props.option.firstname, props.option.lastname)}}</span>
                 <span class="ml-1">{{props.option.fullname}}</span>


### PR DESCRIPTION
## Issue & Reproduction Steps
The problem was related to the `avatar` prop when is null for requester and participant lists. For some reason some users have the prop `avatar` in null and not as empty string (Maybe when the users are imported with ldap or something similar)

**Steps to reproduced:**
1.Log in PM
2.Click on Filter
3.Review Requester and Participants fields

## Solution
- Check if avatar prop exists for requests and participants

**Working video and reproduction explanation**

https://github.com/ProcessMaker/processmaker/assets/90727999/a80937cf-603c-49dd-9e5f-bf124f0fe14f


## How to Test
- Go to the database to the `users` table and modify the `avatar` column for some user to be `NULL` instead `empty`
- Go to requests lists and click on filter

## Related Tickets & Packages
- [FOUR-9721](https://processmaker.atlassian.net/browse/FOUR-9721)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9721]: https://processmaker.atlassian.net/browse/FOUR-9721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ