### PR TITLE
FOUR-9558-A Array to string conversion. ErrorException(code: 0): Arra…

### DIFF
--- a/ProcessMaker/Helpers/ArrayHelper.php
+++ b/ProcessMaker/Helpers/ArrayHelper.php
@@ -32,8 +32,8 @@ class ArrayHelper
     public static function getArrayDifferencesWithFormat(array $changedArray, array $originalArray): array
     {
         $arrayDiff = [];
-        $displayChanges = array_diff_assoc($changedArray, $originalArray);
-        $displayOriginal = array_diff_assoc($originalArray, $changedArray);
+        $displayChanges = self::customArrayDiffAssoc($changedArray, $originalArray);
+        $displayOriginal = self::customArrayDiffAssoc($originalArray, $changedArray);
 
         $arrayHelper = new self();
         $arrayDiff = $arrayHelper->formatChanges($displayChanges, $displayOriginal);
@@ -56,5 +56,36 @@ class ArrayHelper
         }
 
         return $array;
+    }
+
+    /**
+     * This method is analogous to the function array_diff_assoc, with the difference 
+     * that it supports the comparison of array-type elements in the content of the 
+     * compared arrays.
+     * 
+     * @param array $array1
+     * @param array $arrays
+     * @return array
+     */
+    public static function customArrayDiffAssoc(array $array1, ...$arrays): array
+    {
+        if (empty($arrays) === 0) {
+            return $array1;
+        }
+        $diff = [];
+        foreach ($array1 as $key => $value) {
+            $found = false;
+            foreach ($arrays as $array) {
+                $sw = is_array($array) && isset($array[$key]) && $array[$key] === $value;
+                if ($sw) {
+                    $found = true;
+                    break;
+                }
+            }
+            if (!$found) {
+                $diff[$key] = $value;
+            }
+        }
+        return $diff;
     }
 }

--- a/tests/unit/ProcessMaker/Helpers/ArrayHelperTest.php
+++ b/tests/unit/ProcessMaker/Helpers/ArrayHelperTest.php
@@ -146,5 +146,26 @@ class ArrayHelperTest extends TestCase
         ];
         $actual = ArrayHelper::customArrayDiffAssoc($array1, $array2);
         $this->assertEquals($expected, $actual);
+
+        $array1 = [
+            "a" => "green",
+            "b" => "brown",
+            "c" => "blue",
+            "red",
+            "d" => []
+        ];
+        $array2 = [
+            "a" => "green",
+            "yellow",
+            1 => "red",
+            "d" => []
+        ];
+        $expected = [
+            "b" => "brown",
+            "c" => "blue",
+            0 => "red"
+        ];
+        $actual = ArrayHelper::customArrayDiffAssoc($array1, $array2);
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/ProcessMaker/Helpers/ArrayHelperTest.php
+++ b/tests/unit/ProcessMaker/Helpers/ArrayHelperTest.php
@@ -104,4 +104,47 @@ class ArrayHelperTest extends TestCase
             ArrayHelper::replaceKeyInArray($myArray, $oldKey, $newKey)
         );
     }
+    
+    public function testCustomArrayDiffAssoc()
+    {
+        $array1 = [
+            "a" => "green",
+            "b" => "brown",
+            "c" => "blue",
+            "red"
+        ];
+        $array2 = [
+            "a" => "green",
+            "yellow",
+            1 => "red"
+        ];
+        $expected = [
+            "b" => "brown",
+            "c" => "blue",
+            0 => "red"
+        ];
+        $actual = ArrayHelper::customArrayDiffAssoc($array1, $array2);
+        $this->assertEquals($expected, $actual);
+
+        $array1 = [
+            "a" => "green",
+            "b" => "brown",
+            "c" => "blue",
+            "red",
+            "d" => []
+        ];
+        $array2 = [
+            "a" => "green",
+            "yellow",
+            1 => "red"
+        ];
+        $expected = [
+            "b" => "brown",
+            "c" => "blue",
+            0 => "red",
+            "d" => []
+        ];
+        $actual = ArrayHelper::customArrayDiffAssoc($array1, $array2);
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
…y to string conversion at processmaker/ProcessMaker/Helpers/ArrayHelper.php:35, at array_diff_assoc()

## Issue & Reproduction Steps
Array to string conversion. ErrorException(code: 0): Array to string conversion at processmaker/ProcessMaker/Helpers/ArrayHelper.php:35, at array_diff_assoc()

## Solution
- Watch the attached video in the comment. https://processmaker.atlassian.net/browse/FOUR-9558?focusedCommentId=339101


