### PR TITLE
FOUR-9669: Customize UI User Activity Logging Registry is not Working

### DIFF
--- a/ProcessMaker/Events/CustomizeUiUpdated.php
+++ b/ProcessMaker/Events/CustomizeUiUpdated.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Events;
 use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use ProcessMaker\Contracts\SecurityLogEventInterface;
+use ProcessMaker\Helpers\ArrayHelper;
 use ProcessMaker\Traits\FormatSecurityLogChanges;
 
 class CustomizeUiUpdated implements SecurityLogEventInterface
@@ -72,17 +73,8 @@ class CustomizeUiUpdated implements SecurityLogEventInterface
             $this->changes['variables'] = $varChanges;
             $this->original['variables'] = $varOriginal;
         }
-        if (!isset($this->original['sansSerifFont'])) {
-            $this->original['sansSerifFont'] = $this->defaultFont;
-        }
-        if ($this->original['sansSerifFont'] == $this->changes['sansSerifFont']) {
-            unset($this->original['sansSerifFont']);
-            unset($this->changes['sansSerifFont']);
-        }
-        if ($this->original['variables'] == $this->changes['sansSevariablesrifFont']) {
-            unset($this->original['variables']);
-            unset($this->changes['variables']);
-        }
+        // Set a value sansSerifFont
+        $this->original['sansSerifFont'] = !isset($this->original['sansSerifFont']) ? $this->defaultFont : $this->original['sansSerifFont'];
         // Define if the action reset was executed
         $actionReset = ($this->reset) ? ['Action' => 'Reset'] : [];
         $this->data = array_merge(
@@ -94,7 +86,7 @@ class CustomizeUiUpdated implements SecurityLogEventInterface
                 'last_modified' => Carbon::now(),
             ],
             $actionReset,
-            $this->formatChanges($this->changes, $this->original)
+            ArrayHelper::getArrayDifferencesWithFormat($this->changes, $this->original)
         );
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
- Do modifications in Customize UI
- Check the User Activity Logging 

## Solution
- Some keys are not defined.

## How to Test
- Do modifications in Customize UI
- Reset the changes
- Check the User Activity Logging 

## Related Tickets & Packages
- [FOUR-9669](https://processmaker.atlassian.net/browse/FOUR-9669)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9669]: https://processmaker.atlassian.net/browse/FOUR-9669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ