### PR TITLE
FOUR-10322: Save collaboration id reference

### DIFF
--- a/ProcessMaker/Repositories/ExecutionInstanceRepository.php
+++ b/ProcessMaker/Repositories/ExecutionInstanceRepository.php
@@ -156,6 +156,15 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         $instance->collaboration_uuid = $instance->getProperty('collaboration_uuid', null);
         $instance->process_id = $definition->getKey();
         $instance->process_version_id = $definition->getLatestVersion()->getKey();
+        if ($instance->collaboration_uuid && !$instance->process_collaboration_id) {
+            $collaboration = ProcessCollaboration::firstOrCreate([
+                'uuid' => $instance->collaboration_uuid,
+                'process_id' => $instance->process_id,
+            ]);
+            if ($collaboration) {
+                $instance->process_collaboration_id = $collaboration->id;
+            }
+        }
         $instance->user_id = pmUser() ? pmUser()->getKey() : null;
         $instance->name = $definition->name;
         $instance->status = 'ACTIVE';


### PR DESCRIPTION
## Issue & Reproduction Steps
Signal was not catch because the collaboration_id was not saved in the second process request.

## Solution
- Save the collaboration_id when the request is created.

## How to Test
- Run the attached request.
- Complete the task A, then D, then C

[tcp4-2158_verify_event_based_gateway_conditional_and_message_event.zip](https://github.com/ProcessMaker/processmaker/files/12528912/tcp4-2158_verify_event_based_gateway_conditional_and_message_event.zip)
**Password**: 12345678

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10322

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
