### PR TITLE
bugfix/FOUR-8501: Validate if the package exist

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -12,7 +12,6 @@ use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Managers\LoginManager;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
-use ProcessMaker\Package\Auth\Database\Seeds\AuthDefaultSeeder;
 use ProcessMaker\Traits\HasControllerAddons;
 
 class LoginController extends Controller
@@ -90,7 +89,10 @@ class LoginController extends Controller
     protected function getDefaultSSO(array $addons): string
     {
         $addonsData = !empty($addons) ? head($addons)->data : [];
-        $defaultSSO = Setting::byKey(AuthDefaultSeeder::SSO_DEFAULT_LOGIN);
+        $defaultSSO = '';
+        if (class_exists(\ProcessMaker\Package\Auth\Database\Seeds\AuthDefaultSeeder::class)) {
+            $defaultSSO = Setting::byKey(\ProcessMaker\Package\Auth\Database\Seeds\AuthDefaultSeeder::SSO_DEFAULT_LOGIN);
+        }
         if (!empty($defaultSSO) && !empty($addonsData)) {
             // Get the config selected
             $position = $this->getColumnAttribute($defaultSSO, 'config', 'config');

--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -91,7 +91,9 @@ class LoginController extends Controller
         $addonsData = !empty($addons) ? head($addons)->data : [];
         $defaultSSO = '';
         if (class_exists(\ProcessMaker\Package\Auth\Database\Seeds\AuthDefaultSeeder::class)) {
-            $defaultSSO = Setting::byKey(\ProcessMaker\Package\Auth\Database\Seeds\AuthDefaultSeeder::SSO_DEFAULT_LOGIN);
+            $defaultSSO = Setting::byKey(
+                \ProcessMaker\Package\Auth\Database\Seeds\AuthDefaultSeeder::SSO_DEFAULT_LOGIN
+            );
         }
         if (!empty($defaultSSO) && !empty($addonsData)) {
             // Get the config selected


### PR DESCRIPTION
## Issue & Reproduction Steps
An error is appears when the package does not exist
![WhatsApp Image 2023-09-29 at 11 04 56](https://github.com/ProcessMaker/processmaker/assets/42388723/8f417ec1-243a-4e2d-bab8-34749cb89d9e)


## Solution
- Validate if the package exist

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- FOUR-8501

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next