### PR TITLE
FOUR-11337 - Console errors when deleting an external integration item

### DIFF
--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -172,6 +172,7 @@
 </template>
 
 <script>
+// eslint-disable-next-line import/no-unresolved
 import { FormErrorsMixin, Required } from "SharedComponents";
 import settingMixin from "../mixins/setting";
 import AdditionalDriverConnectionProperties from "./AdditionalDriverConnectionProperties.vue";
@@ -181,8 +182,8 @@ export default {
   mixins: [settingMixin, FormErrorsMixin, Required],
   props: {
     setting: {
-      type: Object,
-      required: true,
+      type: [Object, null],
+      default: null,
     },
     value: {
       type: Object,


### PR DESCRIPTION
## Issue & Reproduction Steps
We get errors in the console when deleting an external integration item.

## Solution
- Adjusted the 'setting' prop in the component to accept 'null' as a default value, ensuring compatibility with possible prop values.

https://github.com/ProcessMaker/processmaker/assets/90741874/f2fe54c4-3ba5-41e6-9752-435527b60867

## How to Test
1. Log in 
2. Go to Admin
3. Click on Settings
4. Click on External integration
5. Add a new item
6. Delete the item

## Related Tickets & Packages
- [FOUR-11337](https://processmaker.atlassian.net/browse/FOUR-11337)

ci:next
ci:deploy

[FOUR-11337]: https://processmaker.atlassian.net/browse/FOUR-11337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ