### PR TITLE
Add support for Azure OpenAI, Palm, Replicate, Sagemaker (100+LLMs) - using LiteLLM

### DIFF
--- a/.github/workflows/scripts/translate.py
+++ b/.github/workflows/scripts/translate.py
@@ -1,11 +1,12 @@
 import json
 import os
 import openai
+import litellm
 import sys
 import time
 
-openai.api_key = os.environ["OPENAI_API_KEY"]
-openai.organization = os.environ["OPENAI_ORG"]
+litellm.api_key = os.environ["OPENAI_API_KEY"]
+litellm.organization = os.environ["OPENAI_ORG"]
 
 # Supported languages dictionary
 languages = {
@@ -50,7 +51,7 @@ def main():
             while retry_count < max_retries:
                 try:
                     start_time = time.time()
-                    response=openai.ChatCompletion.create(
+                    response=litellm.completion(
                         model='gpt-4',
                         messages=[
                           {

--- a/.github/workflows/translate_strings.yml
+++ b/.github/workflows/translate_strings.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install openai
+          pip install openai litellm
           
       - name: Download translation script
         run: wget https://raw.githubusercontent.com/ProcessMaker/processmaker/develop/.github/workflows/scripts/translate.py


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM allows you to use any llm as a drop in replacement for gpt-3.5 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
