### PR TITLE
Feature/four 11108: Modify the HOVER in Default Welcome Screen

### DIFF
--- a/resources/js/processes/designer/Assets.vue
+++ b/resources/js/processes/designer/Assets.vue
@@ -13,7 +13,8 @@
           :key="index"
           bg-variant="light"
           class="text-center"
-          @click="toggleButtons(index, 'core')"
+          @mouseover="toggleButtons(index, 'core', true)"
+          @mouseleave="toggleButtons(index, 'core', false)"
         >
           <template v-if="!showButtonsCore[index]">
             <asset
@@ -41,7 +42,8 @@
           :key="index"
           bg-variant="light"
           class="text-center"
-          @click="toggleButtons(index, 'package')"
+          @mouseover="toggleButtons(index, 'package', true)"
+          @mouseleave="toggleButtons(index, 'package', false)"
         >
           <template v-if="!showButtonsPackage[index]">
             <asset
@@ -139,12 +141,12 @@ export default {
     };
   },
   methods: {
-    toggleButtons(index, section) {
+    toggleButtons(index, section, status) {
       if (section === "core") {
-        this.$set(this.showButtonsCore, index, !this.showButtonsCore[index]);
+        this.$set(this.showButtonsCore, index, status);
       }
       if (section === "package") {
-        this.$set(this.showButtonsPackage, index, !this.showButtonsPackage[index]);
+        this.$set(this.showButtonsPackage, index, status);
       }
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
The text in each asset should be a Hover, because right now you have to click to open the options and click again to Close the option, and if you don’t close the Asset Options won’t look good:
![image-20231011-215115](https://github.com/ProcessMaker/processmaker/assets/123644082/c24daaeb-6762-41a7-af50-26fc9e32862e)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11108

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next