### PR TITLE
FOUR-10259: Update broadcasting configuration for process-map blade layout

### DIFF
--- a/resources/views/layouts/process-map.blade.php
+++ b/resources/views/layouts/process-map.blade.php
@@ -35,29 +35,38 @@
   <link href="{{ mix('css/app.css') }}" rel="stylesheet">
   <link href="/css/bpmn-symbols/css/bpmn.css" rel="stylesheet">
   @yield('css')
-  <script type="text/javascript">
-    @if (Auth::user())
+    <script type="text/javascript">
+    @if(Auth::user())
       window.Processmaker = {
-        csrfToken: "{{ csrf_token() }}",
-        userId: "{{ \Auth::user()->id }}",
+        csrfToken: "{{csrf_token()}}",
+        userId: "{{\Auth::user()->id}}",
         messages: [],
-        apiTimeout: {{ config('app.api_timeout') }}
+        apiTimeout: {{config('app.api_timeout')}}
       };
-      @if (config('broadcasting.default') == 'redis')
+      @if(config('broadcasting.default') == 'redis')
         window.Processmaker.broadcasting = {
           broadcaster: "socket.io",
-          host: "{{ config('broadcasting.connections.redis.host') }}",
-          key: "{{ config('broadcasting.connections.redis.key') }}"
+          host: "{{config('broadcasting.connections.redis.host')}}",
+          key: "{{config('broadcasting.connections.redis.key')}}"
         };
       @endif
-      @if (config('broadcasting.default') == 'pusher')
+      @if(config('broadcasting.default') == 'pusher')
         window.Processmaker.broadcasting = {
           broadcaster: "pusher",
-          key: "{{ config('broadcasting.connections.pusher.key') }}",
-          cluster: "{{ config('broadcasting.connections.pusher.options.cluster') }}",
-          forceTLS: {{ config('broadcasting.connections.pusher.options.use_tls') ? 'true' : 'false' }},
-          debug: {{ config('broadcasting.connections.pusher.options.debug') ? 'true' : 'false' }}
+          key: "{{config('broadcasting.connections.pusher.key')}}",
+          cluster: "{{config('broadcasting.connections.pusher.options.cluster')}}",
+          forceTLS: {{config('broadcasting.connections.pusher.options.use_tls') ? 'true' : 'false'}},
+          debug: {{config('broadcasting.connections.pusher.options.debug') ? 'true' : 'false'}},
+          enabledTransports: ['ws', 'wss'],
+          disableStats: true,
         };
+        
+        @if(config('broadcasting.connections.pusher.options.host'))
+          window.Processmaker.broadcasting.wsHost = "{{config('broadcasting.connections.pusher.options.host')}}";
+          window.Processmaker.broadcasting.wsPort = "{{config('broadcasting.connections.pusher.options.port')}}";
+          window.Processmaker.broadcasting.wssPort = "{{config('broadcasting.connections.pusher.options.port')}}";
+        @endif
+
       @endif
     @endif
   </script>


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a request with any process
2. View the request overview page
3. Open the network console and filter to websockets
4. Notice two attempted connections to the socketi events server, one of them failing–usually with an error message similar to `{"event":"pusher:error","data":{"code":4005,"message":"Path not found"}}`
5. Both of these connections should succeed

## Solution
- Recent updates to the broadcasting configuration needed to be included in the `process-map.blade.php` blade template to ensure the websocket connections made to the socketi/pusher server work as intended.

## How to Test
You should only see successful connections when viewing the "Overview" tab on the request summary page

## Related Tickets & Packages
- [FOUR-10259](https://processmaker.atlassian.net/browse/FOUR-10259)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
