### PR TITLE
QA Observation Bugfix/FOUR-11279: Re Link the Designer from breadcrumb to the designer Welcome Screen

### DIFF
--- a/resources/views/processes/index.blade.php
+++ b/resources/views/processes/index.blade.php
@@ -18,7 +18,7 @@
 
 @section('breadcrumbs')
     @include('shared.breadcrumbs', ['routes' => [
-        __('Designer') => route('processes.index'),
+        __('Designer') => route('designer.index'),
         __('Processes') => route('processes.index'),
         $title => null,
     ]])


### PR DESCRIPTION
## Solution
- List the changes you've introduced to solve the issue.The link of Breadcrumb "Designer" in Processes was modified to link Designer Wlecome Screen

## How to Test
Move to Processes, click on Designer link. Designer Welcome screen should be loaded.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11279

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next