### PR TITLE
Set to readonly the ScriptPreview component.

### DIFF
--- a/resources/js/processes/scripts/components/ScriptPreview.vue
+++ b/resources/js/processes/scripts/components/ScriptPreview.vue
@@ -38,7 +38,8 @@ export default {
       executionKey: null,
       resizing: false,
       monacoOptions: {
-        automaticLayout: true
+        automaticLayout: true,
+        readOnly: true,
       },
       code: this.script.code,
       preview: {


### PR DESCRIPTION
## Issue & Reproduction Steps
The Scripts Preview component can be edited.

## Solution
- set component read-only

## How to Test
Review component in preview (Modeler)

## Related Tickets & Packages
- [FOUR-11558](https://processmaker.atlassian.net/browse/FOUR-11558)

ci:next
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11558]: https://processmaker.atlassian.net/browse/FOUR-11558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ