### PR TITLE
FOUR-11182 Fix class declaration compatibility

### DIFF
--- a/ProcessMaker/Exception/HttpResponseException.php
+++ b/ProcessMaker/Exception/HttpResponseException.php
@@ -36,12 +36,12 @@ class HttpResponseException extends Exception implements HttpExceptionInterface
         ]), 0);
     }
 
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->status;
     }
 
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
Since php 8.2 functions declaration must include the exact return type of the interfaces.

## Solution
- Fix class declaration compatibility

## How to Test
- Create a data source and test it in the DS designer
- Then include it in a process

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11182

For testing requires: https://github.com/ProcessMaker/nayra-docker/pull/29

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
