### PR TITLE
Add channel access to requester

### DIFF
--- a/routes/channels.php
+++ b/routes/channels.php
@@ -28,7 +28,8 @@ Broadcast::channel('ProcessMaker.Models.ProcessRequest.{id}', function ($user, $
 
     $request = ProcessRequest::find($id);
 
-    return !empty($request->participants()->where('users.id', $user->getKey())->first())
+    return $request->user_id === $user->id
+        || !empty($request->participants()->where('users.id', $user->getKey())->first())
         || $request->process?->manager_id === $user->id;
 });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
A webentry interstitial page tries to connect to the created request after a submit, but sometimes it gets denied this is because the channel allowing access to the requester (the user or anon user of a webentry)
This was working on the previous engine because it synchronously creates the start event token that brings access indirectly to the requester.

## Solution
- Give access to the Requester User to the ProcessRequest channel

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-10110](https://processmaker.atlassian.net/browse/FOUR-10110)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10110]: https://processmaker.atlassian.net/browse/FOUR-10110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ