### PR TITLE
Clear project filters when 'Reset Filter' button is used

### DIFF
--- a/resources/js/components/shared/PmqlInputFilters.vue
+++ b/resources/js/components/shared/PmqlInputFilters.vue
@@ -436,6 +436,9 @@ export default {
       this.participants = [];
       this.request = [];
       this.name = [];
+      this.projects = [];
+      this.members = [];
+      this.categories = [];
       this.pmql = "";
 
       if (this.type === "tasks") {


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses the issue where Project filters did not clear when selecting the 'Reset Filter' button.

## Solution
- Modified the `resetFilter` method to include project filter variables, ensuring they are cleared when the 'Reset Filter' button is triggered.

## How to Test
1. Ensure you have multiple projects configured.
2. On the Projects listing page, select 'Filter.'
3. Fill out the available filters.
4. Select 'Reset Filter.'
5. Select 'Filter' again.
6. Ensure the filter values are reset.

## Related Tickets & Packages
- Ticket [FOUR-11011](https://processmaker.atlassian.net/browse/FOUR-11011)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11011]: https://processmaker.atlassian.net/browse/FOUR-11011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ