### PR TITLE
Refactor 'remove-item' Screen Action to Ensure Method Uniqueness

### DIFF
--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -58,7 +58,7 @@ export default {
           icon: "fas fa-file-export",
         },
         {
-          value: "remove-item",
+          value: "remove-screen",
           content: "Delete",
           permission: ["delete-screens", "create-projects", "view-projects"],
           icon: "fas fa-trash-alt",

--- a/resources/js/components/shared/screenNavigation.js
+++ b/resources/js/components/shared/screenNavigation.js
@@ -30,7 +30,7 @@ export default {
                 this.dupScreen.id = data.id;
                 this.showModal();
                 break;
-              case "remove-item":
+              case "remove-screen":
                 let that = this;
                 ProcessMaker.confirmModal(
                   this.$t("Caution!"),


### PR DESCRIPTION
## Issue & Reproduction Steps
his PR addresses the issue by updating the screen action from 'remove-item' to 'remove-screen', ensuring method uniqueness and avoiding potential conflicts within the application.

## Solution
- Renamed the screen action from 'remove-item' to 'remove-screen' in the corresponding code files.

## How to Test

1. Create a screen within the application.
2. Navigate to the Designer and locate the created screen.
3. Attempt to delete the screen using the 'remove-screen' action.
4. Confirm that the screen is successfully deleted from the application.
5. Create a new screen and a project.
6. Add the newly created screen to the project.
7. Access the project via the Designer, then select the specific project.
8. Attempt to delete the screen from within the project using the 'remove-screen' action.
9. Verify that the screen is effectively removed from the project without any errors or inconsistencies.

## Related Tickets & Packages
- [FOUR-11133](https://processmaker.atlassian.net/browse/FOUR-11133)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11133]: https://processmaker.atlassian.net/browse/FOUR-11133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ