### PR TITLE
Docker timeouts can also have exit code 9

### DIFF
--- a/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
@@ -73,7 +73,7 @@ trait ScriptDockerBindingFilesTrait
 
         $line = exec($cmd, $output, $returnCode);
         if ($returnCode) {
-            if ($returnCode == 137) {
+            if ($returnCode == 137 || $returnCode == 9) {
                 Log::error('Script timed out');
                 throw new ScriptTimeoutException(
                     __('Script took too long to complete. Consider increasing the timeout.')


### PR DESCRIPTION
## Issue & Reproduction Steps
On k8s, script timeouts are showing an exception trace instead of the timeout error that we had on ECS instances.

## Solution
- For some reason, on alpine linux, the timeout command can have the exit code `9` when run with php's `exec` command. This is different then on Mac and Ubutnu where it returns `137`. The solutions is to treat both exit codes as timeouts.

## How to Test
- On a k8s instance, set the timeout to 5 and run a script with `sleep(10);` to trigger the timeout out. It should show the timeout error instead and not the exception trace.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10600

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
