### PR TITLE
FOUR-11302 | When Creating an Asset from a Project, the Project Must be Preselected When Saving the Asset

### DIFF
--- a/resources/js/components/shared/ProjectSelect.vue
+++ b/resources/js/components/shared/ProjectSelect.vue
@@ -23,7 +23,7 @@
   
 <script>
 export default {
-  props: ["value", "errors", "label", "helper", "params", "apiGet", "apiList"],
+  props: ["value", "errors", "label", "helper", "params", "apiGet", "apiList", "projectId"],
   data() {
     return {
       content: [],
@@ -31,6 +31,8 @@ export default {
       options: [],
       error: '',
       lastSelectedId: null,
+      currentProject: null,
+      initialLoadExecuted: false,
     };
   },
   watch: {
@@ -68,6 +70,17 @@ export default {
         this.content.splice(0);
       }
     },
+    setCurrentProject() {
+      if (!this.projectId) {
+        return;
+      }
+
+      this.currentProject = this.options.find(project => project.id == this.projectId);
+
+      if (this.currentProject) {
+        this.content = [this.currentProject];
+      }
+    },
     completeSelectedLoading(content) {
       this.loading = false;
       this.content.splice(0);
@@ -102,6 +115,11 @@ export default {
         .then(response => {
           this.loading = false;
           this.options = response.data.data;
+
+          if (!this.initialLoadExecuted) {
+            this.setCurrentProject(this.options);
+            this.initialLoadExecuted = true;
+          }
         })
         .catch(err => {
           this.loading = false;

--- a/resources/js/components/templates/SelectTemplateModal.vue
+++ b/resources/js/components/templates/SelectTemplateModal.vue
@@ -31,6 +31,7 @@
       :template-data="templateData" 
       :isProjectsInstalled="isProjectsInstalled"
       @resetModal="resetModal()"
+      :projectId="projectId"
       />
   </div>
 </template>
@@ -42,7 +43,7 @@
 
   export default {
     components: { Modal, TemplateSearch, CreateProcessModal },
-    props: ['type', 'countCategories', 'packageAi', 'isProjectsInstalled', 'hideAddBtn'],
+    props: ['type', 'countCategories', 'packageAi', 'isProjectsInstalled', 'hideAddBtn', 'projectId'],
     data: function() {
       return {
         title: '',

--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -58,6 +58,7 @@
           v-model="projects"
           :errors="addError?.projects"
           name="project"
+          :projectId="projectId"
         ></project-select>
        <b-form-group
           :label="$t('Process Manager')"
@@ -113,7 +114,8 @@
       "isProjectsInstalled", 
       "categoryType", 
       "callFromAiModeler",
-      "isProjectSelectionRequired"
+      "isProjectSelectionRequired",
+      "projectId"
     ],
     data: function() {
       return {

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -81,6 +81,7 @@
           api-list="projects"
           v-model="formData.projects"
           :errors="errors.projects"
+          :projectId="projectId"
         ></project-select>
       </template>
       <template v-else>
@@ -120,7 +121,8 @@ export default {
     "projectAsset", 
     "assetName", 
     "callFromAiModeler",
-    'isProjectSelectionRequired'
+    'isProjectSelectionRequired',
+    "projectId"
   ],
   data() {
     return {

--- a/resources/js/processes/scripts/components/CreateScriptModal.vue
+++ b/resources/js/processes/scripts/components/CreateScriptModal.vue
@@ -73,6 +73,7 @@
           v-model="projects"
           :errors="addError.projects"
           name="project"
+          :projectId="projectId"
         ></project-select>
         <b-form-group
           :invalid-feedback="errorMessage('script_executor_id', addError)"
@@ -203,7 +204,8 @@
       'projectAsset', 
       'assetName', 
       'callFromAiModeler',
-      'isProjectSelectionRequired'
+      'isProjectSelectionRequired',
+      'projectId'
     ],
     data: function() {
       return {


### PR DESCRIPTION
# Issue
Ticket: [FOUR-11302](https://processmaker.atlassian.net/browse/FOUR-11302)

When creating an asset from within a Project, the Project is not preselected within the asset creation modals.

# Solution
1. Pass the ProjectId to the asset creation modals.
2. Add functionality to the ProjectSelect component to set the current Project if a ProjectId is provided.

# How to Test
1. Go to branch `observation/FOUR-11302` in `processmaker`.
2. Go to branch `observation/FOUR-11302` in `package-projects`.
3. Go to Designer → Projects. Open a Project.
4. Add different assets to the Project.
	- Within the asset modals, the current Project should be preselected.

ci:next
ci:package-projects:observation/FOUR-11302

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-11302]: https://processmaker.atlassian.net/browse/FOUR-11302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ