### PR TITLE
Enable Internal Search within Project Select list

### DIFF
--- a/resources/js/components/shared/ProjectSelect.vue
+++ b/resources/js/components/shared/ProjectSelect.vue
@@ -13,7 +13,7 @@
         :multiple="true"
         :show-labels="false"
         :searchable="true"
-        :internal-search="false"
+        :internal-search="true"
         @open="load()"
         @search-change="load"
         @select="(selected) => this.lastSelectedId = selected.id"


### PR DESCRIPTION
## Issue & Reproduction Steps

The Project select list currently lacks internal search functionality, which makes it challenging for users to find specific projects efficiently. This PR addresses this issue by implementing internal search capabilities in the multiselect component.

## Solution
- Enable internal search functionality for the Project

## How to Test
1. Ensure you have multiple projects configured
2. Create a process or update an existing process
3. Within the Project select list search for a project

**Expected Behavior**
The search properly filters the listed Projects based on the inputed value.

## Related Tickets & Packages
- [observation/FOUR-10209](https://processmaker.atlassian.net/browse/FOUR-10209)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
