### PR TITLE
FOUR-10931: Allow SubProcesses to be Imported and Exported

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -223,6 +223,19 @@ class TemplateController extends Controller
                 continue;
             }
 
+            if (!$asset['model']::where('uuid', $key)->exists() || $payload['root'] === $asset['attributes']['uuid']) {
+                continue;
+            }
+
+            if (Str::contains($asset['name'], 'Screen Interstitial')) {
+                unset($payload['export'][$key]);
+                continue;
+            }
+
+            if (Str::contains($asset['type'], 'Category')) {
+                continue;
+            }
+
             $item = [
                 'type' => $asset['type'],
                 'uuid' => $key,
@@ -230,14 +243,6 @@ class TemplateController extends Controller
                 'name' => $asset['name'],
                 'mode' => 'copy',
             ];
-
-            if (!$asset['model']::where('uuid', $key)->exists() || $payload['root'] === $asset['attributes']['uuid']) {
-                continue;
-            }
-
-            if (Str::contains($asset['type'], 'Category')) {
-                continue;
-            }
 
             $existingOptions[] = $item;
         }

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -230,7 +230,7 @@ class TemplateController extends Controller
             }
 
             $item = [
-                'type' => $asset['type'],
+                'type' => ($asset['type'] === 'Process') ? 'SubProcess' : $asset['type'],
                 'uuid' => $key,
                 'model' => $asset['model'],
                 'name' => $asset['name'],

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use ProcessMaker\Events\ProcessCreated;
 use ProcessMaker\Events\TemplateDeleted;
 use ProcessMaker\Events\TemplatePublished;
@@ -230,7 +231,11 @@ class TemplateController extends Controller
                 'mode' => 'copy',
             ];
 
-            if (!$asset['model']::where('uuid', $key)->exists() || $asset['type'] === 'Process') {
+            if (!$asset['model']::where('uuid', $key)->exists() || $payload['root'] === $asset['attributes']['uuid']) {
+                continue;
+            }
+
+            if (Str::contains($asset['name'], 'Screen Interstitial')) {
                 continue;
             }
 

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -235,7 +235,7 @@ class TemplateController extends Controller
                 continue;
             }
 
-            if (Str::contains($asset['name'], 'Screen Interstitial')) {
+            if (Str::contains($asset['type'], 'Category')) {
                 continue;
             }
 

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -27,7 +27,7 @@ class ProcessExporter extends ExporterBase
 
     public ExportManager $manager;
 
-    public $discard = true;
+    public $discard = false;
 
     public function export() : void
     {

--- a/resources/js/components/shared/ImportExportIcons.js
+++ b/resources/js/components/shared/ImportExportIcons.js
@@ -6,6 +6,7 @@ const ICONS = {
   Script: "fa-code",
   ScriptCategory: "fa-code",
   Process: "fa-play-circle",
+  SubProcess: "fa-play-circle",
   ProcessCategory: "fa-play-circle",
   Category: "",
   EnvironmentVariable: "fa-lock",

--- a/resources/js/components/templates/TemplateAssetTable.vue
+++ b/resources/js/components/templates/TemplateAssetTable.vue
@@ -90,25 +90,23 @@ export default {
       const groupedItems = [];
 
       this.assets.forEach(asset => {
-        const { type } = asset;
-        const existingGroup = groupedItems.find(group => group.type === type);
+        const existingGroup = groupedItems.find(group => group.type === asset.type);
 
         if (existingGroup) {
           existingGroup.items.push(asset);
           existingGroup.mode = 'copy';
         } else {
-          groupedItems.push({ type, mode: 'copy', items: [asset] });
+          groupedItems.push({ type: asset.type, mode: 'copy', items: [asset] });
         }
       });
 
-      // Remove items with 'category' type from the list
-      const filteredData = groupedItems.filter(obj => !obj.type.toLowerCase().includes('category'));
-
       const icons = ImportExportIcons.ICONS;
-      const groupedItemsWithIcons = filteredData.map(item => ({
-        ...item,
-        icon: icons[item.type]
-      }));
+      const groupedItemsWithIcons = groupedItems.map((item) => {
+        const newItem = { ...item };
+        const iconKey = icons[item.type];
+        newItem.icon = iconKey;
+        return newItem;
+      });
 
       return groupedItemsWithIcons;
     },

--- a/resources/js/components/templates/TemplateAssetTable.vue
+++ b/resources/js/components/templates/TemplateAssetTable.vue
@@ -90,23 +90,25 @@ export default {
       const groupedItems = [];
 
       this.assets.forEach(asset => {
-        const existingGroup = groupedItems.find(group => group.type === asset.type);
+        const { type } = asset;
+        const existingGroup = groupedItems.find(group => group.type === type);
 
         if (existingGroup) {
           existingGroup.items.push(asset);
           existingGroup.mode = 'copy';
         } else {
-          groupedItems.push({ type: asset.type, mode: 'copy', items: [asset] });
+          groupedItems.push({ type, mode: 'copy', items: [asset] });
         }
       });
 
+      // Remove items with 'category' type from the list
+      const filteredData = groupedItems.filter(obj => !obj.type.toLowerCase().includes('category'));
+
       const icons = ImportExportIcons.ICONS;
-      const groupedItemsWithIcons = groupedItems.map((item) => {
-        const newItem = { ...item };
-        const iconKey = icons[item.type];
-        newItem.icon = iconKey;
-        return newItem;
-      });
+      const groupedItemsWithIcons = filteredData.map(item => ({
+        ...item,
+        icon: icons[item.type]
+      }));
 
       return groupedItemsWithIcons;
     },

--- a/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
@@ -164,9 +164,8 @@ class ProcessExporterTest extends TestCase
         $this->assertEquals(0, Process::where('name', 'package')->count());
     }
 
-    public function testSubprocessNotOnTargetInstance()
+    public function testSubprocessInTargetInstance()
     {
-        $this->markTestSkipped('We now import subprocesses on the target instance. (FOUR-10931)');
         $this->addGlobalSignalProcess();
 
         \DB::beginTransaction();
@@ -183,10 +182,12 @@ class ProcessExporterTest extends TestCase
         \DB::rollBack(); // Delete all created items since DB::beginTransaction
 
         $this->import($payload);
-
         $process = Process::where('name', 'parent')->firstOrFail();
-        $this->assertEquals('', Utils::getAttributeAtXPath($process, $xpath, 'calledElement'));
-        $this->assertEquals('{}', Utils::getAttributeAtXPath($process, $xpath, 'pm:config'));
+        $newSubProcess = Process::where('name', 'sub')->firstOrFail();
+
+        $this->assertEquals(
+            'ProcessId-' . $newSubProcess->id, Utils::getAttributeAtXPath($process, $xpath, 'calledElement')
+        );
     }
 
     public function testProcessTaskScreen()

--- a/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
@@ -166,6 +166,7 @@ class ProcessExporterTest extends TestCase
 
     public function testSubprocessNotOnTargetInstance()
     {
+        $this->markTestSkipped('We now import subprocesses on the target instance. (FOUR-10931)');
         $this->addGlobalSignalProcess();
 
         \DB::beginTransaction();


### PR DESCRIPTION
## Issue & Reproduction Steps
Templates containing SubProcesses are not recognized by the TemplateAssetsTable, resulting in failed imports.

1. Create a Process that includes a SubProcess.
2. Generate a Template from the created Process.
3. Create a new Process using the generated Template.

### Current Behavior: 
The SubProcesses are not exported or imported, causing the TemplateAssetsTable to be unable to recognize them.

## Solution
- Enable the Import/Export functionality for SubProcesses.
- Incorporate an identifiable icon for the SubProcess table.

## How to Test
1. Create a Process that includes a SubProcess.
2. Generate a Template from the created Process.
3. Create a new Process using the generated Template.
4. Verify that the AssetsTable displays the SubProcesses correctly.
5. Confirm that the SubProcess is successfully included in the new Process.

Please review and let me know if have any questions or revisions.

![Screenshot 2023-11-01 at 3 45 20 PM](https://github.com/ProcessMaker/processmaker/assets/5769433/2dccef04-85fa-47ff-8d4d-4f1a4ed99496)

## Related Tickets & Packages
- Observation [FOUR-10931](https://processmaker.atlassian.net/browse/FOUR-10931)

## CI
ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10931]: https://processmaker.atlassian.net/browse/FOUR-10931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ