### PR TITLE
FOUR-8068 Save Test Scenarios for a Process - Added new hook

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -82,6 +82,7 @@ class TaskController extends Controller
                     'files' => $task->processRequest->requestFiles(),
                     'addons' => $this->getPluginAddons('edit', []),
                     'assignedToAddons' => $this->getPluginAddons('edit.assignedTo', []),
+                    'dataActionsAddons' => $this->getPluginAddons('edit.dataActions', []),
                 ]);
             }
 
@@ -93,6 +94,7 @@ class TaskController extends Controller
                 'files' => $task->processRequest->requestFiles(),
                 'addons' => $this->getPluginAddons('edit', []),
                 'assignedToAddons' => $this->getPluginAddons('edit.assignedTo', []),
+                'dataActionsAddons' => $this->getPluginAddons('edit.dataActions', []),
             ]);
         }
     }

--- a/resources/views/tasks/editdata.blade.php
+++ b/resources/views/tasks/editdata.blade.php
@@ -1,12 +1,19 @@
 <!-- data edit -->
 <monaco-editor v-if="!showTree" ref="monaco" :options="monacoLargeOptions" v-model="jsonData"
-    language="json" style="border:1px solid gray; min-height:700px;"></monaco-editor>
+               language="json" style="border:1px solid gray; min-height:700px;"></monaco-editor>
 
-    <tree-view v-if="showTree" v-model="jsonData" style="border:1px; solid gray; min-height:700px;"></tree-view>
+<tree-view v-if="showTree" v-model="jsonData" style="border:1px; solid gray; min-height:700px;"></tree-view>
 
 <div class="d-flex justify-content-between mt-3">
-        <data-tree-toggle v-model="showTree"></data-tree-toggle>
-    <button type="button" class="btn btn-secondary" @click="updateRequestData()">
-        {{__('Save')}}
-    </button> 
+    <data-tree-toggle v-model="showTree"></data-tree-toggle>
+    <span>
+        @isset($dataActionsAddons)
+            @foreach ($dataActionsAddons as $dataActionsAddon)
+                {!! $dataActionsAddon['content'] ?? '' !!}
+            @endforeach
+        @endisset
+        <button type="button" class="btn btn-secondary" @click="updateRequestData()">
+            {{__('Save')}}
+        </button>
+    </span>
 </div>


### PR DESCRIPTION
## Issue & Reproduction Steps
Is not possible to add a new button in the request data edition screen

## Solution
A new hook was added in order to add new buttons in the request data edition screen

## How to Test
Is required install the package "package-testing" using the branch "FOUR-8068".
Go to edit the request data, a new button "Create Scenario" should be displayed

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-8068

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
