### PR TITLE
Remove Custom Icon Upload Button for PM Block Icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ storage/debugbar/*
 storage/api-docs/api-docs.json
 storage/ssl
 storage/api/*
+storage/data-sources/logs/*
 npm.sh
 laravel-echo-server.lock
 public/.htaccess

--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
                 "package-googleplaces": "1.7.1",
                 "package-photo-video": "1.0.0",
                 "package-plaid": "1.0.0",
-                "package-pm-blocks": "1.1.0",
+                "package-pm-blocks": "1.1.1",
                 "package-process-documenter": "1.6.0",
                 "package-process-optimization": "1.6.0",
                 "package-product-analytics": "1.5.4",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "processmaker/processmaker",
-    "version": "4.7.1+nightly-20230814",
+    "version": "4.7.1+nightly-20230815",
     "description": "BPM PHP Software",
     "keywords": [
         "php bpm processmaker"
@@ -96,7 +96,7 @@
             "Gmail"
         ],
         "processmaker": {
-            "build": "9341c0de",
+            "build": "b0dd628c",
             "custom": {
                 "package-ellucian-ethos": "1.12.4"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28442c6ecbd2de75b197659c6ff572b2",
+    "content-hash": "b4a3a1627ad4ec268e113ac3447c4493",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@processmaker/processmaker",
-    "version": "4.7.1+nightly-20230814",
+    "version": "4.7.1+nightly-20230815",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@processmaker/processmaker",
-            "version": "4.7.1+nightly-20230814",
+            "version": "4.7.1+nightly-20230815",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@fortawesome/free-solid-svg-icons": "^5.15.1",
                 "@fortawesome/vue-fontawesome": "^0.1.9",
                 "@panter/vue-i18next": "^0.15.2",
-                "@processmaker/modeler": "1.37.0",
+                "@processmaker/modeler": "1.37.1",
                 "@processmaker/processmaker-bpmn-moddle": "0.14.0",
                 "@processmaker/screen-builder": "2.76.6",
                 "@processmaker/vue-form-elements": "0.49.3",
@@ -2640,9 +2640,9 @@
             "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
         },
         "node_modules/@processmaker/modeler": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/@processmaker/modeler/-/modeler-1.37.0.tgz",
-            "integrity": "sha512-xJY+LLXRS1zqLJAJGhq7A/yrBXQVTlak8Mbn8Acj1qV3ycOw9RDppIQ+qeyYP4Uy6bIOeIXnxMYF1SBb7p6NAg==",
+            "version": "1.37.1",
+            "resolved": "https://registry.npmjs.org/@processmaker/modeler/-/modeler-1.37.1.tgz",
+            "integrity": "sha512-5PGM2hAjn37wviw+Gc92jJ9wSDBAyxXAxwwLwZs3Ft2W8rp0nthlEJ6Ng4efLZvHCNLBYdGZl9dqa2I5OJWmzw==",
             "dependencies": {
                 "@babel/plugin-proposal-private-methods": "^7.12.1",
                 "@fortawesome/fontawesome-free": "^5.11.2",
@@ -23011,9 +23011,9 @@
             "integrity": "sha512-eKnrt2mCtcYFhweNr20mOWSG0431BPPFnhYJEQd+D2/5ssWPaHVEEgD3YnUOmbg1gdRQdVe2rrxcdEvvPugB/A=="
         },
         "@processmaker/modeler": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/@processmaker/modeler/-/modeler-1.37.0.tgz",
-            "integrity": "sha512-xJY+LLXRS1zqLJAJGhq7A/yrBXQVTlak8Mbn8Acj1qV3ycOw9RDppIQ+qeyYP4Uy6bIOeIXnxMYF1SBb7p6NAg==",
+            "version": "1.37.1",
+            "resolved": "https://registry.npmjs.org/@processmaker/modeler/-/modeler-1.37.1.tgz",
+            "integrity": "sha512-5PGM2hAjn37wviw+Gc92jJ9wSDBAyxXAxwwLwZs3Ft2W8rp0nthlEJ6Ng4efLZvHCNLBYdGZl9dqa2I5OJWmzw==",
             "requires": {
                 "@babel/plugin-proposal-private-methods": "^7.12.1",
                 "@fortawesome/fontawesome-free": "^5.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@processmaker/processmaker",
-    "version": "4.7.1+nightly-20230814",
+    "version": "4.7.1+nightly-20230815",
     "description": "ProcessMaker 4",
     "author": "DevOps <devops@processmaker.com>",
     "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.15.1",
         "@fortawesome/vue-fontawesome": "^0.1.9",
         "@panter/vue-i18next": "^0.15.2",
-        "@processmaker/modeler": "1.37.0",
+        "@processmaker/modeler": "1.37.1",
         "@processmaker/processmaker-bpmn-moddle": "0.14.0",
         "@processmaker/screen-builder": "2.76.6",
         "@processmaker/vue-form-elements": "0.49.3",

--- a/resources/js/components/pm-blocks/CreatePmBlockModal.vue
+++ b/resources/js/components/pm-blocks/CreatePmBlockModal.vue
@@ -53,10 +53,11 @@
               :description="formDescription('Choose an icon for this PM Block.', 'icon', errors)"
             >
               <icon-selector
-                v-model="meta"
+                v-model="meta.icon"
                 name="icon"
                 @error="fileError"
                 @input="clearFileError"
+                :allowCustom="false"
               />
               <small v-if="fileUploadError === true" class="text-danger">
                 {{ $t('The custom icon file is too large. File size must be less than 2KB.') }}

--- a/upgrades/2023_08_15_183028_remove_seeded_default_templates.php
+++ b/upgrades/2023_08_15_183028_remove_seeded_default_templates.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Artisan;
 use ProcessMaker\Models\ProcessTemplates;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
 
-class RemoveSeededDefaultTemplates extends Migration
+class RemoveSeededDefaultTemplates extends Upgrade
 {
     /**
      * Run the migrations.


### PR DESCRIPTION
This PR addresses the need to remove the custom icon upload button for PM Block icons in order to align with the intended design and user experience expectations. Currently, the custom icon upload feature does not fit within the established requirements for PM Block icons.

## Changes:
Remove the custom icon upload button for PM Block icons.

## How to Test:
Create a PM Block from the Processes listing page
Ensure the custom icon upload button is not displayed.

Navigate to the configuration page of a PM Block
Ensure the custom icon upload button is not displayed.


Ticket [FOUR-9972](https://processmaker.atlassian.net/browse/FOUR-9972)

[PM Blocks Package PR](https://github.com/ProcessMaker/package-pm-blocks/pull/83)

[FOUR-9972]: https://processmaker.atlassian.net/browse/FOUR-9972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ