### PR TITLE
Add implementation for displaying a 'no data' message in settings

### DIFF
--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -26,7 +26,12 @@
         </template>
     </pmql-input>
 
-    <div class="card card-body table-card">
+    <div class="p-5 text-center" v-if="shouldDisplayNoDataMessage">
+        <h3>{{ noDataMessageConfig.name }}</h3>
+        <small>{{noDataMessageConfig.helper }}</small>
+    </div>
+
+    <div v-else class="card card-body table-card">
       <b-table
         class="settings-table table table-responsive-lg text-break m-0 h-100 w-100"
         :current-page="currentPage"
@@ -179,7 +184,9 @@ export default {
       settings: [],
       to: 0,
       totalRows: 0,
-      url: '/settings'
+      url: '/settings',
+      shouldDisplayNoDataMessage: false,
+      noDataMessageConfig: null,
     };
   },
   computed: {
@@ -277,6 +284,13 @@ export default {
       this.orderBy = context.sortBy;
       this.apiGet().then(response => {
         this.settings = response.data.data;
+        const noDataSettings = this.settings.filter(setting => setting.format === 'no-data');
+
+        if (this.settings.length === 1 && noDataSettings.length > 0) {
+          this.shouldDisplayNoDataMessage = true;
+          this.noDataMessageConfig = noDataSettings[0];
+        }
+        
         this.totalRows = response.data.meta.total;
         this.from = response.data.meta.from;
         this.to = response.data.meta.to;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR introduces a 'No Data' message feature, enhancing the user experience in the CDATA package. The 'No Data' message is now customizable for various settings tabs, allowing for more flexibility.

To configure the 'No Data' message for a settings tab, simply follow this example:

```
Setting::firstOrCreate(['key' => 'cdata.no_data_component'], [
            'format' => 'no-data',
            'group' => self::SETTINGS_GROUP,
            'config' => false,
            'name' => 'Configure External Integrations',
            'helper' => 'No external integrations are currently configured. To set up an external integration, click the "Add Driver" button.',
            'hidden' => false,
        ]);
```


## Solution
When the setting format is set to 'no-data', this PR implements a user-friendly behavior: it hides the settings table and, instead, displays the configured message and helper text for that specific setting. This change provides a clear and context-sensitive user interface, enhancing the overall user experience.

![Screenshot 2023-09-12 at 9 31 13 AM](https://github.com/ProcessMaker/processmaker/assets/52755494/af0010b6-d55a-463e-8901-ff0e64fe945f)


## How to Test
1. Install the CDATA package
2. Navigate to Admin > Settings
3. Select the 'External Integrations' tab

ci:next

**Expected Behavior**
The Configure External Integrations message appears. 

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
