### PR TITLE
Observation/four 11328 - bring back missing timeline

### DIFF
--- a/resources/js/components/Timeline.vue
+++ b/resources/js/components/Timeline.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="px-4 mb-2 timeline">
-    <template v-for="(item,index) in comments">
-      <component 
+    <template v-if="timeline" v-for="(item,index) in comments">
+      <component
         v-bind:is="component(item)"
         v-bind:key="`timeline-item-${index}`"
         v-bind:value="item"
@@ -14,6 +14,21 @@
         @refresh="load"
       />
     </template>
+    <template v-if="!timeline" v-for="(item,index) in comments">
+      <component
+        v-if="item.type==='LOG'"
+        v-bind:is="component(item)"
+        v-bind:key="`timeline-item-${index}`"
+        v-bind:value="item"
+        v-bind:icon="icon(item)"
+        :allow-reactions="reactions"
+        :allow-edit="edit"
+        :allow-remove="remove"
+        :allow-voting="voting"
+        :read-only="readonly"
+        @refresh="load"
+      />
+    </template>    
     <template v-if="isDefined('comment-editor') && adding">
     <comment-editor
       v-model="newComment"
@@ -42,11 +57,12 @@ export default {
             "edit", 
             "remove",
             "adding",
-            "readonly"
+            "readonly",
+            "timeline",
         ],
   data() {
     return {
-      newComment: '',
+      newComment: "",
       form: {
         subject: "",
         body: "",
@@ -62,12 +78,12 @@ export default {
       }
     };
   },
-  watch: {},
   computed: {
     disabled() {
       return this.form.subject.trim() === "" || this.form.body.trim() === "";
-    }
+    },
   },
+  watch: {},
   methods: {
     isDefined(component) {
       return component in Vue.options.components;
@@ -84,6 +100,7 @@ export default {
       this.form.body = "";
     },
     load() {
+      console.log(this.timeline);
       this.comments = [];
       ProcessMaker.apiClient
         .get("comments", {

--- a/resources/js/components/Timeline.vue
+++ b/resources/js/components/Timeline.vue
@@ -100,7 +100,6 @@ export default {
       this.form.body = "";
     },
     load() {
-      console.log(this.timeline);
       this.comments = [];
       ProcessMaker.apiClient
         .get("comments", {

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -259,6 +259,9 @@
             @endisset
           </div>
         </div>
+          <timeline commentable_id="{{ $request->getKey() }}" commentable_type="{{ get_class($request) }}"
+            :adding="false" :readonly="request.status === 'COMPLETED'" 
+            :timeline="false" />
       </div>
       @if (shouldShow('requestStatusContainer'))
         <div class="ml-md-3 mt-md-0 mt-3">

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -66,6 +66,14 @@
                               @redirect="redirectToTask"
                           ></task>
                           @endcan
+                          <div v-if="taskHasComments">
+                                <timeline :commentable_id="task.id"
+                                          commentable_type="ProcessMaker\Models\ProcessRequestToken"
+                                          :adding="false"
+                                          :readonly="task.status === 'CLOSED'"
+                                          :timeline="false"
+                                          />
+                          </div>
                         </div>
                         @can('editData', $task->processRequest)
                             <div v-if="task.process_request.status === 'ACTIVE'" id="tab-data" role="tabpanel" aria-labelledby="tab-data" class="card card-body border-top-0 tab-pane p-3">


### PR DESCRIPTION
## Issue & Reproduction Steps
The time line of the requests is not shown

## Solution
We added the timeline with the request and task LOGS 

## How to Test
Create a request of a process an complete the tasks to see the LOGS on the timeline

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-11328

ci:next