### PR TITLE
FOUR-10735 The create scenario button is missing from a completed request

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -132,6 +132,7 @@ class RequestController extends Controller
         event(new ScreenBuilderStarting($manager, ($request->summary_screen) ? $request->summary_screen->type : 'FORM'));
 
         $addons = $this->getPluginAddons('edit', compact(['request']));
+        $dataActionsAddons = $this->getPluginAddons('edit.dataActions', []);
 
         $isProcessManager = $request->process?->manager_id === Auth::user()->id;
 
@@ -152,6 +153,7 @@ class RequestController extends Controller
             'canPrintScreens',
             'screenRequested',
             'addons',
+            'dataActionsAddons',
             'isProcessManager',
             'eligibleRollbackTask',
             'errorTask',


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior:
Create scenarios from a completed request

Actual behavior:
Is not possible create a scenario from a completed request

## Solution
Add the feature in completed request screen

## How to Test
Test the steps above

## Related Tickets & Packages
FOUR-10735

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
