### PR TITLE
adding more sapce between icons in Admin Settings

### DIFF
--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -66,7 +66,7 @@
                 variant="link" 
                 class="settings-listing-button"
                 >
-                <i class="fa-lg fas fa-edit settings-listing-button mr-1"></i>
+                <i class="fa-lg fas fa-edit settings-listing-button mr-3"></i>
               </b-button>
             </span>
             <template v-if="row.item.key !== 'sso.default.login'">
@@ -80,7 +80,7 @@
                 @click="onCopy(row)"
                 class="settings-listing-button"
                 >
-                <i class="fa-lg fas fa-copy settings-listing-button mr-1" />
+                <i class="fa-lg fas fa-copy settings-listing-button mr-3" />
               </b-button>
 
               <span v-b-tooltip.hover v-if="!['boolean', 'object', 'button'].includes(row.item.format) && enableDeleteSetting(row)" :title="$t('Delete')">
@@ -91,7 +91,7 @@
                   variant="link" 
                   class="settings-listing-button"
                   >
-                  <i class="fa-lg fas fa-trash-alt settings-listing-button mr-1"></i>
+                  <i class="fa-lg fas fa-trash-alt settings-listing-button mr-3"></i>
                 </b-button>
               </span>
 

--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -64,9 +64,9 @@
                 :disabled="row.item.readonly" 
                 @click="onEdit(row)" 
                 variant="link" 
-                class="settings-listing-button"
+                class="btn btn-link"
                 >
-                <i class="fa-lg fas fa-edit settings-listing-button mr-3"></i>
+                <i class="fa-lg fas fa-edit"></i>
               </b-button>
             </span>
             <template v-if="row.item.key !== 'sso.default.login'">
@@ -78,9 +78,9 @@
                 :disabled="row.item.key.includes('cdata.')"
                 :title="$t('Copy to Clipboard')"
                 @click="onCopy(row)"
-                class="settings-listing-button"
+                class="btn btn-link"
                 >
-                <i class="fa-lg fas fa-copy settings-listing-button mr-3" />
+                <i class="fa-lg fas fa-copy" />
               </b-button>
 
               <span v-b-tooltip.hover v-if="!['boolean', 'object', 'button'].includes(row.item.format) && enableDeleteSetting(row)" :title="$t('Delete')">
@@ -89,9 +89,9 @@
                   v-uni-aria-describedby="row.item.id.toString()"
                   @click="onDelete(row)" 
                   variant="link" 
-                  class="settings-listing-button"
+                  class="btn btn-link"
                   >
-                  <i class="fa-lg fas fa-trash-alt settings-listing-button mr-3"></i>
+                  <i class="fa-lg fas fa-trash-alt"></i>
                 </b-button>
               </span>
 
@@ -102,9 +102,9 @@
                   :disabled="disableClear(row.item)" 
                   @click="onClear(row)" 
                   variant="link" 
-                  class="settings-listing-button"
+                  class="btn btn-link"
                   >
-                  <i class="fa-lg fas fa-trash-alt settings-listing-button"></i>
+                  <i class="fa-lg fas fa-trash-alt"></i>
                 </b-button>
               </span>
               <span v-else class="invisible">
@@ -233,21 +233,21 @@ export default {
       key: "name",
       label: "Setting",
       sortable: true,
-      tdClass: "align-middle td-name settings-listing-td1",
+      tdClass: "align-middle td-name",
     });
 
     this.fields.push({
       key: "config",
       label: "Configuration",
       sortable: false,
-      tdClass: "align-middle td-config settings-listing-td2",
+      tdClass: "align-middle td-config",
     });
 
     this.fields.push({
       key: "actions",
       label: "",
       sortable: false,
-      tdClass: "align-middle settings-listing-td3",
+      tdClass: "align-middle text-right",
     });
     
     ProcessMaker.EventBus.$on('setting-added-from-modal', () => {


### PR DESCRIPTION
## Solution
- The space between Icons was increased from margin 1 to margin 3.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy