### PR TITLE
Bump svg-pan-zoom@^3.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "popper.js": "^1.16.1",
                 "pusher-js": "^4.4.0",
                 "snapsvg": "^0.5.1",
-                "svg-pan-zoom": "github:ariutta/svg-pan-zoom",
+                "svg-pan-zoom": "^3.6.1",
                 "timezones.json": "^1.5.2",
                 "tinycolor2": "^1.4.2",
                 "tooltip.js": "^1.3.3",
@@ -35397,7 +35397,7 @@
         },
         "svg-pan-zoom": {
             "version": "git+ssh://git@github.com/ariutta/svg-pan-zoom.git#632c04b408854926087266022aff7557a363e1ba",
-            "from": "svg-pan-zoom@github:ariutta/svg-pan-zoom"
+            "from": "svg-pan-zoom@^3.6.1"
         },
         "svgo": {
             "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "popper.js": "^1.16.1",
         "pusher-js": "^4.4.0",
         "snapsvg": "^0.5.1",
-        "svg-pan-zoom": "github:ariutta/svg-pan-zoom",
+        "svg-pan-zoom": "^3.6.1",
         "timezones.json": "^1.5.2",
         "tinycolor2": "^1.4.2",
         "tooltip.js": "^1.3.3",


### PR DESCRIPTION
## Issue & Reproduction Steps
When using the github branch, when building the PM4 image it downloads all the dev dependencies for the package including phantomjs@2+chromium, which is not required.
Using the released version "^3.6.1" it downoads the released build and does not download the dev dependencies.

## Solution
- Use svg-pan-zoom@^3.6.1.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
