### PR TITLE
Bugfix/FOUR-10378: Download button does not show when you open the first time in an incognito

### DIFF
--- a/resources/js/components/shared/DownloadSvgButton.vue
+++ b/resources/js/components/shared/DownloadSvgButton.vue
@@ -113,6 +113,7 @@ export default {
       const el = this.$refs.modelPrintSection;
 
       this.$html2canvas(el, {
+        logging: false,
         type: "dataURL",
         onclone(clone) {
           clone.getElementById("modelPrintSection").style.display = "block";

--- a/resources/views/processes/modeler/inflight-generative-ai.blade.php
+++ b/resources/views/processes/modeler/inflight-generative-ai.blade.php
@@ -31,12 +31,50 @@
       xml: @json($bpmn),
       enableProcessMapping: false,
     }
+  </script>
 
-    window.ProcessMaker.EventBus.$on('modeler-start', async ({ loadXML }) => {
-      await loadXML(window.ProcessMaker.modeler.xml);
-      window.ProcessMaker.EventBus.$emit('parsed');
+
+  <script>
+    test = new Vue({
+      el: '#modeler-app',
+      data() {
+        return {
+          iframeLoaded: false,
+          modelerStarted: false,
+          loadModel: null
+        }
+      },
+      mounted() {
+        window.ProcessMaker.EventBus.$on('modeler-start', async ({ loadXML }) => {
+          this.loadModel = loadXML;
+          this.modelerStarted = true;
+        });
+        window.ProcessMaker.EventBus.$on('iframe-loaded', () => {
+          this.iframeLoaded = true;
+        });
+      },
+      watch: {
+        modelerStarted(value) {
+          if (value && this.iframeLoaded) {
+            this.load();
+          }
+        },
+        iframeLoaded(value) {
+          if (value && this.modelerStarted) {
+            this.load();
+          }
+        }
+      },
+      methods: {
+        async load() {
+          await this.loadModel(window.ProcessMaker.modeler.xml);
+          window.ProcessMaker.EventBus.$emit('parsed');
+        }
+      }
     });
   </script>
+
+
   @foreach ($manager->getScripts() as $script)
     <script src="{{ $script }}"></script>
   @endforeach

--- a/resources/views/processes/modeler/inflight-generative-ai.blade.php
+++ b/resources/views/processes/modeler/inflight-generative-ai.blade.php
@@ -35,7 +35,7 @@
 
 
   <script>
-    test = new Vue({
+    modelerApp = new Vue({
       el: '#modeler-app',
       data() {
         return {

--- a/resources/views/processes/modeler/inflight-generative-ai.blade.php
+++ b/resources/views/processes/modeler/inflight-generative-ai.blade.php
@@ -35,7 +35,7 @@
 
 
   <script>
-    modelerApp = new Vue({
+    app = new Vue({
       el: '#modeler-app',
       data() {
         return {


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

- Log in
- Go to designer > processes
- Click on + process button
- Open the inspector in the browser
- go to Network tab
- Add a throttle (slow connection 3G)
- Click on new process using AI
- Add a prompt
- Click on generate

## Solution
- Added a watcher to detect if iframe and modeler were correctly loaded and after that emit the parsed event.

## How to Test
- Try all the uses cases with slow connections and fast connections
- Try reloading the AI process modeler with history, the download button should show
- Try reloading the AI process modeler without history, and generate a process. After generate the process the download button should show.
- Try downloading the file, the image should contain the model image

## Related Tickets & Packages
- [FOUR-10378](https://processmaker.atlassian.net/browse/FOUR-10378)
- [package-ai PR](https://github.com/ProcessMaker/package-ai/pull/22)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10378]: https://processmaker.atlassian.net/browse/FOUR-10378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ