### PR TITLE
FOUR-10572: Crown options of controls overlap the asset preview (plus window pane visualizations fixes) 

### DIFF
--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -475,6 +475,11 @@ ProcessMaker.EventBus.$on(
       matcher: (nodeData) => nodeData?.$type === 'bpmn:Task',
     });
     event.registerPreview({
+      url:'/designer/screens/preview',
+      receivingParams: ['screenRef'],
+      matcher: (nodeData) => nodeData?.$type === 'bpmn:ManualTask',
+    });
+    event.registerPreview({
       url:'/designer/scripts/preview',
       receivingParams: ['scriptRef'],
       matcher: (nodeData) => nodeData?.$type === 'bpmn:ScriptTask',


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a process
- Add task form 
- Select the task form
- Press the “Preview“ button
- Drag the task form down the asset preview
- Change the  type the task form 

Expected behavior: 
The crown options of the control should not overlap the asset preview 
Actual behavior: 
The crown options of the control overlap the asset preview and appear an error if the type is changed 
## Solution
-

## How to Test
  - Create a process
- Add task form 
- Select the task form
- Press the “Preview“ button
- Drag the task form down the asset preview
- Change the  type the task form 

Verify that the crown is 'hidden' beneath the preview panel

## Related Tickets & Packages
This PR resolves:
https://processmaker.atlassian.net/browse/FOUR-10572
https://processmaker.atlassian.net/browse/FOUR-10573
https://processmaker.atlassian.net/browse/FOUR-10612
https://processmaker.atlassian.net/browse/FOUR-10613
https://processmaker.atlassian.net/browse/FOUR-11090
https://processmaker.atlassian.net/browse/FOUR-10839


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
