### PR TITLE
Enable Process Duplication Endpoint and Controller

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -134,7 +134,8 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::put('processes/{process}/draft', [ProcessController::class, 'updateDraft'])->name('processes.update_draft')->middleware('can:edit-screens,process');
     Route::post('processes/{process}/close', [ProcessController::class, 'close'])->name('processes.close')->middleware('can:edit-processes');
     Route::delete('processes/{process}', [ProcessController::class, 'destroy'])->name('processes.destroy')->middleware('can:archive-processes,process');
-    Route::put('processes/{processId}/restore', [ProcessController::class, 'restore'])->name('processes.restore')->middleware('can:archive-processes,process');
+    Route::put('processes/{process}/restore', [ProcessController::class, 'restore'])->name('processes.restore')->middleware('can:archive-processes,process');
+    Route::put('processes/{process}/duplicate', [ProcessController::class, 'duplicate'])->name('processes.duplicate')->middleware('can:create-processes,process');
 
     // Process Categories
     Route::get('process_categories', [ProcessCategoryController::class, 'index'])->name('process_categories.index')->middleware('can:view-process-categories');


### PR DESCRIPTION
This PR enables the process duplication endpoint and controller, allowing for the duplication of all data, including the bpmn, from one process to another.

## Solution
- Enabled the process duplication endpoint and controller to facilitate the copying of all data, including the bpmn, from a source process to a target process.

## How to Test

1. Ensure that a project is available with a process type asset.
2. Go to the project assets listing page.
3. From the ellipsis menu for the process, select 'Copy to Project'.
4. Fill out the form with and without selecting a process manager.
5. Submit the form.
6. Confirm that the process is created and navigate back to the project, ensuring that the process is correctly assigned to the project.

## Related Tickets & Packages
- FOUR-11128
- [Projects PR](https://github.com/ProcessMaker/package-projects/pull/60)

ci:next
ci:package-projects:observation/FOUR-11128

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
