### PR TITLE
FOUR-9970: Admin log S3 feature changes in order to support renaming the subfolders

### DIFF
--- a/ProcessMaker/Jobs/DownloadSecurityLog.php
+++ b/ProcessMaker/Jobs/DownloadSecurityLog.php
@@ -101,7 +101,9 @@ class DownloadSecurityLog implements ShouldQueue
     {
         $uuid = Uuid::uuid4()->toString() . Str::random(8);
 
-        return 'security-logs/' . $uuid . '.' . $this->format;
+        $s3Uri = empty(config('app.security_log_s3_uri')) ? 'security-logs' : config('app.security_log_s3_uri');
+
+        return $s3Uri .'/'. $uuid . '.' . $this->format;
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -109,6 +109,9 @@ return [
     // Security log
     'security_log' => env('SECURITY_LOG', 'true'),
 
+    // Security log custom S3 URI
+    'security_log_s3_uri' => env('SECURITY_LOG_S3_URI', 'security-logs'),
+
     // Security log
     'analytics_reporting_default_graph_1' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH_1', 'https://localhost'),
     'analytics_reporting_default_graph_2' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH_2', 'https://localhost'),


### PR DESCRIPTION
## Issue & Reproduction Steps
This is related to the S3 configurations
Cloud Ops team needs to have the capacity to change the folder name **security-logs** for each environment like:
![image-20230815-160202](https://github.com/ProcessMaker/processmaker/assets/42388723/a5e7597b-edb8-41eb-9cbf-eb81d20934d8)

## Solution
- I will add a new variable in the.env in order to define a different name **security-log**

## How to Test

- Define a variable SECURITY_LOG_S3_URI like `SECURITY_LOG_S3_URI = 'customer-a'`
- Download the log 
- Review the S3 has created a bucket with the name defined in  SECURITY_LOG_S3_URI inside AWS_BUCKET

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:SECURITY_LOG_S3_URI="customer-ci"