### PR TITLE
Refactor project select component

### DIFF
--- a/resources/js/components/shared/ProjectSelect.vue
+++ b/resources/js/components/shared/ProjectSelect.vue
@@ -48,8 +48,17 @@ export default {
       }
     },
     value: {
-      handler() {
-        this.loadSelectedOptions();
+      handler(newValue, oldValue) {
+        if (!_.isEqual(newValue, oldValue)) {
+          this.loadSelectedOptions();
+        }
+      }
+    },
+    projectId: {
+      handler(newValue, oldValue) {
+        if (!_.isEqual(newValue, oldValue)) {
+          this.loadSelectedOptions();
+        }
       }
     },
   },
@@ -58,6 +67,10 @@ export default {
       let selectedIds = this.value || [];
       if (!Array.isArray(selectedIds)) {
         selectedIds = this.value.split(',');
+      }
+
+      if (this.projectId && !selectedIds.includes(this.projectId)) {
+        selectedIds.push(this.projectId);
       }
       
       let idsToLoad = [];
@@ -99,6 +112,9 @@ export default {
   },
   mounted() {
     this.load();
+    if (this.projectId || this.value) {
+      this.loadSelectedOptions();
+    }
   },
 };
 </script>

--- a/resources/js/components/shared/ProjectSelect.vue
+++ b/resources/js/components/shared/ProjectSelect.vue
@@ -47,88 +47,55 @@ export default {
         }
       }
     },
-    options: {
-      handler(newValue, oldValue) {
-
-        if (!_.isEqual(newValue, oldValue) && !_.isEmpty(this.value)) {
-          this.setUpOptions();
-        }
-      },
-    }
+    value: {
+      handler() {
+        this.loadSelectedOptions();
+      }
+    },
   },
   methods: {
-    setUpOptions() {
-      if (this.value) {
-        const content = [];
-        const selected = String(this.value).split(',');
-        this.loading = selected.length;
-        selected.forEach(project => {
-          this.getOptionData(project, content);
-        });
-      } else {
-        this.content.splice(0);
+    loadSelectedOptions() {
+      let selectedIds = this.value || [];
+      if (!Array.isArray(selectedIds)) {
+        selectedIds = this.value.split(',');
       }
-    },
-    setCurrentProject() {
-      if (!this.projectId) {
+      
+      let idsToLoad = [];
+      selectedIds.forEach(id => {
+        if (!this.options.find(item => item.id == id)) {
+          idsToLoad.push(id);
+        }
+      });
+
+      if (idsToLoad.length == 0) {
         return;
       }
 
-      this.currentProject = this.options.find(project => project.id == this.projectId);
-
-      if (this.currentProject) {
-        this.content = [this.currentProject];
-      }
-    },
-    completeSelectedLoading(content) {
-      this.loading = false;
-      this.content.splice(0);
-      this.content.push(...content);
-    },
-    getOptionData(id, content) {
-      const option = this.options.concat(this.content).find(item => item.id == id);
-      if (option) {
-        this.loading--;
-        content.push(option);
-        this.handleCompleteSelectedLoading(content);
-        return;
-      }
-      ProcessMaker.apiClient
-        .get(this.apiGet)
-        .then(response => {
-          this.loading--;
-          content.push(response.data.data);
-          this.handleCompleteSelectedLoading(content);
-        })
-        .catch(error => {
-          this.loading--;
-          if (error.response.status === 404) {
-            this.error = this.$t('Selected not found');
+      const params = { only_ids: idsToLoad.join(',') };
+      ProcessMaker.apiClient.get(this.apiList, { params }).then(response => {
+        this.content = response.data.data;
+        response.data.data.forEach(project => {
+          if (!this.options.find(item => item.id == project.id)) {
+            this.options.push(project);
           }
-          this.handleCompleteSelectedLoading(content);
-        });
+        })
+      });
     },
     load: _.debounce(function (filter) {
       ProcessMaker.apiClient
-        .get(this.apiList + "?order_direction=asc&status=active&per_page=1000" + (typeof filter === 'string' ? '&filter=' + filter : ''))
+        .get(this.apiList + "?order_direction=asc&status=active&per_page=10" + (typeof filter === 'string' ? '&filter=' + filter : ''))
         .then(response => {
           this.loading = false;
-          this.options = response.data.data;
-
-          if (!this.initialLoadExecuted) {
-            this.setCurrentProject(this.options);
-            this.initialLoadExecuted = true;
-          }
+          response.data.data.forEach(project => {
+            if (!this.options.find(item => item.id == project.id)) {
+              this.options.push(project);
+            }
+          });
         })
         .catch(err => {
           this.loading = false;
         });
     }, 300),
-    handleCompleteSelectedLoading(content) {
-      if (!this.loading) {
-        this.completeSelectedLoading(content)
-      }
-    }
   },
   mounted() {
     this.load();


### PR DESCRIPTION
## Issue & Reproduction Steps
The project select component was loading all projects and that caused a large payload that was slowing down cypress tests.

## Solution
This refactor
- Only loads 10 projects initially
- Allow for backend typeahead searching when the desired project is not in the initial 10 payload
- Loads the selected projects if they do not exist in the initial 10 project payload

## How to Test
- Have more than 10 projects
- Search and select for projects on an asset that has projects (ie scripts create, scripts update, etc)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12412
- Requires Projects PR: https://github.com/ProcessMaker/package-projects/pull/83/files

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
