### PR TITLE
I get "Set Password" when exporting a process with scripts

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
@@ -51,7 +51,7 @@ class ScriptExporter extends ExporterBase
 
         // Search for environment variable present in the code
         foreach ($environmentVariables as $variable) {
-            if (strpos($this->model->code, $variable->name)) {
+            if (preg_match('/[^a-zA-Z0-9\s]' . $variable->name . '[^a-zA-Z0-9\s]?/', $this->model->code)) {
                 $environmentVariablesFound[] = $variable;
             }
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
when searching within the scripts for the name of an environment variable, the name of the environment variable was found as part of another string, therefore the variable was exported.

## Solution
- Change to a regular expression to search for the environment variable.

## How to Test
when you have a process with scripts verify that they have environment variables and also have names as part of another string

## Related Tickets & Packages
- [FOUR-9755](https://processmaker.atlassian.net/browse/FOUR-9755)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9755]: https://processmaker.atlassian.net/browse/FOUR-9755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ