### PR TITLE
"Select Not Found" error when we create a process from an imported template

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/TemplateExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/TemplateExporter.php
@@ -18,7 +18,14 @@ class TemplateExporter extends ExporterBase
         $this->associateCategories(ProcessCategory::class, 'process_category_id');
         if (!$this->model->process_category_id) {
             // set category by defatult
-            $this->model->process_category_id = ProcessCategory::where(['name' => 'Default Templates'])->first()->getKey();
+            $this->model->process_category_id = ProcessCategory::firstOrCreate(
+                ['name' => 'Default Templates'],
+                [
+                    'name' => 'Default Templates',
+                    'status' => 'ACTIVE',
+                    'is_system' => 0,
+                ]
+            )->getKey();
         }
         $this->model->setProcessCategoryIdAttribute($this->model->process_category_id);
         $this->model->save();

--- a/ProcessMaker/ImportExport/Exporters/TemplateExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/TemplateExporter.php
@@ -2,14 +2,7 @@
 
 namespace ProcessMaker\ImportExport\Exporters;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use ProcessMaker\Assets\ScreensInScreen;
-use ProcessMaker\ImportExport\DependentType;
-use ProcessMaker\Models\ProcessTemplates;
-use ProcessMaker\Models\Screen;
-use ProcessMaker\Models\ScreenCategory;
-use ProcessMaker\Models\Script;
+use ProcessMaker\Models\ProcessCategory;
 
 class TemplateExporter extends ExporterBase
 {
@@ -17,10 +10,18 @@ class TemplateExporter extends ExporterBase
 
     public function export() : void
     {
+        $this->exportCategories();
     }
 
     public function import() : bool
     {
+        $this->associateCategories(ProcessCategory::class, 'process_category_id');
+        if (!$this->model->process_category_id) {
+            // set category by defatult
+            $this->model->process_category_id = ProcessCategory::where(['name' => 'Default Templates'])->first()->getKey();
+        }
+        $this->model->setProcessCategoryIdAttribute($this->model->process_category_id);
+        $this->model->save();
         return true;
     }
 }

--- a/ProcessMaker/Jobs/SyncDefaultTemplates.php
+++ b/ProcessMaker/Jobs/SyncDefaultTemplates.php
@@ -87,15 +87,6 @@ class SyncDefaultTemplates implements ShouldQueue
                 ]);
                 $importer = new Importer($payload, $options);
                 $manifest = $importer->doImport();
-
-                $template = ProcessTemplates::where('uuid', $template['uuid'])->first();
-                $template->setRawAttributes([
-                    'key' => 'default_templates',
-                    'process_id' => null,
-                    'user_id' => null,
-                    'process_category_id' => $processCategoryId,
-                ]);
-                $template->save();
             }
         }
     }


### PR DESCRIPTION
## Issue & Reproduction Steps

Categories were not exported and imported in Template.

## Solution
- Add Export/Import categories for template.
-
## How to Test
In the template modify the category, then export template, and finally import it.

also test comanda `php artisan processmaker:sync-default-templates`

## Related Tickets & Packages
- [FOUR-11330](https://processmaker.atlassian.net/browse/FOUR-11330)

ci:next
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11330]: https://processmaker.atlassian.net/browse/FOUR-11330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ