### PR TITLE
FOUR-8069 Starting Step

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -134,7 +134,7 @@ class Task extends ApiResource
         return $array;
     }
 
-    private function loadUserRequestPermission($request, User $user = null, array $permissions)
+    private function loadUserRequestPermission(ProcessRequest $request, User $user = null, array $permissions)
     {
         $permissions[] = [
             'process_request_id' => $request->id,

--- a/ProcessMaker/Traits/ProcessTrait.php
+++ b/ProcessMaker/Traits/ProcessTrait.php
@@ -161,4 +161,42 @@ trait ProcessTrait
             ? $query->wherePivot('process_version_id', '=', null)
             : $query;
     }
+
+    /**
+     * Get the tasks that can be completed by human users
+     * 
+     * @return array
+     */
+    public function getHumanTasks()
+    {
+        $response = [];
+        if (empty($this->bpmn)) {
+            return $response;
+        }
+        $definitions = new BpmnDocument($this);
+        $definitions->loadXML($this->bpmn);
+        $tasks = $definitions->getElementsByTagNameNS(BpmnDocument::BPMN_MODEL, 'task');
+        foreach ($tasks as $task) {
+            $response[] = [
+                'id' => $task->getAttribute('id'),
+                'name' => $task->getAttribute('name'),
+            ];
+        }
+        $tasks = $definitions->getElementsByTagNameNS(BpmnDocument::BPMN_MODEL, 'userTask');
+        foreach ($tasks as $task) {
+            $response[] = [
+                'id' => $task->getAttribute('id'),
+                'name' => $task->getAttribute('name'),
+            ];
+        }
+        $tasks = $definitions->getElementsByTagNameNS(BpmnDocument::BPMN_MODEL, 'manualTask');
+        foreach ($tasks as $task) {
+            $response[] = [
+                'id' => $task->getAttribute('id'),
+                'name' => $task->getAttribute('name'),
+            ];
+        }
+
+        return $response;
+    }
 }


### PR DESCRIPTION
Add a method to get the human tasks of a process required by package testing.

![image](https://github.com/ProcessMaker/package-testing/assets/8028650/fec53231-d57c-4486-9c81-b08b4bed3f4b)

![image](https://github.com/ProcessMaker/package-testing/assets/8028650/b133c8b2-c3fd-4540-9ca2-09c60fffe7b8)

## How to Test
Run a process test and select a starting step.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8069

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
