### PR TITLE
FOUR-10501 Asset Quick Create QA Observations

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -54,6 +54,7 @@
 
 <script>
 import ModelerAssetQuickCreate from "./ModelerAssetQuickCreate.vue";
+import { find } from "lodash";
 
 export default {
   components: {
@@ -128,7 +129,12 @@ export default {
           }
         });
     },
-    load(filter) {
+    /**
+     *
+     * @param {Object=} filter - The filters to apply for the GET request
+     * @returns {Promise<void>}
+     */
+    async load(filter) {
       const params = {
         type: this.type(),
         interactive: this.interactive(),
@@ -139,25 +145,25 @@ export default {
         ...this.params,
       };
       this.loading = true;
-      ProcessMaker.apiClient
-        .get("screens?exclude=config", {
-          params,
-        })
-        .then(({ data }) => {
-          this.loading = false;
-          this.screens = data.data;
-        })
-        .catch((err) => {
-          this.loading = false;
-        });
+      try {
+        const { data } = await ProcessMaker.apiClient.get("screens?exclude=config", { params });
+        this.loading = false;
+        this.screens = data.data;
+      } catch (err) {
+        console.error("There was a problem getting the screens", err);
+        this.loading = false;
+      }
     },
     /**
      * @param {Object} data - The response we get from the emitter
      * @param {string} data.id - the screen id
      * @param {string} data.assetType - The Asset type, ex: screen
      */
-    processAssetCreation({ id, assetType }) {
-      if (assetType === "screen") this.$emit("input", id);
+    async processAssetCreation({ id, assetType }) {
+      if (assetType === "screen") {
+        await this.load();
+        this.content = find(this.screens, (screen) => screen.id === id);
+      }
     },
     validate() {
       if (!this.required || (this.value && this.value !== undefined)) {

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -144,6 +144,14 @@ export default {
       this.resetFormData();
       this.resetErrors();
     },
+    /**
+     * Check if the search params contains create=true which means is coming from the Modeler as a Quick Asset Creation
+     * @returns {boolean}
+     */
+    isQuickCreate() {
+      const searchParams = new URLSearchParams(window.location.search);
+      return searchParams?.get("create") === "true";
+    },
     onSubmit() {
       this.resetErrors();
       // single click
@@ -155,10 +163,12 @@ export default {
         .post("screens", this.formData)
         .then(({ data }) => {
           ProcessMaker.alert(this.$t("The screen was created."), "success");
-          channel.postMessage({
-            assetType: "screen",
-            id: data.id,
-          });
+          if (this.isQuickCreate()) {
+            channel.postMessage({
+              assetType: "screen",
+              id: data.id,
+            });
+          }
           window.location = `/designer/screen-builder/${data.id}/edit`;
         })
         .catch((error) => {

--- a/resources/js/processes/scripts/components/CreateScriptModal.vue
+++ b/resources/js/processes/scripts/components/CreateScriptModal.vue
@@ -213,6 +213,14 @@
       channel.close();
     },
     methods: {
+      /**
+       * Check if the search params contains create=true which means is coming from the Modeler as a Quick Asset Creation
+       * @returns {boolean}
+       */
+      isQuickCreate() {
+        const searchParams = new URLSearchParams(window.location.search);
+        return searchParams?.get("create") === "true";
+      },
       onClose() {
         this.title = '';
         this.language = '';
@@ -255,10 +263,12 @@
           (this.$refs.createScriptHooks || []).forEach((hook) => {
             hook.onsave(data);
           });
-          channel.postMessage({
-            assetType: "script",
-            id: data.id,
-          });
+          if (this.isQuickCreate()) {
+            channel.postMessage({
+              assetType: "script",
+              id: data.id,
+            });
+          }
           window.location = `/designer/scripts/${data.id}/builder`;
         })
         .catch((error) => {


### PR DESCRIPTION
## Solution
- Made the `load` function to be async and did a try-catch.
- Setting the data variable instead of using emitters, the parent was listening and setting the value to multiple components 🙄 
- Checking if the query params for `created` was present to sent the broadcast message along the wire

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10204
- https://processmaker.atlassian.net/browse/FOUR-10225
- https://processmaker.atlassian.net/browse/FOUR-10565

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
