### PR TITLE
Bugfix/FOUR-11205: Overview is not working in requests

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -271,8 +271,8 @@ if (userID) {
     datetime_format: formatDate.content,
     calendar_format: formatDate.content,
     timezone: timezone.content,
-    fullName: userFullName.content,
-    avatar: userAvatar.content,
+    fullName: userFullName?.content,
+    avatar: userAvatar?.content,
   };
   datetime_format.forEach((value) => {
     if (formatDate.content === value.format) {


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a process with elements like:
- Start Event → Task Form → End Event
- Create a Requests
- Go to the Overview tab

Current Behavior 

The Overview tab does not show the status of the process (see the screenshot in the ticket)

Expected Behavior 

The Overview should show the status of the process like Version 4.8.0+next-20231016 (Build #6cc2498b)


## Solution
- In inflight modeler we don't have the user, so we can't access to userfullName.content userAvatar.content Added the ? operator to handle this behavior.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/8a12bb78-f86d-46a0-af7f-0c9011830ce0


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-11205](https://processmaker.atlassian.net/browse/FOUR-11205)
 
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-11205]: https://processmaker.atlassian.net/browse/FOUR-11205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ