### PR TITLE
Fix data update before to start a webentry

### DIFF
--- a/ProcessMaker/Contracts/WorkflowManagerInterface.php
+++ b/ProcessMaker/Contracts/WorkflowManagerInterface.php
@@ -59,10 +59,12 @@ interface WorkflowManagerInterface
      *
      * @param Definitions $definitions
      * @param StartEventInterface $event
+     * @param array $data
+     * @param callable $beforeStart
      *
      * @return \ProcessMaker\Models\ProcessRequest
      */
-    public function triggerStartEvent(Definitions $definitions, StartEventInterface $event, array $data);
+    public function triggerStartEvent(Definitions $definitions, StartEventInterface $event, array $data, callable $beforeStart = null);
 
     /**
      * Start a process instance.

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerDefault.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerDefault.php
@@ -76,6 +76,28 @@ class WorkflowManagerDefault implements WorkflowManagerInterface
     }
 
     /**
+     * Fail a task.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @param TokenInterface|ProcessRequestToken $token
+     * @param string $error
+     *
+     * @return void
+     */
+    public function taskFailed(ExecutionInstanceInterface $instance, TokenInterface $token, string $message)
+    {
+        $element = $token->getOwnerElement();
+        $token->setStatus(ScriptTaskInterface::TOKEN_STATE_FAILING);
+
+        $error = $element->getRepository()->createError();
+        $error->setName($message);
+
+        $token->setProperty('error', $error);
+
+        Log::error('Script failed: ' . $element->getId() . ' - ' . $message);
+    }
+
+    /**
      * Complete a catch event
      *
      * @param Definitions $definitions
@@ -121,10 +143,12 @@ class WorkflowManagerDefault implements WorkflowManagerInterface
      *
      * @param Definitions $definitions
      * @param StartEventInterface $event
+     * @param array $data
+     * @param callable $beforeStart
      *
      * @return \ProcessMaker\Models\ProcessRequest
      */
-    public function triggerStartEvent(Definitions $definitions, StartEventInterface $event, array $data)
+    public function triggerStartEvent(Definitions $definitions, StartEventInterface $event, array $data, callable $beforeStart = null)
     {
         //Validate data
         $this->validateData($data, $definitions, $event);


### PR DESCRIPTION
## Issue & Reproduction Steps
When a request is started using webentry when it is started with the new engine it is started in background. This could cause a collition because in the same controller action the data of the request is changed after the request was started.

## Solution
- Update the request data (change the file uploaded ids) before to send the startEvent to the engine.

## How to Test
Run the attached process as a webentry.

- Upload a file
- Submit the form
- See the interstitial get properly the next screen.


[webentry.zip](https://github.com/ProcessMaker/screen-builder/files/12501628/webentry.zip)

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
