### PR TITLE
FOUR-11296: CData Microsoft Excel Driver - Authorization issue

### DIFF
--- a/resources/js/admin/settings/components/cdata/ExcelConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/ExcelConnectionProperties.vue
@@ -39,27 +39,6 @@
         name="uri"
       />
     </b-form-group>
-
-    <b-form-group
-      v-if="config.connection_type === 'Dropbox'"
-      :label="$t('Access Token')"
-      :description="
-        formDescription(
-          'The access token can be used to access your account via the API.',
-          'o_auth_access_token',
-          errors
-        )
-      "
-      :invalid-feedback="errorMessage('o_auth_access_token', errors)"
-      :state="errorState('o_auth_access_token', errors)"
-    >
-      <b-form-input
-        v-model="config.o_auth_access_token"
-        autocomplete="off"
-        name="o_auth_access_token"
-        :state="errorState('o_auth_access_token', errors)"
-      />
-    </b-form-group>
   </div>
 </template>
 
@@ -80,7 +59,6 @@ export default {
       config: {
         connection_type: "",
         uri: "",
-        o_auth_access_token: "",
         AuthScheme: "OAuth",
       },
       connectionOptions: {
@@ -130,7 +108,6 @@ export default {
   mounted() {
     this.config.connection_type = this.formData?.connection_type ?? "";
     this.config.uri = this.formData?.uri ?? "";
-    this.config.o_auth_access_token = this.formData?.o_auth_access_token ?? "";
   },
 };
 </script>

--- a/resources/js/admin/settings/components/cdata/ExcelConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/ExcelConnectionProperties.vue
@@ -81,6 +81,7 @@ export default {
         connection_type: "",
         uri: "",
         o_auth_access_token: "",
+        AuthScheme: "OAuth",
       },
       connectionOptions: {
         oauth: [


### PR DESCRIPTION
## Issue & Reproduction Steps
The SettingsFile, which is used for storing and exchanging auth tokens, is not created during the OAuth authorization flow of the Microsoft Excel CData driver.

## Solution
As part of a long discussion with the CData team, it was ultimately identified that in this case, it is necessary to add a connection property: `AuthScheme=OAuth`.

- This solution adds the missing property, allowing the driver to authenticate and function as expected.
- Additionally, an unnecessary field has been removed since the driver now handles tokens automatically.

https://github.com/ProcessMaker/processmaker/assets/90741874/64cf83a9-c9e1-453e-9013-6e8e2d9b6efd

## How to Test
- You can manually test this by creating an OAuth app and authorizing it in the admin settings section.

## Related Tickets & Packages
- [FOUR-11296](https://processmaker.atlassian.net/browse/FOUR-11296)

ci:next


[FOUR-11296]: https://processmaker.atlassian.net/browse/FOUR-11296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ