### PR TITLE
Implement PMQL Search Functionality for Scripts within Project Assets

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -17,6 +17,7 @@ use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\Script;
 use ProcessMaker\Models\ScriptCategory;
 use ProcessMaker\Models\User;
+use ProcessMaker\Query\SyntaxError;
 
 class ScriptController extends Controller
 {

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -117,6 +117,15 @@ class ScriptController extends Controller
             }
         }
 
+        $pmql = $request->input('pmql', '');
+        if (!empty($pmql)) {
+            try {
+                $query->pmql($pmql);
+            } catch (SyntaxError $e) {
+                return response(['message' => __('Your PMQL contains invalid syntax.')], 400);
+            }
+        }
+
         $response =
             $query->orderBy(
                 $request->input('order_by', 'title'),

--- a/ProcessMaker/Models/Script.php
+++ b/ProcessMaker/Models/Script.php
@@ -10,6 +10,7 @@ use ProcessMaker\Models\ScriptCategory;
 use ProcessMaker\Models\User;
 use ProcessMaker\ScriptRunners\ScriptRunner;
 use ProcessMaker\Traits\Exportable;
+use ProcessMaker\Traits\ExtendedPMQL;
 use ProcessMaker\Traits\HasCategories;
 use ProcessMaker\Traits\HasVersioning;
 use ProcessMaker\Traits\HideSystemResources;
@@ -66,6 +67,7 @@ class Script extends ProcessMakerModel implements ScriptInterface
     use HasVersioning;
     use Exportable;
     use ProjectAssetTrait;
+    use ExtendedPMQL;
 
     const categoryClass = ScriptCategory::class;
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses the need for enhanced search functionality within the Project Assets by implementing PMQL search for Scripts.

## Solution
- Integrate ExtendedPMQL Trait into the Script modal to enable advanced querying capabilities.
- Implement PMQL input filtering within the Script Controller index method for streamlined search operations.


## How to Test

1. Create a new Project.
2. Access the 'Script' section through the + Asset button and perform a search.
3. Verify that the search results are accurately displayed and aligned with the search parameters.

## Related Tickets & Packages
- [FOUR-11145](https://processmaker.atlassian.net/browse/FOUR-11145)
- [Data Sources PR](https://github.com/ProcessMaker/package-data-sources/pull/333)
- [Decision Engine PR](https://github.com/ProcessMaker/package-decision-engine/pull/74)

ci:next
ci:package-data-sources:task/FOUR-10237
ci:package-decision-engine:task/FOUR-10237
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

.


[FOUR-11145]: https://processmaker.atlassian.net/browse/FOUR-11145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ