### PR TITLE
FOUR-9971: Move failing migration to upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ storage/debugbar/*
 storage/api-docs/api-docs.json
 storage/ssl
 storage/api/*
+storage/data-sources/logs/*
 npm.sh
 laravel-echo-server.lock
 public/.htaccess

--- a/upgrades/2023_08_15_183028_remove_seeded_default_templates.php
+++ b/upgrades/2023_08_15_183028_remove_seeded_default_templates.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Artisan;
 use ProcessMaker\Models\ProcessTemplates;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
 
-class RemoveSeededDefaultTemplates extends Migration
+class RemoveSeededDefaultTemplates extends Upgrade
 {
     /**
      * Run the migrations.


### PR DESCRIPTION
## Issue & Reproduction Steps
When attempting to build the project, template migrations are encountering issues, leading to failures in the build pipeline. This is likely due to a missing check for the 'versions' column within the default sync job.


## Solution
- After talking with @nolanpro and since we don't make any changes to the database schema, we can safely move the migration to the upgrades folder.
- This solution should also speed up our unitest since the upgrades scripts are not been called by PHPUnit

## How to Test
Please run the following command and make sure that we don't get any errors when running the migrations and that the Default Templates are in sync.

`php artisan db:wipe --force && php artisan migrate:fresh --seed --force && php artisan upgrade`
note: The upgrade artisan command has been added after the db wipe.

## Related Tickets & Packages
- Ticket: [FOUR-9971](https://processmaker.atlassian.net/browse/FOUR-9971)

## CI
ci:DEFAULT_TEMPLATE_CATEGORIES=all
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9971]: https://processmaker.atlassian.net/browse/FOUR-9971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ