### PR TITLE
bugfix/FOUR-11364: Login mobile is given an error with Home

### DIFF
--- a/ProcessMaker/Http/Controllers/HomeController.php
+++ b/ProcessMaker/Http/Controllers/HomeController.php
@@ -15,14 +15,19 @@ class HomeController extends Controller
             $isMobile = (
                 isset($_SERVER['HTTP_USER_AGENT']) && MobileHelper::isMobile($_SERVER['HTTP_USER_AGENT'])
             ) ? true : false;
+            // If is mobile redirect to view mobile request
+            if ($isMobile) {
+                return redirect('/requests');
+            }
+            // Redirect to home dynamic only if the package was enable
             if (!$isMobile && class_exists(\ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::class)) {
                 $user = \Auth::user();
                 $homePage = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::getHomePage($user);
 
                 return redirect($homePage);
             }
-
-            return redirect('/home');
+            // Redirect to the default view
+            return redirect('/requests');
         }
     }
 }

--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -19,6 +19,8 @@ class GenerateMenus
     public function handle(Request $request, Closure $next)
     {
         Menu::make('topnav', function ($menu) {
+            // The home will display the dynamic ui view
+            // @todo home will replace the request and task
             $menu->group(['prefix' => 'home'], function ($request_items) {
                 $request_items->add(
                     __('Home'),


### PR DESCRIPTION
## Issue & Reproduction Steps
Login mobile is given an error with Home

## Solution
- If is mobile redirect to **request**
- If is web and the package dynamic exist redirect to **home**
- If is web and the package dynamic does exist redirect to **request**

## How to Test

- Login usign mobile
- Login using desktop

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11364

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next