### PR TITLE
The process in the modeler is distorted when it contains blocks and we refresh the browser

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -10,6 +10,7 @@ use ProcessMaker\Managers\ModelerManager;
 use ProcessMaker\Managers\SignalManager;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Package\PackagePmBlocks\Http\Controllers\Api\PmBlockController;
 use ProcessMaker\PackageHelper;
 use ProcessMaker\Traits\HasControllerAddons;
 use ProcessMaker\Traits\ProcessMapTrait;
@@ -24,6 +25,8 @@ class ModelerController extends Controller
      */
     public function show(ModelerManager $manager, Process $process, Request $request)
     {
+        $pmBlockList = $this->getPmBlockList();
+
         /*
          * Emit the ModelerStarting event, passing in our ModelerManager instance. This will
          * allow packages to add additional javascript for modeler initialization which
@@ -43,6 +46,7 @@ class ModelerController extends Controller
             'autoSaveDelay' => config('versions.delay.process', 5000),
             'isVersionsInstalled' => PackageHelper::isPackageInstalled('ProcessMaker\Package\Versions\PluginServiceProvider'),
             'isDraft' => $draft !== null,
+            'pmBlockList' => $pmBlockList,
         ]);
     }
 
@@ -51,6 +55,8 @@ class ModelerController extends Controller
      */
     public function inflight(ModelerManager $manager, Process $process, ProcessRequest $request)
     {
+        $pmBlockList = $this->getPmBlockList();
+
         event(new ModelerStarting($manager));
 
         $bpmn = $process->bpmn;
@@ -91,7 +97,26 @@ class ModelerController extends Controller
             'requestInProgressNodes' => $requestInProgressNodes,
             'requestIdleNodes' => $requestIdleNodes,
             'requestId' => $request->id,
+            'pmBlockList' => $pmBlockList,
         ]);
+    }
+
+    /**
+     * Load PMBlock list
+     */
+    private function getPmBlockList()
+    {
+        $pmBlockList = null;
+        if (hasPackage('package-pm-blocks')) {
+            $controller = new PmBlockController();
+            $newRequest = new Request(['per_page' => 10000]);
+            $response = $controller->index($newRequest);
+            if ($response->response()->status() === 200) {
+                $pmBlockList = json_decode($response->response()->content())->data;
+            }
+        }
+
+        return $pmBlockList;
     }
 
     /**

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -55,6 +55,7 @@ div.main {
       'url':''
     },
   ]
+  window.ProcessMaker.PMBlockList = @json($pmBlockList);
   window.ProcessMaker.modeler = {
     process: @json($process),
     autoSaveDelay: @json($autoSaveDelay),

--- a/resources/views/processes/modeler/inflight.blade.php
+++ b/resources/views/processes/modeler/inflight.blade.php
@@ -28,6 +28,7 @@
 @section('js')
   <script>
     const breadcrumbData = [];
+    window.ProcessMaker.PMBlockList = @json($pmBlockList);
     window.ProcessMaker.modeler = {
       xml: @json($bpmn),
       configurables: [],


### PR DESCRIPTION
## Issue & Reproduction Steps
The listing of the PMBLocks took too long and caused problems in the events to start the modeler correctly.

## Solution
- The call to load the PMBlock listing is made in the modeler controller to be loaded before starting the modeler and saved in a global variable.

## How to Test

- Log in
- create a new  process
- create  a  PMBlocks  in process
- save the  process
- refresh the screen two or more times

note: Modeler and in-flight

## Related Tickets & Packages
- [FOUR-9860](https://processmaker.atlassian.net/browse/FOUR-9860)

depends
https://github.com/ProcessMaker/package-pm-blocks/pull/87

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9860]: https://processmaker.atlassian.net/browse/FOUR-9860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ