### PR TITLE
It is not possible to import templates that were modified

### DIFF
--- a/ProcessMaker/ImportExport/Manifest.php
+++ b/ProcessMaker/ImportExport/Manifest.php
@@ -163,6 +163,10 @@ class Manifest
             case 'copy':
                 // Make new copy of the model with a new UUID
                 unset($attrs['uuid']);
+                // parameter for templates
+                if (array_key_exists('editing_process_uuid', $attrs)) {
+                    unset($attrs['editing_process_uuid']);
+                }
                 $model = new $class();
                 $model->fill($attrs);
                 break;


### PR DESCRIPTION
## Issue & Reproduction Steps
when a ProcessTemeplate was edited and exported, this file cannot be exported, because another uuid parameter existed in the table that should be unique.

## Solution
- I removed the edit_process_uuid parameter because this template is new

## How to Test
steps in ticket

## Related Tickets & Packages
- [FOUR-9876](https://processmaker.atlassian.net/browse/FOUR-9876)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9876]: https://processmaker.atlassian.net/browse/FOUR-9876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ