### PR TITLE
Bugfix/FOUR-10874: It is not possible to save a created script

### DIFF
--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -376,7 +376,7 @@ export default {
         icon: "fas fa-save",
         loaderAction: "",
         action: () => {
-          ProcessMaker.EventBus.$emit("save-script", this.processId);
+          ProcessMaker.EventBus.$emit("save-script", true);
         },
       },
     ];
@@ -504,10 +504,8 @@ export default {
     this.subscribeToProgress();
 
     ProcessMaker.EventBus.$emit("script-builder-init", this);
-    ProcessMaker.EventBus.$on("save-script", (processId, onSuccess, onError) => {
-      if (processId) {
-        this.save(onSuccess, onError, processId);
-      }
+    ProcessMaker.EventBus.$on("save-script", (shouldRedirect, onSuccess, onError) => {
+      this.save(onSuccess, onError, shouldRedirect);
     });
     ProcessMaker.EventBus.$on("script-close", () => {
       this.onClose();
@@ -750,7 +748,7 @@ export default {
         this.executionKey = response.data.key;
       });
     },
-    save(onSuccess, onError, processId) {
+    save(onSuccess, onError, shouldRedirect = false) {
       ProcessMaker.apiClient
         .put(`scripts/${this.script.id}`, {
           code: this.code,
@@ -769,7 +767,8 @@ export default {
           if (typeof onSuccess === "function") {
             onSuccess(response);
           }
-          if (processId !== 0 && processId !== undefined) {
+
+          if (this.processId !== 0 && this.processId !== undefined && shouldRedirect) {
             window.location = `/modeler/${this.processId}`;
           }
         }).catch((err) => {
@@ -811,7 +810,7 @@ export default {
         }
 
         // Save boilerplate template to avoid issues when script code is [].
-        ProcessMaker.EventBus.$emit("save-script");
+        ProcessMaker.EventBus.$emit("save-script", false);
       }
     },
     setVersionIndicator(isDraft = null) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

- Log in
- Click on Designer
- Click on Scripts 
- Create a new  script 
- Click on Publish


## Solution
- Add a flag to detect if redirect is needed or not. Removed the condition that checks if processId is present

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-10874](https://processmaker.atlassian.net/browse/FOUR-10874)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-10874]: https://processmaker.atlassian.net/browse/FOUR-10874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ