### PR TITLE
FOUR-12193 Added channel receipt of message to emit data to the parents

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ModelerAssetQuickCreate.vue
+++ b/resources/js/processes/modeler/components/inspector/ModelerAssetQuickCreate.vue
@@ -16,6 +16,8 @@ import { capitalize, kebabCase } from "lodash";
 import { AssetTypes } from "../../../../models/AssetTypes";
 import { ScreenTypes } from "../../../../models/screens";
 
+const channel = new BroadcastChannel("assetCreation");
+
 export default {
   name: "ModelerAssetQuickCreate",
   props: {
@@ -39,6 +41,11 @@ export default {
       type: String,
       required: false,
     },
+  },
+  mounted() {
+    channel.onmessage = ({ data }) => {
+      this.$emit("asset", data);
+    };
   },
   methods: {
     goToAsset() {

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -60,8 +60,6 @@ import { uniqueId } from "lodash";
 import ModelerAssetQuickCreate from "./ModelerAssetQuickCreate.vue";
 import "@processmaker/vue-multiselect/dist/vue-multiselect.min.css";
 
-const channel = new BroadcastChannel("assetCreation");
-
 export default {
   components: {
     ModelerAssetQuickCreate,
@@ -116,10 +114,6 @@ export default {
       this.loadScreen(this.value);
     }
     this.setDefault();
-    channel.onmessage = ({ data }) => {
-      console.log("channel message", data);
-      this.processAssetCreation(data);
-    };
   },
   methods: {
     type() {

--- a/resources/js/processes/scripts/components/CreateScriptModal.vue
+++ b/resources/js/processes/scripts/components/CreateScriptModal.vue
@@ -191,6 +191,7 @@ import Modal from "../../../components/shared/Modal.vue";
 import Required from "../../../components/shared/Required.vue";
 import ProjectSelect from "../../../components/shared/ProjectSelect.vue";
 import SliderWithInput from "../../../components/shared/SliderWithInput.vue";
+import { isQuickCreate as isQuickCreateFunc } from "../../../utils/isQuickCreate";
 
 const channel = new BroadcastChannel("assetCreation");
 
@@ -234,6 +235,7 @@ export default {
       createScriptHooks: [],
       script: null,
       projects: [],
+      isQuickCreate: isQuickCreateFunc(),
     };
   },
   computed: {
@@ -260,14 +262,6 @@ export default {
   methods: {
     show() {
       this.$bvModal.show("createScript");
-    },
-    /**
-       * Check if the search params contains create=true which means is coming from the Modeler as a Quick Asset Creation
-       * @returns {boolean}
-       */
-    isQuickCreate() {
-      const searchParams = new URLSearchParams(window.location.search);
-      return searchParams?.get("create") === "true";
     },
     onClose() {
       this.title = "";
@@ -326,7 +320,7 @@ export default {
           } else if (this.copyAssetMode) {
             this.close();
           } else {
-            if (this.isQuickCreate()) {
+            if (this.isQuickCreate === true) {
               channel.postMessage({
                 assetType: "script",
                 asset: data,


### PR DESCRIPTION
## Solution
- Moved the channel `onMessage` to the mounted call on `ModelerAssetQuickCreate` to be emitted to the parent

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12193
- https://github.com/ProcessMaker/connector-pdf-print/pull/73

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:connector-pdf-print:bugfix/FOUR-11731