### PR TITLE
feature/FOUR-1200: Add a new Filter overdue in the API  "/tasks"

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -213,6 +213,9 @@ class TaskController extends Controller
             return $query->count();
         }
 
+        // Apply filter overdue
+        $query->overdue($request->input('overdue'));
+
         try {
             $response = $this->handleOrderByRequestName($request, $query->get());
         } catch (QueryException $e) {

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -102,9 +102,7 @@ class TaskController extends Controller
         }
 
         $query = ProcessRequestToken::with(['processRequest', 'user']);
-
         $query->select('process_request_tokens.*');
-
         $include = $request->input('include') ? explode(',', $request->input('include')) : [];
 
         if (in_array('data', $include)) {
@@ -118,7 +116,14 @@ class TaskController extends Controller
             $query->filter($filter);
         }
 
-        $filterByFields = ['process_id', 'process_request_tokens.user_id' => 'user_id', 'process_request_tokens.status' => 'status', 'element_id', 'element_name', 'process_request_id'];
+        $filterByFields = [
+            'process_id',
+            'process_request_tokens.user_id' => 'user_id',
+            'process_request_tokens.status' => 'status',
+            'element_id',
+            'element_name',
+            'process_request_id'
+        ];
         $parameters = $request->all();
         foreach ($parameters as $column => $fieldFilter) {
             if (in_array($column, $filterByFields)) {
@@ -133,10 +138,16 @@ class TaskController extends Controller
                             $user = User::find($fieldFilter);
                             $query->where(function ($query) use ($user) {
                                 foreach ($user->groups as $group) {
-                                    $query->orWhereJsonContains('process_request_tokens.self_service_groups', strval($group->getKey())); // backwards compatibility
-                                    $query->orWhereJsonContains('process_request_tokens.self_service_groups->groups', strval($group->getKey()));
+                                    $query->orWhereJsonContains(
+                                        'process_request_tokens.self_service_groups', strval($group->getKey())
+                                    ); // backwards compatibility
+                                    $query->orWhereJsonContains(
+                                        'process_request_tokens.self_service_groups->groups', strval($group->getKey())
+                                    );
                                 }
-                                $query->orWhereJsonContains('process_request_tokens.self_service_groups->users', strval($user->getKey()));
+                                $query->orWhereJsonContains(
+                                    'process_request_tokens.self_service_groups->users', strval($user->getKey())
+                                );
                             });
                         });
                     });
@@ -191,9 +202,9 @@ class TaskController extends Controller
             try {
                 $query->pmql($pmql, null, $user);
             } catch (QueryException $e) {
-                return response(['message' => __('Your PMQL search could not be completed.')], 400);
+                abort('Your PMQL search could not be completed.', 400);
             } catch (SyntaxError $e) {
-                return response(['message' => __('Your PMQL contains invalid syntax.')], 400);
+                abort('Your PMQL contains invalid syntax.', 400);
             }
         }
 
@@ -204,11 +215,13 @@ class TaskController extends Controller
 
         try {
             $response = $this->handleOrderByRequestName($request, $query->get());
-        } catch (\Illuminate\Database\QueryException $e) {
+        } catch (QueryException $e) {
             $regex = '~Column not found: 1054 Unknown column \'(.*?)\' in \'where clause\'~';
             preg_match($regex, $e->getMessage(), $m);
 
-            return response(['message' => __('PMQL Is Invalid.') . ' ' . __('Column not found: ') . '"' . $m[1] . '"'], 422);
+            return response([
+                'message' => __('PMQL Is Invalid.') . ' ' . __('Column not found: ') . '"' . $m[1] . '"'
+            ], 422);
         }
 
         // Only filter results if the user id was specified
@@ -217,12 +230,11 @@ class TaskController extends Controller
                 if ($request->input('status') === 'CLOSED') {
                     return $user->can('view', $processRequestToken->processRequest);
                 }
-
                 return $user->can('view', $processRequestToken);
             })->values();
         }
 
-        //Map each item through its resource
+        // Map each item through its resource
         $response = $response->map(function ($processRequestToken) use ($request) {
             return new Resource($processRequestToken);
         });

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -510,6 +510,18 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     }
 
     /**
+     * Scope overdue
+     *
+     * @var Builder
+     */
+    public function scopeOverdue($query, $overdue = '')
+    {
+        if (!empty($overdue)) {
+            return $query->where('due_at', '<', Carbon::now());
+        }
+    }
+
+    /**
      * Filter tokens with a string
      *
      * @param $query


### PR DESCRIPTION
## Issue & Reproduction Steps
Add a new Filter overdue in the API  "/tasks"

## Solution
- We need to implement a new filter over the API `/tasks` in order to filter the overdue
- 
![image](https://github.com/ProcessMaker/processmaker/assets/42388723/8330df3b-320d-4000-820c-dc399c590217)

## How to Test
a new parameter was added overdue=true in order to show only the overdue request
`api/1.0/tasks?page=1&include=process,processRequest,processRequest.user,user,data&pmql=(user_id = 1) AND (status = "In Progress")&per_page=10&order_by=ID&order_direction=DESC&overdue=true`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11200

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next