### PR TITLE
Resolve Error and Improve Data Handling in Asset Assignment

### DIFF
--- a/ProcessMaker/Traits/ProjectAssetTrait.php
+++ b/ProcessMaker/Traits/ProjectAssetTrait.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Traits;
 
+use Carbon\Carbon;
+
 trait ProjectAssetTrait
 {
     public function assignAssetsToProjects($request, $assetModelClass)
@@ -9,14 +11,17 @@ trait ProjectAssetTrait
         if ($request->input('projects')) {
             $projectAssetModelClass = 'ProcessMaker\Package\Projects\Models\ProjectAsset';
             $projectAssets = new $projectAssetModelClass;
-            $projectIds = (array) $request->input('projects');
+            $projectIds = explode(',', $request->input('projects'));
             $assetData = [];
 
             foreach ($projectIds as $id) {
+                $now = Carbon::now('utc')->toDateTimeString();
                 $assetData[] = [
                     'asset_id' => $this->id,
                     'project_id' => $id,
                     'asset_type' => $assetModelClass,
+                    'created_at' => $now,
+                    'updated_at' => $now,
                 ];
             }
 


### PR DESCRIPTION
This PR addresses an issue encountered when selecting multiple projects for an asset (process, screens, etc.).

- Error in the foreach loop due to attempting to iterate over a non-array.
- Absence of `created_at` and `modified_at` values during record insertion.

## Solution

- Corrected the foreach loop to handle non-array scenarios gracefully.
- Added the necessary code to ensure `created_at` and `modified_at` values are correctly set during record insertion.


## How to Test

1. Ensure you have multiple Projects created.
2. Assign multiple projects to an asset.
3. Select 'Save'.


**Expected Behavior**
The Asset should be successfully assigned to ALL selected projects without any errors.

## Related Tickets & Packages
- Ticket [FOUR-10945](https://processmaker.atlassian.net/browse/FOUR-10945)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10945]: https://processmaker.atlassian.net/browse/FOUR-10945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ