### PR TITLE
feature/FOUR-9527: Main View - Switch to desktop mode and Log Out

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -177,6 +177,26 @@ window.ProcessMaker.navbar = new Vue({
   },
 });
 
+// Assign our navbar component to our global ProcessMaker object
+window.ProcessMaker.navbarMobile = new Vue({
+  el: "#navbarMobile",
+  components: {
+  },
+  data() {
+    return {
+    };
+  },
+  methods: {
+    switchToDesktop() {
+      document.cookie = "isMobile=false";
+      window.location.reload();
+    },
+    onResize() {
+      this.isMobile = window.innerWidth < 992;
+    },
+  },
+});
+
 // Breadcrumbs are now part of the navbar component. Alias it here.
 window.ProcessMaker.breadcrumbs = window.ProcessMaker.navbar;
 

--- a/resources/views/layouts/navbarMobile.blade.php
+++ b/resources/views/layouts/navbarMobile.blade.php
@@ -1,5 +1,5 @@
 <div class="flex-grow-1">
-  <div id="navbar-mobile">
+  <div id="navbarMobile">
   <nav class="navbar navbar-light bg-primary d-print-none">
       @php
         $loginLogo = \ProcessMaker\Models\Setting::getLogin();
@@ -36,10 +36,20 @@
                 <i class="fa fa-user"></i>
               </button>
             </a>
-            <div class="dropdown-menu">
-              <a class="dropdown-item" href="#">Switch to Desktop View</a>
+            <div class="dropdown-menu dropdown-menu-right mr-3 mt-2 p-2">
+              <a 
+                class="dropdown-item"
+                @click="switchToDesktop()"
+              >
+                {{ __('Switch to Desktop View') }}
+              </a>
               <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="#">Log Out</a>
+              <a 
+                class="dropdown-item" 
+                href="/logout"
+              >
+                {{ __('Log Out') }}
+              </a>
             </div>
           </li>
         </ul>
@@ -56,5 +66,8 @@
     align-items: center;
     justify-content: space-between;
     padding: 10 0 10 0;
+  }
+  .dropdown-toggle::after {
+    display:none;
   }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
As a mobile participant I want to see the UI as it regularly displays on a desktop, so I can access otherwise tucked away sections of the app.

## How to Test
User visits the default mobile home page, finds the Switch to Desktop View, and is then presented with the regular UI. This is the only way to access Designer and Admin sections when appropriate.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9527
-
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next