### PR TITLE
Feature/four 9500: Next-Back Pane Navigation

### DIFF
--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -442,7 +442,7 @@ export default {
       });
     },
     previewTasks(info) {
-      this.$refs.preview.showSideBar(info);
+      this.$refs.preview.showSideBar(info, this.data.data);
     },
   },
 };

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -12,19 +12,41 @@
         <div class="p-3">
           <div class="d-flex w-100 h-100 mb-3">
             <div class="my-1">
-              <a class="lead text-secondary font-weight-bold">{{ task.element_name }}</a>
+              <a class="lead text-secondary font-weight-bold">
+                {{ task.element_name }}
+              </a>
             </div>
             <div class="ml-auto mr-0 text-right">
-              <b-button class="btn-light text-secondary" aria-label="$t('Previous Tasks')" @click="goPrevious()">
+              <b-button
+                class="btn-light text-secondary"
+                :aria-label="$t('Previous Tasks')"
+                @click="goPrevious()"
+              >
                 <i class="fas fa-chevron-left"></i>
-                {{$t('Prev')}}
+                {{ $t("Prev") }}
               </b-button>
-              <b-button class="btn-light text-secondary" aria-label="$t('Next Tasks')" @click="goNext()">
-                {{$t('Next')}}
+              <b-button
+                class="btn-light text-secondary"
+                :aria-label="$t('Next Tasks')"
+                @click="goNext()"
+              >
+                {{ $t("Next") }}
                 <i class="fas fa-chevron-right"></i>
               </b-button>
               <a class="text-secondary">|</a>
-              <b-button class="btn-light text-secondary" aria-label="$t('Close')" @click="hide">
+              <b-button
+                class="btn-light text-secondary"
+                :aria-label="$t('Open Task')"
+                :href="openTask()"
+              >
+                <i class="fas fa-external-link-alt"></i>
+              </b-button>
+              <a class="text-secondary">|</a>
+              <b-button
+                class="btn-light text-secondary"
+                :aria-label="$t('Close')"
+                @click="hide"
+              >
                 <i class="fas fa-times"></i>
               </b-button>
             </div>
@@ -59,6 +81,12 @@ export default {
       this.task = info;
       this.linkTasks = `/tasks/${info.id}/edit/preview`;
       this.showPreview = true;
+    },
+    /**
+     * Expand Open task
+     */
+    openTask() {
+      return `/tasks/${this.task.id}/edit`;
     },
   },
 };

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -21,6 +21,7 @@
                 class="btn-light text-secondary"
                 :aria-label="$t('Previous Tasks')"
                 @click="goPrevNext('Prev')"
+                :disabled="!existPrev"
               >
                 <i class="fas fa-chevron-left"></i>
                 {{ $t("Prev") }}
@@ -29,6 +30,7 @@
                 class="btn-light text-secondary"
                 :aria-label="$t('Next Tasks')"
                 @click="goPrevNext('Next')"
+                :disabled="!existNext"
               >
                 {{ $t("Next") }}
                 <i class="fas fa-chevron-right"></i>

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -10,8 +10,11 @@
     >
       <template #default="{ hide }">
         <div class="p-3">
-          <div class="w-100 h-100 mb-3">
-            <div class="text-right">
+          <div class="d-flex w-100 h-100 mb-3">
+            <div class="my-1">
+              <a class="lead text-secondary font-weight-bold">{{ task.element_name }}</a>
+            </div>
+            <div class="ml-auto mr-0 text-right">
               <b-button class="btn-light text-secondary" aria-label="$t('Previous Tasks')" @click="goPrevious()">
                 <i class="fas fa-chevron-left"></i>
                 {{$t('Prev')}}

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -20,6 +20,10 @@
                 {{$t('Next')}}
                 <i class="fas fa-chevron-right"></i>
               </b-button>
+              <a class="text-secondary">|</a>
+              <b-button class="btn-light text-secondary" aria-label="$t('Close')" @click="hide">
+                <i class="fas fa-times"></i>
+              </b-button>
             </div>
           </div>
           <div>

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -6,15 +6,21 @@
       v-model="showPreview"
       :right="showRight"
       shadow
+      no-header
     >
       <template #default="{ hide }">
         <div class="p-3">
-          <div>
-            <!-- Set Controls to navigate -->
-            <i
-              class="fa fa-close"
-              @click="hide"
-            />
+          <div class="w-100 h-100 mb-3">
+            <div class="text-right">
+              <b-button class="btn-light text-secondary" aria-label="$t('Previous Tasks')" @click="goPrevious()">
+                <i class="fas fa-chevron-left"></i>
+                {{$t('Prev')}}
+              </b-button>
+              <b-button class="btn-light text-secondary" aria-label="$t('Next Tasks')" @click="goNext()">
+                {{$t('Next')}}
+                <i class="fas fa-chevron-right"></i>
+              </b-button>
+            </div>
           </div>
           <div>
             <b-embed

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -20,7 +20,7 @@
               <b-button
                 class="btn-light text-secondary"
                 :aria-label="$t('Previous Tasks')"
-                @click="goPrevious()"
+                @click="goPrevNext('Prev')"
               >
                 <i class="fas fa-chevron-left"></i>
                 {{ $t("Prev") }}
@@ -28,7 +28,7 @@
               <b-button
                 class="btn-light text-secondary"
                 :aria-label="$t('Next Tasks')"
-                @click="goNext()"
+                @click="goPrevNext('Next')"
               >
                 {{ $t("Next") }}
                 <i class="fas fa-chevron-right"></i>
@@ -71,22 +71,66 @@ export default {
       showRight: true,
       linkTasks: "",
       task: {},
+      data: [],
+      prevTask: {},
+      nextTask: {},
+      existPrev: false,
+      existNext: false,
     };
   },
   methods: {
     /**
      * Show the sidebar
      */
-    showSideBar(info) {
+    showSideBar(info, data) {
       this.task = info;
       this.linkTasks = `/tasks/${info.id}/edit/preview`;
       this.showPreview = true;
+      this.data = data;
+      this.existPrev = false;
+      this.existNext = false;
+      this.defineNextPrevTask();
+    },
+    /**
+     * Defined Previuos and Next task
+    */
+    defineNextPrevTask() {
+      let prevTask = {};
+      let nextTask = {};
+      let seeNextTask = false;
+      for (let task in this.data) {
+        if (!seeNextTask) {
+          if (this.data[task] === this.task) {
+            seeNextTask = true;
+          } else {
+            prevTask = this.data[task];
+            this.existPrev = true;
+          }
+        } else {
+          nextTask = this.data[task];
+          this.existNext = true;
+          break;
+        }
+      }
+      this.prevTask = prevTask;
+      this.nextTask = nextTask;
     },
     /**
      * Expand Open task
      */
     openTask() {
       return `/tasks/${this.task.id}/edit`;
+    },
+    /**
+     * Go to previous or next task
+     */
+    goPrevNext(action) {
+      if (action === "Next") {
+        this.showSideBar(this.nextTask, this.data);
+      }
+      if (action === "Prev") {
+        this.showSideBar(this.prevTask, this.data);
+      }
     },
   },
 };

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -20,20 +20,20 @@
               <b-button
                 class="btn-light text-secondary"
                 :aria-label="$t('Previous Tasks')"
-                @click="goPrevNext('Prev')"
                 :disabled="!existPrev"
+                @click="goPrevNext('Prev')"
               >
-                <i class="fas fa-chevron-left"></i>
+                <i class="fas fa-chevron-left" />
                 {{ $t("Prev") }}
               </b-button>
               <b-button
                 class="btn-light text-secondary"
                 :aria-label="$t('Next Tasks')"
-                @click="goPrevNext('Next')"
                 :disabled="!existNext"
+                @click="goPrevNext('Next')"
               >
                 {{ $t("Next") }}
-                <i class="fas fa-chevron-right"></i>
+                <i class="fas fa-chevron-right" />
               </b-button>
               <a class="text-secondary">|</a>
               <b-button
@@ -41,7 +41,7 @@
                 :aria-label="$t('Open Task')"
                 :href="openTask()"
               >
-                <i class="fas fa-external-link-alt"></i>
+                <i class="fas fa-external-link-alt" />
               </b-button>
               <a class="text-secondary">|</a>
               <b-button
@@ -49,14 +49,24 @@
                 :aria-label="$t('Close')"
                 @click="hide"
               >
-                <i class="fas fa-times"></i>
+                <i class="fas fa-times" />
               </b-button>
             </div>
           </div>
           <div>
+            <div
+              v-show="loading"
+              class="text-center"
+            >
+              <b-spinner />
+            </div>
             <b-embed
+              v-show="!loading"
+              id="tasksFrame"
               type="iframe"
+              :class="loading ? 'loadingFrame' : ''"
               :src="linkTasks"
+              @load="frameLoaded"
             />
           </div>
         </div>
@@ -78,6 +88,7 @@ export default {
       nextTask: {},
       existPrev: false,
       existNext: false,
+      loading: true,
     };
   },
   methods: {
@@ -100,7 +111,7 @@ export default {
       let prevTask = {};
       let nextTask = {};
       let seeNextTask = false;
-      for (let task in this.data) {
+      for (const task in this.data) {
         if (!seeNextTask) {
           if (this.data[task] === this.task) {
             seeNextTask = true;
@@ -127,12 +138,20 @@ export default {
      * Go to previous or next task
      */
     goPrevNext(action) {
+      this.linkTasks = "";
+      this.loading = true;
       if (action === "Next") {
         this.showSideBar(this.nextTask, this.data);
       }
       if (action === "Prev") {
         this.showSideBar(this.prevTask, this.data);
       }
+    },
+    /**
+     * Show the frame when this is loaded
+     */
+    frameLoaded() {
+      this.loading = false;
     },
   },
 };
@@ -142,5 +161,8 @@ export default {
 #tasks-preview {
   top: 11%;
   width: 50%;
+}
+.loadingFrame {
+  opacity: 0.6;
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
As a Participant, I want to jump between task and their Preview, without having to close the preview and opening the next one or previous one, so that I can understand my open tasks

## How to Test

1. Visit the task list.
2. Select a task and open the Preview Pane.
3. Find and click the Next and Previous Buttons.
4. See the next or previous task in their list.
5. For tasks that are first (or last) in their respective lists, will have these buttons inactive.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9500

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy