### PR TITLE
FOUR-9792: Improve the default URL reports adding in the .env

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -110,7 +110,9 @@ return [
     'security_log' => env('SECURITY_LOG', 'true'),
 
     // Security log
-    'analytics_reporting_default_graph' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH', 'https://localhost'),
+    'analytics_reporting_default_graph_1' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH_1', 'https://localhost'),
+    'analytics_reporting_default_graph_2' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH_2', 'https://localhost'),
+    'analytics_reporting_default_graph_3' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH_3', 'https://localhost'),
 
     // Message broker driver to use in Workflow Manager
     'message_broker_driver' => env('MESSAGE_BROKER_DRIVER', 'default'),


### PR DESCRIPTION
## Issue & Reproduction Steps
Improve the default URL reports adding in the .env
## Solution
- Add the variables in the .env in order to define the default charts
```
ANALYTICS_REPORTING_DEFAULT_GRAPH_1 = 'https://us-east-1.quicksight.aws.amazon.com/sn/embed/share/accounts/441441716351/dashboards/39d4b078-87d4-4272-8399-2b8b3324f5b7/sheets/39d4b078-87d4-4272-8399-2b8b3324f5b7_83f09431-ba5f-4a3b-99ec-456a618239ac/visuals/39d4b078-87d4-4272-8399-2b8b3324f5b7_3d430118-e980-41d8-b753-1bba4e282f35?directory_alias=researchquicksight'
ANALYTICS_REPORTING_DEFAULT_GRAPH_2 = 'https://us-east-1.quicksight.aws.amazon.com/sn/embed/share/accounts/441441716351/dashboards/39d4b078-87d4-4272-8399-2b8b3324f5b7/sheets/39d4b078-87d4-4272-8399-2b8b3324f5b7_83f09431-ba5f-4a3b-99ec-456a618239ac/visuals/39d4b078-87d4-4272-8399-2b8b3324f5b7_5fc8e340-0e63-4a5f-a92c-a79113819310?directory_alias=researchquicksight'
ANALYTICS_REPORTING_DEFAULT_GRAPH_3 = 'https://us-east-1.quicksight.aws.amazon.com/sn/embed/share/accounts/441441716351/dashboards/39d4b078-87d4-4272-8399-2b8b3324f5b7/sheets/39d4b078-87d4-4272-8399-2b8b3324f5b7_83f09431-ba5f-4a3b-99ec-456a618239ac/visuals/39d4b078-87d4-4272-8399-2b8b3324f5b7_b442b5ff-0773-4bb0-bbee-60f4e80b3838?directory_alias=researchquicksight'
```

## How to Test
Test the steps above

## Related Tickets & Packages
[-FOUR-9792 ](https://processmaker.atlassian.net/browse/FOUR-9792)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
