### PR TITLE
Default blocks are not shown

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExecutorExporter.php
@@ -2,8 +2,10 @@
 
 namespace ProcessMaker\ImportExport\Exporters;
 
+use Auth;
 use ProcessMaker\Events\ScriptExecutorUpdated;
 use ProcessMaker\Jobs\BuildScriptExecutor;
+use ProcessMaker\Models\User;
 
 class ScriptExecutorExporter extends ExporterBase
 {
@@ -28,7 +30,12 @@ class ScriptExecutorExporter extends ExporterBase
                 if (!empty($this->model->getChanges())) {
                     $original = $this->model->getAttributes();
                     ScriptExecutorUpdated::dispatch($this->model->id, $original, $this->model->getChanges());
-                    BuildScriptExecutor::dispatch($this->model->id, auth()->user()->id);
+                    if (!app()->runningInConsole()) {
+                        $user = Auth::user();
+                    } else {
+                        $user = User::where('is_administrator', 1)->first();
+                    }
+                    BuildScriptExecutor::dispatch($this->model->id, $user->id);
                 }
                 break;
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The command to synchronize the PMBlocks by default was not executed because the user was not defined when it was executed through the console.

## Solution
- Add validation user when building script executor

## How to Test
execute the command `php artisan package-pm-blocks:sync-pm-blocks`
and review the list of PMBlock default

## Related Tickets & Packages
- [FOUR-10911](https://processmaker.atlassian.net/browse/FOUR-10911)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10911]: https://processmaker.atlassian.net/browse/FOUR-10911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ