### PR TITLE
FOUR-11071 License Artisan commands

### DIFF
--- a/ProcessMaker/Console/Commands/ProcessMakerLicenseRemove.php
+++ b/ProcessMaker/Console/Commands/ProcessMakerLicenseRemove.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class ProcessMakerLicenseRemove extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'processmaker:license-remove';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove the license.json file from the system';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if (Storage::disk('local')->exists('license.json')) {
+            if ($this->confirm('Are you sure you want to remove the license.json file?')) {
+                Storage::disk('local')->delete('license.json');
+                $this->info('license.json removed successfully!');
+            } else {
+                $this->info('Operation cancelled. license.json was not removed.');
+            }
+        } else {
+            $this->error('license.json does not exist on the local disk.');
+        }
+
+        return 0;
+    }
+}

--- a/ProcessMaker/Console/Commands/ProcessMakerLicenseUpdate.php
+++ b/ProcessMaker/Console/Commands/ProcessMakerLicenseUpdate.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+class ProcessMakerLicenseUpdate extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'processmaker:license-update {licenseFile}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update the license from a given URL or local path and store it in local disk';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $input = $this->argument('licenseFile');
+
+        try {
+            $content = file_get_contents($input);
+            if (!$this->isValidLicenseContent($content)) {
+                return 1;
+            }
+
+            Storage::disk('local')->put('license.json', $content);
+
+            Artisan::call('package:discover');
+            $this->info('License updated successfully');
+        } catch (Exception $e) {
+            $this->error('An error occurred: ' . $e->getMessage());
+        }
+
+        return 0;
+    }
+
+    /**
+     * Validates the license content.
+     *
+     * @param string $content
+     * @return bool
+     */
+    protected function isValidLicenseContent(string $content): bool
+    {
+        $data = json_decode($content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->error('The provided license does not have a valid format.');
+
+            return false;
+        }
+
+        if (!isset($data['expires_at']) || !is_string($data['expires_at'])) {
+            $this->error('The provided license does not have a valid "expires_at" property.');
+
+            return false;
+        }
+
+        try {
+            Carbon::parse($data['expires_at']);
+        } catch (Exception $e) {
+            $this->error('The "expires_at" property is not a valid date.');
+            return false;
+        }
+
+        if (!isset($data['packages']) || !is_array($data['packages'])) {
+            $this->error('The provided license does not have a valid "packages" property.');
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Feature/LicenseCommandsTest.php
+++ b/tests/Feature/LicenseCommandsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class LicenseCommandsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+    }
+
+    public function testLicenseUpdateFromLocalPath()
+    {
+        // Create a sample license file for testing.
+        $sampleLicense = '{"expires_at": "2023-12-31", "packages": ["package-translations", "package-projects"]}';
+        $licenseFilePath = tempnam(sys_get_temp_dir(), 'license_');
+        file_put_contents($licenseFilePath, $sampleLicense);
+
+        $this->artisan('processmaker:license-update', ['licenseFile' => $licenseFilePath])
+            ->assertExitCode(0);
+
+        $this->assertTrue(Storage::disk('local')->exists('license.json'));
+    }
+
+    public function testLicenseUpdateWithInvalidContent()
+    {
+        $invalidLicense = '"invalid": "data"';
+        $licenseFilePath = tempnam(sys_get_temp_dir(), 'license_');
+        file_put_contents($licenseFilePath, $invalidLicense);
+
+        $this->artisan('processmaker:license-update', ['licenseFile' => $licenseFilePath])
+            ->expectsOutput('The provided license does not have a valid format.')
+            ->assertExitCode(1);
+    }
+
+    public function testLicenseRemoveConfirmation()
+    {
+        Storage::disk('local')->put('license.json', 'sample content');
+
+        $this->artisan('processmaker:license-remove')
+            ->expectsQuestion('Are you sure you want to remove the license.json file?', false)
+            ->expectsOutput('Operation cancelled. license.json was not removed.')
+            ->assertExitCode(0);
+
+        $this->assertTrue(Storage::disk('local')->exists('license.json'));
+    }
+
+    public function testLicenseRemove()
+    {
+        Storage::disk('local')->put('license.json', '{"expires_at": "2023-12-31", "packages": []}');
+
+        $this->artisan('processmaker:license-remove')
+            ->expectsQuestion('Are you sure you want to remove the license.json file?', true)
+            ->expectsOutput('license.json removed successfully!')
+            ->assertExitCode(0);
+
+        $this->assertFalse(Storage::disk('local')->exists('license.json'));
+    }
+
+    public function testLicenseRemoveNonExistent()
+    {
+        $this->artisan('processmaker:license-remove')
+            ->expectsOutput('license.json does not exist on the local disk.')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
License Artisan commands

## Solution
- Implements license artisan commands:
  - processmaker:license-update 
  - processmaker:license-remove

## How to Test
To update a license:
```
php artisan processmaker:license-update /path/to/license.json
```
To remove the current license:
```
php artisan processmaker:license-remove
```

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
