### PR TITLE
Bugfix/FOUR-10277: Prompt not used on the image downloaded

### DIFF
--- a/resources/js/components/shared/DownloadSvgButton.vue
+++ b/resources/js/components/shared/DownloadSvgButton.vue
@@ -21,12 +21,11 @@
 
     <!-- Used for the design -->
     <!-- Page -->
-    <div ref="modelPrintSection" style="
-        position: absolute;
-        z-index: 0;
+    <div ref="modelPrintSection" id="modelPrintSection" style="
+        display: none;
+        position: relative;
         color: #000;
         min-width: 90em;
-        left: -9999999px;
         padding: 1rem;
         background: #ffffff;
         text-transform: initial;
@@ -55,7 +54,7 @@
             background: #ffffff;
         ">
           <div class="w-50 p-3" style="background: #E5F1FF; border-radius: 8px 0 0 8px"><h5><b>{{ title }}</b></h5></div>
-          <div class="w-50 p-3 text-muted" style="border-radius: 0 8px 8px 0"><small>{{ description }}</small></div>
+          <div class="w-50 p-3 text-muted" style="border-radius: 0 8px 8px 0"><small>{{ prompt }}</small></div>
         </div>
       </div>
     </div>
@@ -77,6 +76,10 @@ export default {
       default: "",
     },
     description: {
+      type: String,
+      default: "",
+    },
+    prompt: {
       type: String,
       default: "",
     },
@@ -108,22 +111,26 @@ export default {
     async download(event) {
       this.isLoading = true;
       const el = this.$refs.modelPrintSection;
-      const options = {
+
+      this.$html2canvas(el, {
         type: "dataURL",
-      };
-      this.img = await this.$html2canvas(el, options);
+        onclone(clone) {
+          clone.getElementById("modelPrintSection").style.display = "block";
+        },
+      }).then((canvas) => {
+        this.img = canvas;
+        const dataURL = this.img;
 
-      const dataURL = this.img;
+        const downloadLink = document.createElement("a");
+        downloadLink.href = dataURL;
+        downloadLink.download = `${this.fileName}.png`;
 
-      const downloadLink = document.createElement("a");
-      downloadLink.href = dataURL;
-      downloadLink.download = `${this.fileName}.png`;
+        document.body.appendChild(downloadLink);
+        downloadLink.click();
 
-      document.body.appendChild(downloadLink);
-      downloadLink.click();
-
-      document.body.removeChild(downloadLink);
-      this.isLoading = false;
+        document.body.removeChild(downloadLink);
+        this.isLoading = false;
+      });
     },
 
     async convertImagesToBase64(svgString) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Please refer to acceptance criteria of ticket:
https://processmaker.atlassian.net/browse/FOUR-10277

## Solution
- Replaced the ai description with the prompt entered by the user
- Fix the scroll problem
- Allows to print divs with **display:none** 

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/a1403c64-1e4a-4b44-8910-7bd496e47b11


## Related Tickets & Packages
- [FOUR-10277](https://processmaker.atlassian.net/browse/FOUR-10277)
- [package-ai](https://github.com/ProcessMaker/package-ai/pull/20)

ci:deploy

[FOUR-10277]: https://processmaker.atlassian.net/browse/FOUR-10277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ