### PR TITLE
FOUR-11635: Remove redundant method

### DIFF
--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -194,14 +194,6 @@ export default {
       this.disabled = false;
       this.$emit('reload');
     },  
-    /**
-     * Check if the search params contains create=true which means is coming from the Modeler as a Quick Asset Creation
-     * @returns {boolean}
-     */
-    isQuickCreate() {
-      const searchParams = new URLSearchParams(window.location.search);
-      return searchParams?.get("create") === "true";
-    },
     onSubmit() {
       this.resetErrors();
       // single click


### PR DESCRIPTION
## Issue & Reproduction Steps
When navigating to the Projects page, an error is encountered in the console: 'Method "isQuickCreate" has already been defined as a data property.'

**Steps to reproduce**

1. Navigate to Designer
2. Navigate to the Projects page 
3. Click on a Project
4. Open the Console

You’ll notice an error within the Console 

<img width="1430" alt="Screenshot 2023-11-07 at 10 01 46 AM" src="https://github.com/ProcessMaker/processmaker/assets/5769433/b3fe6c5f-c16a-42f1-9cad-3166882a9a66">


## Solution
- Remove redundant method within the CreateScreenModal

## How to Test
1. Navigate to Designer
2. Navigate to the Projects page 
3. Click on a Project
4. Open the Console

Please ensure that no errors appear within the Console 

## CI 
ci:next

## Related Tickets & Packages
- Observation [FOUR-11635](https://processmaker.atlassian.net/browse/FOUR-11635)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11635]: https://processmaker.atlassian.net/browse/FOUR-11635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ