### PR TITLE
FOUR-11057: Request filter options names should be updated

### DIFF
--- a/resources/js/Mobile/FilterMobile.vue
+++ b/resources/js/Mobile/FilterMobile.vue
@@ -67,7 +67,7 @@
               @click="selectOption(`requester`, 'filter', 'fas fa-user')"
             >
               <i class="fas fa-user" />
-              {{ $t('Requested by Me') }}
+              {{ $t('As Requester') }}
               <i
                 v-if="selectedIconFilter=== 'fas fa-user'"
                 class="fas fa-check ml-auto text-success"
@@ -78,7 +78,7 @@
               @click="selectOption(`participant`, 'filter', 'fas fa-users')"
             >
               <i class="fas fa-users" />
-              {{ $t('With me as Participant') }}
+              {{ $t('As Participant') }}
               <i
                 v-if="selectedIconFilter === 'fas fa-users'"
                 class="fas fa-check ml-auto text-success"

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -134,6 +134,8 @@
   "Aria Label": "Aria Label",
   "Array": "Array",
   "as": "as",
+  "As Participant": "As Participant",
+  "As Requester": "As Requester",
   "Assign all permissions to this group": "Assign all permissions to this group",
   "Assign all permissions to this user": "Assign all permissions to this user",
   "Assign by Expression Use a rule to assign this Task conditionally": "Assign by Expression: Use a rule to assign this Task conditionally",


### PR DESCRIPTION
## Issue & Reproduction Steps
Request Filter option names, should have this names:
As Requester insted of Requested by Me.
As Participant insted of With me as Participant

## Solution
- Update the labels related to the filters

## How to Test

- login from  mobile
- Review the filter related to the Request filter

## Related Tickets & Packages
- [FOUR](https://processmaker.atlassian.net/browse/FOUR-11057)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next