### PR TITLE
FOUR-12338 - You need to disable and enable the Use Sandbox toggle in external integrations

### DIFF
--- a/resources/js/admin/settings/components/cdata/DocusignConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/DocusignConnectionProperties.vue
@@ -51,6 +51,9 @@ export default {
   },
   mounted() {
     this.config.use_sandbox = this.formData?.use_sandbox ?? true;
+
+    // Emit the updateFormData event after assigning values.
+    this.$emit("updateFormData", this.config);
   },
 };
 </script>


### PR DESCRIPTION
## Issue & Reproduction Steps

When I do not click the Use Sandbox switch the connection does not work.
When I disable it and then enable it again, it just works correctly.

1. Log in 
2. Click on Admin
3. Click on Settings 
4. create connection for docusign driver
5. configure 
6. click on AUTHORIZE

## Solution
- The 'updateFormData' event is now emitted after assigning the 'use_sandbox' value in the mounted block of the Vue component. This ensures that configuration changes are properly reflected in other components listening to this event.
  - Now, whenever a DocuSign CDATA driver is added, the 'UseSandbox' property will be correctly set to default.

## How to Test
Follow the reproduction steps of above.

## Related Tickets & Packages
- [FOUR-12338](https://processmaker.atlassian.net/browse/FOUR-12338)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12338]: https://processmaker.atlassian.net/browse/FOUR-12338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ