### PR TITLE
[FOUR-10496] Add new option for custom Docker params

### DIFF
--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -85,6 +85,9 @@ abstract class Base
 
         // Set docker shared memory size
         $parameters .= ' --shm-size=' . env('DOCKER_SHARED_MEMORY', '256m');
+        
+        // Add any custom parameters specified in the config file
+        $parameters .= ' ' . config('app.processmaker_scripts_docker_params');
 
         $dockerConfig = $this->config($code, [
             'timeout' => $timeout,

--- a/config/app.php
+++ b/config/app.php
@@ -66,6 +66,9 @@ return [
 
     // tcp/other protocol uri to the docker host
     'processmaker_scripts_docker_host' => env('PROCESSMAKER_SCRIPTS_DOCKER_HOST', ''),
+    
+    // Default parameters for docker run command
+    'processmaker_scripts_docker_params' => env('PROCESSMAKER_SCRIPTS_DOCKER_PARAMS', ''),
 
     // Default timeout for scripts
     'processmaker_scripts_timeout' => env('PROCESSMAKER_SCRIPTS_TIMEOUT', 'timeout'),


### PR DESCRIPTION
## Issue & Reproduction Steps
The [docker-executor-cdata](https://github.com/ProcessMaker/docker-executor-cdata) requires the `linux/amd64` platform in order to function correctly due to CData's support for AMD64 but not ARM64. This means that on Apple Silicon macOS systems, the docker executor returns a warning message when executing even though Rosetta support enables it to function correctly.

## Solution
We are adding the new .env variable `PROCESSMAKER_SCRIPTS_DOCKER_PARAMS` to allow for custom parameters to be sent to the Docker executor at runtime. This enables us to add the param `--platform=linux/amd64` in order to prevent the warning message if we are running on an Apple Silicon macOS system.

## How to Test
Add the following to your .env file:
`PROCESSMAKER_SCRIPTS_DOCKER_PARAMS="--platform=linux/amd64"`

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-10496

ci:next
ci:deploy