### PR TITLE
Bugfix/FOUR-9798: Cannot create a process if it is added and then clears the Process Manager field

### DIFF
--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -116,6 +116,11 @@
           this.process_category_id = this.templateData.category_id;
         }
       },
+      manager: function() {
+        if (!this.manager) {
+          this.manager = "";
+        }
+      },
     },
     methods: {
       onShown() {


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to reproduced:

1.Go to designer
2.Click on +Process
3.Complete Name
4.Complete Description
5.Add Process Manager
6.Remove Process Manager
7. Click on Save button

**Current Behavior:**
The process cannot be created, the save button is blocked and a message is displayed in the console "Cannot read properties of null".

**Expected Behavior:**
You should be able to create a process without problem.

## Solution
- Set manager to empty string instead to null when changing the value.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/5c00d9f3-c95f-49a6-9315-b57384c7b4c1


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-9798](https://processmaker.atlassian.net/browse/FOUR-9798)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9798]: https://processmaker.atlassian.net/browse/FOUR-9798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ