### PR TITLE
Fix 500 Error When Creating Process from Template

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -215,6 +215,13 @@ class TemplateController extends Controller
         $existingOptions = [];
 
         foreach ($payload['export'] as $key => $asset) {
+            // Exclude the import of comment configurations to account for the unavailability
+            // of the comment configuration table in the database.
+            if ($asset['model'] === 'ProcessMaker\Package\PackageComments\Models\CommentConfiguration') {
+                unset($payload['export'][$key]);
+                continue;
+            }
+
             $item = [
                 'type' => $asset['type'],
                 'uuid' => $key,

--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -220,6 +220,13 @@ class ProcessTemplate implements TemplateInterface
 
         $postOptions = [];
         foreach ($payload['export'] as $key => $asset) {
+            // Exclude the import of comment configurations to account for the unavailability
+            // of the comment configuration table in the database.
+            if ($asset['model'] === 'ProcessMaker\Package\PackageComments\Models\CommentConfiguration') {
+                unset($payload['export'][$key]);
+                continue;
+            }
+
             $postOptions[$key] = [
                 'mode' => 'copy',
                 'isTemplate' => false,


### PR DESCRIPTION
This PR resolves a 500 error encountered when attempting to create a process from a template. The issue was traced to the removal of the `comment_configurations` table from the database. As the template exports reference the `comment_configurations`, this caused the error. The solution involved unsetting the `comment_configuration` asset in the Template payload, enabling the template to be imported and saved as a process.

## Solution
- Implemented a check for the asset model type. If it is a CommentConfiguration instance, the asset is removed, allowing the importing process to continue seamlessly.

## How to Test

1. Ensure you have the latest comments package and run migrations. 
2. Attempt to create a process from a default template.
3. Confirm that the process creation no longer triggers a 500 error.
4. Verify that the template can be successfully imported and saved as a process without any issues.

## Related Tickets & Packages
- [FOUR-11323](https://processmaker.atlassian.net/browse/FOUR-11323)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11323]: https://processmaker.atlassian.net/browse/FOUR-11323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ