### PR TITLE
bugfix/FOUR-11126: Switch to mobile view does not work when the Default Home is enable

### DIFF
--- a/ProcessMaker/Http/Controllers/HomeController.php
+++ b/ProcessMaker/Http/Controllers/HomeController.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Helpers\MobileHelper;
 use ProcessMaker\Http\Controllers\Controller;
 
 class HomeController extends Controller
@@ -11,7 +12,10 @@ class HomeController extends Controller
     public function index(Request $request)
     {
         if (Auth::check()) {
-            if (class_exists(\ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::class)) {
+            $isMobile = (
+                isset($_SERVER['HTTP_USER_AGENT']) && MobileHelper::isMobile($_SERVER['HTTP_USER_AGENT'])
+            ) ? true : false;
+            if (!$isMobile && class_exists(\ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::class)) {
                 $user = \Auth::user();
                 $homePage = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::getHomePage($user);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Switch to mobile view does not work when the Default Home is enable

- Configure a Home page for a user using dynamic-ui
- Loging using mobile browser the home page defined is showed
- Loging using desktop browser the home page defined is showed

## Solution
if the HomePage was defined this will show only if is not Mobile browser
- Loging using mobile browser the mobile view needs to show
- Loging using desktop browser the home page defined needs to show

## How to Test
- Configure a Home page for a user using dynamic-ui
- Loging using mobile browser the home page defined is showed
- Loging using desktop browser the home page defined is showed


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11126

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next