### PR TITLE
Bugfix/FOUR-10371: Percentage number is going up an down

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -90,6 +90,7 @@ export default {
   data() {
     return {
       active: false,
+      lastProgress: 0,
     };
   },
   computed: {
@@ -153,6 +154,12 @@ export default {
 
       if (chunkProgress?.percentage > 0) {
         totalProgress += ((chunkProgress.percentage * progressSlot) / 100);
+      }
+
+      if (totalProgress < this.lastProgress) {
+        totalProgress = this.lastProgress;
+      } else {
+        this.lastProgress = totalProgress;
       }
 
       return Math.trunc(totalProgress);

--- a/resources/js/processes/translations/components/ProcessTranslationListing.vue
+++ b/resources/js/processes/translations/components/ProcessTranslationListing.vue
@@ -278,12 +278,7 @@ export default {
 
         // Subscribe to streamed responses
         this.addSocketListener(channel, streamProgressEvent, (response) => {
-          console.log('response 1 -------');
-          console.log(response);
-          console.log(key);
-          console.log('response 1 -------');
           if (response.stream && this.translatingLanguages[key]) {
-            console.log(response.progress);
             this.$set(this.translatingLanguages[key], "stream", response.stream);
             this.$set(this.translatingLanguages[key], "progress", response.progress);
           }
@@ -291,10 +286,6 @@ export default {
 
         // Subscribe to chunk progress
         this.addSocketListener(channel, batchProgressEvent, (response) => {
-          console.log('response 2');
-          console.log(response);
-          console.log(key);
-          console.log('response 2 -------');
           if (response.batch && this.translatingLanguages[key]) {
             this.$set(this.translatingLanguages[key], "batch", response.batch);
             if (this.translatingLanguages[key].progress) {

--- a/resources/js/processes/translations/components/ProcessTranslationListing.vue
+++ b/resources/js/processes/translations/components/ProcessTranslationListing.vue
@@ -278,7 +278,12 @@ export default {
 
         // Subscribe to streamed responses
         this.addSocketListener(channel, streamProgressEvent, (response) => {
+          console.log('response 1 -------');
+          console.log(response);
+          console.log(key);
+          console.log('response 1 -------');
           if (response.stream && this.translatingLanguages[key]) {
+            console.log(response.progress);
             this.$set(this.translatingLanguages[key], "stream", response.stream);
             this.$set(this.translatingLanguages[key], "progress", response.progress);
           }
@@ -286,6 +291,10 @@ export default {
 
         // Subscribe to chunk progress
         this.addSocketListener(channel, batchProgressEvent, (response) => {
+          console.log('response 2');
+          console.log(response);
+          console.log(key);
+          console.log('response 2 -------');
           if (response.batch && this.translatingLanguages[key]) {
             this.$set(this.translatingLanguages[key], "batch", response.batch);
             if (this.translatingLanguages[key].progress) {


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduce:**
- Login as admin
- Go to Designer
- Create a simple process with some screens
- Close the process and search it
- Click on the options button of the process
- Click on Configure
- Click on Translations tab
- Click on +Translation
- Select a language and Translate Process

**Issue explanation**
The problem is that we have chunks per each screen and we have a progress per chunk (not updating in real time the progress only when each chunk finish) and we have a partial progress update for the streaming responses (this makes the real time progress).
If we have multiple workers, using this configuration:

```
PM4_HORIZON_SUPERVISOR_BPMN_BALANCE=auto
PM4_HORIZON_SUPERVISOR_BPMN_MAX_PROCESSES=12
PM4_HORIZON_SUPERVISOR_1_BALANCE=auto
PM4_HORIZON_SUPERVISOR_1_MAX_PROCESSES=12

```
The jobs for the streamed responses triggers multiple responses at same time (stream 1, stream 2, stream 3) and each of those streams contains different progresses, so it's updating the UI for each of those progresses

**Current behavior:**
The percentage number goes up and down while complete the generation

**Expected behavior:**
The percentage should only goes up 

## Solution
- Add a check if the progress is less than the actual and do not update

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/658ca916-4792-44f0-a593-93e849477a51


## How to Test
Follow steps above

## Related Tickets & Packages
- [FOUR-10371](https://processmaker.atlassian.net/browse/FOUR-10371)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy

[FOUR-10371]: https://processmaker.atlassian.net/browse/FOUR-10371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ