### PR TITLE
Resolve 'version' is required when creating a process from template

### DIFF
--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -143,7 +143,8 @@ export default {
         'id': $event.template.id, 
         'name': $event.template.name, 
         'description': $event.template.description,
-        'category_id': $event.template.process_category_id
+        'category_id': $event.template.process_category_id,
+        'version' : $event.template.version,
       });
       this.template = $event.template;
     },

--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -97,6 +97,7 @@
         categoryOptions: "",
         description: "",
         process_category_id: "",
+        template_version: null,
         addError: {},
         status: "",
         bpmn: "",
@@ -114,6 +115,7 @@
           this.name = this.templateData.name;
           this.description = this.templateData.description;  
           this.process_category_id = this.templateData.category_id;
+          this.template_version = this.templateData.version;
         }
       },
       manager: function() {
@@ -182,6 +184,7 @@
           formData.append("file", this.file);
         }
         if (this.selectedTemplate) {
+          formData.append("version", this.template_version);
           this.handleCreateFromTemplate(this.templateData.id, formData);
         } else {
           if (this.generativeProcessData) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket: [FOUR-9962](https://processmaker.atlassian.net/browse/FOUR-9962)

Upon attempting to select a template for process creation, a 422 error is encountered, impeding the successful utilization of the chosen template to generate the process. This error disrupts the expected workflow and needs to be resolved promptly to enable seamless template-based process creation.

## Solution
-Include the template version when creating a process from a template.

## How to Test
1. Within the Process Designer select '+ Process' button
2. Select a template and select 'Use Template' button
3. Fill out the form
4. Select the 'save' button

**Expected Behavior**
A process is created from the template with no errors.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9962]: https://processmaker.atlassian.net/browse/FOUR-9962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ