### PR TITLE
Bugfix/FOUR-10079: We get a Request aborted message when we want to create a process from AI in fire fox

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -279,9 +279,13 @@ window.addEventListener("unhandledrejection", (event) => {
     // Already handeled
     event.preventDefault(); // stops the unhandled rejection error
   } else if (error.response && error.response.data && error.response.data.message) {
-    window.ProcessMaker.alert(error.response.data.message, "danger");
+    if (!(error.code && error.code === "ECONNABORTED")) {
+      window.ProcessMaker.alert(error.response.data.message, "danger");
+    }
   } else if (error.message) {
-    window.ProcessMaker.alert(error.message, "danger");
+    if (!(error.code && error.code === "ECONNABORTED")) {
+      window.ProcessMaker.alert(error.message, "danger");
+    }
   }
 });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The problem happens in firefox when a request is aborted. If the user clicks on the button Generate process using AI before the templates request finished it shows a Request abort message.

Steps to Reproduce: 

- Log in with  Fire Fox  browser
- Click on +PROCESS
- click on Generate from text 

NOTE: If you can't reproduce the issue, add in TemplateController.php in the index method the following code to simulate a slow request:

`
if ($type === 'process') {
    sleep(10);
}`

## Solution
- Do not show the error messages related to ECONNABORTED.

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-10079](https://processmaker.atlassian.net/browse/FOUR-10079)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy


[FOUR-10079]: https://processmaker.atlassian.net/browse/FOUR-10079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ