### PR TITLE
Fix CDATA Node Configuration Loss on Slow Network or Multiple Screen Refreshes

### DIFF
--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -62,6 +62,7 @@ div.main {
     enabled: "{{ config('multiplayer.enabled') }}",
   };
   window.ProcessMaker.PMBlockList = @json($pmBlockList);
+  window.ProcessMaker.ExternalIntegrationsList = @json($externalIntegrationsList);
   window.ProcessMaker.modeler = {
     process: @json($process),
     autoSaveDelay: @json($autoSaveDelay),

--- a/resources/views/processes/modeler/inflight.blade.php
+++ b/resources/views/processes/modeler/inflight.blade.php
@@ -29,6 +29,7 @@
   <script>
     const breadcrumbData = [];
     window.ProcessMaker.PMBlockList = @json($pmBlockList);
+    window.ProcessMaker.ExternalIntegrationsList = @json($externalIntegrationsList);
     window.ProcessMaker.modeler = {
       xml: @json($bpmn),
       configurables: [],


### PR DESCRIPTION
This PR addresses the issue of lost CDATA node configurations that occurred when refreshing the screen multiple times or while loading on a slow network. The solution involves preloading the CDATA node configurations during the initialization of the modeler, storing them in an `ExternalIntegrationsList` variable. Additionally, a fallback mechanism is implemented to fetch the CDATA configurations if the `ExternalIntegrationsList` is empty.

## Solution
- Introduced a preload mechanism for CDATA node configurations during modeler initialization.
- Implemented a fallback to fetch CDATA configurations if the externalIntegrationsList is empty.

## How to Test

1. Ensure you have CDATA installed using this [PR](https://github.com/ProcessMaker/package-cdata/pull/21)
2. Ensure that External Integrations are enabled under Admin > Settings > External Integrations tab.
3. Create a process and add enabled external integration nodes, then save the process.
4. Simulate a slow network by updating settings to Slow 3G in the browser's Network tab.
![Screenshot 2023-11-15 at 1 19 51 PM](https://github.com/ProcessMaker/processmaker/assets/52755494/f95e9d47-edee-46a5-af57-07ac56735db0)

5. Reload the page.
6. Select a node and open the inspector panel.
7. Confirm that the inspector panel configurations for the selected node are correctly displayed, even on a slow network or after multiple screen refreshes.

## Related Tickets & Packages
- [FOUR-12340](https://processmaker.atlassian.net/browse/FOUR-12340)
- CDATA Package PR

ci:package-cdata:observation/FOUR-12340

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12340]: https://processmaker.atlassian.net/browse/FOUR-12340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ