### PR TITLE
Implement flash message when editing a default template

### DIFF
--- a/ProcessMaker/Http/Controllers/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/TemplateController.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
 use ProcessMaker\Http\Controllers\Api\TemplateController as TemplateApiController;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\Template;
@@ -53,6 +54,7 @@ class TemplateController extends Controller
     {
         $templateApiController = new TemplateApiController(new Template);
         $response = $templateApiController->show('process', $request);
+        Session::flash('_alert', json_encode(['success', __('The template was created.')]));
 
         return view('processes.modeler.showTemplate')->with('id', $response['id']);
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
When editing a default template for the first time, in some cases we will get a json_decode error or Server Error in the nightly build.
<img width="932" alt="Screenshot 2023-08-02 at 12 45 04 PM" src="https://github.com/ProcessMaker/processmaker/assets/5769433/52f6b3d2-0142-4817-b256-9a8b95f55d7c">

1. Click on Designer->Templates
2. Click on Edit Template within the Ellipsis menu of one of the Default Templates.
If the error doesn't show up, click on a different template.

## Solution
- Implement flash message similar to what we have when we create a Process from a Template.

## How to Test
1. Click on Designer->Templates
2. Click on Edit Template within the Ellipsis menu of one of the Default Templates.
3. Make sure we don't get an error when editing a template and the flash message is included. (The template was created.) 
<img width="883" alt="Screenshot 2023-08-02 at 12 52 37 PM" src="https://github.com/ProcessMaker/processmaker/assets/5769433/bf4b842a-d8a8-4456-807a-1e0729cbda79">


## Related Tickets & Packages
Ticket: [FOUR-9718](https://processmaker.atlassian.net/browse/FOUR-9718)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9718]: https://processmaker.atlassian.net/browse/FOUR-9718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ