### PR TITLE
FOUR-11398

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -122,8 +122,8 @@ class LoginController extends Controller
     {
         $defaultSSO = '';
         // Check if the package-auth is installed and has a const SSO_DEFAULT_LOGIN was defined
-        if (class_exists(AuthDefaultSeeder::class) && defined('AuthDefaultSeeder::SSO_DEFAULT_LOGIN')) {
-            $defaultSSO = Setting::byKey(AuthDefaultSeeder::SSO_DEFAULT_LOGIN);
+        if (class_exists(AuthDefaultSeeder::class)) {
+            $defaultSSO = Setting::byKey('sso.default.login');
         }
 
         return $defaultSSO;
@@ -131,13 +131,7 @@ class LoginController extends Controller
 
     protected function getPmLogin()
     {
-        $pmLogin = 'ProcessMaker';
-        // Check if the package-auth is installed and has a const PM_LOGIN was defined
-        if (class_exists(AuthDefaultSeeder::class) && defined('AuthDefaultSeeder::PM_LOGIN')) {
-            $pmLogin = AuthDefaultSeeder::PM_LOGIN;
-        }
-
-        return $pmLogin;
+        return 'ProcessMaker';
     }
 
     protected function getColumnAttribute(object $setting, string $attribute, string $key = '')


### PR DESCRIPTION
## Issue & Reproduction Steps
Login does not enable the redirect SSO login

## Solution
- We need to get the default SSO defined

## How to Test

- Login into plataform
- Enable the Default SSO = Processmaker
- Login using mobile using PM login
- Change other Default SSO = google
- Login using mobile using google service

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11398

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next