### PR TITLE
Bugfix/FOUR-9727: Non-system assets are being hidden from the UI as if they were system assets

### DIFF
--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -59,37 +59,41 @@ trait HideSystemResources
         if (substr(static::class, -8) === 'Category') {
             return $query->where('is_system', false);
         } elseif (static::class === Process::class) {
-            $systemCategory = ProcessCategory::where('is_system', true)->pluck('id');
-
-            return $query->whereNotIn('process_category_id', $systemCategory)
+            return $query
                 ->where('is_template', false)
                 ->when(Schema::hasColumn('processes', 'asset_type'), function ($query) {
                     return $query->whereNull('asset_type');
+                })
+                ->whereDoesntHave('categories', function ($query) {
+                    $query->where('is_system', true);
                 });
         } elseif (static::class === Screen::class) {
-            $systemCategory = ScreenCategory::where('is_system', true)->pluck('id');
-
-            return $query->whereNotIn('screen_category_id', $systemCategory)
-                    ->where('is_template', false)
-                    ->when(Schema::hasColumn('screens', 'asset_type'), function ($query) {
-                        return $query->whereNull('asset_type');
-                    });
+            return $query
+                ->where('is_template', false)
+                ->when(Schema::hasColumn('screens', 'asset_type'), function ($query) {
+                    return $query->whereNull('asset_type');
+                })
+                ->whereDoesntHave('categories', function ($query) {
+                    $query->where('is_system', true);
+                });
         } elseif (static::class === Script::class) {
-            $systemCategory = ScriptCategory::where('is_system', true)->pluck('id');
-
-            return $query->whereNotIn('script_category_id', $systemCategory)
-                    ->where('is_template', false)
-                    ->when(Schema::hasColumn('scripts', 'asset_type'), function ($query) {
-                        return $query->whereNull('asset_type');
-                    });
+            return $query
+                ->where('is_template', false)
+                ->when(Schema::hasColumn('scripts', 'asset_type'), function ($query) {
+                    return $query->whereNull('asset_type');
+                })
+                ->whereDoesntHave('categories', function ($query) {
+                    $query->where('is_system', true);
+                });
         } elseif (static::class === DataSource::class) {
-            $systemCategory = DataSourceCategory::where('is_system', true)->pluck('id');
-
-            return $query->whereNotIn('data_source_category_id', $systemCategory)
-                    ->where('is_template', false)
-                    ->when(Schema::hasColumn('data_sources', 'asset_type'), function ($query) {
-                        return $query->whereNull('asset_type');
-                    });
+            return $query
+                ->where('is_template', false)
+                ->when(Schema::hasColumn('data_sources', 'asset_type'), function ($query) {
+                    return $query->whereNull('asset_type');
+                })
+                ->whereDoesntHave('categories', function ($query) {
+                    $query->where('is_system', true);
+                });
         } elseif (static::class == ProcessRequest::class) {
             // ProcessRequests must be filtered this way since
             // they could be in a separate database

--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -73,8 +73,8 @@ trait HideSystemResources
                 ->when(Schema::hasColumn('screens', 'asset_type'), function ($query) {
                     return $query->whereNull('asset_type');
                 })
-                ->whereHas('categories', function ($query) {
-                    $query->where('is_system', false);
+                ->whereDoesntHave('categories', function ($query) {
+                    $query->where('is_system', true);
                 });
         } elseif (static::class === Script::class) {
             return $query

--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -73,8 +73,8 @@ trait HideSystemResources
                 ->when(Schema::hasColumn('screens', 'asset_type'), function ($query) {
                     return $query->whereNull('asset_type');
                 })
-                ->whereDoesntHave('categories', function ($query) {
-                    $query->where('is_system', true);
+                ->whereHas('categories', function ($query) {
+                    $query->where('is_system', false);
                 });
         } elseif (static::class === Script::class) {
             return $query

--- a/upgrades/2023_08_02_168972_add_default_screens_to_system_category.php
+++ b/upgrades/2023_08_02_168972_add_default_screens_to_system_category.php
@@ -1,0 +1,39 @@
+<?php
+
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\ScreenCategory;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class AddDefaultScreensToSystemCategory extends Upgrade
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->assignToSystemCategory('default-display-screen');
+        $this->assignToSystemCategory('default-form-screen');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+    }
+
+    /**
+     * Assign system screens to system category.
+     */
+    private function assignToSystemCategory(string $key)
+    {
+        $screens = Screen::where('key', $key)->get();
+        $screenCategory = ScreenCategory::where('name', 'System')
+            ->where('is_system', 1)
+            ->firstOrFail();
+
+        foreach ($screens as $screen) {
+            $screen->categories()->attach([$screenCategory->id]);
+        }
+    }
+}

--- a/upgrades/2023_08_02_168972_add_default_screens_to_system_category.php
+++ b/upgrades/2023_08_02_168972_add_default_screens_to_system_category.php
@@ -28,9 +28,7 @@ class AddDefaultScreensToSystemCategory extends Upgrade
     private function assignToSystemCategory(string $key)
     {
         $screens = Screen::where('key', $key)->get();
-        $screenCategory = ScreenCategory::where('name', 'System')
-            ->where('is_system', 1)
-            ->firstOrFail();
+        $screenCategory = ScreenCategory::firstOrCreate(['name' => 'System', 'is_system' => 1]);
 
         foreach ($screens as $screen) {
             $screen->categories()->attach([$screenCategory->id]);


### PR DESCRIPTION
## Issue & Reproduction Steps
Please see to the ticket https://processmaker.atlassian.net/browse/FOUR-9727

## Solution
- Update the scopeNonSystem function to look at category_assignments to make sure the asset does not belong to a system category.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/07e6dd84-5e70-494a-b2ef-a0e8fa045927


## How to Test
Test 1
- Import the attached process in the ticket
- Go to scripts and verify that the script is showing in the list

Test 2
- In category_assignments table, modify the category_id to point to a system category (you need to go to script_categories table and modify some script category to be is_system = 1)
- Go back to scripts, and the script using the system category should not show

Test 3
- Test the same as test 2 but with processes
- Test the same as test 2 but with screens
- Test the same as test 2 but with data sources

## Related Tickets & Packages
- [FOUR-9727](https://processmaker.atlassian.net/browse/FOUR-9727)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9727]: https://processmaker.atlassian.net/browse/FOUR-9727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ