### PR TITLE
FOUR-11316 Catch kafka connection problem in about page

### DIFF
--- a/ProcessMaker/Http/Controllers/AboutController.php
+++ b/ProcessMaker/Http/Controllers/AboutController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use ProcessMaker\Facades\MessageBrokerService;
 use ProcessMaker\Models\Setting;
+use Throwable;
 
 class AboutController extends Controller
 {
@@ -97,7 +98,7 @@ class AboutController extends Controller
             $url = config('app.ai_microservice_host') . '/pm/getVersion';
             try {
                 $response = Http::post($url, []);
-            } catch (\Throwable $th) {
+            } catch (Throwable $th) {
                 return [
                     'name' => 'Pmai microservice',
                     'waiting' => true,
@@ -120,7 +121,15 @@ class AboutController extends Controller
             $about = Cache::get('nayra.about', null);
             if (!$about) {
                 // Send about message to receive about information from nayra service
-                MessageBrokerService::sendAboutMessage();
+                try {
+                    MessageBrokerService::sendAboutMessage();
+                } catch (Throwable $e) {
+                    return [
+                        'name' => 'processmaker/nayra-service',
+                        'description' => __('Nayra microservice is not available at this moment.'),
+                        'waiting' => true,
+                    ];
+                }
                 $about = [
                     'name' => 'processmaker/nayra-service',
                     'waiting' => true,

--- a/ProcessMaker/Nayra/Repositories/PersistenceTokenTrait.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceTokenTrait.php
@@ -272,6 +272,6 @@ trait PersistenceTokenTrait
         $name = $aboutInfo['name'];
         $version = $aboutInfo['version'];
         error_log("Microservice $name version $version is running.");
-        Cache::forever(self::$aboutCacheKey, $aboutInfo);
+        Cache::put(self::$aboutCacheKey, $aboutInfo, 60);
     }
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -909,6 +909,7 @@
   "Name": "Name",
   "Names must be unique.": "Names must be unique.",
   "Navigation": "Navigation",
+  "Nayra microservice is not available at this moment.": "Nayra microservice is not available at this moment.",
   "Nested Screen": "Nested Screen",
   "Never": "Never",
   "New Array of Objects": "New Array of Objects",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -493,6 +493,7 @@
   "name": "Nombre",
   "Name": "Nombre",
   "Navigation": "Navegación",
+  "Nayra microservice is not available at this moment.": "El microservicio Nayra no está disponible en este momento.",
   "Never": "Nunca",
   "New Boundary Timer Event": "Nuevo evento de temporizador de límite",
   "New Boundary Message Event": "Nuevo evento de mensaje de límite",

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -66,10 +66,14 @@
 <script>
 async function refreshMs() {
   const update = await (await fetch('?partial=ms')).text();
-  document.getElementById('ms-section').innerHTML = update;
+  const msSection = document.getElementById('ms-section');
+  if (!msSection) {
+    return;
+  }
+  msSection.innerHTML = update;
   const hasWaiting = update.indexOf('waiting') > -1;
   if (hasWaiting) {
-    setTimeout(refreshMs, 1000);
+    setTimeout(refreshMs, 3000);
   }
 }
 setTimeout(refreshMs, 1000);


### PR DESCRIPTION
## Issue & Reproduction Steps
When kafka connection fails, it throws an server error.

## Solution
- Catch the exception and show the Nayra microservice waiting for connection.

## How to Test
Go to the about page. When kafka connection fails it shows Nayra is trying to connect.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11316

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
