### PR TITLE
FOUR-10388: CI Unit Test failing when we sync-pm-blocks 

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
@@ -21,16 +21,19 @@ class ScriptExecutorExporter extends ExporterBase
 
     public function import() : bool
     {
+        $authenticatedUser = Auth::user();
+        $userId = $authenticatedUser ? $authenticatedUser->id : 1;
+
         switch ($this->mode) {
             case 'copy':
             case 'new':
-                BuildScriptExecutor::dispatch($this->model->id);
+                BuildScriptExecutor::dispatch($this->model->id, $userId);
                 break;
             case 'update':
                 if (!empty($this->model->getChanges())) {
                     $original = $this->model->getAttributes();
                     ScriptExecutorUpdated::dispatch($this->model->id, $original, $this->model->getChanges());
-                    BuildScriptExecutor::dispatch($this->model->id);
+                    BuildScriptExecutor::dispatch($this->model->id, $userId);
                 }
                 break;
 

--- a/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
@@ -22,7 +22,7 @@ class ScriptExecutorExporter extends ExporterBase
     public function import() : bool
     {
         $authenticatedUser = Auth::user();
-        $userId = $authenticatedUser ? $authenticatedUser->id : 1;
+        $userId = $authenticatedUser ? $authenticatedUser->id : User::where('username', 'admin')->pluck('id');
 
         switch ($this->mode) {
             case 'copy':

--- a/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
@@ -22,7 +22,7 @@ class ScriptExecutorExporter extends ExporterBase
     public function import() : bool
     {
         $authenticatedUser = Auth::user();
-        $userId = $authenticatedUser ? $authenticatedUser->id : User::where('username', 'admin')->pluck('id');
+        $userId = $authenticatedUser ? $authenticatedUser->id : null;
 
         switch ($this->mode) {
             case 'copy':

--- a/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
@@ -22,7 +22,7 @@ class ScriptExecutorExporter extends ExporterBase
     public function import() : bool
     {
         $authenticatedUser = Auth::user();
-        $userId = $authenticatedUser ? $authenticatedUser->id : User::where('username', 'admin')->firstOrFail()->id;
+        $userId = $authenticatedUser ? $authenticatedUser->id : User::where('username', 'admin')->pluck('id');
 
         switch ($this->mode) {
             case 'copy':

--- a/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
@@ -21,19 +21,16 @@ class ScriptExecutorExporter extends ExporterBase
 
     public function import() : bool
     {
-        $authenticatedUser = Auth::user();
-        $userId = $authenticatedUser ? $authenticatedUser->id : null;
-
         switch ($this->mode) {
             case 'copy':
             case 'new':
-                BuildScriptExecutor::dispatch($this->model->id, $userId);
+                BuildScriptExecutor::dispatch($this->model->id);
                 break;
             case 'update':
                 if (!empty($this->model->getChanges())) {
                     $original = $this->model->getAttributes();
                     ScriptExecutorUpdated::dispatch($this->model->id, $original, $this->model->getChanges());
-                    BuildScriptExecutor::dispatch($this->model->id, $userId);
+                    BuildScriptExecutor::dispatch($this->model->id);
                 }
                 break;
 


### PR DESCRIPTION
## Issue & Reproduction Steps
An issue arises when the CI executes `php artisan package-pm-blocks:sync-pm-blocks` and this action triggers an error. Furthermore, if the UUID does not exist within the `pm_blocks_category`, it results in another error.

## How to replicate
- Checkout to the next branch on Core, PmBlocks and Package Projects
- Install the PmBlocks Package. (uuid error may occur at this time)
- Sync the PmBlocks `php artisan package-pm-blocks:sync-pm-blocks`

## Solution

- Package: Create a migration that will check if the uuid of the category exists.
- Core: Add a conditional within the ScriptExecutorExporter that will check for an admin user if an authenticated user doesn’t exist.

How To Test
- Check out the following branches in Core, Pm Blocks and and Package Projects.
-- bugfix/FOUR-10388
- Install the Pm Blocks package
- Install the Package Projects package
- Sync the PmBlocks `php artisan package-pm-blocks:sync-pm-blocks`

## Related Tickets & Packages
- Ticket [FOUR-10388](https://processmaker.atlassian.net/browse/FOUR-10388)
- Pm Blocks
- Package Projects

## CI
ci:package-pm-blocks:bugfix/FOUR-10388
ci:package-projects:bugfix/FOUR-10388
ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10388]: https://processmaker.atlassian.net/browse/FOUR-10388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ