### PR TITLE
[FOUR-11225] Add CData executor to Script Executor Seeder

### DIFF
--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -36,6 +36,10 @@ env:
   GITHUB_COMMENT: ${{ secrets.GH_COMMENT }}
   pull_req_id: ${{github.event.pull_request.number}}
   BASE: ${{ contains(github.event.pull_request.body, 'ci:next') && 'ci-base-php82' || 'ci-base' }}
+  CDATA_LICENSE_DOCUSIGN: ${{ secrets.CDATA_LICENSE_DOCUSIGN }}
+  CDATA_LICENSE_EXCEL: ${{ secrets.CDATA_LICENSE_EXCEL }}
+  CDATA_LICENSE_GITHUB: ${{ secrets.CDATA_LICENSE_GITHUB }}
+  CDATA_LICENSE_SLACK: ${{ secrets.CDATA_LICENSE_SLACK }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -206,4 +210,3 @@ jobs:
           cd pm4-stm-docker/deploy-stm
           composer install --no-dev
           php run-delete-instance.php
-      

--- a/composer.json
+++ b/composer.json
@@ -107,6 +107,7 @@
                 "connector-pdf-print": "1.14.0",
                 "connector-send-email": "1.22.0",
                 "connector-slack": "1.6.0",
+                "docker-executor-cdata": "0.1.0",
                 "docker-executor-node-ssr": "1.5.0",
                 "package-actions-by-email": "1.14.0",
                 "package-advanced-user-manager": "1.7.1",

--- a/database/seeders/ScriptExecutorSeeder.php
+++ b/database/seeders/ScriptExecutorSeeder.php
@@ -17,6 +17,9 @@ class ScriptExecutorSeeder extends Seeder
             if ($key === 'javascript-ssr') {
                 $key = 'node-ssr';
             }
+            if ($key === 'sql') {
+                $key = 'cdata';
+            }
             try {
                 if (isset($this->command)) {
                     $this->command->line("Running docker-executor-{$key}:install");


### PR DESCRIPTION
## Issue & Reproduction Steps
The CData executor needs to be installed.

## Solution
Add a conditional to change the key from `sql` to `cdata` if it is being installed.

ci:next
ci:package-cdata:FOUR-11225
ci:deploy