### PR TITLE
[PHP 8.3] Fix `get_parent_class()` deprecation

### DIFF
--- a/ProcessMaker/Models/AnonymousUser.php
+++ b/ProcessMaker/Models/AnonymousUser.php
@@ -16,7 +16,7 @@ class AnonymousUser extends User
 
     public function receivesBroadcastNotificationsOn($notification)
     {
-        $class = str_replace('\\', '.', get_parent_class());
+        $class = str_replace('\\', '.', parent::class);
 
         return $class . '.' . $this->getKey();
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
In PHP 8.3, [calling `get_class()` and `get_parent_class()` functions without arguments is deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated).

References:
 - [PHP RFC: Deprecate functions with overloaded signatures](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [PHP 8.3: get_class() and get_parent_class() function calls without arguments deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated)

## Solution
This fixes one `get_parent_class` call with an identical alternative that do not cause the deprecation notice.

## How to Test
_None_

## Related Tickets & Packages
_None_

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
