### PR TITLE
FOUR-11039: Hide the text when is mobile

### DIFF
--- a/resources/views/auth/newLogin.blade.php
+++ b/resources/views/auth/newLogin.blade.php
@@ -17,9 +17,17 @@
       <div class="flex-fill">
         <div class="row" align-v="center">
           <div class="col-md-6 col-lg-8">
+          @php
+            $isMobile = (
+              isset($_SERVER['HTTP_USER_AGENT'])
+              && \ProcessMaker\Helpers\MobileHelper::isMobile($_SERVER['HTTP_USER_AGENT'])
+            ) ? true : false;
+          @endphp
+          @if (!$isMobile)
             <div class="slogan">
               <img src="/img/slogan.svg" alt="Slogan ProcessMaker" />
             </div>
+          @endif
           </div>
           <div class="col-md-6 col-lg-3">
             <div class="card card-body p-3">


### PR DESCRIPTION
## Issue & Reproduction Steps
As a PM user I would like to have the login page for mobile as the one we have in desktop, so we can relate

## Solution
- Hide the text when is mobile

## How to Test
Login using Desktop browser the text will showed
Login using Mobile browser the text will hide

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11039

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next