### PR TITLE
Export/import process with category

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -58,12 +58,20 @@ class ProcessExporter extends ExporterBase
 
         // Screens
         if ($process->cancel_screen_id) {
-            $screen = Screen::findOrFail($process->cancel_screen_id);
-            $this->addDependent('cancel-screen', $screen, ScreenExporter::class);
+            $screen = Screen::find($process->cancel_screen_id);
+            if ($screen) {
+                $this->addDependent('cancel-screen', $screen, ScreenExporter::class);
+            } else {
+                \Log::debug("Cancel ScreenId: $process->cancel_screen_id not exists");
+            }
         }
         if ($process->request_detail_screen_id) {
-            $screen = Screen::findOrFail($process->request_detail_screen_id);
-            $this->addDependent('request-detail-screen', $screen, ScreenExporter::class);
+            $screen = Screen::find($process->request_detail_screen_id);
+            if ($screen) {
+                $this->addDependent('request-detail-screen', $screen, ScreenExporter::class);
+            } else {
+                \Log::debug("Request Detail ScreenId: $process->request_detail_screen_id not exists");
+            }
         }
 
         $this->exportSubprocesses();
@@ -301,14 +309,22 @@ class ProcessExporter extends ExporterBase
             $allowInterstitial = $element->getAttribute('pm:allowInterstitial');
 
             if (is_numeric($screenId)) {
-                $screen = Screen::findOrFail($screenId);
-                $this->addDependent(DependentType::SCREENS, $screen, ScreenExporter::class, $meta);
+                $screen = Screen::find($screenId);
+                if ($screen) {
+                    $this->addDependent(DependentType::SCREENS, $screen, ScreenExporter::class, $meta);
+                } else {
+                    \Log::debug("ScreenId: $screenId not exists");
+                }
             }
 
             // Let's check if interstitialScreen exist
             if (is_numeric($interstitialScreenId) && $allowInterstitial === 'true') {
-                $interstitialScreen = Screen::findOrFail($interstitialScreenId);
-                $this->addDependent(DependentType::INTERSTITIAL_SCREEN, $interstitialScreen, ScreenExporter::class, $meta);
+                $interstitialScreen = Screen::find($interstitialScreenId);
+                if ($interstitialScreen) {
+                    $this->addDependent(DependentType::INTERSTITIAL_SCREEN, $interstitialScreen, ScreenExporter::class, $meta);
+                } else {
+                    \Log::debug("Interstitial screenId: $interstitialScreenId not exists");
+                }
             }
         }
     }
@@ -343,8 +359,12 @@ class ProcessExporter extends ExporterBase
             $scriptId = $element->getAttribute('pm:scriptRef');
 
             if (is_numeric($scriptId)) {
-                $script = Script::findOrFail($scriptId);
-                $this->addDependent(DependentType::SCRIPTS, $script, ScriptExporter::class, $meta);
+                $script = Script::find($scriptId);
+                if ($script) {
+                    $this->addDependent(DependentType::SCRIPTS, $script, ScriptExporter::class, $meta);
+                } else {
+                    \Log::debug("ScriptId: $scriptId not exists");
+                }
             }
         }
     }

--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -80,7 +80,12 @@ class ScreenExporter extends ExporterBase
         $screenFinder = new ScreensInScreen();
         foreach ($screenFinder->referencesToExport($this->model, [], null, false) as $screen) {
             try {
-                $screens[] = Screen::findOrFail($screen[1]);
+                $screen = Screen::find($screen[1]);
+                if ($screen) {
+                    $screens[] = $screen;
+                } else {
+                    \Log::debug("NestedScreen screenId: $screen[1] not exists");
+                }
             } catch (ModelNotFoundException $error) {
                 \Log::error($error->getMessage());
                 continue;

--- a/resources/js/processes/export/DataProvider.js
+++ b/resources/js/processes/export/DataProvider.js
@@ -15,6 +15,7 @@ export default {
     
     return ProcessMaker.apiClient.post('/import/do-import', formData,
     {
+        timeout: 60_000, // 60 seconds
         headers: {
             'Content-Type': 'multipart/form-data'
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
When a process is exported and a screen or script is not found, dependencies are no longer searched for and an incomplete file is created

## Solution
It prevents the search for dependencies from ending when a screen or script is not found, now it will continue searching for all dependencies.

## How to Test
Create a process assign it screens, scripts then save it.
Go eliminate the screens and scripts in the database.
then without updating the screens and scripts in the export process.
It shouldn't cut the dependency lookup and create a file to export.

## Related Tickets & Packages
- [FOUR-9163](https://processmaker.atlassian.net/browse/FOUR-9163)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:connector-send-email:bugfix/FOUR-9163
ci:package-webentry:bugfix/FOUR-9163
ci:connector-pdf-print:bugfix/FOUR-9163
ci:package-actions-by-email:bugfix/FOUR-9163

[FOUR-9163]: https://processmaker.atlassian.net/browse/FOUR-9163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ