### PR TITLE
Fix Category Ellipsis Display Issue by Refactoring 'filterActionsByPermission' for 'Object' Type Permissions

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -165,25 +165,26 @@ export default {
     filterActionsByPermissions() {
       return this.actions.filter(action => {
         // Check if the action has a 'permission' property and it's a non-empty string
-        if (
-          !action.hasOwnProperty('permission') ||
-          (typeof action.permission !== 'string') ||
-          action.permission.trim() === ''
-        ) {
-          return true; // No specific permission required or invalid format, so allow the action.
+        if (!action.permission || typeof action.permission !== 'string' || action.permission.trim() === '') {
+            return true; // No specific permission required or invalid format, so allow the action.
         }
 
         const requiredPermissions = action.permission.split(',');
 
-        // Check if this.permission is an array
-        if (Array.isArray(this.permission)) {
-          return requiredPermissions.some(permission => this.permission.includes(permission));
-        } else if (typeof this.permission === 'string') {
-          return requiredPermissions.some(permission => this.permission.includes(permission));
-        } else {
-          // Invalid permission format, exclude the action
-          return false;
+        // Check if this.permission is of type object
+        if (typeof this.permission === 'object' && this.permission !== null) {
+            return requiredPermissions.some(permission => this.permission.hasOwnProperty(permission) && this.permission[permission]);
         }
+
+        // Check if this.permission is a string or an array
+        if (typeof this.permission === 'string') {
+            return requiredPermissions.some(permission => this.permission.split(',').includes(permission));
+        } else if (Array.isArray(this.permission)) {
+            return requiredPermissions.some(permission => this.permission.includes(permission));
+        }
+
+        // Invalid permission format, exclude the action
+        return false;
       });
     },
     filterActionsByConditionals(btns) {


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR resolves the issue by modifying the 'filterActionsByPermission' function to consider 'Object' type permissions, ensuring the proper display of category ellipsis menus.

## Solution
- Updated the 'filterActionsByPermission' function to incorporate 'Object' type permissions for accurate evaluation.

## How to Test

1. Confirm the visibility of all category ellipsis menu actions, including those for Screens, Scripts, Projects, and Processes.
2. Verify that all actions within the category ellipsis menus function correctly and perform the intended actions without any inconsistencies.

## Related Tickets & Packages
- [FOUR-11129](https://processmaker.atlassian.net/browse/FOUR-11129)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11129]: https://processmaker.atlassian.net/browse/FOUR-11129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ