### PR TITLE
FOUR-9964 | Template Search Behaving Erratically

### DIFF
--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -3,7 +3,7 @@
     <div class="pb-3">
       <b-input-group v-if="component === 'template-select-card'">
         <b-input-group-prepend>
-          <b-btn class="btn-search-run px-2" :title="$t('Search Templates')">
+          <b-btn class="btn-search-run px-2" :title="$t('Search Templates')" @click="fetch()">
             <i class="fas fa-search search-icon" />
           </b-btn>
         </b-input-group-prepend>
@@ -38,8 +38,8 @@
 
       <div class="pb-2 template-container">
         <template v-if="noResults === true">
-          <div class="no-data-icon d-flex d-block justify-content-center mt-5 pt-5 pb-2">
-            <i class="fas fa-umbrella-beach mt-5 pt-5" />
+          <div class="no-data-icon d-flex d-block justify-content-center pb-2">
+            <i class="fas fa-umbrella-beach mt-5" />
           </div>
           <div class="no-data d-block d-flex justify-content-center">
             {{ $t('No Data Available') }}
@@ -133,7 +133,9 @@ export default {
       this.fetch();
     },
     filter() {
-      this.fetch();
+      if (this.filter === "") {
+        this.fetch();
+      }
     },
   },
   beforeMount() {},

--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -88,7 +88,6 @@
 </template>
 
 <script>
-import { debounce } from "lodash";
 import ButtonCard from "./ButtonCard.vue";
 import TemplateSelectCard from "./TemplateSelectCard.vue";
 import TemplateDetails from "./TemplateDetails.vue";
@@ -133,12 +132,6 @@ export default {
     perPage() {
       this.fetch();
     },
-    filter() {
-      this.fetchDebounced();
-    },
-  },
-  created() {
-    this.fetchDebounced = debounce(this.fetch, 300);
   },
   methods: {
     showDetails($event) {
@@ -185,9 +178,11 @@ export default {
                 this.totalRow = response.data.meta.total;
                 this.apiDataLoading = false;
                 this.apiNoResults = false;
-                this.loading = false;
                 this.noResults = false;
                 }
+            })
+            .finally(() => {
+              this.loading = false;
             });
       },
   },

--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -88,6 +88,7 @@
 </template>
 
 <script>
+import { debounce } from "lodash";
 import ButtonCard from "./ButtonCard.vue";
 import TemplateSelectCard from "./TemplateSelectCard.vue";
 import TemplateDetails from "./TemplateDetails.vue";
@@ -133,12 +134,12 @@ export default {
       this.fetch();
     },
     filter() {
-      if (this.filter === "") {
-        this.fetch();
-      }
+      this.fetchDebounced();
     },
   },
-  beforeMount() {},
+  created() {
+    this.fetchDebounced = debounce(this.fetch, 300);
+  },
   methods: {
     showDetails($event) {
       this.$emit('show-details', {


### PR DESCRIPTION
# Issue
Ticket: [FOUR-9964](https://processmaker.atlassian.net/browse/FOUR-9964)

When searching for a template in the New Process Modal, the search functionality is behaving erratically.

# Solution
- There was a watcher on the search filter that fetched templates with each change of the filter.
	- Search functionality works without the watcher. However, the watcher is needed to fetch templates when the filter is an empty string (i.e. when a user searches and then backspaces/clears our their search term). Added a conditional to the watcher for this case.
- This PR also adds functionality to the search button in the search bar when clicked.
- This PR also removes the extra spacing above the 'No Data Available' search result so that users don't have to scroll to see the image when there are no results.

# How to Test
1. Go to branch `bugfix/FOUR-9964` in `processmaker`.
2. Go to Designer → Processes → +PROCESS.
3. Search for templates.
	- The functionality should not behave erratically.
    - If searching for a template that doesn't exist, you should not have to scroll to see the 'No Data Available' result.

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-9964]: https://processmaker.atlassian.net/browse/FOUR-9964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ