### PR TITLE
FOUR-10881: Screen interstitial now is displayed when a request is cr…

### DIFF
--- a/resources/js/processes/modeler/components/inspector/Interstitial.vue
+++ b/resources/js/processes/modeler/components/inspector/Interstitial.vue
@@ -61,6 +61,12 @@ export default {
         this.$set(this.node, "interstitialScreenRef", value);
       },
     },
+    allowInterstitialGetter: {
+      handler(value) {
+        this.allowInterstitialSetter(value);
+      },
+      immediate: true,
+    },
   },
   methods: {
     /**


### PR DESCRIPTION
…eated

## Issue & Reproduction Steps
Screen interstitial is not displayed when a request is created
Steps to Reproduce:
1. Go to URL [https://ci-1fc5121f8d.eng.processmaker.net](https://ci-1fc5121f8d.eng.processmaker.net/) (Next build 20230926)
2. Create a process
3. Create a Start Timer Event (the screen interstitial is checked by default)
4. Create a Script Task or Data Connector or task
5. Create a Task
6. Create a Request

## Solution
Create a watch to verify if we use the correct value to fill on field allowInterstitial inside DB.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
