### PR TITLE
Refactor associateNestedScreen to include loops

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -42,14 +42,13 @@ class ScreenExporter extends ExporterBase
     public function import() : bool
     {
         $screen = $this->model;
-
-        $config = $this->model->config;
         $watchers = $this->model->watchers;
 
+        $screenIdMap = [];
         foreach ($this->dependents as $dependent) {
             switch ($dependent->type) {
                 case DependentType::SCREENS:
-                    $this->associateNestedScreen($dependent, $config);
+                    $screenIdMap[$dependent->originalId] = $dependent->model->id;
                     break;
                 case DependentType::SCRIPTS:
                     $originalId = $dependent->meta;
@@ -58,8 +57,8 @@ class ScreenExporter extends ExporterBase
             }
         }
 
+        $screen->config = $this->associateNestedScreens($screenIdMap, $screen->config);
         $this->associateCategories(ScreenCategory::class, 'screen_category_id');
-        $screen->config = $config;
         $screen->watchers = $watchers;
 
         $success = $screen->saveOrFail();
@@ -104,19 +103,24 @@ class ScreenExporter extends ExporterBase
         return null;
     }
 
-    private function associateNestedScreen($dependent, &$config) : void
+    private function associateNestedScreens($screenIdMap, $config)
     {
-        $originalId = $dependent->originalId;
-        $newId = $dependent->model->id;
-        foreach ($config as $pageKey => $page) {
-            foreach (Arr::get($page, 'items', []) as $itemKey => $item) {
-                if (Arr::get($item, 'component') === 'FormNestedScreen') {
-                    if (Arr::get($item, 'config.screen') === $originalId) {
-                        Arr::set($config, "$pageKey.items.$itemKey.config.screen", $newId);
-                    }
+        if (!is_array($config)) {
+            return $config;
+        }
+        foreach ($config as $i => $item) {
+            if (Arr::has($item, 'items')) {
+                $config[$i]['items'] = $this->associateNestedScreens($screenIdMap, $item['items']);
+            } elseif (Arr::get($item, 'component') === 'FormNestedScreen') {
+                $originalId = Arr::get($item, 'config.screen', null);
+                if ($originalId) {
+                    $newId = Arr::get($screenIdMap, $originalId, null);
+                    Arr::set($config, "{$i}.config.screen", $newId);
                 }
             }
         }
+
+        return $config;
     }
 
     private function associateWatchers($type, $dependent, &$watchers, $originalId) : void

--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -109,7 +109,12 @@ class ScreenExporter extends ExporterBase
             return $config;
         }
         foreach ($config as $i => $item) {
-            if (Arr::has($item, 'items')) {
+            if (Arr::get($item, 'component') === 'FormMultiColumn') {
+                foreach ($item['items'] as $mi => $mcItems) {
+                    $config[$i]['items'][$mi] = $this->associateNestedScreens($screenIdMap, $mcItems);
+                }
+            } elseif (Arr::has($item, 'items')) {
+                // This covers both pages and FormLoops
                 $config[$i]['items'] = $this->associateNestedScreens($screenIdMap, $item['items']);
             } elseif (Arr::get($item, 'component') === 'FormNestedScreen') {
                 $originalId = Arr::get($item, 'config.screen', null);

--- a/tests/Feature/ImportExport/fixtures/screen_with_nested_screens_in_loop_and_multicolumns.json
+++ b/tests/Feature/ImportExport/fixtures/screen_with_nested_screens_in_loop_and_multicolumns.json
@@ -1,0 +1,577 @@
+[
+	{
+		"name": "Child",
+		"items": [
+			{
+				"label": "Rich Text",
+				"config": {
+					"icon": "fas fa-pencil-ruler",
+					"label": null,
+					"content": "<p>Child</p>\n<p>LOOP:</p>",
+					"interactive": true,
+					"renderVarHtml": false
+				},
+				"component": "FormHtmlViewer",
+				"inspector": [
+					{
+						"type": "FormTextArea",
+						"field": "content",
+						"config": {
+							"rows": 5,
+							"label": "Content",
+							"value": null,
+							"helper": "The HTML text to display"
+						}
+					},
+					{
+						"type": "FormCheckbox",
+						"field": "renderVarHtml",
+						"config": {
+							"label": "Render HTML from a Variable",
+							"value": null,
+							"helper": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "conditionalHide",
+						"config": {
+							"label": "Visibility Rule",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "DeviceVisibility",
+						"field": "deviceVisibility",
+						"config": {
+							"label": "Device Visibility",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customFormatter",
+						"config": {
+							"label": "Custom Format String",
+							"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+							"validation": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customCssSelector",
+						"config": {
+							"label": "CSS Selector Name",
+							"helper": "Use this in your custom css rules",
+							"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "ariaLabel",
+						"config": {
+							"label": "Aria Label",
+							"helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "tabindex",
+						"config": {
+							"label": "Tab Order",
+							"helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+							"validation": "regex: [0-9]*"
+						}
+					}
+				],
+				"editor-control": "FormHtmlEditor",
+				"editor-component": "FormHtmlEditor"
+			},
+			{
+				"items": [
+					{
+						"items": [
+							[
+								{
+									"label": "Nested Screen",
+									"config": {
+										"icon": "fas fa-file-invoice",
+										"name": "Nested Screen",
+										"label": "Nested Screen",
+										"value": null,
+										"screen": 1006,
+										"variant": "primary"
+									},
+									"component": "FormNestedScreen",
+									"inspector": [
+										{
+											"type": "ScreenSelector",
+											"field": "screen",
+											"config": {
+												"name": "SelectScreen",
+												"label": "Screen",
+												"helper": "Select a screen",
+												"validate-nested": false
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "conditionalHide",
+											"config": {
+												"label": "Visibility Rule",
+												"helper": "This control is hidden until this expression is true"
+											}
+										},
+										{
+											"type": "DeviceVisibility",
+											"field": "deviceVisibility",
+											"config": {
+												"label": "Device Visibility",
+												"helper": "This control is hidden until this expression is true"
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "customFormatter",
+											"config": {
+												"label": "Custom Format String",
+												"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+												"validation": null
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "customCssSelector",
+											"config": {
+												"label": "CSS Selector Name",
+												"helper": "Use this in your custom css rules",
+												"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "ariaLabel",
+											"config": {
+												"label": "Aria Label",
+												"helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "tabindex",
+											"config": {
+												"label": "Tab Order",
+												"helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+												"validation": "regex: [0-9]*"
+											}
+										}
+									],
+									"editor-control": "FormNestedScreen",
+									"editor-component": "FormNestedScreen"
+								}
+							],
+							[
+								{
+									"label": "Nested Screen",
+									"config": {
+										"icon": "fas fa-file-invoice",
+										"name": "Nested Screen",
+										"label": "Nested Screen",
+										"value": null,
+										"screen": 1006,
+										"variant": "primary"
+									},
+									"component": "FormNestedScreen",
+									"inspector": [
+										{
+											"type": "ScreenSelector",
+											"field": "screen",
+											"config": {
+												"name": "SelectScreen",
+												"label": "Screen",
+												"helper": "Select a screen",
+												"validate-nested": false
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "conditionalHide",
+											"config": {
+												"label": "Visibility Rule",
+												"helper": "This control is hidden until this expression is true"
+											}
+										},
+										{
+											"type": "DeviceVisibility",
+											"field": "deviceVisibility",
+											"config": {
+												"label": "Device Visibility",
+												"helper": "This control is hidden until this expression is true"
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "customFormatter",
+											"config": {
+												"label": "Custom Format String",
+												"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+												"validation": null
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "customCssSelector",
+											"config": {
+												"label": "CSS Selector Name",
+												"helper": "Use this in your custom css rules",
+												"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "ariaLabel",
+											"config": {
+												"label": "Aria Label",
+												"helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+											}
+										},
+										{
+											"type": "FormInput",
+											"field": "tabindex",
+											"config": {
+												"label": "Tab Order",
+												"helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+												"validation": "regex: [0-9]*"
+											}
+										}
+									],
+									"editor-control": "FormNestedScreen",
+									"editor-component": "FormNestedScreen"
+								}
+							]
+						],
+						"label": "Multicolumn / Table",
+						"config": {
+							"icon": "fas fa-table",
+							"label": null,
+							"options": [
+								{
+									"value": "1",
+									"content": "6"
+								},
+								{
+									"value": "2",
+									"content": "6"
+								}
+							]
+						},
+						"component": "FormMultiColumn",
+						"container": true,
+						"inspector": [
+							{
+								"type": "ContainerColumns",
+								"field": "options",
+								"config": {
+									"label": "Column Width",
+									"helper": null,
+									"validation": "columns-adds-to-12"
+								}
+							},
+							{
+								"type": "ColorSelect",
+								"field": "color",
+								"config": {
+									"label": "Text Color",
+									"helper": "Set the element's text color",
+									"options": [
+										{
+											"value": "text-primary",
+											"content": "primary"
+										},
+										{
+											"value": "text-secondary",
+											"content": "secondary"
+										},
+										{
+											"value": "text-success",
+											"content": "success"
+										},
+										{
+											"value": "text-danger",
+											"content": "danger"
+										},
+										{
+											"value": "text-warning",
+											"content": "warning"
+										},
+										{
+											"value": "text-info",
+											"content": "info"
+										},
+										{
+											"value": "text-light",
+											"content": "light"
+										},
+										{
+											"value": "text-dark",
+											"content": "dark"
+										}
+									]
+								}
+							},
+							{
+								"type": "ColorSelect",
+								"field": "bgcolor",
+								"config": {
+									"label": "Background Color",
+									"helper": "Set the element's background color",
+									"options": [
+										{
+											"value": "alert alert-primary",
+											"content": "primary"
+										},
+										{
+											"value": "alert alert-secondary",
+											"content": "secondary"
+										},
+										{
+											"value": "alert alert-success",
+											"content": "success"
+										},
+										{
+											"value": "alert alert-danger",
+											"content": "danger"
+										},
+										{
+											"value": "alert alert-warning",
+											"content": "warning"
+										},
+										{
+											"value": "alert alert-info",
+											"content": "info"
+										},
+										{
+											"value": "alert alert-light",
+											"content": "light"
+										},
+										{
+											"value": "alert alert-dark",
+											"content": "dark"
+										}
+									]
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "conditionalHide",
+								"config": {
+									"label": "Visibility Rule",
+									"helper": "This control is hidden until this expression is true"
+								}
+							},
+							{
+								"type": "DeviceVisibility",
+								"field": "deviceVisibility",
+								"config": {
+									"label": "Device Visibility",
+									"helper": "This control is hidden until this expression is true"
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "customFormatter",
+								"config": {
+									"label": "Custom Format String",
+									"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+									"validation": null
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "customCssSelector",
+								"config": {
+									"label": "CSS Selector Name",
+									"helper": "Use this in your custom css rules",
+									"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "ariaLabel",
+								"config": {
+									"label": "Aria Label",
+									"helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "tabindex",
+								"config": {
+									"label": "Tab Order",
+									"helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+									"validation": "regex: [0-9]*"
+								}
+							}
+						],
+						"editor-control": "MultiColumn",
+						"editor-component": "MultiColumn"
+					},
+					{
+						"label": "Nested Screen",
+						"config": {
+							"icon": "fas fa-file-invoice",
+							"name": "Nested Screen",
+							"label": "Nested Screen",
+							"value": null,
+							"screen": 1006,
+							"variant": "primary"
+						},
+						"component": "FormNestedScreen",
+						"inspector": [
+							{
+								"type": "ScreenSelector",
+								"field": "screen",
+								"config": {
+									"name": "SelectScreen",
+									"label": "Screen",
+									"helper": "Select a screen",
+									"validate-nested": false
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "conditionalHide",
+								"config": {
+									"label": "Visibility Rule",
+									"helper": "This control is hidden until this expression is true"
+								}
+							},
+							{
+								"type": "DeviceVisibility",
+								"field": "deviceVisibility",
+								"config": {
+									"label": "Device Visibility",
+									"helper": "This control is hidden until this expression is true"
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "customFormatter",
+								"config": {
+									"label": "Custom Format String",
+									"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+									"validation": null
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "customCssSelector",
+								"config": {
+									"label": "CSS Selector Name",
+									"helper": "Use this in your custom css rules",
+									"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "ariaLabel",
+								"config": {
+									"label": "Aria Label",
+									"helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+								}
+							},
+							{
+								"type": "FormInput",
+								"field": "tabindex",
+								"config": {
+									"label": "Tab Order",
+									"helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+									"validation": "regex: [0-9]*"
+								}
+							}
+						],
+						"editor-control": "FormNestedScreen",
+						"editor-component": "FormNestedScreen"
+					}
+				],
+				"label": "Loop",
+				"config": {
+					"icon": "fas fa-redo",
+					"name": "loop_1",
+					"label": null,
+					"settings": {
+						"add": true,
+						"type": "existing",
+						"times": "2",
+						"varname": "loop_1"
+					}
+				},
+				"component": "FormLoop",
+				"container": true,
+				"inspector": [
+					{
+						"type": "LoopInspector",
+						"field": "settings",
+						"config": {
+							"label": null,
+							"helper": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "conditionalHide",
+						"config": {
+							"label": "Visibility Rule",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "DeviceVisibility",
+						"field": "deviceVisibility",
+						"config": {
+							"label": "Device Visibility",
+							"helper": "This control is hidden until this expression is true"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customFormatter",
+						"config": {
+							"label": "Custom Format String",
+							"helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+							"validation": null
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "customCssSelector",
+						"config": {
+							"label": "CSS Selector Name",
+							"helper": "Use this in your custom css rules",
+							"validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "ariaLabel",
+						"config": {
+							"label": "Aria Label",
+							"helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+						}
+					},
+					{
+						"type": "FormInput",
+						"field": "tabindex",
+						"config": {
+							"label": "Tab Order",
+							"helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+							"validation": "regex: [0-9]*"
+						}
+					}
+				],
+				"editor-control": "Loop",
+				"editor-component": "Loop"
+			}
+		]
+	}
+]


### PR DESCRIPTION
## Issue & Reproduction Steps
See Jira issue. Nested screens in loops are being exported but are not being re-associated to the correct ID when importing.

## Solution
- Refactor the logic to include loops when looking for nested screens to re-associate.
- Bonus performance update by using an old-to-new ID map so we don't iterate the entire config for every nested screen.

## How to Test
Follow reproduction steps in Jira issue. Nested screens should correctly associate to the new screens

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9641

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
