### PR TITLE
CICD: Change default base image to php82

### DIFF
--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -79,6 +79,7 @@ jobs:
           docker push ${REPOSITORY}:ci-cache
       - name: Build and Push the image to ECR
         run: |
+          echo "Base Image: ${BASE}"
           cd pm4-stm-docker
           docker-compose build processmaker
           docker push ${IMAGE}

--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -35,7 +35,7 @@ env:
   IMAGE_TAG1: $(echo "$CI_PROJECT-$CI_PACKAGE_BRANCH" | sed "s;/;-;g")
   GITHUB_COMMENT: ${{ secrets.GH_COMMENT }}
   pull_req_id: ${{github.event.pull_request.number}}
-  BASE: ${{ contains(github.event.pull_request.body, 'ci:next') && 'ci-base-php82' || 'ci-base' }}
+  BASE: ${{ contains(github.event.pull_request.body, 'ci:php81') && 'ci-base' || 'ci-base-php82' }}
   CDATA_LICENSE_DOCUSIGN: ${{ secrets.CDATA_LICENSE_DOCUSIGN }}
   CDATA_LICENSE_EXCEL: ${{ secrets.CDATA_LICENSE_EXCEL }}
   CDATA_LICENSE_GITHUB: ${{ secrets.CDATA_LICENSE_GITHUB }}

--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -51,7 +51,7 @@ jobs:
     steps:     
       - name: Export Params                
         run: |
-          echo "Env Check: CI_PROJECT: $CI_PROJECT CI_PACKAGE_BRANCH: $CI_PACKAGE_BRANCH CI_PR_BODY: $CI_PR_BODY"
+          echo "Env Check: CI_PROJECT: $CI_PROJECT CI_PACKAGE_BRANCH: $CI_PACKAGE_BRANCH CI_PR_BODY: $CI_PR_BODY BASE: $BASE"
           echo "REPOSITORY=${{env.aws-url}}/enterprise" >> $GITHUB_ENV
           echo "TAG=${{env.IMAGE_TAG1}}" >> $GITHUB_ENV
           echo "IMAGE=${{env.aws-url}}/enterprise:${{env.IMAGE_TAG1}}" >> $GITHUB_ENV

--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -79,7 +79,6 @@ jobs:
           docker push ${REPOSITORY}:ci-cache
       - name: Build and Push the image to ECR
         run: |
-          echo "Base Image: ${BASE}"
           cd pm4-stm-docker
           docker-compose build processmaker
           docker push ${IMAGE}


### PR DESCRIPTION
Change default base image to php82

Develop and Next branches will now use php82

To use the php81 base for older version of processmaker, use the ci tag: `ci`:`php81` the PR body

ci:deploy