### PR TITLE
FOUR-10611 Change the Title for a Script task when Data Browser modal is opened

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
+++ b/resources/js/processes/modeler/components/inspector/ConfigEditor.vue
@@ -62,7 +62,7 @@
             <b-card no-body>
               <template #header>
                 <div class="sidebar-subtitle">
-                  <h6>{{ $t('Preview screen') }}</h6>
+                  <h6>{{ $t('Script Config Editor') }}</h6>
                 </div>
               </template>
               <b-card-body>


### PR DESCRIPTION
## Issue & Reproduction Steps
Incorrect Title for a Script task when Data Browser modal is opened

## Solution
Change the Title for a Script task when Data Browser modal is opened

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-10611

ci:next