### PR TITLE
FOUR-11117 Add missing translation

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -20,6 +20,7 @@ return [
     'after_or_equal' => 'The :attribute field must be a date after or equal to :date.',
     'alpha' => 'The :attribute field must only contain letters.',
     'alpha_dash' => 'The :attribute field must only contain letters, numbers, dashes, and underscores.',
+    'alpha_spaces' => 'The :Attribute may only contain alphanumeric characters.',
     'alpha_num' => 'The :attribute field must only contain letters and numbers.',
     'array' => 'The :attribute field must be an array.',
     'ascii' => 'The :attribute field must only contain single-byte alphanumeric characters and symbols.',


### PR DESCRIPTION
## Issue & Reproduction Steps
`alpha_spaces` validation label was lost after laravel upgrade.

## Solution
- Check if there was additional labels removed in the file validations.php. There were multiple changes required by the next version of laravel, but only `alpha_spaces`.
- Restored label `alpha_spaces` in validations.php

## How to Test
- Go to decisions table.
- Create a new table
- Put `!` on name and description
- Submit
- Now will see the proper label

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11117

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
