### PR TITLE
FOUR-9567 - Include Child Assets When Assigning an Asset to a Project

### DIFF
--- a/ProcessMaker/Enums/ExporterMap.php
+++ b/ProcessMaker/Enums/ExporterMap.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ProcessMaker\Enums;
+
+enum ExporterMap
+{
+    const TYPES = [
+        'screen' => [\ProcessMaker\Models\Screen::class, \ProcessMaker\ImportExport\Exporters\ScreenExporter::class],
+        'process' => [\ProcessMaker\Models\Process::class, \ProcessMaker\ImportExport\Exporters\ProcessExporter::class],
+        'script' => [\ProcessMaker\Models\Script::class, \ProcessMaker\ImportExport\Exporters\ScriptExporter::class],
+        'process_templates' => [\ProcessMaker\Models\ProcessTemplates::class, \ProcessMaker\ImportExport\Exporters\TemplateExporter::class],
+        'data_source' => [\ProcessMaker\Packages\Connectors\DataSources\Models\DataSource::class, \ProcessMaker\Packages\Connectors\DataSources\ImportExport\DataSourceExporter::class],
+        'decision_table' => [\ProcessMaker\Package\PackageDecisionEngine\Models\DecisionTable::class, \ProcessMaker\Package\PackageDecisionEngine\ImportExport\DecisionTableExporter::class],
+    ];
+
+    public static function getModelClass(string $type): ?string
+    {
+        return self::TYPES[$type][0] ?? null;
+    }
+
+    public static function getExporterClass(string $type): ?string
+    {
+        return self::TYPES[$type][1] ?? null;
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR is part of: https://github.com/ProcessMaker/package-projects/pull/28

## Solution

- Added ExporterMap enum class in order to reuse some of its logic in the Package Projects.

## Related Tickets & Packages
- [FOUR-9567](https://processmaker.atlassian.net/browse/FOUR-9567)
- [Package Projects PR](https://github.com/ProcessMaker/package-projects/pull/28)