### PR TITLE
Rich text-html settings stopped working to initiate a requests

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -246,11 +246,10 @@ class ProcessController extends Controller
 
     public function triggerStartEventApi(Process $process, Request $request)
     {
-        $api_request = new ApiProcessController();
-        $response = $api_request->triggerStartEvent($process, $request);
-        $instance_id = $response->data['_request']['id'];
+        $apiRequest = new ApiProcessController();
+        $response = $apiRequest->triggerStartEvent($process, $request);
 
-        return redirect('/requests/' . $instance_id);
+        return redirect('/requests/' . $response->id);
     }
 
     private function checkAuth()


### PR DESCRIPTION
## Issue & Reproduction Steps
the problem is replicated when using NayraDocker when you want to start a request by URL
http://192.168.1.205/process_events/2?event=node_21

the _request variable is not defined.


## Solution
- as the request id is needed we no longer use the _request variable

## How to Test
try to start a case by url
http://192.168.1.205/process_events/2?event=node_21

## Related Tickets & Packages
[FOUR-9840](https://processmaker.atlassian.net/browse/FOUR-9840)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9840]: https://processmaker.atlassian.net/browse/FOUR-9840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ