### PR TITLE
FOUR-11282: Add Home menu in platform

### DIFF
--- a/ProcessMaker/Http/Controllers/HomeController.php
+++ b/ProcessMaker/Http/Controllers/HomeController.php
@@ -22,7 +22,7 @@ class HomeController extends Controller
                 return redirect($homePage);
             }
 
-            return redirect('/requests');
+            return redirect('/home');
         }
     }
 }

--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -19,6 +19,12 @@ class GenerateMenus
     public function handle(Request $request, Closure $next)
     {
         Menu::make('topnav', function ($menu) {
+            $menu->group(['prefix' => 'home'], function ($request_items) {
+                $request_items->add(
+                    __('Home'),
+                    ['route' => 'home', 'id' => 'home']
+                )->active('home/*');
+            });
             $menu->group(['prefix' => 'requests'], function ($request_items) {
                 $request_items->add(
                     __('Requests'),


### PR DESCRIPTION
## Issue & Reproduction Steps
Add **Home** menu in platform

![image](https://github.com/ProcessMaker/processmaker/assets/42388723/319e0142-2ca5-446d-9127-51e8aea6d70a)


## Solution
- We need to add a new menu HOME
- This new menu needs to show the information related to the Dashboards

## How to Test
Login and review the Menu

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11282

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:package-dynamic-ui:feature/FOUR-11282