### PR TITLE
FOUR-10223: Publish button and Top Menu elements on Script Editor now visible after Ai Assistant actions 

### DIFF
--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -1,8 +1,7 @@
 <template>
   <b-container class="h-100">
     <b-card no-body class="h-100" >
-      <top-menu v-if="!previewChanges" ref="menuScript" :options="optionsMenu" />
-
+      <top-menu v-show="!previewChanges" ref="menuScript" :options="optionsMenu" />
       <b-card-body ref="editorContainer" class="overflow-hidden p-4" >
         <b-row class="h-100">
           <b-col :cols="previewChanges && action !== 'generate' ? 12 : 9" class="h-100 p-0">
@@ -880,8 +879,6 @@ export default {
 }
 .explanation-header {
   font-size: 130%;
-}
-.explanation-content {
 }
 
 .blink {


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Login as admin
2. Go to Designer
3. Click on Scripts
4. Click on +Script
5. Set the information required
6. Click on Cornea AI Assistant
7. Click on Any option and generate

## Solution
By modifying the `v-if` that hides the Top Menu and replacing it with a `v-show` the destruction of that component is avoided. The problem was caused because `package-versions` only included the Publish button and other elements once and would not do it again when the Top Menu component was destroyed and recreated.

## Related Tickets & Packages
- [FOUR-10223](https://processmaker.atlassian.net/browse/FOUR-10223)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10223]: https://processmaker.atlassian.net/browse/FOUR-10223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:next
ci:deploy