### PR TITLE
FOUR-10020:Intercom Overlaps Save Icon in Customize UI

### DIFF
--- a/resources/js/admin/cssOverride/components/SiteDesign.vue
+++ b/resources/js/admin/cssOverride/components/SiteDesign.vue
@@ -140,7 +140,7 @@
       </b-form-group>
       
       <br>
-      <div class="d-flex">
+      <div class="d-flex group-button">
           <b-button variant="outline-danger" :disabled="isLoading" @click="onReset">
               <i class="fas fa-undo"></i> {{ $t('Reset') }}
           </b-button>
@@ -555,4 +555,7 @@ export default {
 </script>
 
 <style>
+.group-button {
+  padding-bottom: 50px;
+}
 </style>


### PR DESCRIPTION

## Issue & Reproduction Steps

- Go to Customize UI https://ci-cd8f9a6170.eng.processmaker.net/admin/customize-ui
- Check the Save button 

## Solution
- Add padding bottom.

## Related Tickets & Packages
- [FOUR-10020](https://processmaker.atlassian.net/browse/FOUR-10020)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy

[FOUR-10020]: https://processmaker.atlassian.net/browse/FOUR-10020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ