### PR TITLE
FOUR-9787: Server error when updating user permissions

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/PermissionController.php
+++ b/ProcessMaker/Http/Controllers/Api/PermissionController.php
@@ -83,8 +83,7 @@ class PermissionController extends Controller
         //Obtain the requested user or group
         if ($request->input('user_id')) {
             $entity = User::findOrFail($request->input('user_id'));
-            //Obtain user old Permissions before save
-            $entity->memberships = $entity->groupMembersFromMemberable()->get();
+            // Obtain user old Permissions before save
             $originalPermissionNames = $entity->permissions()->pluck('name')->toArray();
 
             if ($request->has('is_administrator')) {
@@ -97,14 +96,20 @@ class PermissionController extends Controller
             $originalPermissionNames = $entity->permissions()->pluck('name')->toArray();
         }
 
-        //Obtain the requested permission names for that entity
+        // Obtain the requested permission names for that entity
         $requestPermissions = $request->input('permission_names');
 
-        //Convert permission names into a collection of Permission models
+        // Convert permission names into a collection of Permission models
         $permissions = Permission::whereIn('name', $requestPermissions)->get();
 
         // Call Event to store Permissions Changes in Log
-        PermissionUpdated::dispatch($requestPermissions, $originalPermissionNames, $entity->is_administrator ?: false, $request->input('user_id'), $request->input('group_id'));
+        PermissionUpdated::dispatch(
+            $requestPermissions,
+            $originalPermissionNames,
+            $entity->is_administrator ?: false,
+            $request->input('user_id'),
+            $request->input('group_id')
+        );
 
         //Sync the entity's permissions with the database
         $entity->permissions()->sync($permissions->pluck('id')->toArray());


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a new user
- Go to the user’s Permissions tab
- Attempt to assign all permissions or any permissions to the user
- Click the Save button

## Solution
- The property memberships was not defined and is not used

## How to Test
- Create a new user
- Go to the user’s Permissions tab
- Attempt to assign all permissions or any permissions to the user
- Click the Save button

## Related Tickets & Packages
- [FOUR-9787](https://processmaker.atlassian.net/browse/FOUR-9787)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9787]: https://processmaker.atlassian.net/browse/FOUR-9787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ