### PR TITLE
FOUR-111165 | When Creating a Process from a Template, the Project Assignment Does Not Work As Expected

### DIFF
--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -17,7 +17,6 @@ use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessTemplates;
 use ProcessMaker\Models\Template;
-use ProcessMaker\Package\Projects\Models\ProjectAsset;
 use ProcessMaker\Traits\HasControllerAddons;
 use SebastianBergmann\CodeUnit\Exception;
 
@@ -27,6 +26,8 @@ use SebastianBergmann\CodeUnit\Exception;
 class ProcessTemplate implements TemplateInterface
 {
     use HasControllerAddons;
+
+    const PROJECT_ASSET_MODEL_CLASS = 'ProcessMaker\Package\Projects\Models\ProjectAsset';
 
     /**
      * List process templates
@@ -263,13 +264,14 @@ class ProcessTemplate implements TemplateInterface
 
         $process = Process::findOrFail($processId);
 
-        if (!empty($requestData['projects'])) {
+        if (class_exists(self::PROJECT_ASSET_MODEL_CLASS) && !empty($requestData['projects'])) {
             $manifest = $this->getManifest('process', $processId);
 
             foreach (explode(',', $requestData['projects']) as $project) {
                 foreach ($manifest['export'] as $asset) {
                     $model = $asset['model']::find($asset['attributes']['id']);
-                    ProjectAsset::create([
+                    $projectAsset = new (self::PROJECT_ASSET_MODEL_CLASS);
+                    $projectAsset->create([
                         'project_id' => $project,
                         'asset_id' => $model->id,
                         'asset_type' => get_class($model),


### PR DESCRIPTION
# Issue
Ticket: [FOUR-11165](https://processmaker.atlassian.net/browse/FOUR-11165)

When creating a Process from a Template, if a Project is selected, the Process is not added to the selected Project.

# How to Test
1. Go to branch `observation/FOUR-11165` in `processmaker`.
2. Have a Project and Template created in your environment.
3. Go Designer → +PROCESS. Select a template to create your Process from.
4. In the Create Process Model, add your Process to a Project.
	- You can also test adding your Process to multiple Projects.
5. Create the Process.
6. Ensure that the Process was added to the correct Projects.

ci:next
ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-11165]: https://processmaker.atlassian.net/browse/FOUR-11165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ