### PR TITLE
Cannot export a previously imported process containing a script with a missing script executor

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -48,6 +48,8 @@ abstract class ExporterBase implements ExporterInterface
 
     public $discard = false;
 
+    public static $forceUpdate = false;
+
     // public $ignoreExplicitDiscard = false;
 
     public static $fallbackMatchColumn = null;

--- a/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
@@ -2,11 +2,14 @@
 
 namespace ProcessMaker\ImportExport\Exporters;
 
+use ProcessMaker\Events\ScriptExecutorUpdated;
+use ProcessMaker\Jobs\BuildScriptExecutor;
+
 class ScriptExecutorExporter extends ExporterBase
 {
     public static $fallbackMatchColumn = 'title';
 
-    public $discard = true;
+    public $discard = false;
 
     public function export() : void
     {
@@ -14,6 +17,23 @@ class ScriptExecutorExporter extends ExporterBase
 
     public function import() : bool
     {
+        switch ($this->mode) {
+            case 'copy':
+                BuildScriptExecutor::dispatch($this->model->id, auth()->user()->id);
+                break;
+            case 'update':
+                if (!empty($this->model->getChanges())) {
+                    $original = $this->model->getAttributes();
+                    ScriptExecutorUpdated::dispatch($this->model->id, $original, $this->model->getChanges());
+                    BuildScriptExecutor::dispatch($this->model->id, auth()->user()->id);
+                }
+                break;
+
+            default:
+                // code...
+                break;
+        }
+
         return true;
     }
 }

--- a/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
@@ -9,7 +9,9 @@ class ScriptExecutorExporter extends ExporterBase
 {
     public static $fallbackMatchColumn = 'title';
 
-    public $discard = false;
+    // Do not copy if it exists on the target instance. Only create if it does
+    // not exist. Otherwise associate existing on import.
+    public static $forceUpdate = true;
 
     public function export() : void
     {
@@ -19,6 +21,7 @@ class ScriptExecutorExporter extends ExporterBase
     {
         switch ($this->mode) {
             case 'copy':
+            case 'new':
                 BuildScriptExecutor::dispatch($this->model->id, auth()->user()->id);
                 break;
             case 'update':

--- a/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
@@ -24,7 +24,9 @@ class ScriptExporter extends ExporterBase
             $this->addDependent('user', $this->model->runAsUser, UserExporter::class);
         }
 
-        $this->addDependent('executor', $this->model->scriptExecutor, ScriptExecutorExporter::class);
+        if ($this->model->scriptExecutor) {
+            $this->addDependent('executor', $this->model->scriptExecutor, ScriptExecutorExporter::class);
+        }
     }
 
     public function import() : bool
@@ -36,7 +38,7 @@ class ScriptExporter extends ExporterBase
             $this->model->run_as_user_id = $scriptUser->id;
         }
 
-        foreach ($this->getDependents('executor') as $dependent) {
+        foreach ($this->getDependents('executor', true) as $dependent) {
             $executor = $dependent->model;
             $this->model->script_executor_id = $executor->id;
         }

--- a/ProcessMaker/ImportExport/Importer.php
+++ b/ProcessMaker/ImportExport/Importer.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\ImportExport;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use ProcessMaker\Models\Script;
 
 class Importer
 {

--- a/ProcessMaker/ImportExport/Manifest.php
+++ b/ProcessMaker/ImportExport/Manifest.php
@@ -142,6 +142,10 @@ class Manifest
             $mode = 'discard';
         }
 
+        if ($exporterClass::$forceUpdate) {
+            $mode = 'update';
+        }
+
         $attrs = $exporterClass::prepareAttributes($attrs);
 
         if (!$model) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently exporting a ScriptExecutor was not enabled, for that reason when you have Custom ScriptExectors it is not reflected on the import on a new server

## Solution
Just enabled the option, and added a fix to continue if a ScriptExecutor doesn't exist.

Also added the BuildScriptExecutor when creating or updating a ScriptExecutor.

## How to Test
Create a script executor that exists like PHP or another language
Create a Script with the script executor
Create a process with a script task
Publish the changes 
Export the process
Import the process in a new instance the PM 
Try to export the process

## Related Tickets & Packages
- [FOUR-9997](https://processmaker.atlassian.net/browse/FOUR-9997)
- [FOUR-9996](https://processmaker.atlassian.net/browse/FOUR-9996)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9997]: https://processmaker.atlassian.net/browse/FOUR-9997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-9996]: https://processmaker.atlassian.net/browse/FOUR-9996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ