### PR TITLE
feature/FOUR-9582

### DIFF
--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -21,6 +21,7 @@
                 class="btn-light text-secondary"
                 :aria-label="$t('Previous Tasks')"
                 @click="goPrevNext('Prev')"
+                :disabled="!existPrev"
               >
                 <i class="fas fa-chevron-left"></i>
                 {{ $t("Prev") }}
@@ -29,6 +30,7 @@
                 class="btn-light text-secondary"
                 :aria-label="$t('Next Tasks')"
                 @click="goPrevNext('Next')"
+                :disabled="!existNext"
               >
                 {{ $t("Next") }}
                 <i class="fas fa-chevron-right"></i>


### PR DESCRIPTION
## Issue & Reproduction Steps
next previous: Show buttons inactive for first or last

## How to Test
Select a task in the modeler.
Find and click the new Preview icon in the list in the last or the first visible element.
Find the prev or next button disabled.

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-9582

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
