### PR TITLE
I can only see the first 10 PMblock created in the modeler

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -111,7 +111,7 @@ class ModelerController extends Controller
             $controller = new PmBlockController();
             $newRequest = new Request(['per_page' => 10000]);
             $response = $controller->index($newRequest);
-            if ($response->response()->status() === 200) {
+            if ($response->response($newRequest)->status() === 200) {
                 $pmBlockList = json_decode($response->response()->content())->data;
             }
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
The per_page parameter was not passed in the response pager.

## Solution
- add the per_page parameter in the pager

## How to Test
review the PMBlock list in the modeler with more than 10 records

## Related Tickets & Packages
- [FOUR-10863](https://processmaker.atlassian.net/browse/FOUR-10863)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10863]: https://processmaker.atlassian.net/browse/FOUR-10863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy