### PR TITLE
bugfix/FOUR-11191: View Project Permission

### DIFF
--- a/ProcessMaker/Http/Controllers/Designer/DesignerController.php
+++ b/ProcessMaker/Http/Controllers/Designer/DesignerController.php
@@ -19,36 +19,10 @@ class DesignerController extends Controller
      */
     public function index(Request $request)
     {
-        $redirect = $this->checkAuth();
-        if ($redirect) {
-            return redirect()->route($redirect);
-        }
-
         $listConfig = (object) [
             'status' => $request->input('status'),
         ];
 
         return view('designer.index', compact('listConfig'));
-    }
-
-    private function checkAuth()
-    {
-        $perm = 'view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables|view-projects';
-        switch (Auth::user()->canAnyFirst($perm)) {
-            case 'view-processes':
-                return false; // already on index, continue with it
-            case 'view-process-categories':
-                return 'process-categories.index';
-            case 'view-scripts':
-                return 'scripts.index';
-            case 'view-screens':
-                return 'screens.index';
-            case 'view-environment_variables':
-                return 'environment-variables.index';
-            case 'view-projects':
-                return 'projects.index';
-            default:
-                throw new AuthorizationException();
-        }
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

-  Create a user with one of the following permissions  `view-processes|view-process-categories|view-scripts|view-screens|view-environment_variables|view-projects`
- The user can to see the Welcome Designer

## Solution
- If the user can see the designer can see the Welcome Designer

## How to Test
Create a user with one permissions 
Review if can see the Welcome Designer

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11191

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next