### PR TITLE
Bugfix/FOUR-11320: Server error when importing a process

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -66,7 +66,7 @@ abstract class ExporterBase implements ExporterInterface
         $baseQuery = $class::query();
 
         $model = new $class;
-        
+
         // If table does not exists for model, continue.
         if (!Schema::hasTable($model->getTable())) {
             return [null, null];

--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -65,10 +65,8 @@ abstract class ExporterBase implements ExporterInterface
         $matchedBy = null;
         $baseQuery = $class::query();
 
-        $model = new $class;
-
         // If table does not exists for model, continue.
-        if (!Schema::hasTable($model->getTable())) {
+        if (!Schema::hasTable($baseQuery->getModel()->getTable())) {
             return [null, null];
         }
 

--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -65,6 +65,13 @@ abstract class ExporterBase implements ExporterInterface
         $matchedBy = null;
         $baseQuery = $class::query();
 
+        $model = new $class;
+        
+        // If table does not exists for model, continue.
+        if (!Schema::hasTable($model->getTable())) {
+            return [null, null];
+        }
+
         // Check if the model has soft deletes
         if (in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($class))) {
             $baseQuery->withTrashed();


### PR DESCRIPTION
## Issue & Reproduction Steps
1.Login in the server https://next-qa.processmaker.net/
2.Go to process
3.Import to process
[tc-53931_verify_that_a_screen_containing_nested_screen_and_loop_is_imported (1).json](https://github.com/ProcessMaker/processmaker/files/13178342/tc-53931_verify_that_a_screen_containing_nested_screen_and_loop_is_imported.1.json)


## Solution
- The table comment_configurations was removed [in this PR](https://github.com/ProcessMaker/processmaker/pull/5237) because is no longer needed. Verify if table exists, if not return a null model.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/781a4af2-1a27-492a-b10a-2722f486f18f


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-11320](https://processmaker.atlassian.net/browse/FOUR-11320)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy

[FOUR-11320]: https://processmaker.atlassian.net/browse/FOUR-11320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ