### PR TITLE
Bugfix/FOUR-10009: Saved Search not returning results for Tasks

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -530,7 +530,16 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                     ->orWhere('id', 'like', $filter)
                     ->orWhere('created_at', 'like', $filter)
                     ->orWhere('due_at', 'like', $filter)
-                    ->orWhere('updated_at', 'like', $filter);
+                    ->orWhere('updated_at', 'like', $filter)
+                    ->orWhereHas('processRequest', function ($query) use ($filter) {
+                        $query->where(DB::raw('LOWER(name)'), 'like', $filter);
+                    })
+                    ->orWhereHas('processRequest', function ($query) use ($filter) {
+                        $query->where(DB::raw('LOWER(data)'), 'like', $filter);
+                    })
+                    ->orWhereHas('process', function ($query) use ($filter) {
+                        $query->where(DB::raw('LOWER(name)'), 'like', $filter);
+                    });
             });
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

- Steps to Reproduce:
- login to Processmaker
- Go to TASK and create a saved search (example for in progress and complete requests).
- Choose the saved search, and perform a simple search.

**Current Behavior:**

It does not find anything always shows empty no matter what the search is.

**Expected Behavior:**

Depending on the search, it should find the parameter in any field.

## Solution
- Search in process request data and by process request name in the scopeFilter for tasks.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/09daeee6-69c9-4bce-8e6a-abee869d002f

https://github.com/ProcessMaker/processmaker/assets/90727999/64c9fbbb-0c80-47f2-9b24-f87140b2192c


## How to Test
- Go to tasks and search for some task using the request name
- Go to tasks and search for some task using the request data

## Related Tickets & Packages
- [FOUR-10009](https://processmaker.atlassian.net/browse/FOUR-10009)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10009]: https://processmaker.atlassian.net/browse/FOUR-10009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ