### PR TITLE
FOUR-10152: Making changes to create one Dashboard defined in the .env

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -112,10 +112,8 @@ return [
     // Security log custom S3 URI
     'security_log_s3_uri' => env('SECURITY_LOG_S3_URI', 'security-logs'),
 
-    // Security log
-    'analytics_reporting_default_graph_1' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH_1', 'https://localhost'),
-    'analytics_reporting_default_graph_2' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH_2', 'https://localhost'),
-    'analytics_reporting_default_graph_3' => env('ANALYTICS_REPORTING_DEFAULT_GRAPH_3', 'https://localhost'),
+    // PM Analytics Dashboard
+    'pm_analytics_dashboard' => env('PM_ANALYTICS_DASHBOARD', 'https://localhost'),
 
     // Message broker driver to use in Workflow Manager
     'message_broker_driver' => env('MESSAGE_BROKER_DRIVER', 'default'),


### PR DESCRIPTION
## Issue & Reproduction Steps
As a user I want to have a default Dashboard that will be placed in the Analytics option. 

## Solution
- A Dashboard was created in the Quicksight
- This Dashboard will defined in the Analytics Default

## How to Test
- Configure in the .env the variable: `PM_ANALYTICS_DASHBOARD="https://quicksight.aws.amazon.com/"`
- Install the package
- Review the **Analytics Management**, this will show per default the Dashboard defined in PM_ANALYTICS_DASHBOARD

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10152

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-analytics-reporting:feature/FOUR-10152