### PR TITLE
Add upgrade script to fix missing UUIDs

### DIFF
--- a/upgrades/2023_08_11_168972_add_missing_uuids_to_script_executors.php
+++ b/upgrades/2023_08_11_168972_add_missing_uuids_to_script_executors.php
@@ -1,0 +1,25 @@
+<?php
+
+use ProcessMaker\Models\ScriptExecutor;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class AddMissingUuidsToScriptExecutors extends Upgrade
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach (ScriptExecutor::whereNull('uuid')->get() as $scriptExecutor) {
+            $scriptExecutor->uuid = ScriptExecutor::generateUuid();
+            $scriptExecutor->saveOrFail();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-9830?focusedCommentId=349049

Due to the hotfixs, some script executors may not have UUIDs, which causes exporting to fail.

## Solution
- Add any missing UUIDs for script executors

## How to Test
Have some script executors with null UUIDs and run the `php artisan upgrade`. They should be populated

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9880
- https://processmaker.atlassian.net/browse/FOUR-9830?focusedCommentId=349049

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
