### PR TITLE
Bugfix/FOUR-11696: No option of type displayed on AI Modeler - Screen

### DIFF
--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -165,6 +165,9 @@ export default {
       // in any case the screenType if the only one, default to the first value
       if (Object.keys(this.screenTypes).length === 1) this.formData.type = Object.keys(this.screenTypes)[0];
     }
+    if (this.callFromAiModeler === true) {
+      this.screenTypes = this.types;
+    } 
   },
   methods: {
     show() {
@@ -194,14 +197,6 @@ export default {
       this.disabled = false;
       this.$emit('reload');
     },  
-    /**
-     * Check if the search params contains create=true which means is coming from the Modeler as a Quick Asset Creation
-     * @returns {boolean}
-     */
-    isQuickCreate() {
-      const searchParams = new URLSearchParams(window.location.search);
-      return searchParams?.get("create") === "true";
-    },
     onSubmit() {
       this.resetErrors();
       // single click


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to reproduce:
- Login as admin
- Go to Designer
- Click on +Process
- Click on Build Your Own
- Drag and Drop the AI Generated control
- On Configuration of the control click on Screen Form Text

Current behavior:
When try to select the type of form there is no options

Expected behavior:
The option Form should be displayed## Solution
- List the changes you've introduced to solve the issue.

## Related Tickets & Packages
- FOUR-11696
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/5603)
- [Package-ai PR
](https://github.com/ProcessMaker/package-ai/pull/39)
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next