### PR TITLE
FOUR-12193 Removed Broadcast channel to be closed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12733,7 +12733,7 @@
             "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
             "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
@@ -13860,7 +13860,7 @@
                 "node": ">=16"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
@@ -21658,7 +21658,7 @@
                 "lib0": "^0.2.31"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "peerDependencies": {
@@ -21677,7 +21677,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "peerDependencies": {
@@ -21698,7 +21698,7 @@
                 "y-websocket-server": "bin/server.js"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "optionalDependencies": {
@@ -21948,7 +21948,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -110,9 +110,6 @@ export default {
       },
     },
   },
-  beforeDestroy() {
-    channel.close();
-  },
   mounted() {
     this.validate();
     if (this.value) {

--- a/resources/js/processes/scripts/components/CreateScriptModal.vue
+++ b/resources/js/processes/scripts/components/CreateScriptModal.vue
@@ -257,51 +257,48 @@ export default {
       return this.$t("Create Script");
     },
   },
-  destroyed() {
-    channel.close();
-  },
   methods: {
-      show() {
-        this.$bvModal.show("createScript");
-      },
-      /**
+    show() {
+      this.$bvModal.show("createScript");
+    },
+    /**
        * Check if the search params contains create=true which means is coming from the Modeler as a Quick Asset Creation
        * @returns {boolean}
        */
-      isQuickCreate() {
-        const searchParams = new URLSearchParams(window.location.search);
-        return searchParams?.get("create") === "true";
-      },
-      onClose() {
-        this.title = '';
-        this.language = '';
-        this.script_executor_id = null;
-        this.description = '';
-        this.script_category_id = '';
-        this.category_type_id = "";
-        this.code = '';
-        this.timeout = 60;
-        this.retry_attempts = 0;
-        this.retry_wait_time = 5;
-        this.addError = {};
-      },
-      close() {
-        this.$bvModal.hide('createScript');
-        this.disabled = false;
-        this.$emit('reload');
-      }, 
-      onSubmit() {
-        this.errors = {
-          name: null,
-          description: null,
-          status: null,
-          script_category_id: null,
-        };
-        //single click
-        if (this.disabled) {
-          return
-        }
-        this.disabled = true;
+    isQuickCreate() {
+      const searchParams = new URLSearchParams(window.location.search);
+      return searchParams?.get("create") === "true";
+    },
+    onClose() {
+      this.title = "";
+      this.language = "";
+      this.script_executor_id = null;
+      this.description = "";
+      this.script_category_id = "";
+      this.category_type_id = "";
+      this.code = "";
+      this.timeout = 60;
+      this.retry_attempts = 0;
+      this.retry_wait_time = 5;
+      this.addError = {};
+    },
+    close() {
+      this.$bvModal.hide("createScript");
+      this.disabled = false;
+      this.$emit("reload");
+    },
+    onSubmit() {
+      this.errors = {
+        name: null,
+        description: null,
+        status: null,
+        script_category_id: null,
+      };
+      // single click
+      if (this.disabled) {
+        return;
+      }
+      this.disabled = true;
 
       ProcessMaker.apiClient
         .post("/scripts", {


### PR DESCRIPTION
* package-lock.json updates

## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).
The Asset Quick Create was working on the first try but subsequent tries wouldn't work since the channel may be closing before hand.

## Solution
- List the changes you've introduced to solve the issue.
Removal of the channel closure, in theory, the channel should close on window reload / navigation

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages
- https://processmaker.atlassian.net/browse/FOUR-12193
- https://github.com/ProcessMaker/package-decision-engine/pull/87

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:package-decision-engine:bugfix/FOUR-12193