### PR TITLE
Allow null run_as_user_id in scripts export

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
@@ -20,7 +20,9 @@ class ScriptExporter extends ExporterBase
             $this->addDependent(DependentType::ENVIRONMENT_VARIABLES, $environmentVariable, EnvironmentVariableExporter::class);
         }
 
-        $this->addDependent('user', $this->model->runAsUser, UserExporter::class);
+        if ($this->model->runAsUser) {
+            $this->addDependent('user', $this->model->runAsUser, UserExporter::class);
+        }
 
         $this->addDependent('executor', $this->model->scriptExecutor, ScriptExecutorExporter::class);
     }

--- a/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
@@ -118,7 +118,20 @@ class ScriptExporterTest extends TestCase
         $user = User::factory()->create(['username' => 'test']);
         $script = Script::factory()->create(['title' => 'test', 'run_as_user_id' => $user->id]);
 
-        // $payload = $this->export($script, ScriptExporter::class);
+        $payload = $this->export($script, ScriptExporter::class, null, false);
+        DB::rollBack(); // Delete all created items since DB::beginTransaction
+
+        $this->import($payload);
+
+        $script = Script::where('title', 'test')->firstOrFail();
+        $this->assertNull($script->run_as_user_id);
+    }
+
+    public function testRunAsUserIdNull()
+    {
+        DB::beginTransaction();
+        $script = Script::factory()->create(['title' => 'test', 'run_as_user_id' => null]);
+
         $payload = $this->export($script, ScriptExporter::class, null, false);
         DB::rollBack(); // Delete all created items since DB::beginTransaction
 


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-9646?focusedCommentId=339247

We now allow null values for run_as_user_id (from [9747](https://processmaker.atlassian.net/browse/FOUR-9747)) however a script with null run_as_user_id is not able to export.

## Solution
- Check for a null run_as_user_id before adding the user as a dependent in the script exporter.

## How to Test
- Create a script with a regular user as the Run Script As user
- Create process with the script
- Export the process
- Clear your DB or use another instance that does not have the user
- Import the process (this should work fine, as it did before this fix. The run_as_user_id will be null in the database)
- Create a PM block form the imported process. Before this fix we would get an error.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9646

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
