### PR TITLE
Set CI Base on develop

### DIFF
--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -35,6 +35,7 @@ env:
   IMAGE_TAG1: $(echo "$CI_PROJECT-$CI_PACKAGE_BRANCH" | sed "s;/;-;g")
   GITHUB_COMMENT: ${{ secrets.GH_COMMENT }}
   pull_req_id: ${{github.event.pull_request.number}}
+  BASE: ${{ contains(github.event.pull_request.body, 'ci:next') && 'ci-base-php82' || 'ci-base' }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/composer.lock
+++ b/composer.lock
@@ -6850,10 +6850,16 @@
         {
             "name": "processmaker/nayra",
             "version": "1.9.5",
-            "dist": {
-                "type": "path",
-                "url": "/Users/ryancooley/Developer/ProcessMaker/nayra",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ProcessMaker/nayra.git",
                 "reference": "f55c40174c1b6926e266a4e2ac8a4a03924d9ccb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ProcessMaker/nayra/zipball/f55c40174c1b6926e266a4e2ac8a4a03924d9ccb",
+                "reference": "f55c40174c1b6926e266a4e2ac8a4a03924d9ccb",
+                "shasum": ""
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5"
@@ -6864,32 +6870,16 @@
                     "ProcessMaker\\": "src/ProcessMaker/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Tests\\Feature\\": "tests/Feature/",
-                    "ProcessMaker\\": [
-                        "src/ProcessMaker/",
-                        "tests/unit/ProcessMaker/",
-                        "tests/ProcessMaker/"
-                    ]
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit"
-                ],
-                "coverage": [
-                    "phpunit -d memory_limit=-1 --coverage-html coverage"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
             ],
             "description": "BPMN compliant engine",
-            "transport-options": {
-                "symlink": true,
-                "relative": false
-            }
+            "support": {
+                "issues": "https://github.com/ProcessMaker/nayra/issues",
+                "source": "https://github.com/ProcessMaker/nayra/tree/v1.9.5"
+            },
+            "time": "2023-08-31T20:31:55+00:00"
         },
         {
             "name": "processmaker/pmql",


### PR DESCRIPTION
Since all packages use the github actions settings from the develop branch, we need to allow the settings on develop to choose the correct base image

ci:deploy