### PR TITLE
Update export filename format

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ExportController.php
+++ b/ProcessMaker/Http/Controllers/Api/ExportController.php
@@ -77,11 +77,13 @@ class ExportController extends Controller
             $payload = $exporter->encrypt($password, $payload);
         }
 
+        $filename = strtolower(str_replace(' ', '_', $payload['name'])) . '.json';
+
         return response()->streamDownload(
             function () use ($payload) {
                 echo json_encode($payload);
             },
-            $payload['name'] . '.json',
+            $filename,
             [
                 'Content-type' => 'application/json',
                 'export-info' => $exported,

--- a/resources/js/processes/export/DataProvider.js
+++ b/resources/js/processes/export/DataProvider.js
@@ -83,7 +83,7 @@ export default {
       const url = window.URL.createObjectURL(new Blob([response.data]));
       const link = document.createElement("a");
       link.href = url;
-      link.setAttribute("download", exportInfo.name.replace(' ', '_') + ".json");
+      link.setAttribute("download", exportInfo.name.replace(/ /g, "_").toLowerCase() + ".json");
       document.body.appendChild(link);
       link.click();
       return exportInfo;

--- a/tests/Feature/ImportExport/Api/ExportImportTest.php
+++ b/tests/Feature/ImportExport/Api/ExportImportTest.php
@@ -35,7 +35,7 @@ class ExportImportTest extends TestCase
 
     public function testDownloadExportFile()
     {
-        $screen = Screen::factory()->create(['title' => 'Screen']);
+        $screen = Screen::factory()->create(['title' => 'Screen With Space']);
 
         $response = $this->apiCall(
             'POST',
@@ -51,7 +51,7 @@ class ExportImportTest extends TestCase
 
         // Ensure we can download the exported file.
         $response->assertStatus(200);
-        $response->assertHeader('content-disposition', "attachment; filename={$screen->title}.json");
+        $response->assertHeader('content-disposition', 'attachment; filename=screen_with_space.json');
 
         // Ensure it's encrypted.
         $payload = json_decode($response->streamedContent(), true);


### PR DESCRIPTION
## Issue & Reproduction Steps
Filename formats are not consistent between the exported processes and exported PM Blocks.

## Solution
Change the exported process filename to be all lowercase and replace all spaces with underscores to match PM Blocks

## How to Test
- Create a process with uppercase letters and spaces in the title
- Export the process and verify the filename format is correct

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9724

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
