### PR TITLE
FOUR-12374: The signature control is not shown in the windows pane screen preview

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScreenController.php
@@ -7,7 +7,9 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
+use ProcessMaker\Events\ScreenBuilderStarting;
 use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Managers\ScreenBuilderManager;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
 use ProcessMaker\Models\ScreenType;
@@ -125,6 +127,9 @@ class ScreenController extends Controller
         $data = json_decode($request->query('node'), true) ?? [];
         $screen = Screen::find($data['screenRef']);
 
-        return view('processes.screens.preview', compact('screen'));
+        $manager = app(ScreenBuilderManager::class);
+        event(new ScreenBuilderStarting($manager, $screen->type ?? 'FORM'));
+
+        return view('processes.screens.preview', compact('screen', 'manager'));
     }
 }

--- a/resources/views/processes/screens/preview.blade.php
+++ b/resources/views/processes/screens/preview.blade.php
@@ -17,6 +17,9 @@
 @endsection
 
 @section('js')
+    @foreach($manager->getScripts() as $script)
+        <script src="{{$script}}"></script>
+    @endforeach
     <script src="{{mix('js/processes/screens/preview.js')}}"></script>
     <script>
         new Vue({


### PR DESCRIPTION
## Issue & Reproduction Steps
    Log in 
    Create a  screen with  signature  control
     create a new process
    create a form task
    add the screen that contains signature
    click in windows pane preview

Current Behavior: 

As we see, the signature is not shown in the screen preview
and we get an eroor on the console

Expected Behavior:

the signature must be displayed without errors
## Solution
- Now scripts registered by packages are registered in the preview page.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12374
- https://processmaker.atlassian.net/browse/FOUR-12343

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
