### PR TITLE
FOUR-10886: Sorry API Failed to Load message displayed when refreshing requests view

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -250,6 +250,9 @@ window.ProcessMaker.apiClient.interceptors.response.use((response) => {
   }
   return response;
 }, (error) => {
+  if (error.code && error.code === "ERR_CANCELED") {
+    return Promise.reject(error);
+  }
   window.ProcessMaker.EventBus.$emit("api-client-error", error);
   if (error.response && error.response.status && error.response.status === 401) {
     // stop 401 error consuming endpoints with data-sources


### PR DESCRIPTION
## Issue & Reproduction Steps

1.) Navigate to Requests/My requests.

2.) Refresh page

Actual result: Sorry API Failed to Load message displayed when refreshing requests view

https://github.com/ProcessMaker/processmaker/assets/90727999/dedfa229-b297-40dc-8e5b-8877fc0acb2e


Expected result: No data Available message if no data and data if we have it as result.

## Solution
- Do not emit api client error if is request canceled

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/fe255dd9-7021-42fc-97b4-9239c003baed


## Related Tickets & Packages
- [FOUR-10886](https://processmaker.atlassian.net/browse/FOUR-10886)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10886]: https://processmaker.atlassian.net/browse/FOUR-10886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy