### PR TITLE
Bugfix/FOUR-11285: When a task has a screen assigned, the 'create new screen' option should not be displayed.

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -38,6 +38,7 @@
       class="form-text text-muted"
     >{{ $t(helper) }}</small>
     <modeler-asset-quick-create
+      v-if="!content.id"
       :screen-select-id="uniqId"
       :screen-type="params.type"
       label="screen"

--- a/resources/js/processes/modeler/components/inspector/ScriptSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScriptSelect.vue
@@ -37,6 +37,7 @@
       class="form-text text-muted"
     >{{ $t(helper) }}</small>
     <modeler-asset-quick-create
+      v-if="!content.id"
       label="script"
       @asset="processAssetCreation"
     />


### PR DESCRIPTION
## Issue & Reproduction Steps
- When a task has a screen assigned, the 'create new screen' option should not be displayed.
- Just display the Open Screen button

Please see https://processmaker.atlassian.net/browse/FOUR-11285

## Solution
- Show quick create asset only if not selected a script/screen using v-if.

**Working video**


https://github.com/ProcessMaker/processmaker/assets/90727999/1cf6dd40-b399-4e9b-af30-b5684d0f142c



## How to Test
- Add a task and a script task
- Verify in task/script task inspector you can see the Create new [asset] + link
- Select an asset for task/script task in the inspector.  You should not see the Create new [asset] + link. S=You should only see the Open [asset] if an asset is selected in the list

## Related Tickets & Packages
- [FOUR-11285](https://processmaker.atlassian.net/browse/FOUR-11285)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/5597) 
- [Connector PDF Print PR](https://github.com/ProcessMaker/connector-pdf-print/pull/72)
- [Decision engine PR](https://github.com/ProcessMaker/package-decision-engine/pull/83)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11285]: https://processmaker.atlassian.net/browse/FOUR-11285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:next