### PR TITLE
Enhancement: Centralized Ellipsis Action Menus Configuration

### DIFF
--- a/resources/js/components/pm-blocks/CreatePmBlockModal.vue
+++ b/resources/js/components/pm-blocks/CreatePmBlockModal.vue
@@ -140,7 +140,10 @@
 </template>
 
 <script>
-import { FormErrorsMixin, Modal, Required, IconSelector } from "SharedComponents";
+import Required from "../shared/Required.vue";
+import Modal from "../shared/Modal.vue";
+import FormErrorsMixin from "../shared/FormErrorsMixin";
+import IconSelector from "../shared/IconSelector.vue";
 import CategorySelect from "../../processes/categories/components/CategorySelect.vue";
 
 export default {

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -1,0 +1,104 @@
+import DataLoading from "../common/DataLoading";
+
+export default {
+  components: {
+    DataLoading,
+  },
+  data() {
+    return {
+      processActions: [
+        { value: "unpause-start-timer", content: "Unpause Start Timer Events", icon: "fas fa-play", conditional: "if(has_timer_start_events and pause_timer_start, true, false)" },
+        { value: "pause-start-timer", content: "Pause Start Timer Events", icon: "fas fa-pause", conditional: "if(has_timer_start_events and not(pause_timer_start), true, false)"},
+        { value: "edit-designer", content: "Edit Process", link: true, href:"/modeler/{{id}}", permission: ["edit-processes", "create-projects", "view-projects"], icon: "fas fa-edit", conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)"},
+        { value: "create-template", content: "Save as Template", permission: "create-process-templates", icon: "fas fa-layer-group" },
+        { value: "create-pm-block", content: "Save as PM Block", permission: "create-pm-blocks", icon: "fas nav-icon fa-cube" },
+        { value: "add-to-project", content: "Add to Project", icon: "fas fa-folder-plus" },
+        { value: "edit-item", content: "Configure", link: true, href:"/processes/{{id}}/edit", permission: ["edit-processes", "create-projects", "view-projects"], icon: "fas fa-cog", conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)"},
+        { value: "view-documentation", content: "View Documentation", link: true, href:"/modeler/{{id}}/print", permission: ["view-processes", "create-projects", "view-projects"], icon: "fas fa-sign", conditional: "isDocumenterInstalled"},
+        { value: "remove-item", content: "Archive", permission: ["archive-processes", "create-projects", "view-projects"], icon: "fas fa-archive", conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)" },
+        { value: "divider" },
+        { value: "export-item", content: "Export", link: true, href:"/processes/{{id}}/export", permission: ["export-processes", "create-projects", "view-projects"], icon: "fas fa-file-export"},
+        { value: "restore-item", content: "Restore", permission: ["archive-processes", "create-projects", "view-projects"], icon: "fas fa-upload", conditional: "if(status == 'ARCHIVED', true, false)" },
+        { value: "download-bpmn", content: "Download BPMN", permission: ["view-processes", "create-projects", "view-projects"], icon: "fas fa-file-download"},
+      ],
+      screenActions: [
+        {
+          value: "edit-screen",
+          content: "Edit Screen",
+          link: true,
+          href: "/designer/screen-builder/{{id}}/edit",
+          permission: ["edit-screens", "create-projects", "view-projects"],
+          icon: "fas fa-pen-square",
+        },
+        {
+          value: "edit-item",
+          content: "Configure",
+          link: true,
+          href: "/designer/screens/{{id}}/edit",
+          permission: ["edit-screens", "create-projects", "view-projects"],
+          icon: "fas fa-cog",
+        },
+        { 
+          value: "add-to-project", 
+          content: "Add to Project",
+          icon: "fas fa-folder-plus"
+        },
+        {
+          value: "duplicate-item",
+          content: "Copy",
+          permission: ["create-screens", "create-projects", "view-projects"],
+          icon: "fas fa-copy",
+        },
+        {
+          value: "export-item",
+          content: "Export",
+          link: true,
+          href: "/designer/screens/{{id}}/export",
+          permission: ["export-screens", "create-projects", "view-projects"],
+          icon: "fas fa-file-export",
+        },
+        {
+          value: "remove-item",
+          content: "Delete",
+          permission: ["delete-screens", "create-projects", "view-projects"],
+          icon: "fas fa-trash-alt",
+        },
+      ],
+      scriptActions: [
+        {
+          value: "edit-script",
+          content: "Edit Script",
+          link: true,
+          href: "/designer/scripts/{{id}}/builder",
+          permission: ["edit-scripts", "create-projects", "view-projects"],
+          icon: "fas fa-pen-square",
+        },
+        {
+          value: "edit-item",
+          content: "Configure",
+          link: true,
+          href: "/designer/scripts/{{id}}/edit",
+          permission: ["edit-scripts", "create-projects", "view-projects"],
+          icon: "fas fa-cog",
+        },
+        { 
+          value: "add-to-project", 
+          content: "Add to Project",
+          icon: "fas fa-folder-plus" 
+        },
+        {
+          value: "duplicate-item",
+          content: "Copy",
+          permission: ["create-scripts", "create-projects", "view-projects"],
+          icon: "fas fa-copy",
+        },
+        {
+          value: "remove-item",
+          content: "Delete",
+          permission: ["delete-scripts", "create-projects", "view-projects"],
+          icon: "fas fa-trash-alt",
+        },
+      ],
+    };
+  },
+};

--- a/resources/js/components/shared/index.js
+++ b/resources/js/components/shared/index.js
@@ -34,6 +34,8 @@ import CreateScriptModal from "../../processes/scripts/components/CreateScriptMo
 import CreateProcessModal from "../../processes/components/CreateProcessModal.vue";
 import EllipsisMenuMixin from "./ellipsisMenuActions";
 import ProcessNavigationMixin from "./processNavigation";
+import ScreenNavigationMixin from "./screenNavigation";
+import ScriptNavigationMixin from "./scriptNavigation";
 import CreateTemplateModal from "../templates/CreateTemplateModal.vue";
 import CreatePmBlockModal from "../pm-blocks/CreatePmBlockModal.vue";
 
@@ -75,5 +77,7 @@ export {
   EllipsisMenuMixin,
   ProcessNavigationMixin,
   CreateTemplateModal,
-  CreatePmBlockModal
+  CreatePmBlockModal,
+  ScreenNavigationMixin,
+  ScriptNavigationMixin
 };

--- a/resources/js/components/shared/index.js
+++ b/resources/js/components/shared/index.js
@@ -32,6 +32,10 @@ import ExportStateMixin from "../../processes/export/state";
 import CreateScreenModal from "../../processes/screens/components/CreateScreenModal.vue";
 import CreateScriptModal from "../../processes/scripts/components/CreateScriptModal.vue";
 import CreateProcessModal from "../../processes/components/CreateProcessModal.vue";
+import EllipsisMenuMixin from "./ellipsisMenuActions";
+import ProcessNavigationMixin from "./processNavigation";
+import CreateTemplateModal from "../templates/CreateTemplateModal.vue";
+import CreatePmBlockModal from "../pm-blocks/CreatePmBlockModal.vue";
 
 export {
   AddToProjectModal,
@@ -68,4 +72,8 @@ export {
   DownloadSvgButton,
   CustomExportView,
   ExportStateMixin,
+  EllipsisMenuMixin,
+  ProcessNavigationMixin,
+  CreateTemplateModal,
+  CreatePmBlockModal
 };

--- a/resources/js/components/shared/processNavigation.js
+++ b/resources/js/components/shared/processNavigation.js
@@ -1,0 +1,114 @@
+export default {
+  components: {
+  },
+  data() {
+    return {
+      assetType: null,
+      showAddProjectModal: false,
+      showTemplateModal: false,
+      showCreatePmBlockModal: false,
+    }
+  },
+  methods: {
+    onNavigate(action, data) {
+        let putData = {
+          name: data.name,
+          description: data.description,
+        };
+        switch (action.value) {
+          case "unpause-start-timer":
+            putData.pause_timer_start = false;
+            ProcessMaker.apiClient
+                .put("processes/" + data.id, putData)
+                .then(response => {
+                  ProcessMaker.alert(
+                      this.$t("The process was unpaused."),
+                      "success"
+                  );
+                  this.$emit("reload");
+                });
+            break;
+          case "pause-start-timer":
+            putData.pause_timer_start = true;
+            ProcessMaker.apiClient
+                .put("processes/" + data.id, putData)
+                .then(response => {
+                  ProcessMaker.alert(
+                      this.$t("The process was paused."),
+                      "success"
+                  );
+                  this.$emit("reload");
+                });
+            break;
+          case "create-template":
+            this.showCreateTemplateModal(data.name, data.id);
+            break;
+          case "create-pm-block":
+            this.showPmBlockModal(data.name, data.id);
+            break;
+          case "restore-item":
+            ProcessMaker.apiClient
+                .put("processes/" + data.id + "/restore")
+                .then(response => {
+                  ProcessMaker.alert(
+                      this.$t("The process was restored."),
+                      "success"
+                  );
+                  this.$emit("reload");
+                });
+            break;
+          case "remove-item":
+            ProcessMaker.confirmModal(
+                this.$t("Caution!"),
+                this.$t("Are you sure you want to archive the process") +
+                data.name +
+                "?",
+                "",
+                () => {
+                  ProcessMaker.apiClient
+                      .delete("processes/" + data.id)
+                      .then(response => {
+                        ProcessMaker.alert(
+                            this.$t("The process was archived."),
+                            "success"
+                        );
+                        this.$refs.pagination.loadPage(1);
+                      });
+                }
+            );
+            break;
+
+          case "download-bpmn":
+            ProcessMaker.confirmModal(
+                this.$t("Caution!"),
+                this.$t("Are you sure you want to download the BPMN definition of the process?"),
+                "",
+                () => {
+                  ProcessMaker.apiClient
+                      .get("processes/" + data.id + "/bpmn")
+                      .then(response => {
+
+                        const link = document.createElement("a");
+                        const file = new Blob([response.data], { type: 'text/plain' });
+
+                        link.href = URL.createObjectURL(file);
+                        link.download = "bpmnProcess.xml";
+                        link.click();
+                        URL.revokeObjectURL(link.href);
+
+                        ProcessMaker.alert(
+                            this.$t("The process BPMN has been downloaded."),
+                            "success"
+                        );
+                      });
+                }
+            );
+            break;
+            case 'add-to-project':
+              this.assetType = data.asset_type;
+              this.showAddToProjectModal(data.name, data.id);
+            break;
+        }
+      },
+  },
+};

--- a/resources/js/components/shared/screenNavigation.js
+++ b/resources/js/components/shared/screenNavigation.js
@@ -1,0 +1,69 @@
+export default {
+    components: {
+    },
+    data() {
+      return {
+        assetType: null,
+        showAddProjectModal: false,
+        showTemplateModal: false,
+        showCreatePmBlockModal: false,
+        dupScreen: {
+            title: "",
+            type: "",
+            category: {},
+            screen_category_id: "",
+            description: ""
+        },
+        errors:[],
+      }
+    },
+    methods: {
+        onNavigate(actionType, data, index) {
+            if (actionType.value) {
+              switch (actionType.value) {
+              case "duplicate-item":
+                this.dupScreen.title = data.title + ' ' + this.$t('Copy');
+                this.dupScreen.type = data.type;
+                this.dupScreen.category = data.category;
+                this.dupScreen.screen_category_id = data.screen_category_id;
+                this.dupScreen.description = data.description;
+                this.dupScreen.id = data.id;
+                this.showModal();
+                break;
+              case "remove-item":
+                let that = this;
+                ProcessMaker.confirmModal(
+                  this.$t("Caution!"),
+                   this.$t("Are you sure you want to delete the screen {{item}}? Deleting this asset will break any active tasks that are assigned.", {
+                      item: data.title,
+                    }),
+                    "",
+                  function() {
+                    ProcessMaker.apiClient
+                      .delete("screens/" + data.id)
+                      .then(response => {
+                        ProcessMaker.alert(
+                          this.$t("The screen was deleted."),
+                          "success"
+                        );
+                        that.fetch();
+                      });
+                  }
+                );
+                  break;
+                  case 'add-to-project':
+                    this.showAddToProjectModal(data.title, data.id);
+                  break;
+              }
+          } else {
+              switch (actionType) {
+              case "edit-screen":
+                let link = "/designer/screen-builder/" + data.id + "/edit";
+                return link;
+                break;
+              }
+          }
+        },
+    },
+  };
+  

--- a/resources/js/components/shared/scriptNavigation.js
+++ b/resources/js/components/shared/scriptNavigation.js
@@ -1,0 +1,53 @@
+export default {
+    components: {
+    },
+    data() {
+      return {
+        assetType: null,
+        showAddProjectModal: false,
+        showTemplateModal: false,
+        showCreatePmBlockModal: false,
+        dupScript: {
+            title: "",
+            type: "",
+            category: {},
+            description: "",
+            script_category_id: "",
+          },
+        errors:[],
+      }
+    },
+    methods: {
+        onNavigate(action, data) {
+            switch (action.value) {
+              case "duplicate-item":
+                this.dupScript.title = data.title + " Copy";
+                this.dupScript.language = data.language;
+                this.dupScript.code = data.code;
+                this.dupScript.description = data.description;
+                this.dupScript.category = data.category;
+                this.dupScript.script_category_id = data.script_category_id;
+                this.dupScript.id = data.id;
+                this.dupScript.run_as_user_id = data.run_as_user_id;
+                this.showModal();
+                break;
+              case "remove-item":
+                ProcessMaker.confirmModal(
+                  this.$t("Caution!"),
+                  this.$t("Are you sure you want to delete {{item}}? Deleting this asset will break any active tasks that are assigned.", {
+                    item: data.title
+                  }),
+                  "",
+                  () => {
+                    this.$emit("delete", data);
+                  }
+                );
+                break;
+              case 'add-to-project':
+                this.showAddToProjectModal(data.title, data.id);
+                break;
+            }
+        },
+    },
+  };
+  

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -47,7 +47,7 @@
         <template slot="actions" slot-scope="props">
           <ellipsis-menu 
             @navigate="onNavigate"
-            :actions="actions"
+            :actions="processActions"
             :permission="permission"
             :data="props.rowData"
             :is-documenter-installed="isDocumenterInstalled"
@@ -59,12 +59,12 @@
       <create-pm-block-modal id="create-pm-block-modal" ref="create-pm-block-modal" :currentUserId="currentUserId" :assetName="pmBlockName" :assetId="processId" />
       <add-to-project-modal id="add-to-project-modal" ref="add-to-project-modal"  assetType="process" :assetId="processId" :assetName="assetName"/>
       <pagination
-              :single="$t('Process')"
-              :plural="$t('Processes')"
-              :per-page-select-enabled="true"
-              @changePerPage="changePerPage"
-              @vuetable-pagination:change-page="onPageChange"
-              ref="pagination"
+        :single="$t('Process')"
+        :plural="$t('Processes')"
+        :per-page-select-enabled="true"
+        @changePerPage="changePerPage"
+        @vuetable-pagination:change-page="onPageChange"
+        ref="pagination"
       ></pagination>
     </div>
   </div>
@@ -79,31 +79,18 @@
   import CreateTemplateModal from "../../components/templates/CreateTemplateModal.vue";
   import CreatePmBlockModal from "../../components/pm-blocks/CreatePmBlockModal.vue";
   import EllipsisMenu from "../../components/shared/EllipsisMenu.vue";
+  import ellipsisMenuMixin from "../../components/shared/ellipsisMenuActions";
   import AddToProjectModal from "../../components/shared/AddToProjectModal.vue";
+  import processNavigationMixin from "../../components/shared/processNavigation";
 
   const uniqIdsMixin = createUniqIdsMixin();
 
   export default {
     components: { TemplateExistsModal, CreateTemplateModal, EllipsisMenu, CreatePmBlockModal, AddToProjectModal},
-    mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin],
+    mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin, processNavigationMixin],
     props: ["filter", "id", "status", "permission", "isDocumenterInstalled", "pmql", "processName", "currentUserId"],
     data() {
       return {
-        actions: [
-        { value: "unpause-start-timer", content: "Unpause Start Timer Events", icon: "fas fa-play", conditional: "if(has_timer_start_events and pause_timer_start, true, false)" },
-        { value: "pause-start-timer", content: "Pause Start Timer Events", icon: "fas fa-pause", conditional: "if(has_timer_start_events and not(pause_timer_start), true, false)"},
-        { value: "edit-designer", content: "Edit Process", link: true, href:"/modeler/{{id}}", permission: "edit-processes", icon: "fas fa-edit", conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)"},
-        { value: "create-template", content: "Save as Template", permission: "create-process-templates", icon: "fas fa-layer-group" },
-        { value: "create-pm-block", content: "Save as PM Block", permission: "create-pm-blocks", icon: "fas nav-icon fa-cube" },
-        { value: "add-to-project", content: "Add to Project", icon: "fas fa-folder-plus" },
-        { value: "edit-item", content: "Configure", link: true, href:"/processes/{{id}}/edit", permission: "edit-processes", icon: "fas fa-cog", conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)"},
-        { value: "view-documentation", content: "View Documentation", link: true, href:"/modeler/{{id}}/print", permission: "view-processes", icon: "fas fa-sign", conditional: "isDocumenterInstalled"},
-        { value: "remove-item", content: "Archive", permission: "archive-processes", icon: "fas fa-archive", conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)" },
-        { value: "divider" },
-        { value: "export-item", content: "Export", link: true, href:"/processes/{{id}}/export", permission: "export-processes", icon: "fas fa-file-export"},
-        { value: "restore-item", content: "Restore", permission: "archive-processes", icon: "fas fa-upload", conditional: "if(status == 'ARCHIVED', true, false)" },
-        { value: "download-bpmn", content: "Download BPMN", permission: "view-processes", icon: "fas fa-file-download"},
-      ],
         orderBy: "name",
         processId: null,
         processTemplateName: '',
@@ -176,106 +163,8 @@
       showAddToProjectModal(name, id) {        
         this.processId = id;
         this.assetName = name;
+        this.assetType = "process";
         this.$refs["add-to-project-modal"].show();
-      },
-      onNavigate(action, data) {
-        let putData = {
-          name: data.name,
-          description: data.description,
-        };
-        switch (action.value) {
-          case "unpause-start-timer":
-            putData.pause_timer_start = false;
-            ProcessMaker.apiClient
-                .put("processes/" + data.id, putData)
-                .then(response => {
-                  ProcessMaker.alert(
-                      this.$t("The process was unpaused."),
-                      "success"
-                  );
-                  this.$emit("reload");
-                });
-            break;
-          case "pause-start-timer":
-            putData.pause_timer_start = true;
-            ProcessMaker.apiClient
-                .put("processes/" + data.id, putData)
-                .then(response => {
-                  ProcessMaker.alert(
-                      this.$t("The process was paused."),
-                      "success"
-                  );
-                  this.$emit("reload");
-                });
-            break;
-          case "create-template":
-            this.showCreateTemplateModal(data.name, data.id);
-            break;
-          case "create-pm-block":
-            this.showPmBlockModal(data.name, data.id);
-            break;
-          case "restore-item":
-            ProcessMaker.apiClient
-                .put("processes/" + data.id + "/restore")
-                .then(response => {
-                  ProcessMaker.alert(
-                      this.$t("The process was restored."),
-                      "success"
-                  );
-                  this.$emit("reload");
-                });
-            break;
-          case "remove-item":
-            ProcessMaker.confirmModal(
-                this.$t("Caution!"),
-                this.$t("Are you sure you want to archive the process") +
-                data.name +
-                "?",
-                "",
-                () => {
-                  ProcessMaker.apiClient
-                      .delete("processes/" + data.id)
-                      .then(response => {
-                        ProcessMaker.alert(
-                            this.$t("The process was archived."),
-                            "success"
-                        );
-                        this.$refs.pagination.loadPage(1);
-                      });
-                }
-            );
-            break;
-
-          case "download-bpmn":
-            ProcessMaker.confirmModal(
-                this.$t("Caution!"),
-                this.$t("Are you sure you want to download the BPMN definition of the process?"),
-                "",
-                () => {
-                  ProcessMaker.apiClient
-                      .get("processes/" + data.id + "/bpmn")
-                      .then(response => {
-
-                        const link = document.createElement("a");
-                        const file = new Blob([response.data], { type: 'text/plain' });
-
-                        link.href = URL.createObjectURL(file);
-                        link.download = "bpmnProcess.xml";
-                        link.click();
-                        URL.revokeObjectURL(link.href);
-
-                        ProcessMaker.alert(
-                            this.$t("The process BPMN has been downloaded."),
-                            "success"
-                        );
-                      });
-                }
-            );
-            break;
-            case 'add-to-project':
-              this.showAddToProjectModal(data.name, data.id);
-            break;
-        }
       },
       formatStatus(status) {
         status = status.toLowerCase();

--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -30,7 +30,7 @@
 
         <template slot="actions" slot-scope="props">
           <ellipsis-menu
-            :actions="actions"
+            :actions="screenActions"
             :permission="permission"
             :data="props.rowData"
             :divider="true"
@@ -93,6 +93,7 @@
 <script>
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
+import ellipsisMenuMixin from "../../../components/shared/ellipsisMenuActions";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
 import { createUniqIdsMixin } from "vue-uniq-ids";
 import AddToProjectModal from "../../../components/shared/AddToProjectModal.vue";
@@ -100,53 +101,10 @@ const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
   components: { EllipsisMenu, AddToProjectModal },
-  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin],
+  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin,],
   props: ["filter", "id", "permission"],
   data() {
     return {
-      actions: [
-        {
-          value: "edit-screen",
-          content: "Edit Screen",
-          link: true,
-          href: "/designer/screen-builder/{{id}}/edit",
-          permission: "edit-screens",
-          icon: "fas fa-pen-square",
-        },
-        {
-          value: "edit-item",
-          content: "Configure",
-          link: true,
-          href: "/designer/screens/{{id}}/edit",
-          permission: "edit-screens",
-          icon: "fas fa-cog",
-        },
-        { 
-          value: "add-to-project", 
-          content: "Add to Project",
-          icon: "fas fa-folder-plus"
-        },
-        {
-          value: "duplicate-item",
-          content: "Copy",
-          permission: "create-screens",
-          icon: "fas fa-copy",
-        },
-        {
-          value: "export-item",
-          content: "Export",
-          link: true,
-          href: "/designer/screens/{{id}}/export",
-          permission: "export-screens",
-          icon: "fas fa-file-export",
-        },
-        {
-          value: "remove-item",
-          content: "Delete",
-          permission: "delete-screens",
-          icon: "fas fa-trash-alt",
-        },
-      ],
       orderBy: "title",
       screenId: null,
       assetName: " ",

--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -22,7 +22,7 @@
       >
         <template slot="title" slot-scope="props">
           <b-link
-            :href="onAction('edit-screen', props.rowData, props.rowIndex)"
+            :href="onNavigate('edit-screen', props.rowData, props.rowIndex)"
             v-if="permission.includes('edit-screens')"
           ><span v-uni-id="props.rowData.id.toString()">{{props.rowData.title}}</span></b-link>
           <span v-uni-id="props.rowData.id.toString()" v-else="permission.includes('edit-screens')">{{props.rowData.title}}</span>
@@ -34,7 +34,7 @@
             :permission="permission"
             :data="props.rowData"
             :divider="true"
-            @navigate="onAction"
+            @navigate="onNavigate"
           />
         </template>
       </vuetable>
@@ -94,28 +94,30 @@
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import ellipsisMenuMixin from "../../../components/shared/ellipsisMenuActions";
+import screenNavigationMixin from "../../../components/shared/screenNavigation";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
+
 import { createUniqIdsMixin } from "vue-uniq-ids";
 import AddToProjectModal from "../../../components/shared/AddToProjectModal.vue";
 const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
   components: { EllipsisMenu, AddToProjectModal },
-  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin,],
+  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin, screenNavigationMixin],
   props: ["filter", "id", "permission"],
   data() {
     return {
       orderBy: "title",
       screenId: null,
       assetName: " ",
-      dupScreen: {
-        title: "",
-        type: "",
-        category: {},
-        screen_category_id: "",
-        description: ""
-      },
-      errors: [],
+      // dupScreen: {
+      //   title: "",
+      //   type: "",
+      //   category: {},
+      //   screen_category_id: "",
+      //   description: ""
+      // },
+      // errors: [],
       sortOrder: [
         {
           field: "title",
@@ -199,52 +201,52 @@ export default {
       this.assetName = title;
       this.$refs["add-to-project-modal"].show();
     },
-    onAction(actionType, data, index) {
-      if (actionType.value) {
-        switch (actionType.value) {
-        case "duplicate-item":
-          this.dupScreen.title = data.title + ' ' + this.$t('Copy');
-          this.dupScreen.type = data.type;
-          this.dupScreen.category = data.category;
-          this.dupScreen.screen_category_id = data.screen_category_id;
-          this.dupScreen.description = data.description;
-          this.dupScreen.id = data.id;
-          this.showModal();
-          break;
-        case "remove-item":
-          let that = this;
-          ProcessMaker.confirmModal(
-            this.$t("Caution!"),
-             this.$t("Are you sure you want to delete the screen {{item}}? Deleting this asset will break any active tasks that are assigned.", {
-                item: data.title,
-              }),
-              "",
-            function() {
-              ProcessMaker.apiClient
-                .delete("screens/" + data.id)
-                .then(response => {
-                  ProcessMaker.alert(
-                    this.$t("The screen was deleted."),
-                    "success"
-                  );
-                  that.fetch();
-                });
-            }
-          );
-            break;
-            case 'add-to-project':
-              this.showAddToProjectModal(data.title, data.id);
-            break;
-        }
-    } else {
-        switch (actionType) {
-        case "edit-screen":
-          let link = "/designer/screen-builder/" + data.id + "/edit";
-          return link;
-          break;
-        }
-    }
-  },
+  //   onAction(actionType, data, index) {
+  //     if (actionType.value) {
+  //       switch (actionType.value) {
+  //       case "duplicate-item":
+  //         this.dupScreen.title = data.title + ' ' + this.$t('Copy');
+  //         this.dupScreen.type = data.type;
+  //         this.dupScreen.category = data.category;
+  //         this.dupScreen.screen_category_id = data.screen_category_id;
+  //         this.dupScreen.description = data.description;
+  //         this.dupScreen.id = data.id;
+  //         this.showModal();
+  //         break;
+  //       case "remove-item":
+  //         let that = this;
+  //         ProcessMaker.confirmModal(
+  //           this.$t("Caution!"),
+  //            this.$t("Are you sure you want to delete the screen {{item}}? Deleting this asset will break any active tasks that are assigned.", {
+  //               item: data.title,
+  //             }),
+  //             "",
+  //           function() {
+  //             ProcessMaker.apiClient
+  //               .delete("screens/" + data.id)
+  //               .then(response => {
+  //                 ProcessMaker.alert(
+  //                   this.$t("The screen was deleted."),
+  //                   "success"
+  //                 );
+  //                 that.fetch();
+  //               });
+  //           }
+  //         );
+  //           break;
+  //           case 'add-to-project':
+  //             this.showAddToProjectModal(data.title, data.id);
+  //           break;
+  //       }
+  //   } else {
+  //       switch (actionType) {
+  //       case "edit-screen":
+  //         let link = "/designer/screen-builder/" + data.id + "/edit";
+  //         return link;
+  //         break;
+  //       }
+  //   }
+  // },
     fetch() {
       this.loading = true;
       //change method sort by slot name

--- a/resources/js/processes/scripts/components/ScriptListing.vue
+++ b/resources/js/processes/scripts/components/ScriptListing.vue
@@ -35,7 +35,7 @@
             :permission="permission"
             :data="props.rowData"
             :divider="true"
-            @navigate="onAction"
+            @navigate="onNavigate"
           />
         </template>
       </vuetable>
@@ -90,13 +90,14 @@ import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
 import ellipsisMenuMixin from "../../../components/shared/ellipsisMenuActions";
+import scriptNavigationMixin from "../../../components/shared/scriptNavigation";
 import AddToProjectModal from "../../../components/shared/AddToProjectModal.vue";
 import { createUniqIdsMixin } from "vue-uniq-ids";
 const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
   components: { EllipsisMenu, AddToProjectModal },
-  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin],
+  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin, scriptNavigationMixin],
   props: ["filter", "id", "permission", "scriptExecutors"],
   data() {
     return {
@@ -187,36 +188,36 @@ export default {
           }
         });
     },
-    onAction(action, data) {
-      switch (action.value) {
-        case "duplicate-item":
-          this.dupScript.title = data.title + " Copy";
-          this.dupScript.language = data.language;
-          this.dupScript.code = data.code;
-          this.dupScript.description = data.description;
-          this.dupScript.category = data.category;
-          this.dupScript.script_category_id = data.script_category_id;
-          this.dupScript.id = data.id;
-          this.dupScript.run_as_user_id = data.run_as_user_id;
-          this.showModal();
-          break;
-        case "remove-item":
-          ProcessMaker.confirmModal(
-            this.$t("Caution!"),
-            this.$t("Are you sure you want to delete {{item}}? Deleting this asset will break any active tasks that are assigned.", {
-              item: data.title
-            }),
-            "",
-            () => {
-              this.$emit("delete", data);
-            }
-          );
-          break;
-        case 'add-to-project':
-          this.showAddToProjectModal(data.title, data.id);
-          break;
-      }
-    },
+    // onAction(action, data) {
+    //   switch (action.value) {
+    //     case "duplicate-item":
+    //       this.dupScript.title = data.title + " Copy";
+    //       this.dupScript.language = data.language;
+    //       this.dupScript.code = data.code;
+    //       this.dupScript.description = data.description;
+    //       this.dupScript.category = data.category;
+    //       this.dupScript.script_category_id = data.script_category_id;
+    //       this.dupScript.id = data.id;
+    //       this.dupScript.run_as_user_id = data.run_as_user_id;
+    //       this.showModal();
+    //       break;
+    //     case "remove-item":
+    //       ProcessMaker.confirmModal(
+    //         this.$t("Caution!"),
+    //         this.$t("Are you sure you want to delete {{item}}? Deleting this asset will break any active tasks that are assigned.", {
+    //           item: data.title
+    //         }),
+    //         "",
+    //         () => {
+    //           this.$emit("delete", data);
+    //         }
+    //       );
+    //       break;
+    //     case 'add-to-project':
+    //       this.showAddToProjectModal(data.title, data.id);
+    //       break;
+    //   }
+    // },
     formatLanguage(language) {
       return language;
     },

--- a/resources/js/processes/scripts/components/ScriptListing.vue
+++ b/resources/js/processes/scripts/components/ScriptListing.vue
@@ -31,7 +31,7 @@
 
         <template slot="actions" slot-scope="props">
           <ellipsis-menu
-            :actions="actions"
+            :actions="scriptActions"
             :permission="permission"
             :data="props.rowData"
             :divider="true"
@@ -89,53 +89,19 @@
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
+import ellipsisMenuMixin from "../../../components/shared/ellipsisMenuActions";
 import AddToProjectModal from "../../../components/shared/AddToProjectModal.vue";
 import { createUniqIdsMixin } from "vue-uniq-ids";
 const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
   components: { EllipsisMenu, AddToProjectModal },
-  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin],
+  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin],
   props: ["filter", "id", "permission", "scriptExecutors"],
   data() {
     return {
       assetId: null,
       assetName: "",
-      actions: [
-        {
-          value: "edit-script",
-          content: "Edit Script",
-          link: true,
-          href: "/designer/scripts/{{id}}/builder",
-          permission: "edit-scripts",
-          icon: "fas fa-pen-square",
-        },
-        {
-          value: "edit-item",
-          content: "Configure",
-          link: true,
-          href: "/designer/scripts/{{id}}/edit",
-          permission: "edit-scripts",
-          icon: "fas fa-cog",
-        },
-        { 
-          value: "add-to-project", 
-          content: "Add to Project",
-          icon: "fas fa-folder-plus" 
-        },
-        {
-          value: "duplicate-item",
-          content: "Copy",
-          permission: "create-scripts",
-          icon: "fas fa-copy",
-        },
-        {
-          value: "remove-item",
-          content: "Delete",
-          permission: "delete-scripts",
-          icon: "fas fa-trash-alt",
-        },
-      ],
       dupScript: {
         title: "",
         type: "",


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR introduces a central configuration area via the `ellipsisMenuActions.js` file, serving as a mixin to manage ellipsis menu actions for Processes, Scripts, and Screens within packages. This file provides a single point for adding, updating, or removing actions related to these assets.

Additionally, each asset type (Process, Script, Screen) now includes an associated mixin file (`processNavigation.js`, `screenNavigation.js`, `scriptNavigation.js`) to control methods that facilitate when specific actions are triggered. These mixin files can also be utilized within packages to extend ellipsis actions as needed.

All of these files have been implemented within the 'shared' components, making them accessible for use within packages by importing from SharedComponents.

## Key Changes:

- Refactoring of action button filtering based on conditionals and permissions.
- Restructuring of ellipsis action and event handling.

## How to Test

1. For each asset type (Processes, Screens, Scripts), test the ellipsis menu on the respective designer page.
2. Create a project and assign the above-mentioned assets.
3. Ensure that actions for these assets are enabled or disabled based on permissions and conditions, and that they are displayed alongside project-specific actions such as 'Copy to Project' and 'Assign to Project.'
4. Confirm that all actions function as expected.

## Related Tickets & Packages
- [FOUR-11019](https://processmaker.atlassian.net/browse/FOUR-11019)
- Projects PR

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
