### PR TITLE
FOUR-11350: Validate if the const PM_LOGIN exist

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -121,10 +121,9 @@ class LoginController extends Controller
     protected function getLoginDefaultSSO()
     {
         $defaultSSO = '';
-        if (class_exists(AuthDefaultSeeder::class)) {
-            $defaultSSO = Setting::byKey(
-                AuthDefaultSeeder::SSO_DEFAULT_LOGIN
-            );
+        // Check if the package-auth is installed and has a const SSO_DEFAULT_LOGIN was defined
+        if (class_exists(AuthDefaultSeeder::class) && defined('AuthDefaultSeeder::SSO_DEFAULT_LOGIN')) {
+            $defaultSSO = Setting::byKey(AuthDefaultSeeder::SSO_DEFAULT_LOGIN);
         }
 
         return $defaultSSO;
@@ -133,7 +132,8 @@ class LoginController extends Controller
     protected function getPmLogin()
     {
         $pmLogin = 'ProcessMaker';
-        if (class_exists(AuthDefaultSeeder::class)) {
+        // Check if the package-auth is installed and has a const PM_LOGIN was defined
+        if (class_exists(AuthDefaultSeeder::class) && defined('AuthDefaultSeeder::PM_LOGIN')) {
             $pmLogin = AuthDefaultSeeder::PM_LOGIN;
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

- Have the last version of next processmaker:next-fall
- Have the last version of next package-auth:develop
- The package-auth from develop (This does not have the const PM_LOGIN SSO_DEFAULT_LOGIN defined)
- The following error is showing

## Solution
- Validate if the const ProcessMaker\Http\Controllers\Auth\AuthDefaultSeeder::PM_LOGIN  and ProcessMaker\Http\Controllers\Auth\AuthDefaultSeeder::SSO_DEFAULT_LOGIN exist 

## How to Test
- Have the last version of next processmaker:next-fall
- Have the last version of next package-auth:develop
- The package-auth from develop (This does not have the const PM_LOGIN SSO_DEFAULT_LOGIN defined)
- The following error is showing

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11350

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next