### PR TITLE
Update asset endpoints within the Designer Page

### DIFF
--- a/resources/js/processes/designer/RecentAssetsList.vue
+++ b/resources/js/processes/designer/RecentAssetsList.vue
@@ -235,18 +235,18 @@ export default {
      */
     generateAssetLink(data) {
       switch (data.asset_type) {
-        case "Process":
-          return `/modeler/${data.id}`;
-        case "Screen":
-          return `/designer/screen-builder/${data.id}/edit`;
-        case "Script":
-          return `/designer/scripts/${data.id}/edit`;
-        case "Data Source":
-          return `/designer/data-sources/${data.id}/edit`;
-        case "Decision Table":
-          return `/designer/decision-tables/${data.id}/edit`;
+        case 'Process':
+            return `/modeler/${data.id}`;
+        case 'Screen':
+            return `/designer/screen-builder/${data.id}/edit`;
+        case 'Script':
+            return `/designer/scripts/${data.id}/builder`;
+        case 'Data Source':
+            return `/designer/data-sources/${data.id}/edit`;
+        case 'Decision Table':
+            return `/designer/decision-tables/table-builder/${data.id}/edit`;
         default:
-          return ""; // Handle unknown asset types as needed
+            return ''; // Handle unknown asset types as needed
       }
     },
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
When clicking on Scripts, Data Sources, or Decision Table assets within the Designer page within the Resent Assets section, it opens the configuration instead of the actual builder, resulting in inconsistent behavior compared to other lists.
![Screenshot 2023-11-15 at 3 19 21 PM](https://github.com/ProcessMaker/processmaker/assets/5769433/664445cb-ea8e-40ac-a292-a309ce672371)

## Steps to Reproduce:

- Create a Project
- Add assets to the Project
-- Script, Process, Screen, Data Connector, Decision Table
- Navigate to the Designer page.
- Click on each asset within the RECENT ASSETS FROM MY PROJECTS section

## Expected Behavior:
The asset should open the builder for each asset.

## Observed Behavior:
In certain cases, the configuration page is opened instead of the intended builder.
(Script, Decision Table, Data Connector)

This behavior is inconsistent with other lists. 

## Solution
- Update asset endpoints within the Designer Page

## How to Test
Please follow the reproduction steps and ensure that when we click on each asset, the correct builder page opens instead of the Configuration page. 

Note: The Data Connector's editor it's the actual Configuration page

## Related Tickets & Packages
- Observation [FOUR-12402](https://processmaker.atlassian.net/browse/FOUR-12402)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12402]: https://processmaker.atlassian.net/browse/FOUR-12402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ