### PR TITLE
Resolve 500 error when selecting multiple members and categories in Project filtering

### DIFF
--- a/resources/js/components/shared/PmqlInputFilters.vue
+++ b/resources/js/components/shared/PmqlInputFilters.vue
@@ -509,7 +509,7 @@ export default {
         let string = '';
         this.members.forEach((member, key) => {
           string += 'participant = "' + member.name + '"';
-          if (key < this.projects.length - 1) string += ' OR ';
+          if (key < this.members.length - 1) string += ' OR ';
         });
         clauses.push(string);
       }
@@ -518,7 +518,7 @@ export default {
         let string = '';
         this.categories.forEach((category, key) => {
           string += 'category = "' + category.name + '"';
-          if (key < this.projects.length - 1) string += ' OR ';
+          if (key < this.categories.length - 1) string += ' OR ';
         });
         clauses.push(string);
       }


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses a 500 error that occurs when selecting multiple members and categories in Project filtering.


## How to Test
1. Ensure you have multiple projects configured.
2. On the Project Listing page, click the 'Filter' button.
3. Add more than one selection for each of the available filters.
4. Verify that no errors occur during the selection process.
5. Confirm that the data returns correctly based on the applied filters.

## Related Tickets & Packages
- Ticket [FOUR-11013](https://processmaker.atlassian.net/browse/FOUR-11013)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11013]: https://processmaker.atlassian.net/browse/FOUR-11013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:next