### PR TITLE
FOUR-12193 Opening the channel only when opening in a new tab and set…

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ModelerAssetQuickCreate.vue
+++ b/resources/js/processes/modeler/components/inspector/ModelerAssetQuickCreate.vue
@@ -42,13 +42,11 @@ export default {
       required: false,
     },
   },
-  mounted() {
-    channel.onmessage = ({ data }) => {
-      this.$emit("asset", data);
-    };
-  },
   methods: {
     goToAsset() {
+      channel.onmessage = ({ data }) => {
+        this.$emit("asset", data);
+      };
       let url = `/designer/${kebabCase(
         this.label,
       )}s?create=true&screenSelectId=${this.screenSelectId}`;

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -38,7 +38,7 @@
       class="form-text text-muted"
     >{{ $t(helper) }}</small>
     <modeler-asset-quick-create
-      v-if="!content.id"
+      v-if="!content?.id"
       :screen-select-id="uniqId"
       :screen-type="params.type"
       label="screen"
@@ -128,6 +128,10 @@ export default {
       }
       return false;
     },
+    /**
+     * Loads the screen
+     * @param {Object} value - Screen
+     */
     loadScreen(value) {
       this.loading = true;
       ProcessMaker.apiClient
@@ -192,7 +196,7 @@ export default {
      */
     processAssetCreation({ asset, assetType, screenSelectId }) {
       if (assetType === "screen" && this.uniqId === screenSelectId) {
-        this.content = asset;
+        this.loadScreen(asset.id);
       }
     },
     validate() {


### PR DESCRIPTION
…ting the screen using a already existing function to trigger the setter

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11736
- https://processmaker.atlassian.net/browse/FOUR-12359
- https://processmaker.atlassian.net/browse/FOUR-12407
- https://processmaker.atlassian.net/browse/FOUR-12411

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
