### PR TITLE
Remove dependent assignment when not on target instance

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -165,14 +165,21 @@ abstract class ExporterBase implements ExporterInterface
         return $dependent;
     }
 
-    public function getDependents($type = null)
+    public function getDependents($type = null, $includeEmptyModels = false)
     {
         return array_values(
-            array_filter($this->dependents, function ($dependent) use ($type) {
+            array_filter($this->dependents, function ($dependent) use ($type, $includeEmptyModels) {
                 if ($type && $dependent->type !== $type) {
                     return false;
                 }
                 if ($dependent->model === null) {
+                    if ($includeEmptyModels) {
+                        // Return an empty model when the dependent does not exist
+                        $dependent->model = new $dependent->modelClass();
+
+                        return true;
+                    }
+
                     return false;
                 }
 

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -121,10 +121,16 @@ class ProcessExporter extends ExporterBase
 
     private function importSubprocesses()
     {
-        foreach ($this->getDependents(DependentType::SUB_PROCESSES) as $dependent) {
-            Utils::setAttributeAtXPath($this->model, $dependent->meta, 'calledElement', 'ProcessId-' . $dependent->model->id);
-            Utils::setPmConfigValueAtXPath($this->model, $dependent->meta, 'calledElement', 'ProcessId-' . $dependent->model->id);
-            Utils::setPmConfigValueAtXPath($this->model, $dependent->meta, 'processId', $dependent->model->id);
+        foreach ($this->getDependents(DependentType::SUB_PROCESSES, true) as $dependent) {
+            $id = $dependent->model->id;
+            if ($id) {
+                Utils::setAttributeAtXPath($this->model, $dependent->meta, 'calledElement', 'ProcessId-' . $dependent->model->id);
+                Utils::setPmConfigValueAtXPath($this->model, $dependent->meta, 'calledElement', 'ProcessId-' . $dependent->model->id);
+                Utils::setPmConfigValueAtXPath($this->model, $dependent->meta, 'processId', $dependent->model->id);
+            } else {
+                Utils::setAttributeAtXPath($this->model, $dependent->meta, 'calledElement', '');
+                Utils::setAttributeAtXPath($this->model, $dependent->meta, 'pm:config', '{}');
+            }
         }
     }
 
@@ -133,7 +139,7 @@ class ProcessExporter extends ExporterBase
         $userAssignments = [];
         $groupAssignments = [];
 
-        foreach ($this->getDependents(DependentType::USER_ASSIGNMENT) as $dependent) {
+        foreach ($this->getDependents(DependentType::USER_ASSIGNMENT, true) as $dependent) {
             if (!array_key_exists($dependent->meta['path'], $userAssignments)) {
                 $userAssignments[$dependent->meta['path']] = [];
             }
@@ -143,7 +149,7 @@ class ProcessExporter extends ExporterBase
             ];
         }
 
-        foreach ($this->getDependents(DependentType::GROUP_ASSIGNMENT) as $dependent) {
+        foreach ($this->getDependents(DependentType::GROUP_ASSIGNMENT, true) as $dependent) {
             if (!array_key_exists($dependent->meta['path'], $groupAssignments)) {
                 $groupAssignments[$dependent->meta['path']] = [];
             }
@@ -155,12 +161,12 @@ class ProcessExporter extends ExporterBase
 
         foreach ($userAssignments as $path => $ids) {
             Utils::setAttributeAtXPath($this->model, $path, 'pm:assignment', $dependent->meta['assignmentType']);
-            Utils::setAttributeAtXPath($this->model, $path, 'pm:assignedUsers', implode(',', $ids));
+            Utils::setAttributeAtXPath($this->model, $path, 'pm:assignedUsers', implode(',', array_filter($ids)));
         }
 
         foreach ($groupAssignments as $path => $ids) {
             Utils::setAttributeAtXPath($this->model, $path, 'pm:assignment', $dependent->meta['assignmentType']);
-            Utils::setAttributeAtXPath($this->model, $path, 'pm:assignedGroups', implode(',', $ids));
+            Utils::setAttributeAtXPath($this->model, $path, 'pm:assignedGroups', implode(',', array_filter($ids)));
         }
     }
 

--- a/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
@@ -29,7 +29,7 @@ class ScriptExporter extends ExporterBase
     {
         $this->associateCategories(ScriptCategory::class, 'script_category_id');
 
-        foreach ($this->getDependents('user') as $dependent) {
+        foreach ($this->getDependents('user', true) as $dependent) {
             $scriptUser = $dependent->model;
             $this->model->run_as_user_id = $scriptUser->id;
         }

--- a/ProcessMaker/ImportExport/Utils.php
+++ b/ProcessMaker/ImportExport/Utils.php
@@ -29,6 +29,13 @@ class Utils
         return json_decode($element->getAttribute('pm:config'), true);
     }
 
+    // public static function getPmConfigAtXPath(Process $process, string $xmlPath)
+    // {
+    //     $definitions = $process->getDefinitions(true);
+    //     $element = self::getElementByPath($definitions, $xmlPath);
+    //     return self::getPmConfig($element);
+    // }
+
     public static function getElementByPath($document, $path)
     {
         $elements = self::getElementsByPath($document, $path);

--- a/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
@@ -111,4 +111,20 @@ class ScriptExporterTest extends TestCase
         $this->assertEquals('test category A 2', $newCategory1->name);
         $this->assertEquals('test category B 2', $newCategory2->name);
     }
+
+    public function testNoMatchingRunAsUser()
+    {
+        DB::beginTransaction();
+        $user = User::factory()->create(['username' => 'test']);
+        $script = Script::factory()->create(['title' => 'test', 'run_as_user_id' => $user->id]);
+
+        // $payload = $this->export($script, ScriptExporter::class);
+        $payload = $this->export($script, ScriptExporter::class, null, false);
+        DB::rollBack(); // Delete all created items since DB::beginTransaction
+
+        $this->import($payload);
+
+        $script = Script::where('title', 'test')->firstOrFail();
+        $this->assertNull($script->run_as_user_id);
+    }
 }

--- a/tests/Feature/ImportExport/HelperTrait.php
+++ b/tests/Feature/ImportExport/HelperTrait.php
@@ -55,11 +55,11 @@ trait HelperTrait
         SignalManager::addSignal($this->globalSignal);
     }
 
-    public function runExportAndImport($model, $exporterClass, $between)
+    public function runExportAndImport($model, $exporterClass, $between, $ignoreExplicitExport = true)
     {
         $this->addGlobalSignalProcess();
 
-        $payload = $this->export($model, $exporterClass);
+        $payload = $this->export($model, $exporterClass, null, $ignoreExplicitExport);
 
         $between();
 

--- a/tests/Feature/ImportExport/fixtures/process-with-different-kinds-of-call-activities.bpmn.xml
+++ b/tests/Feature/ImportExport/fixtures/process-with-different-kinds-of-call-activities.bpmn.xml
@@ -22,8 +22,8 @@
         </bpmn:callActivity>
         <bpmn:sequenceFlow id="node_5" name="" sourceRef="node_1" targetRef="node_8" />
         <bpmn:sequenceFlow id="node_7" name="" sourceRef="node_8" targetRef="node_2" />
-        <bpmn:task id="node_3" name="usergroup" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="user_group" pm:assignedUsers="1" pm:assignedGroups="1,2" pm:assignmentLock="false" pm:allowReassignment="false" />
-        <bpmn:task id="node_4" name="selfserve" pm:screenRef="2" pm:allowInterstitial="false" pm:assignment="self_service" pm:assignedUsers="1" pm:assignedGroups="2,1" pm:assignmentLock="false" pm:allowReassignment="false" />
+        <bpmn:task id="node_3" name="usergroup" pm:screenRef="" pm:allowInterstitial="false" pm:assignment="user_group" pm:assignedUsers="1" pm:assignedGroups="1,2" pm:assignmentLock="false" pm:allowReassignment="false" />
+        <bpmn:task id="node_4" name="selfserve" pm:screenRef="" pm:allowInterstitial="false" pm:assignment="self_service" pm:assignedUsers="1" pm:assignedGroups="2,1" pm:assignmentLock="false" pm:allowReassignment="false" />
         <bpmn:serviceTask id="node_10" name="Send Email" pm:config="{&#34;emailServer&#34;:&#34;&#34;,&#34;type&#34;:&#34;text&#34;,&#34;subject&#34;:&#34;some subject&#34;,&#34;textBody&#34;:&#34;test&#34;,&#34;screenRef&#34;:null,&#34;users&#34;:[1],&#34;groups&#34;:[2,1],&#34;addEmails&#34;:[],&#34;requestRecipients&#34;:[],&#34;usersAndGroupsOptionSelected&#34;:true}" implementation="connector-send-email/processmaker-communication-email-send" />
     </bpmn:process>
     <bpmndi:BPMNDiagram id="BPMNDiagramId">


### PR DESCRIPTION
## Issue & Reproduction Steps

See description in Jira issue

If we export a process with a script, the script will have a "Run script as" user assigned. Users are not exported. When we import the process, the system searches for a user with the same UUID, email, or username. If found, it sets the "Run script as" user to that user. However, if the user is not found in the target instance, it does not change the "Run script as" user id. This could create a problem if the source instance had a Run script as user: bob with the id 5 and the target instance does not have bob, but does have the user alice and happens to have the same ID: 5. When the script imports, since it does not change the "Run script as" user id, the script will be accidentally assigned to alice My suggestion is that we set the "Run script as" user to null if the user does not exist in the target instance

## Solution
- Remove assignments for script's user, process's subprocesses, and process's task assignments when they do not exist on the the target instance

## How to Test
- Create a regular user
- Create a process and the set the process manager to the admin user
- Create a form task and assign it to the regular user
- Export the process
- Import on another instance that does not have the regular user (or has a clean database).
- Run the process. The task should automatically assign to the Process Manager (admin user) because the user assignment is now blank. Before this fix, you would get an error `Undefined array key "assign_to"` if the user did not exist, or, if a different user exists with the same ID, it would wrongfully be assigned to that user.


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9747

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
