### PR TITLE
Server Error when importing a process that contains multiple connectors

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -397,8 +397,8 @@ abstract class ExporterBase implements ExporterInterface
             $value = $this->model->$attribute;
             $i = 0;
             while ($this->duplicateExists($attribute, $value)) {
-                if ($i > 100) {
-                    throw new \Exception('Can not fix duplicate attribute after 100 iterations');
+                if ($i > 1000) {
+                    throw new \Exception('Can not fix duplicate attribute after 1000 iterations');
                 }
                 $i++;
                 $value = $handler($value);


### PR DESCRIPTION
## Issue & Reproduction Steps
This happens when you have many identical names (Process 1, Process 2, ..., Process 100), then you have a maximum of 100.

## Solution
The maximum value has been increased.

## How to Test
test if any attribute is duplicated more than 100 times when importing/exporting

## Related Tickets & Packages
[FOUR-11314](https://processmaker.atlassian.net/browse/FOUR-11314)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11314]: https://processmaker.atlassian.net/browse/FOUR-11314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:next