### PR TITLE
Fix PM Block Export/Import with Data Source Scripts and Collections

### DIFF
--- a/ProcessMaker/Assets/ScreensInScreen.php
+++ b/ProcessMaker/Assets/ScreensInScreen.php
@@ -78,7 +78,6 @@ class ScreensInScreen
                     $oldRef = $item['config']['screen'];
                     if ((array_key_exists($oldRef, $references[Screen::class]))) {
                         $newRef = $references[Screen::class][$oldRef]->getKey();
-                        
                     } else {
                         $newRef = null;
                         $exportManager->addLogMessage(

--- a/ProcessMaker/Console/Commands/ReviewCategoryNull.php
+++ b/ProcessMaker/Console/Commands/ReviewCategoryNull.php
@@ -48,26 +48,25 @@ class ReviewCategoryNull extends Command
         DB::table($table)->select('id', 'title')
             ->whereNull([$field, 'key'])
             ->orderBy('id', 'DESC')->chunkById(100, function (Collection $items) use ($table, $field, $class, $default) {
-            foreach ($items as $item) {
-                $category = DB::table('category_assignments')
-                    ->select('category_id')
-                    ->where([
-                        ['assignable_type', '=', $class],
-                        ['assignable_id', '=', $item->id],
-                    ])->first();
-                
-                $categoryId = $default;
-                if ($category) {
-                    $categoryId = $category->category_id;
-                }
+                foreach ($items as $item) {
+                    $category = DB::table('category_assignments')
+                        ->select('category_id')
+                        ->where([
+                            ['assignable_type', '=', $class],
+                            ['assignable_id', '=', $item->id],
+                        ])->first();
 
-                DB::table($table)
-                    ->where('id', $item->id)
-                    ->update([$field => $categoryId]);
-                
-                $this->info('- ' . $item->title . '   ==>   Category: ' . $categoryId);
-                
-            }
-        });
+                    $categoryId = $default;
+                    if ($category) {
+                        $categoryId = $category->category_id;
+                    }
+
+                    DB::table($table)
+                        ->where('id', $item->id)
+                        ->update([$field => $categoryId]);
+
+                    $this->info('- ' . $item->title . '   ==>   Category: ' . $categoryId);
+                }
+            });
     }
 }

--- a/ProcessMaker/Events/ProcessPublished.php
+++ b/ProcessMaker/Events/ProcessPublished.php
@@ -24,6 +24,7 @@ class ProcessPublished implements SecurityLogEventInterface
         'conditional_events',
         'properties',
     ];
+
     public const REMOVE_KEYS_AUX = [
         'tmp_process_category_id',
         'process_category_id',

--- a/ProcessMaker/Events/TemplateUpdated.php
+++ b/ProcessMaker/Events/TemplateUpdated.php
@@ -17,6 +17,7 @@ class TemplateUpdated implements SecurityLogEventInterface
     use FormatSecurityLogChanges;
 
     private Process|ProcessTemplates $process;
+
     private array $changes;
 
     private array $original;
@@ -79,7 +80,7 @@ class TemplateUpdated implements SecurityLogEventInterface
     public function getChanges(): array
     {
         return [
-            'id' => $this->process->id ?? ''
+            'id' => $this->process->id ?? '',
         ];
     }
 

--- a/ProcessMaker/Events/TokenCreated.php
+++ b/ProcessMaker/Events/TokenCreated.php
@@ -12,7 +12,9 @@ class TokenCreated implements SecurityLogEventInterface
     use Dispatchable;
 
     private Token $data;
+
     private User $user;
+
     private string $name;
 
     /**

--- a/ProcessMaker/Events/TokenDeleted.php
+++ b/ProcessMaker/Events/TokenDeleted.php
@@ -13,7 +13,9 @@ class TokenDeleted implements SecurityLogEventInterface
     use Dispatchable;
 
     private Token $data;
+
     private User $user;
+
     private string $name;
 
     /**

--- a/ProcessMaker/SanitizeHelper.php
+++ b/ProcessMaker/SanitizeHelper.php
@@ -197,7 +197,7 @@ class SanitizeHelper
                     $elements = array_merge($elements, self::getRichTextElements($item['items'], ($parent ? $parent . '.' . $item['config']['name'] : $item['config']['name'])));
                 } elseif (isset($item['component']) && $item['component'] === 'FormTextArea' && isset($item['config']['richtext']) && $item['config']['richtext'] === true) {
                     $elements[] = ($parent ? $parent . '.' . $item['config']['name'] : $item['config']['name']);
-                // Inside a table ..
+                    // Inside a table ..
                 } elseif ($item['component'] == 'FormMultiColumn') {
                     foreach ($item['items'] as $cell) {
                         if (

--- a/tests/Feature/Api/SecurityLogsTest.php
+++ b/tests/Feature/Api/SecurityLogsTest.php
@@ -51,10 +51,10 @@ use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessTemplates;
 use ProcessMaker\Models\Screen;
-use ProcessMaker\Models\SecurityLog;
-use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\Script;
 use ProcessMaker\Models\ScriptExecutor;
+use ProcessMaker\Models\SecurityLog;
+use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\SignalData;
 use ProcessMaker\Models\User;
 use ProcessMaker\Providers\AuthServiceProvider;
@@ -711,7 +711,7 @@ class SecurityLogsTest extends TestCase
         $this->addGlobalSignalProcess();
         // When the template is a process
         $process = Process::factory()->create([
-            'is_template' => 1
+            'is_template' => 1,
         ]);
         TemplateUpdated::dispatch([], [], true, $process);
         // Review the asserts about the response of Security Log
@@ -730,7 +730,7 @@ class SecurityLogsTest extends TestCase
     {
         $user = User::factory()->create([
             'status' => 'ACTIVE',
-            'is_administrator' => true
+            'is_administrator' => true,
         ]);
         $token = $user->createToken('API Token');
         TokenCreated::dispatch($token->token, $user, 'API token');
@@ -745,7 +745,7 @@ class SecurityLogsTest extends TestCase
     {
         $user = User::factory()->create([
             'status' => 'ACTIVE',
-            'is_administrator' => true
+            'is_administrator' => true,
         ]);
         $token = $user->createToken('API Token');
         TokenDeleted::dispatch($token->token, $user, 'API token');

--- a/tests/Feature/Templates/Api/ProcessTemplateTest.php
+++ b/tests/Feature/Templates/Api/ProcessTemplateTest.php
@@ -274,33 +274,33 @@ class ProcessTemplateTest extends TestCase
         return ['user' => $user, 'processCategoryId' => $processCategoryId, 'allTemplates' => $allTemplates];
     }
 
-     /**
-      * Compares the count of imported templates with the templates in the database.
-      *
-      * @param array $config The configuration array containing the base URL, template repository, and template branch.
-      * @throws Exception If the default template list could not be fetched.
-      * @return int The count of templates.
-      */
-     private function countTemplatesFromRepo($config)
-     {
-         $url = $config['base_url'] . $config['template_repo'] . '/' . $config['template_branch'] . '/index.json';
-         $response = Http::get($url);
+    /**
+     * Compares the count of imported templates with the templates in the database.
+     *
+     * @param array $config The configuration array containing the base URL, template repository, and template branch.
+     * @throws Exception If the default template list could not be fetched.
+     * @return int The count of templates.
+     */
+    private function countTemplatesFromRepo($config)
+    {
+        $url = $config['base_url'] . $config['template_repo'] . '/' . $config['template_branch'] . '/index.json';
+        $response = Http::get($url);
 
-         if (!$response->successful()) {
-             throw new Exception('Unable to fetch default template list.');
-         }
+        if (!$response->successful()) {
+            throw new Exception('Unable to fetch default template list.');
+        }
 
-         $templates = $response->json();
-         $count = 0;
+        $templates = $response->json();
+        $count = 0;
 
-         foreach ($templates as $template) {
-             if (is_array($template)) {
-                 $count += count($template);
-             }
-         }
+        foreach ($templates as $template) {
+            if (is_array($template)) {
+                $count += count($template);
+            }
+        }
 
-         return $count;
-     }
+        return $count;
+    }
 
     /**
      * Create processes from a given template.


### PR DESCRIPTION
## Issue & Reproduction Steps
This pull request (PR) addresses a critical issue related to exporting and importing script tasks with webhooks enabled when they are referenced in the `data_source_scripts table`. The previous error was hindering the proper export and import of PM Blocks that utilize a data source script into an instance. With this PR, we have introduced a comprehensive solution that allows for seamless import of the data source script, generating a new ID, and updating the BPMN scriptRef ID to reflect the newly generated ID.

Additionally, as part of this solution, we have created separate PRs for both Data Sources and the Collections package to ensure smooth handling of script dependencies and proper UUID generation during the export/import process.

## Key Changes and Improvements:

- **Fixing Script Task Export/Import Error**: Addressed the root cause of the error that was preventing the export/import of script tasks with webhooks enabled.
- **Enhanced Data Source Script Import:** Implemented a solution to import data source scripts correctly with the generation of new IDs and updating of BPMN scriptRef ID.
- **Script Dependency Management:** The separate PR for Data Sources ensures the script dependency is properly added and retrieved during the export/import process.
- **Improved UUID Generation in Collections:** The separate PR within the Collections package now correctly generates UUIDs when exporting/importing collections referenced in a data source, resolving related issues.

## How to Test

1. Import this process into your instance. 
[Process_ with  Data Connectors.json.txt](https://github.com/ProcessMaker/processmaker/files/12233907/Process_.with.Data.Connectors.json.txt)

2. Save the process as a PM Block.
3. Export the PM Block.
4. Reimport the PM Block.

**Expected Behavior**

1. The process saves as a PM Block without encountering any errors.
2. The PM Block can be successfully exported without any issues.
3. The PM Block can be reimported, and all components, including script tasks and data source scripts, maintain their integrity.


## Related Tickets & Packages
- Ticket [FOUR-9383](https://processmaker.atlassian.net/browse/FOUR-9383)
- [Data Source Package PR](https://github.com/ProcessMaker/package-data-sources/pull/308)
- [Collections Package PR](https://github.com/ProcessMaker/package-collections/pull/359)

ci:package-collections:observation/FOUR-9383
ci:package-data-sources:observation/FOUR-9383
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9383]: https://processmaker.atlassian.net/browse/FOUR-9383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ