### PR TITLE
Resolve Project Permissions and UI Updates

### DIFF
--- a/ProcessMaker/Http/Controllers/Designer/DesignerController.php
+++ b/ProcessMaker/Http/Controllers/Designer/DesignerController.php
@@ -29,12 +29,7 @@ class DesignerController extends Controller
 
     private function checkAuth()
     {
-        $perm = 'view-processes|
-            view-process-categories|
-            view-scripts|
-            view-screens|
-            view-environment_variables|
-            view-projects';
+        $perm = 'view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables|view-projects';
         switch (Auth::user()->canAnyFirst($perm)) {
             case 'view-processes':
                 return false; // already on index, continue with it

--- a/ProcessMaker/Http/Controllers/Designer/DesignerController.php
+++ b/ProcessMaker/Http/Controllers/Designer/DesignerController.php
@@ -29,7 +29,12 @@ class DesignerController extends Controller
 
     private function checkAuth()
     {
-        $perm = 'view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables|view-projects';
+        $perm = 'view-processes|
+            view-process-categories|
+            view-scripts|
+            view-screens|
+            view-environment_variables|
+            view-projects';
         switch (Auth::user()->canAnyFirst($perm)) {
             case 'view-processes':
                 return false; // already on index, continue with it

--- a/ProcessMaker/Http/Controllers/Designer/DesignerController.php
+++ b/ProcessMaker/Http/Controllers/Designer/DesignerController.php
@@ -29,7 +29,7 @@ class DesignerController extends Controller
 
     private function checkAuth()
     {
-        $perm = 'view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables';
+        $perm = 'view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables|view-projects';
         switch (Auth::user()->canAnyFirst($perm)) {
             case 'view-processes':
                 return false; // already on index, continue with it
@@ -41,6 +41,8 @@ class DesignerController extends Controller
                 return 'screens.index';
             case 'view-environment_variables':
                 return 'environment-variables.index';
+            case 'view-projects':
+                return 'projects.index';
             default:
                 throw new AuthorizationException();
         }

--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -32,14 +32,7 @@ class GenerateMenus
                     ['route' => 'tasks.index', 'id' => 'tasks']
                 )->active('tasks/*');
             });
-            if (\Auth::check() && \Auth::user()->canAny('
-                view-processes|
-                view-process-categories|
-                view-scripts|
-                view-screens|
-                view-environment_variables|
-                view-projects'
-            )) {
+            if (\Auth::check() && \Auth::user()->canAny('view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables|view-projects')) {
                 $menu->group(['prefix' => 'designer'], function ($request_items) {
                     $request_items->add(
                         __('Designer'),

--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -32,7 +32,7 @@ class GenerateMenus
                     ['route' => 'tasks.index', 'id' => 'tasks']
                 )->active('tasks/*');
             });
-            if (\Auth::check() && \Auth::user()->canAny('view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables')) {
+            if (\Auth::check() && \Auth::user()->canAny('view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables|view-projects')) {
                 $menu->group(['prefix' => 'designer'], function ($request_items) {
                     $request_items->add(
                         __('Designer'),

--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -32,7 +32,14 @@ class GenerateMenus
                     ['route' => 'tasks.index', 'id' => 'tasks']
                 )->active('tasks/*');
             });
-            if (\Auth::check() && \Auth::user()->canAny('view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables|view-projects')) {
+            if (\Auth::check() && \Auth::user()->canAny('
+                view-processes|
+                view-process-categories|
+                view-scripts|
+                view-screens|
+                view-environment_variables|
+                view-projects'
+            )) {
                 $menu->group(['prefix' => 'designer'], function ($request_items) {
                     $request_items->add(
                         __('Designer'),


### PR DESCRIPTION
## Issue & Reproduction Steps
As part of ticket FOUR-10303 this PR enables the 'Designer' link for users who have Project permissions.

## Solution
- Include `view-projects` permission to enable the 'Designer' link in the top menu

## How to Test

1. Ensure you have the Projects package installed using this [PR](https://github.com/ProcessMaker/package-projects/pull/32)
2. Create a new user.
3. Confirm that the user has Project permissions enabled by default.
4. Log in as the newly created user.
5. Ensure that the 'Designer' tab is visible.

## Related Tickets & Packages
- [FOUR-10303](https://processmaker.atlassian.net/browse/FOUR-10303)
- [Projects PR](https://github.com/ProcessMaker/package-projects/pull/32)

ci:next
ci:package-projects:task/FOUR-10303

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10303]: https://processmaker.atlassian.net/browse/FOUR-10303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ