### PR TITLE
[FOUR-9740] Update documentation links

### DIFF
--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -179,7 +179,7 @@ class GenerateMenus
                 'id' => 'dropdownItem',
             ]);
             $submenu->add(__('Documentation'), [
-                'url' => 'https://processmaker.gitbook.io/processmaker',
+                'url' => 'https://docs.processmaker.com',
                 'icon' => 'fa-question-circle',
                 'id' => 'dropdownItem',
                 'target' => '_blank',

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://processmaker.atlassian.net/wiki/spaces/PM4/pages/480149598/Server+Deploy
 
 The online documentation for usage of ProcessMaker 4 can be found by clicking the link below.
 
-https://processmaker.gitbook.io/processmaker/
+https://docs.processmaker.com/
 
 ## Testing
 All PRs for PM4 and it's packages should be accompanied by a test.

--- a/resources/js/components/NavbarProfile.vue
+++ b/resources/js/components/NavbarProfile.vue
@@ -61,7 +61,7 @@
         </li>
         <li class="list-group-item px-2">
           <a
-            href="https://processmaker.gitbook.io/processmaker/"
+            href="https://docs.processmaker.com/"
             role="menuitem"
             :aria-label="$t('Documentation')"
             target="_blank"

--- a/resources/js/processes/scripts/customFilters.js
+++ b/resources/js/processes/scripts/customFilters.js
@@ -64,7 +64,7 @@ Vue.filter("lua", (value) => {
       line = line.replace("{dataVariable}", "data");
       line = line.replace("{configVariable}", "config");
       line = line.replace("{apiExample}", "users_api:get_users(filter, order_by, order_direction, per_page, include)");
-      line = line.replace("{apiDocsUrl}", "https://processmaker.gitbook.io/processmaker/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples");
+      line = line.replace("{apiDocsUrl}", "https://docs.processmaker.com/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples");
       format = `  ${line}`;
     }
     content.push(format);
@@ -89,7 +89,7 @@ Vue.filter("csharp", (value) => {
       line = line.replace("{dataVariable}", "data");
       line = line.replace("{configVariable}", "config");
       line = line.replace("{apiExample}", "apiInstance.GetUserById(id)");
-      line = line.replace("{apiDocsUrl}", "https://processmaker.gitbook.io/processmaker/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples");
+      line = line.replace("{apiDocsUrl}", "https://docs.processmaker.com/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples");
       format = line;
     }
     content.push(format);
@@ -114,7 +114,7 @@ Vue.filter("java", (value) => {
       line = line.replace("{dataVariable}", "data");
       line = line.replace("{configVariable}", "config");
       line = line.replace("{apiExample}", "apiInstance.getUserByID(id);");
-      line = line.replace("{apiDocsUrl}", "https://processmaker.gitbook.io/processmaker/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples");
+      line = line.replace("{apiDocsUrl}", "https://docs.processmaker.com/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples");
       format = ` * ${line}`;
     }
     content.push(format);
@@ -135,7 +135,7 @@ Vue.filter("python", (value) => {
     line = line.replace("{dataVariable}", "the data variable");
     line = line.replace("{configVariable}", "the config variable");
     line = line.replace("{apiExample}", ":");
-    line = line.replace("{apiDocsUrl}", "https://processmaker.gitbook.io/processmaker/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples");
+    line = line.replace("{apiDocsUrl}", "https://docs.processmaker.com/designing-processes/scripts/script-editor#processmaker-and-environment-variable-syntax-usage-sdk-and-examples");
     format = `# ${line}`;
     content.push(format);
   });

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -24,7 +24,7 @@
         <hr>
         <a href="https://github.com/ProcessMaker/processmaker/issues/new" target="_blank">{{__('Report an issue')}}  <i class="fas fa-caret-right fa-lg float-right mr-1"></i></a>
         <hr>
-        <a href="https://processmaker.gitbook.io/processmaker/" target="_blank">{{__('Documentation')}}  <i class="fas fa-caret-right fa-lg float-right mr-1"></i></a>
+        <a href="https://docs.processmaker.com/" target="_blank">{{__('Documentation')}}  <i class="fas fa-caret-right fa-lg float-right mr-1"></i></a>
         <hr>
         @if ($packages)
         <h5>{{ __('Packages Installed') }}</h5>


### PR DESCRIPTION
## Story
As a ProcessMaker user, I want to access ProcessMaker documentation via the new, more friendly documentation subdomain [docs.processmaker.com.](http://docs.processmaker.com/)

## Solution
- Change all links from [https://processmaker.gitbook.io/processmaker](https://processmaker.gitbook.io/processmaker) to [https://docs.processmaker.com/](https://docs.processmaker.com/).
- Ensure all packages also have the correct links.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9740