### PR TITLE
Error 500 import PmBlock with script task in diferent versions

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -500,7 +500,11 @@ abstract class ExporterBase implements ExporterInterface
         // If a template is being used and an associated category is present, add that category to the collection.
         // Otherwise, if the collection is empty and there's an uncategorized reference, add the uncategorized category.
         if ($isTemplate && isset($this->model->process_category_id)) {
-            $categories->push($categoryClass::findOrFail($this->model->process_category_id));
+            if ($this->getReference('uncategorized-category')) {
+                $categories->push($categoryClass::where('name', 'Uncategorized')->firstOrFail());
+            } else {
+                $categories->push($categoryClass::findOrFail($this->model->process_category_id));
+            }
         } elseif ($categories->empty() && $this->getReference('uncategorized-category')) {
             $categories->push($categoryClass::where('name', 'Uncategorized')->firstOrFail());
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
When a PMblock is exported, the process has assigned the category Uncategorized, and also the process is type template.

## Solution
- Verify when the process is template also has a category Uncategorized.

## How to Test

- Create a process containing a script ( the process should have a ProcessCategory of Uncategorized.)
- With the previous process create a PmBlock.
- Export the PmBlock
- Go to Designer--PmBlock
- Import the PmBlock

## Related Tickets & Packages
- [FOUR-11006](https://processmaker.atlassian.net/browse/FOUR-11006)

depends
https://github.com/ProcessMaker/package-pm-blocks/pull/93

ci:package-pm-blocks:bugfix/FOUR-11006
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11006]: https://processmaker.atlassian.net/browse/FOUR-11006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ