### PR TITLE
Fix Issue with Script Creation Without Project Selection

### DIFF
--- a/ProcessMaker/Traits/ProjectAssetTrait.php
+++ b/ProcessMaker/Traits/ProjectAssetTrait.php
@@ -17,17 +17,19 @@ trait ProjectAssetTrait
     {
         $projectIds = $request->input('projects', '');
 
-        // Check if the string is in the JSON array format,
-        // which happens during updates from the asset 'designer' (e.g., modeler, screen builder, etc.)
-        if (is_array($decodedProjects = json_decode($projectIds, true))) {
-            $ids = array_column($decodedProjects, 'id');
-            $projectIds = implode(',', $ids);
-        } else {
-            $projectIds = trim($projectIds, ',');
-        }
+        if (!empty($projectIds)) {
+            // Check if the string is in the JSON array format,
+            // which happens during updates from the asset 'designer' (e.g., modeler, screen builder, etc.)
+            if (is_array($decodedProjects = json_decode($projectIds, true))) {
+                $ids = array_column($decodedProjects, 'id');
+                $projectIds = implode(',', $ids);
+            } else {
+                $projectIds = trim($projectIds, ',');
+            }
 
-        // Explode the comma-separated string, filter, and convert to integers
-        $projectIds = array_filter(array_map('intval', explode(',', $projectIds)));
+            // Explode the comma-separated string, filter, and convert to integers
+            $projectIds = array_filter(array_map('intval', explode(',', $projectIds)));
+        }
 
         try {
             // Sync the project assets with the prepared project IDs

--- a/ProcessMaker/Traits/ProjectAssetTrait.php
+++ b/ProcessMaker/Traits/ProjectAssetTrait.php
@@ -15,39 +15,44 @@ trait ProjectAssetTrait
 
     public function syncProjectAsset($request, $assetModelClass)
     {
-        $projectIds = $request->input('projects', '');
+        if (class_exists(self::PROJECT_ASSET_MODEL_CLASS) && $request->has('projects')) {
+            $projectIds = $request->input('projects', '');
 
-        if (!empty($projectIds)) {
-            // Check if the string is in the JSON array format,
-            // which happens during updates from the asset 'designer' (e.g., modeler, screen builder, etc.)
-            if (is_array($decodedProjects = json_decode($projectIds, true))) {
-                $ids = array_column($decodedProjects, 'id');
-                $projectIds = implode(',', $ids);
-            } else {
-                $projectIds = trim($projectIds, ',');
+            if (!empty($projectIds)) {
+                // Check if the string is in the JSON array format
+                $decodedProjects = json_decode($projectIds, true);
+                if (is_array($decodedProjects)) {
+                    $projectIds = implode(',', array_column($decodedProjects, 'id'));
+                } else {
+                    $projectIds = trim($projectIds, ',');
+                }
+
+                // Explode the comma-separated string, filter, and convert to integers
+                $projectIds = array_map('intval', array_filter(explode(',', $projectIds)));
             }
 
-            // Explode the comma-separated string, filter, and convert to integers
-            $projectIds = array_filter(array_map('intval', explode(',', $projectIds)));
-        }
-
-        try {
-            // Sync the project assets with the prepared project IDs
-            $this->projectAssets()->syncWithPivotValues($projectIds, ['asset_type' => $assetModelClass]);
-            \Log::debug('Synced project assets', ['projectIds' => $projectIds]);
-        } catch (Exception $e) {
-            throw new ProjectAssetSyncException('Error syncing project assets: ' . $e->getMessage());
+            try {
+                // Sync the project assets with the prepared project IDs
+                $this->projectAssets()->syncWithPivotValues($projectIds, ['asset_type' => $assetModelClass]);
+                \Log::debug('Synced project assets', ['projectIds' => $projectIds]);
+            } catch (Exception $e) {
+                throw new ProjectAssetSyncException('Error syncing project assets: ' . $e->getMessage());
+            }
         }
     }
 
     public function getProjectsAttribute()
     {
-        $projectAssets = self::PROJECT_ASSET_MODEL_CLASS::where('asset_id', $this->id)
-            ->where('asset_type', get_class($this))
-            ->get();
+        if (class_exists(self::PROJECT_ASSET_MODEL_CLASS)) {
+            $projectAssets = self::PROJECT_ASSET_MODEL_CLASS::where('asset_id', $this->id)
+                ->where('asset_type', get_class($this))
+                ->get();
 
-        return json_encode($projectAssets->map(function ($projectAsset) {
-            return $projectAsset->project;
-        }));
+            return json_encode($projectAssets->map(function ($projectAsset) {
+                return $projectAsset->project;
+            }));
+        }
+
+        return json_encode([]);
     }
 }


### PR DESCRIPTION
This PR resolves an issue that occurs when creating a script without selecting a project. The problem was attributed to the ProjectAssetTrait running on an empty array value. The solution involves checking if the $projectId variable in the trait is empty before proceeding.

## Solution
- Implemented a check for the $projectId variable in the ProjectAssetTrait to prevent errors when the array value is empty.

## How to Test

1. Create a script within the Designer > Script page.
2. Do not select any project in the Create Modal.
3. Ensure that no errors occur during the script creation process.
4. Verify that if a project is selected, the script is successfully added to the chosen project.

## Related Tickets & Packages
-[ FOUR-11210](https://processmaker.atlassian.net/browse/FOUR-11210)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
