### PR TITLE
FOUR-10935: Remove 'Categories' from the AssetTable in Templates V2

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -223,6 +223,19 @@ class TemplateController extends Controller
                 continue;
             }
 
+            if (!$asset['model']::where('uuid', $key)->exists() || $payload['root'] === $asset['attributes']['uuid']) {
+                continue;
+            }
+
+            if (Str::contains($asset['name'], 'Screen Interstitial')) {
+                unset($payload['export'][$key]);
+                continue;
+            }
+
+            if (Str::contains($asset['type'], 'Category')) {
+                continue;
+            }
+
             $item = [
                 'type' => $asset['type'],
                 'uuid' => $key,
@@ -230,14 +243,6 @@ class TemplateController extends Controller
                 'name' => $asset['name'],
                 'mode' => 'copy',
             ];
-
-            if (!$asset['model']::where('uuid', $key)->exists() || $payload['root'] === $asset['attributes']['uuid']) {
-                continue;
-            }
-
-            if (Str::contains($asset['type'], 'Category')) {
-                continue;
-            }
 
             $existingOptions[] = $item;
         }

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use ProcessMaker\Events\ProcessCreated;
 use ProcessMaker\Events\TemplateDeleted;
 use ProcessMaker\Events\TemplatePublished;
@@ -230,7 +231,11 @@ class TemplateController extends Controller
                 'mode' => 'copy',
             ];
 
-            if (!$asset['model']::where('uuid', $key)->exists() || $asset['type'] === 'Process') {
+            if (!$asset['model']::where('uuid', $key)->exists() || $payload['root'] === $asset['attributes']['uuid']) {
+                continue;
+            }
+
+            if (Str::contains($asset['name'], 'Screen Interstitial')) {
                 continue;
             }
 

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -235,7 +235,7 @@ class TemplateController extends Controller
                 continue;
             }
 
-            if (Str::contains($asset['name'], 'Screen Interstitial')) {
+            if (Str::contains($asset['type'], 'Category')) {
                 continue;
             }
 

--- a/resources/js/components/templates/TemplateAssetTable.vue
+++ b/resources/js/components/templates/TemplateAssetTable.vue
@@ -90,25 +90,23 @@ export default {
       const groupedItems = [];
 
       this.assets.forEach(asset => {
-        const { type } = asset;
-        const existingGroup = groupedItems.find(group => group.type === type);
+        const existingGroup = groupedItems.find(group => group.type === asset.type);
 
         if (existingGroup) {
           existingGroup.items.push(asset);
           existingGroup.mode = 'copy';
         } else {
-          groupedItems.push({ type, mode: 'copy', items: [asset] });
+          groupedItems.push({ type: asset.type, mode: 'copy', items: [asset] });
         }
       });
 
-      // Remove items with 'category' type from the list
-      const filteredData = groupedItems.filter(obj => !obj.type.toLowerCase().includes('category'));
-
       const icons = ImportExportIcons.ICONS;
-      const groupedItemsWithIcons = filteredData.map(item => ({
-        ...item,
-        icon: icons[item.type]
-      }));
+      const groupedItemsWithIcons = groupedItems.map((item) => {
+        const newItem = { ...item };
+        const iconKey = icons[item.type];
+        newItem.icon = iconKey;
+        return newItem;
+      });
 
       return groupedItemsWithIcons;
     },

--- a/resources/js/components/templates/TemplateAssetTable.vue
+++ b/resources/js/components/templates/TemplateAssetTable.vue
@@ -90,23 +90,25 @@ export default {
       const groupedItems = [];
 
       this.assets.forEach(asset => {
-        const existingGroup = groupedItems.find(group => group.type === asset.type);
+        const { type } = asset;
+        const existingGroup = groupedItems.find(group => group.type === type);
 
         if (existingGroup) {
           existingGroup.items.push(asset);
           existingGroup.mode = 'copy';
         } else {
-          groupedItems.push({ type: asset.type, mode: 'copy', items: [asset] });
+          groupedItems.push({ type, mode: 'copy', items: [asset] });
         }
       });
 
+      // Remove items with 'category' type from the list
+      const filteredData = groupedItems.filter(obj => !obj.type.toLowerCase().includes('category'));
+
       const icons = ImportExportIcons.ICONS;
-      const groupedItemsWithIcons = groupedItems.map((item) => {
-        const newItem = { ...item };
-        const iconKey = icons[item.type];
-        newItem.icon = iconKey;
-        return newItem;
-      });
+      const groupedItemsWithIcons = filteredData.map(item => ({
+        ...item,
+        icon: icons[item.type]
+      }));
 
       return groupedItemsWithIcons;
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
When creating a Process from a Template, if the assets within the template already exist in the system, users are redirected to an Assets page where they can choose actions for each asset (Update | Keep Previous | Duplicate). However, the displayed categories for each asset do not correspond to the user's input, as each Category is specific to each asset. This inconsistency can lead to confusion, especially considering that multiple categories can belong to any of the assets, and there is currently no visibility regarding the parent assets.

## Solution
- This PR addresses the issue by removing any displayed Categories within the TemplateAssetTable.
- Additionally, the Screen Interstitial has been removed from the import

## How to Test
- Navigate to Designer/Processes.
- Create a new Process using a template.
- Create another process with the same template.
- Verify that the Template Assets page does not display any categories.
- Verify that the Screen Interstitial is not been duplicated when creating a Process form a Template

Please ensure that the expected behavior is observed as mentioned above. Thank you.

## CI 
ci:next
ci:deploy


## Related Tickets & Packages
- Tickets [FOUR-10935](https://processmaker.atlassian.net/browse/FOUR-10935), [FOUR-10936](https://processmaker.atlassian.net/browse/FOUR-10936), [FOUR-10937](https://processmaker.atlassian.net/browse/FOUR-10937)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10935]: https://processmaker.atlassian.net/browse/FOUR-10935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ