### PR TITLE
FOUR-9739: Fix error handling

### DIFF
--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -348,7 +348,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
             $thisWasFinalAttempt = true;
             if (isset($errorHandling)) {
                 $thisWasFinalAttempt = ($errorHandling->retryAttempts() === 0) || ($job->attemptNum >= $errorHandling->retryAttempts());
-                $message = $errorHandling->handleRetries($job, $exception);
+                [$message] = $errorHandling->handleRetries($job, $exception);
 
                 $error = $element->getRepository()->createError();
                 $error->setName($message);


### PR DESCRIPTION
## Issue & Reproduction Steps
A process stops when a service task fails at https://nightly-qa.processmaker.net/.

Steps to reproduces:

1. Create a decision table with invalid rules
2. Create a process that calls to the decision table (See the attached process)
3. Run the process
4. When the process runs the invalid decision table will stop to process.

Expected behavior:
Show the error response from the task

## Solution
- Fix the code where the error is handled.

## How to Test
1. Create a decision table with invalid rules
2. Create a process that calls to the decision table (See the attached process)
3. Run the process
4. When the process runs the invalid decision table will stop to process.
[Test_OR AND.zip](https://github.com/ProcessMaker/processmaker/files/12244045/Test_OR.AND.zip)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9739

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy