### PR TITLE
Update config for Pusher and Soketi

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -1,5 +1,16 @@
 <?php
 
+$soketi_settings = [];
+if (env('PUSHER_HOST')) {
+    $soketi_settings = [
+        'host' => env('PUSHER_HOST'),
+        'port' => env('PUSHER_PORT', 6001),
+        'scheme' => env('PUSHER_SCHEME', 'http'),
+        'encrypted' => true,
+        'useTLS' => false,
+    ];
+}
+
 return [
 
     /*
@@ -35,13 +46,11 @@ return [
             'key' => env('PUSHER_APP_KEY', 'app-key'),
             'secret' => env('PUSHER_APP_SECRET', 'app-secret'),
             'app_id' => env('PUSHER_APP_ID', 'app-id'),
-            'options' => [
-                'host' => env('PUSHER_HOST', '127.0.0.1'),
-                'port' => env('PUSHER_PORT', 6001),
-                'scheme' => env('PUSHER_SCHEME', 'http'),
-                'encrypted' => true,
-                'useTLS' => env('PUSHER_SCHEME') === 'https',
-            ],
+            'options' => array_merge([
+                'cluster' => env('PUSHER_CLUSTER', 'mt1'),
+                'debug' => env('PUSHER_DEBUG', false),
+                'useTLS' => env('PUSHER_TLS', true),
+            ], $soketi_settings),
         ],
 
         'ably' => [

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -58,14 +58,18 @@
           broadcaster: "pusher",
           key: "{{config('broadcasting.connections.pusher.key')}}",
           cluster: "{{config('broadcasting.connections.pusher.options.cluster')}}",
-          wsHost: "{{config('broadcasting.connections.pusher.options.host')}}",
-          wsPort: "{{config('broadcasting.connections.pusher.options.port')}}",
-          wssPort: "{{config('broadcasting.connections.pusher.options.port')}}",
           forceTLS: {{config('broadcasting.connections.pusher.options.use_tls') ? 'true' : 'false'}},
           debug: {{config('broadcasting.connections.pusher.options.debug') ? 'true' : 'false'}},
           enabledTransports: ['ws', 'wss'],
           disableStats: true,
         };
+        
+        @if(config('broadcasting.connections.pusher.options.host'))
+          window.Processmaker.broadcasting.wsHost = "{{config('broadcasting.connections.pusher.options.host')}}";
+          window.Processmaker.broadcasting.wsPort = "{{config('broadcasting.connections.pusher.options.port')}}";
+          window.Processmaker.broadcasting.wssPort = "{{config('broadcasting.connections.pusher.options.port')}}";
+        @endif
+
       @endif
     @endif
   </script>


### PR DESCRIPTION
## Issue & Reproduction Steps

Backporting the hotfixes enabled Soketi but broke Pusher. We need to support all 3 broadcasting services:
- Laravel Echo Server (local development)
- Pusher (CICD)
- Soketi (k8s)

## Solution
- Update config to support all 3

## How to Test
- Laravel Echo Server
  - run `npx laravel-echo-server start` if its not already running
  - Set .env
    ```
    BROADCAST_DRIVER=redis
    ```
- Pusher
  - Create a pusher account and add to your .env
    ```
    BROADCAST_DRIVER=pusher
    PUSHER_APP_ID=947781
    PUSHER_APP_KEY=<key>
    PUSHER_APP_SECRET=<secret>
    PUSHER_CLUSTER=<cluster>
    PUSHER_TLS=FALSE
    PUSHER_DEBUG=FALSE
    ```
- Soketi
  - run `docker run -p 6001:6001 -p 9601:9601 quay.io/soketi/soketi:1.4-16-debian`
  - .env
    ```
    BROADCAST_DRIVER=pusher
    PUSHER_HOST=127.0.0.1
    ```
NOTE: `BROADCAST_DRIVER` is `pusher` for both Pusher and Soketi. Having `PUSHER_HOST` is what enables Soketi

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
