### PR TITLE
FOUR-9742 - AI Process>> Text overlap of control

### DIFF
--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'none';">
+    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'self';">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="app-url" content="{{ config('app.url') }}">


### PR DESCRIPTION
## Issue & Reproduction Steps

After selecting a previous version of history the Text overlap of control.

1. Generate a process using AI and Google Chrome browser.
2. Set the following text in Description: `create process for selling shoes`.
3. Update text in Description: `create process for selling shoes and reports in pdf connector`.
4. Go to History
5. Select the previous version
6. **Repeat step 5 until you see Text overlapping (it's a random bug)**

## Solution
- Use the object tag instead of iframe.
  - Enabling the use of the object tag for same-origin resources.

![example](https://github.com/ProcessMaker/package-ai/assets/90741874/4be02d0d-108e-45dc-b814-ae33feb1d5d0)

## How to Test
- Follow the reproduction steps of above.

## Related Tickets & Packages
- [FOUR-9742](https://processmaker.atlassian.net/browse/FOUR-9742)
- [Package AI PR](https://github.com/ProcessMaker/package-ai/pull/11)


[FOUR-9742]: https://processmaker.atlassian.net/browse/FOUR-9742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ