### PR TITLE
Increase Per Page for Project Search

### DIFF
--- a/resources/js/components/shared/ProjectSelect.vue
+++ b/resources/js/components/shared/ProjectSelect.vue
@@ -110,7 +110,7 @@
         },
         load(filter) {
           ProcessMaker.apiClient
-            .get(this.apiList + "?order_direction=asc&status=active" + (typeof filter === 'string' ? '&filter=' + filter : ''))
+            .get(this.apiList + "?order_direction=asc&status=active&per_page=1000" + (typeof filter === 'string' ? '&filter=' + filter : ''))
             .then(response => {
               this.loading = false;
               this.options = response.data.data;


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR addresses an issue encountered when searching for projects in the Project Select list. Currently, only the first 10 projects are returned during the search. This limitation arises from the default setting of the `per_page` parameter, which is set to 10. 

## Solution
To resolve this issue and improve the user experience, this PR increases the `per_page` parameter value from its default of 10 to 1000. This change ensures that users can see a more comprehensive list of projects when performing searches.

## How to Test
1. Ensure that your development environment contains more than 10 projects.
2. Access an Asset designer, such as Processes, Screens, etc.
3. Within the Project Select list, initiate a search for projects.

**Expected Behavior**
When searching, all projects should be visible, allowing for a more efficient and comprehensive project selection process.

## Related Tickets & Packages
Ticket[ FOUR-10209](https://processmaker.atlassian.net/browse/FOUR-10209)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
