### PR TITLE
FOUR-10746: Preview for screen is not working with page navigations 

### DIFF
--- a/resources/js/processes/screens/preview.js
+++ b/resources/js/processes/screens/preview.js
@@ -1,3 +1,3 @@
 import Vue from "vue";
-import ScreenDetail from '../../requests/components/screenDetail';
-Vue.component('screen-detail', ScreenDetail);
+import ScreenPreview from '../../requests/components/screenPreview.vue';
+Vue.component('screen-preview', ScreenPreview);

--- a/resources/js/requests/components/screenPreview.vue
+++ b/resources/js/requests/components/screenPreview.vue
@@ -5,9 +5,6 @@
       no-body
       class="h-100 bg-white border-top-0"
     >
-      <!-- Card Header -->
-
-      <!-- Card Body -->
       <b-card-body
         id="screen-builder-container"
         class="overflow-auto p-0 h-100"

--- a/resources/js/requests/components/screenPreview.vue
+++ b/resources/js/requests/components/screenPreview.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="h-100">
+    <b-card
+      id="app"
+      no-body
+      class="h-100 bg-white border-top-0"
+    >
+      <!-- Card Header -->
+
+      <!-- Card Body -->
+      <b-card-body
+        id="screen-builder-container"
+        class="overflow-auto p-0 h-100"
+      >
+        <vue-form-renderer
+          ref="renderer"
+          :key="rendererKey"
+          v-model="previewData"
+          class="p-3"
+          :mode="mode"
+          :config="preview.config"
+          :computed="preview.computed"
+          :custom-css="preview.custom_css"
+          :watchers="preview.watchers"
+          :show-errors="true"
+          :device-screen="deviceScreen"
+          @submit="previewSubmit"
+          @css-errors="cssErrors = $event"
+        />
+      </b-card-body>
+    </b-card>
+    <!-- Modals -->
+  </div>
+</template>
+
+<script>
+import { VueFormRenderer } from "@processmaker/screen-builder";
+import "@processmaker/vue-form-elements/dist/vue-form-elements.css";
+
+export default {
+  components: {
+    VueFormRenderer,
+  },
+  props: {
+    screen: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    const defaultConfig = [
+      {
+        name: "Default",
+        computed: [],
+        items: [],
+      },
+    ];
+
+
+    return {
+      preview: {
+        config: [
+          {
+            name: "Default",
+            computed: [],
+            items: [],
+          },
+        ],
+        computed: [],
+        custom_css: "",
+        watchers: [],
+      },
+      type: "form",
+      mode: "editor",
+      deviceScreen: "desktop",
+      previewData: {},
+      cssErrors: "",
+      rendererKey: 0,
+    };
+  },
+  mounted() {
+    this.preview = this.screen;
+  },
+  methods: {
+    previewSubmit() {
+      // eslint-disable-next-line no-alert
+      alert("Preview Form was Submitted");
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+$primary-white: #f7f7f7;
+
+html,
+body {
+  height: 100%;
+  min-height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+}
+</style>

--- a/resources/views/processes/screens/preview.blade.php
+++ b/resources/views/processes/screens/preview.blade.php
@@ -8,11 +8,8 @@
                 {{ $screen->title }}
             </div>
             <div class="col-12">
-                <screen-detail
-                    :can-print="false"
-                    :row-data="formData"
-                    :row-index="0"
-                    :timeout-on-load="false"
+                <screen-preview
+                    :screen="formData"
                 />
             </div>
         </div>


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce 
  - Create a screen with a page navigator 
  - Create a process
  - Add task form 
  - Assign the screen in the form task

    Click on the preview option 
## Solution
- Now is is allowed the interaction with buttons

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-10746

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next