### PR TITLE
FOUR-11505 Fix error handler in run script

### DIFF
--- a/ProcessMaker/Jobs/RunNayraScriptTask.php
+++ b/ProcessMaker/Jobs/RunNayraScriptTask.php
@@ -66,11 +66,6 @@ class RunNayraScriptTask implements ShouldQueue
         }
         $scriptRef = $element->getProperty('scriptRef');
         $configuration = json_decode($element->getProperty('config'), true);
-        $errorHandling = json_decode($element->getProperty('errorHandling'), true);
-        if ($errorHandling === null) {
-            $errorHandling = [];
-        }
-
         // Check to see if we've failed parsing.  If so, let's convert to empty array.
         if ($configuration === null) {
             $configuration = [];
@@ -96,9 +91,13 @@ class RunNayraScriptTask implements ShouldQueue
                 $script = $script->versionFor($instance);
             }
 
+            $errorHandling = new ErrorHandling($element, $token);
+            $errorHandling->setDefaultsFromDataSourceConfig($configuration);
+
             $dataManager = new DataManager();
             $data = $dataManager->getData($token);
-            $response = $script->runScript($data, $configuration, $token->getId(), $errorHandling);
+
+            $response = $script->runScript($data, $configuration, $token->getId(), $errorHandling->timeout());
 
             // Dispatch complete task action
             WorkflowManager::completeTask($processModel, $instance, $token, $response['output']);


### PR DESCRIPTION
## Issue & Reproduction Steps
Wrong error handling in run script job cause to return a wrong error message

## Solution
- Fix error handler in run script.

## How to Test
- Create a process with an script with a syntax error.
- Run the process.
- When the script is executed it should show the script error

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11505

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
