### PR TITLE
Backport hotfix changes from STM

### DIFF
--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Models;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\Rule;
 use ProcessMaker\Exception\ScriptLanguageNotSupported;
+use ProcessMaker\Facades\Docker;
 use ProcessMaker\Traits\Exportable;
 use ProcessMaker\Traits\HasVersioning;
 
@@ -196,7 +197,7 @@ class ScriptExecutor extends ProcessMakerModel
 
     public static function listOfExecutorImages($filterByLanguage = null)
     {
-        exec('docker images | awk \'{r=$1":"$2; print r}\'', $result);
+        exec(Docker::command() . ' images | awk \'{r=$1":"$2; print r}\'', $result);
 
         $instance = config('app.instance');
 

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -32,13 +32,15 @@ return [
 
         'pusher' => [
             'driver' => 'pusher',
-            'key' => env('PUSHER_APP_KEY'),
-            'secret' => env('PUSHER_APP_SECRET'),
-            'app_id' => env('PUSHER_APP_ID'),
+            'key' => env('PUSHER_APP_KEY', 'app-key'),
+            'secret' => env('PUSHER_APP_SECRET', 'app-secret'),
+            'app_id' => env('PUSHER_APP_ID', 'app-id'),
             'options' => [
-                'cluster' => env('PUSHER_CLUSTER'),
-                'debug' => env('PUSHER_DEBUG', false),
-                'useTLS' => env('PUSHER_TLS', true),
+                'host' => env('PUSHER_HOST', '127.0.0.1'),
+                'port' => env('PUSHER_PORT', 6001),
+                'scheme' => env('PUSHER_SCHEME', 'http'),
+                'encrypted' => true,
+                'useTLS' => env('PUSHER_SCHEME') === 'https',
             ],
         ],
 

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -34,7 +34,7 @@ class UserSeeder extends Seeder
             'is_administrator' => true,
         ], [
             'username' => self::$INSTALLER_ADMIN_USERNAME,
-            'password' => Hash::make(self::$INSTALLER_ADMIN_PASSWORD),
+            'password' => Hash::make(env('INSTALL_ADMIN_PASSWORD', self::$INSTALLER_ADMIN_PASSWORD)),
             'email' => self::$INSTALLER_ADMIN_EMAIL,
             'firstname' => self::$INSTALLER_ADMIN_FIRSTNAME,
             'lastname' => self::$INSTALLER_ADMIN_LASTNAME,

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -58,8 +58,13 @@
           broadcaster: "pusher",
           key: "{{config('broadcasting.connections.pusher.key')}}",
           cluster: "{{config('broadcasting.connections.pusher.options.cluster')}}",
+          wsHost: "{{config('broadcasting.connections.pusher.options.host')}}",
+          wsPort: "{{config('broadcasting.connections.pusher.options.port')}}",
+          wssPort: "{{config('broadcasting.connections.pusher.options.port')}}",
           forceTLS: {{config('broadcasting.connections.pusher.options.use_tls') ? 'true' : 'false'}},
-          debug: {{config('broadcasting.connections.pusher.options.debug') ? 'true' : 'false'}}
+          debug: {{config('broadcasting.connections.pusher.options.debug') ? 'true' : 'false'}},
+          enabledTransports: ['ws', 'wss'],
+          disableStats: true,
         };
       @endif
     @endif


### PR DESCRIPTION
## Issue & Reproduction Steps

DevOps was using old hotfix files when building the images: https://github.com/ProcessMaker/pm4-k8s-distribution/tree/b95cbada6e479a033f533b5c8f8ebfebca257632/images/hotfixes/core

The old ScriptExecutor.php file didn't have the code that generates UUIDs

## Solution
This PR backports DevOps's changes into core so they don't have to use hotfixes, and as a result, will use the current ScriptExecutor.php file (and other files) and so fixes this issue.

**Note: DevOps must be alerted when this is merged so they can delete the hotfixes**

## How to Test
See Jira issues

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9830
- several other QA observations from nightly-qa.processmaker.net

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
