### PR TITLE
FOUR-12334 - Enhancing UX in External Integrations Authorize Button

### DIFF
--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -3,9 +3,9 @@
     <div v-if="hasAuthorizedBadge">
       <b-badge
         pill
-        :variant="setting.ui.authorizedBadge ? 'success' : 'warning'"
+        :variant="isAuthorized ? 'success' : 'warning'"
       >
-        <span v-if="setting.ui.authorizedBadge">{{ $t('Authorized') }}</span>
+        <span v-if="isAuthorized">{{ $t('Authorized') }}</span>
         <span v-else>{{ $t('Not Authorized') }}</span>
       </b-badge>
     </div>
@@ -146,7 +146,7 @@
         <button
           type="button"
           class="btn btn-secondary ml-3"
-          :disabled=" isInvalid || !changed "
+          :disabled="isButtonDisabled"
           @click="onSave"
         >
           {{ $t('Authorize') }}
@@ -216,6 +216,12 @@ export default {
       const hasAuthorizedBadge = !!_.has(this.setting, "ui.authorizedBadge");
       return hasAuthorizedBadge;
     },
+    isAuthorized() {
+      if (this.hasAuthorizedBadge) {
+        return Boolean(this.setting.ui.authorizedBadge);
+      }
+      return false;
+    },
     changed() {
       return JSON.stringify(this.formData) !== JSON.stringify(this.transformed);
     },
@@ -224,6 +230,9 @@ export default {
         return "fa-eye";
       }
       return "fa-eye-slash";
+    },
+    isButtonDisabled() {
+      return this.isInvalid || (this.isAuthorized && !this.changed);
     },
   },
   watch: {


### PR DESCRIPTION
## Issue & Reproduction Steps

The AUTHORIZE button of external integration (CDATA) remains disabled after a connection, if I want to perform the authorization again, I have to remove the disable attribute from the DOM.

## Solution

The condition for determining whether the "Authorize" button should be disabled or not has been adjusted.
- While the driver has not been authorized, the button will remain enabled unless "isInvalid" is true.
- Once the driver has been authorized, the "changed" and "isInvalid" conditions will apply.

The above changes will enhance the user experience, especially when the driver has not been authorized and needs to perform multiple tests with the authorize button.

## How to Test
Follow the reproduction steps from the JIRA ticket.

## Related Tickets & Packages
- [FOUR-12334](https://processmaker.atlassian.net/browse/FOUR-12334)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12334]: https://processmaker.atlassian.net/browse/FOUR-12334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ