### PR TITLE
[34709 - 34744] Unable to import processes FIdelity Bank Prod

### DIFF
--- a/ProcessMaker/ImportExport/Manifest.php
+++ b/ProcessMaker/ImportExport/Manifest.php
@@ -204,7 +204,11 @@ class Manifest
                     break;
                 case 'object':
                     if (!is_object($model->$field)) {
-                        $model->$field = json_decode($model->$field);
+                        if (gettype($model->$field) !== 'array') {
+                            $model->$field = json_decode($model->$field);
+                        } else {
+                            $model->$field = (object)$model->$field;
+                        }
                     }
                     break;
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
When you are importing a process, you have a problem with an array type field.
In this case, in the database, there is a value of "[]" in the Users table in the fileds field.

## Solution
- Add validation by type

## How to Test
Import a process and the user exists in the database and the meta field has the value [].

## Related Tickets & Packages
- [FOUR-12192](https://processmaker.atlassian.net/browse/FOUR-12192)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
