### PR TITLE
FOUR-9800:Customize UI Shows Server Error After Changes

### DIFF
--- a/ProcessMaker/Events/CustomizeUiUpdated.php
+++ b/ProcessMaker/Events/CustomizeUiUpdated.php
@@ -58,6 +58,9 @@ class CustomizeUiUpdated implements SecurityLogEventInterface
         if (!isset($this->original['variables'])) {
             $this->original['variables'] = $this->defaultVariables;
         }
+        if (!isset($this->changes['variables'])) {
+            $this->changes['variables'] = $this->defaultVariables;
+        }
         if (isset($this->changes['variables']) && isset($this->original['variables'])) {
             $varChanges = [];
             $varOriginal = [];
@@ -75,11 +78,14 @@ class CustomizeUiUpdated implements SecurityLogEventInterface
         if (!isset($this->original['sansSerifFont'])) {
             $this->original['sansSerifFont'] = $this->defaultFont;
         }
+        if (!isset($this->changes['sansSerifFont'])) {
+            $this->changes['sansSerifFont'] = $this->defaultFont;
+        }
         if ($this->original['sansSerifFont'] == $this->changes['sansSerifFont']) {
             unset($this->original['sansSerifFont']);
             unset($this->changes['sansSerifFont']);
         }
-        if ($this->original['variables'] == $this->changes['sansSevariablesrifFont']) {
+        if ($this->original['variables'] == $this->changes['variables']) {
             unset($this->original['variables']);
             unset($this->changes['variables']);
         }

--- a/ProcessMaker/Http/Controllers/Api/CssOverrideController.php
+++ b/ProcessMaker/Http/Controllers/Api/CssOverrideController.php
@@ -336,7 +336,7 @@ class CssOverrideController extends Controller
             'logo' => $request->input('fileLogoName', ''),
             'icon' => $request->input('fileIconName', ''),
             'favicon' => $request->input('fileFaviconName', ''),
-            'variables' => $request->input('variables', ''),
+            'variables' => $request->input('variables', '[]'),
             'sansSerifFont' => $request->input('sansSerifFont', $this->sansSerifFontDefault()),
         ];
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
 - Do any modification in Customize ui
 - Save these modifications

## Solution
- Add validations and set some variables with default variables

## Related Tickets & Packages
- [FOUR-9800](https://processmaker.atlassian.net/browse/FOUR-9800)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9800]: https://processmaker.atlassian.net/browse/FOUR-9800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ