### PR TITLE
FOUR-11230 - it is not possible to make the external connection with github

### DIFF
--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -1,252 +1,323 @@
 <template>
-    <div>
-        <div v-if="hasAuthorizedBadge">
-            <b-badge pill :variant="setting.ui.authorizedBadge ? 'success' : 'warning'">
-                <span v-if="setting.ui.authorizedBadge">{{ $t('Authorized') }}</span>
-                <span v-else>{{ $t('Not Authorized') }}</span>
-            </b-badge>
-        </div>
-        <div v-else>
-            Empty
-        </div>
-        <b-modal class="setting-object-modal" v-model="showModal" size="lg" @hidden="onModalHidden" centered>
-            <template v-slot:modal-header class="d-block">
-                <div>
-                <h5 class="mb-0" v-if="setting.name">{{ $t(setting.name) }}</h5>
-                <h5 class="mb-0" v-else>{{ setting.key }}</h5>
-                <small class="form-text text-muted">{{ $t('Configure the driver connection properties.') }}</small>
-                </div>
-                <button type="button" :aria-label="$t('Close')" class="close" @click="onCancel">×</button>
-            </template>
-            <div>
-                <b-form-group
-                    required
-                    :label="$t('Client ID')"
-                    :description="formDescription('The client ID assigned when you register your application.', 'client_id', errors)"
-                    :invalid-feedback="errorMessage('client_id', errors)"
-                    :state="errorState('client_id', errors)"
-                >
-                    <b-form-input
-                        required
-                        autofocus
-                        v-model="formData.client_id"
-                        autocomplete="off"
-                        :state="errorState('client_id', errors)"
-                        name="client_id"
-                    ></b-form-input>
-                </b-form-group>
-
-                <b-form-group
-                    required
-                    :label="$t('Client Secret')"
-                    :description="formDescription('The client secret assigned when you register your application.', 'client_secret', errors)"
-                    :invalid-feedback="errorMessage('client_secret', errors)"
-                    :state="errorState('client_secret', errors)"
-                >
-                    <b-input-group>
-                        <b-form-input
-                            required
-                            autofocus
-                            v-model="formData.client_secret"
-                            autocomplete="off"
-                            trim
-                            :type="type"
-                            :state="errorState('client_secret', errors)"
-                            name="client_secret"
-                        ></b-form-input>
-                        <b-input-group-append>
-                            <b-button :aria-label="$t('Toggle Show Password')" variant="secondary" @click="togglePassword">
-                                <i class="fas" :class="icon"></i>
-                            </b-button>
-                        </b-input-group-append>
-                    </b-input-group>
-                </b-form-group>
-
-                <b-form-group
-                    required
-                    :label="$t('Redirect URL')"
-                    :description="formDescription('This value must match the callback URL you specify in your app settings.', 'callback_url', errors)"
-                    :invalid-feedback="errorMessage('callback_url', errors)"
-                    :state="errorState('callback_url', errors)"
-                >
-                    <b-input-group>
-                        <b-form-input
-                            autofocus
-                            v-model="formData.callback_url"
-                            readonly
-                            autocomplete="off"
-                            :state="errorState('callback_url', errors)"
-                            name="callback_url"
-                        ></b-form-input>
-                        <b-input-group-append>
-                            <b-button :aria-label="$t('Copy')" variant="secondary" @click="onCopy">
-                                <i class="fas fa-copy"></i>
-                            </b-button>
-                        </b-input-group-append>
-                    </b-input-group>
-                </b-form-group>
-
-                <additional-driver-connection-properties :driverKey="setting?.key" :formData="formData" @updateFormData="updateFormData"></additional-driver-connection-properties>  
-            </div>
-            <div slot="modal-footer" class="w-100 m-0 d-flex">
-                <button type="button" class="btn btn-outline-secondary ml-auto" @click="onCancel">
-                    {{ $t('Cancel') }}
-                </button>
-                <button type="button" class="btn btn-secondary ml-3" @click="onSave" :disabled=" isInvalid || !changed ">
-                    {{ $t('Authorize')}}
-                </button>
-            </div>
-        </b-modal>
-
-        <b-modal class="setting-object-modal" v-model="showAuthorizingModal" size="md" hide-footer hide-header centered no-fade>
-            <div class="text-center">
-                <h3>{{ $t('Connecting Driver') }}</h3>
-                <i class="fas fa-circle-notch fa-spin fa-3x p-0 text-primary"></i>
-            </div>
-        </b-modal>
+  <div>
+    <div v-if="hasAuthorizedBadge">
+      <b-badge
+        pill
+        :variant="setting.ui.authorizedBadge ? 'success' : 'warning'"
+      >
+        <span v-if="setting.ui.authorizedBadge">{{ $t('Authorized') }}</span>
+        <span v-else>{{ $t('Not Authorized') }}</span>
+      </b-badge>
     </div>
+    <div v-else>
+      Empty
+    </div>
+    <b-modal
+      v-model="showModal"
+      class="setting-object-modal"
+      size="lg"
+      centered
+      @hidden="onModalHidden"
+    >
+      <template
+        #modal-header
+        class="d-block"
+      >
+        <div>
+          <h5
+            v-if="setting.name"
+            class="mb-0"
+          >
+            {{ $t(setting.name) }}
+          </h5>
+          <h5
+            v-else
+            class="mb-0"
+          >
+            {{ setting.key }}
+          </h5>
+          <small class="form-text text-muted">{{ $t('Configure the driver connection properties.') }}</small>
+        </div>
+        <button
+          type="button"
+          :aria-label="$t('Close')"
+          class="close"
+          @click="onCancel"
+        >
+          ×
+        </button>
+      </template>
+      <div>
+        <b-form-group
+          required
+          :label="$t('Client ID')"
+          :description="formDescription('The client ID assigned when you register your application.', 'client_id', errors)"
+          :invalid-feedback="errorMessage('client_id', errors)"
+          :state="errorState('client_id', errors)"
+        >
+          <b-form-input
+            v-model="formData.client_id"
+            required
+            autofocus
+            autocomplete="off"
+            :state="errorState('client_id', errors)"
+            name="client_id"
+          />
+        </b-form-group>
+
+        <b-form-group
+          required
+          :label="$t('Client Secret')"
+          :description="formDescription('The client secret assigned when you register your application.', 'client_secret', errors)"
+          :invalid-feedback="errorMessage('client_secret', errors)"
+          :state="errorState('client_secret', errors)"
+        >
+          <b-input-group>
+            <b-form-input
+              v-model="formData.client_secret"
+              required
+              autofocus
+              autocomplete="off"
+              trim
+              :type="type"
+              :state="errorState('client_secret', errors)"
+              name="client_secret"
+            />
+            <b-input-group-append>
+              <b-button
+                :aria-label="$t('Toggle Show Password')"
+                variant="secondary"
+                @click="togglePassword"
+              >
+                <i
+                  class="fas"
+                  :class="icon"
+                />
+              </b-button>
+            </b-input-group-append>
+          </b-input-group>
+        </b-form-group>
+
+        <b-form-group
+          required
+          :label="$t('Redirect URL')"
+          :description="formDescription('This value must match the callback URL you specify in your app settings.', 'callback_url', errors)"
+          :invalid-feedback="errorMessage('callback_url', errors)"
+          :state="errorState('callback_url', errors)"
+        >
+          <b-input-group>
+            <b-form-input
+              v-model="formData.callback_url"
+              autofocus
+              readonly
+              autocomplete="off"
+              :state="errorState('callback_url', errors)"
+              name="callback_url"
+            />
+            <b-input-group-append>
+              <b-button
+                :aria-label="$t('Copy')"
+                variant="secondary"
+                @click="onCopy"
+              >
+                <i class="fas fa-copy" />
+              </b-button>
+            </b-input-group-append>
+          </b-input-group>
+        </b-form-group>
+
+        <additional-driver-connection-properties
+          :driver-key="setting?.key"
+          :form-data="formData"
+          @updateFormData="updateFormData"
+        />
+      </div>
+      <div
+        slot="modal-footer"
+        class="w-100 m-0 d-flex"
+      >
+        <button
+          type="button"
+          class="btn btn-outline-secondary ml-auto"
+          @click="onCancel"
+        >
+          {{ $t('Cancel') }}
+        </button>
+        <button
+          type="button"
+          class="btn btn-secondary ml-3"
+          :disabled=" isInvalid || !changed "
+          @click="onSave"
+        >
+          {{ $t('Authorize') }}
+        </button>
+      </div>
+    </b-modal>
+
+    <b-modal
+      v-model="showAuthorizingModal"
+      class="setting-object-modal"
+      size="md"
+      hide-footer
+      hide-header
+      centered
+      no-fade
+    >
+      <div class="text-center">
+        <h3>{{ $t('Connecting Driver') }}</h3>
+        <i class="fas fa-circle-notch fa-spin fa-3x p-0 text-primary" />
+      </div>
+    </b-modal>
+  </div>
 </template>
 
 <script>
+import { FormErrorsMixin, Required } from "SharedComponents";
 import settingMixin from "../mixins/setting";
-import { FormErrorsMixin,Required } from "SharedComponents";
 import AdditionalDriverConnectionProperties from "./AdditionalDriverConnectionProperties.vue";
 
 export default {
-    mixins: [settingMixin, FormErrorsMixin, Required],
-    props: ['setting', 'value'],
-    components: {AdditionalDriverConnectionProperties},
-    data() {
-        return {
-            input: '',
-            formData: {
-                client_id: "",
-                client_secret: "",
-                callback_url: "",
-            },
-            selected: null,
-            showModal: false,
-            showAuthorizingModal: false,
-            transformed: null,
-            errors: {},
-            isInvalid: true,
-            type: 'password',
-            resetData: true,
-        }
+  components: { AdditionalDriverConnectionProperties },
+  mixins: [settingMixin, FormErrorsMixin, Required],
+  props: {
+    setting: {
+      type: Object,
+      required: true,
     },
-    computed: {
-        hasAuthorizedBadge() {
-            if (!this.setting) {
-                return false;
-            }
-            const hasAuthorizedBadge = _.has(this.setting, 'ui.authorizedBadge') ? true : false;
-            return hasAuthorizedBadge;
-        },
-        changed() {
-            return JSON.stringify(this.formData) !== JSON.stringify(this.transformed)
-        },
-        icon() {
-            if (this.type == 'password') {
-                return 'fa-eye';
-            } else {
-                return 'fa-eye-slash';
-            }
-        },
+    value: {
+      type: Object,
+      default: null,
     },
-    watch: {
-        formData: {
-            handler() {
-                this.isInvalid = this.validateData();
-            },
-            deep: true,
-        }
+  },
+  data() {
+    return {
+      input: "",
+      formData: {
+        client_id: "",
+        client_secret: "",
+        callback_url: "",
+      },
+      selected: null,
+      showModal: false,
+      showAuthorizingModal: false,
+      transformed: null,
+      errors: {},
+      isInvalid: true,
+      type: "password",
+      resetData: true,
+    };
+  },
+  computed: {
+    hasAuthorizedBadge() {
+      if (!this.setting) {
+        return false;
+      }
+      const hasAuthorizedBadge = !!_.has(this.setting, "ui.authorizedBadge");
+      return hasAuthorizedBadge;
     },
-    methods: {
-        onCopy() {
-            navigator.clipboard.writeText(this.formData.callback_url).then(() => {
-                ProcessMaker.alert(this.$t("The setting was copied to your clipboard."), "success");
-            }, () => {
-                ProcessMaker.alert(this.$t("The setting was not copied to your clipboard."), "danger");
-            });
-        },
-        togglePassword() {
-            if (this.type == 'text') {
-                this.type = 'password';
-            } else {
-                this.type = 'text';
-            }
-        },
-        validateData() {
-            // Check if client_id and client_secret are empty
-            const clientIdEmpty = _.isEmpty(this.formData.client_id);
-            const clientSecretEmpty = _.isEmpty(this.formData.client_secret);
-
-            return _.isEmpty(this.formData) || clientIdEmpty || clientSecretEmpty;
-        },
-        onCancel() {
-            this.showModal = false;
-        },
-        onEdit(row) {
-            if (this.value !== null) {
-                this.formData = this.value;
-            }
-            this.generateCallbackUrl(row.item);
-            this.$nextTick(() => {
-                this.showModal = true;
-                
-            });
-        },
-        onModalHidden() {
-            this.resetFormData();
-        },
-        authorizeConnection() {
-            this.showAuthorizingModal = true;
-            this.showModal = false;
-            this.resetData = false;
-            ProcessMaker.apiClient.post(`settings/${this.setting.id}/get-oauth-url`, this.formData)
-            .then(response => {
-                window.location = response.data?.url;
-            })
-            .catch(error => {
-                ProcessMaker.alert(error.message, 'danger');
-                this.showModal = true;
-                this.showAuthorizingModal = false;
-            });
-        },
-        onSave() {
-            const driver = this.setting.key.split('cdata.')[1];
-
-            this.formData.driver = driver;
-            this.transformed = { ...this.formData };
-            this.authorizeConnection();
-        },
-        generateCallbackUrl(data) {
-            const name = data.key.split('cdata.')[1];
-            const app_url = document.head.querySelector('meta[name="app-url"]').content;
-            
-            this.formData.callback_url = `${app_url}/external-integrations/${name}`;
-        },
-        resetFormData() {
-            if (this.resetData) {
-                this.formData = {
-                    client_id: "",
-                    client_secret: "",
-                    callback_url: "",
-                };
-            }
-        },
-        updateFormData(val) {
-            this.formData = {...this.formData, ...val};
-        }
+    changed() {
+      return JSON.stringify(this.formData) !== JSON.stringify(this.transformed);
     },
-    mounted() {
-        if (this.value === null) {
-            this.resetFormData();
-        } else {
-            this.formData = this.value;
-        }
+    icon() {
+      if (this.type === "password") {
+        return "fa-eye";
+      }
+      return "fa-eye-slash";
+    },
+  },
+  watch: {
+    formData: {
+      handler() {
         this.isInvalid = this.validateData();
-        this.transformed = this.copy(this.formData);
-    } 
-}
+      },
+      deep: true,
+    },
+  },
+  mounted() {
+    if (this.value === null) {
+      this.resetFormData();
+    } else {
+      this.formData = this.value;
+    }
+    this.isInvalid = this.validateData();
+    this.transformed = this.copy(this.formData);
+  },
+  methods: {
+    onCopy() {
+      navigator.clipboard.writeText(this.formData.callback_url).then(() => {
+        ProcessMaker.alert(this.$t("The setting was copied to your clipboard."), "success");
+      }, () => {
+        ProcessMaker.alert(this.$t("The setting was not copied to your clipboard."), "danger");
+      });
+    },
+    togglePassword() {
+      if (this.type === "text") {
+        this.type = "password";
+      } else {
+        this.type = "text";
+      }
+    },
+    validateData() {
+      // Check if client_id and client_secret are empty
+      const clientIdEmpty = _.isEmpty(this.formData.client_id);
+      const clientSecretEmpty = _.isEmpty(this.formData.client_secret);
+
+      return _.isEmpty(this.formData) || clientIdEmpty || clientSecretEmpty;
+    },
+    onCancel() {
+      this.showModal = false;
+    },
+    onEdit(row) {
+      if (this.value !== null) {
+        this.formData = this.value;
+      }
+      this.generateCallbackUrl(row.item);
+      this.$nextTick(() => {
+        this.showModal = true;
+      });
+    },
+    onModalHidden() {
+      this.resetFormData();
+    },
+    authorizeConnection() {
+      this.showAuthorizingModal = true;
+      this.showModal = false;
+      this.resetData = false;
+      ProcessMaker.apiClient.post(`settings/${this.setting.id}/get-oauth-url`, this.formData)
+        .then((response) => {
+          window.location = response.data?.url;
+        })
+        .catch((error) => {
+          ProcessMaker.alert(error.message, "danger");
+          this.showModal = true;
+          this.showAuthorizingModal = false;
+        });
+    },
+    onSave() {
+      const driver = this.setting.key.split("cdata.")[1];
+
+      this.formData.driver = driver;
+      this.transformed = { ...this.formData };
+      this.authorizeConnection();
+    },
+    generateCallbackUrl(data) {
+      const name = data.key.split("cdata.")[1];
+      const appUrl = document.head.querySelector("meta[name=\"app-url\"]").content;
+
+      this.formData.callback_url = `${appUrl}/external-integrations/${name}`;
+    },
+    resetFormData() {
+      if (this.resetData) {
+        this.formData = {
+          client_id: "",
+          client_secret: "",
+          callback_url: "",
+        };
+      }
+    },
+    updateFormData(val) {
+      this.formData = { ...this.formData, ...val };
+    },
+  },
+};
 </script>

--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -288,7 +288,8 @@ export default {
           window.location = response.data?.url;
         })
         .catch((error) => {
-          ProcessMaker.alert(error.message, "danger");
+          const errorMessage = error.response?.data?.message || error.message;
+          ProcessMaker.alert(errorMessage, "danger");
           this.showModal = true;
           this.showAuthorizingModal = false;
         });


### PR DESCRIPTION
## Issue & Reproduction Steps
When clicking on the "Authorize" button of a CData driver, a 500 error appears.

## Solution
- The error is related to the absence of RTK values in the .env file.
- Now a custom error is displayed correctly instead of the generic 500 error.

## How to Test
- Test authorizing a CData driver on the QA server.

## Related Tickets & Packages
- [FOUR-11230](https://processmaker.atlassian.net/browse/FOUR-11230)
- [Package CData PR](https://github.com/ProcessMaker/package-cdata/pull/16)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:package-cdata:observation/FOUR-11230
ci:deploy

[FOUR-11230]: https://processmaker.atlassian.net/browse/FOUR-11230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ