### PR TITLE
Bugfix/FOUR-11248: About page can't load if micro service is down

### DIFF
--- a/ProcessMaker/Http/Controllers/AboutController.php
+++ b/ProcessMaker/Http/Controllers/AboutController.php
@@ -78,6 +78,7 @@ class AboutController extends Controller
         }
 
         $view = request()->get('partial') === 'ms' ? 'about.microservices' : 'about.index';
+
         return view($view,
             compact(
                 'packages',
@@ -94,7 +95,13 @@ class AboutController extends Controller
     {
         if (hasPackage('package-ai')) {
             $url = config('app.ai_microservice_host') . '/pm/getVersion';
-            $response = Http::post($url, []);
+            try {
+                $response = Http::post($url, []);
+            } catch (\Throwable $th) {
+                return [
+                    'name' => 'Pmai microservice (Offline)',
+                ];
+            }
 
             return $response->json();
         }
@@ -119,6 +126,7 @@ class AboutController extends Controller
                     'waiting' => true,
                 ];
             }
+
             return $about;
         }
 

--- a/ProcessMaker/Http/Controllers/AboutController.php
+++ b/ProcessMaker/Http/Controllers/AboutController.php
@@ -78,7 +78,6 @@ class AboutController extends Controller
         }
 
         $view = request()->get('partial') === 'ms' ? 'about.microservices' : 'about.index';
-
         return view($view,
             compact(
                 'packages',
@@ -99,10 +98,10 @@ class AboutController extends Controller
                 $response = Http::post($url, []);
             } catch (\Throwable $th) {
                 return [
-                    'name' => 'Pmai microservice (Offline)',
+                    'name' => 'Pmai microservice',
+                    'waiting' => true,
                 ];
             }
-
             return $response->json();
         }
 
@@ -126,7 +125,6 @@ class AboutController extends Controller
                     'waiting' => true,
                 ];
             }
-
             return $about;
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

- Have the micro service down
- Go to about page

**Current Behavior:**
If micro service is down, the request to get the version failed causing the entire about page can’t load


**Expected Behavior:**
if microservice is down the entire about screen should work normally


## Solution
- Catch the error and show an offline message.

https://github.com/ProcessMaker/processmaker/assets/90727999/dff0a79a-81fe-4853-a171-27d5287a1f22


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-11248](https://processmaker.atlassian.net/browse/FOUR-11248)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-11248]: https://processmaker.atlassian.net/browse/FOUR-11248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ