### PR TITLE
FOUR-11529 Trigger Comments Subscriber

### DIFF
--- a/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
@@ -69,6 +69,9 @@ class PersistenceHandler
                 case 'activity_closed':
                     $this->persistActivityClosed($transaction);
                     break;
+                case 'activity_skipped':
+                    $this->persistActivitySkipped($transaction);
+                    break;
                 case 'throw_event_token_arrives':
                     $this->persistThrowEventTokenArrives($transaction);
                     break;


### PR DESCRIPTION
## Issue & Reproduction Steps
Comments subscriber is not being triggered.

## Solution
- Trigger the missing events in nayra-service
- Call to the comments subscriber

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11529

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
.