### PR TITLE
Bugfix/four 10671

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -29,7 +29,12 @@ class ScreenExporter extends ExporterBase
         foreach ((array) $this->model->watchers as $watcher) {
             if ($this->watcherType($watcher) === self::WATCHER_TYPE_SCRIPT) {
                 $id = $watcher['script_id'];
-                $this->addDependent(DependentType::SCRIPTS, Script::find($id), ScriptExporter::class, $id);
+                $script = Script::find($id);
+                if ($script) {
+                    $this->addDependent(DependentType::SCRIPTS, $script, ScriptExporter::class, $id);
+                } else {
+                    \Log::debug("ScriptId: $script not exists in watcher " . $watcher['name']);
+                }
             }
         }
 

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -875,6 +875,12 @@ class ImportProcess implements ShouldQueue
             $this->file = base64_decode($this->fileContents);
             $this->file = json_decode($this->file);
         }
+
+        //replace tag prefix bpmn2 to bpmn
+        if (property_exists($this->file, 'process') && property_exists($this->file->process, 'bpmn')) {
+            $this->file->process->bpmn = str_replace('bpmn2', 'bpmn', $this->file->process->bpmn);
+        }
+        
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
When you have old processes you can see that you have the bpmn2 tag, this tag causes problems when we export the process.

## Solution
- When importing the process, the bpmn2 tag is replaced with bpmn.
- It is validated that a watcher has the script, if it does not it is not added to the dependencies for export.

## How to Test
- Import the process that is in the ticket.
- then export the process.

## Related Tickets & Packages
- [FOUR-10671](https://processmaker.atlassian.net/browse/FOUR-10671)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10671]: https://processmaker.atlassian.net/browse/FOUR-10671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ