### PR TITLE
FOUR-12442: Implement Soft Deletes in All 'Versions' Tables

### DIFF
--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use ProcessMaker\Contracts\ProcessModelInterface;
 use ProcessMaker\Traits\HasCategories;
 use ProcessMaker\Traits\HasSelfServiceTasks;
@@ -26,6 +27,7 @@ class ProcessVersion extends ProcessMakerModel implements ProcessModelInterface
     use HasSelfServiceTasks;
     use HasCategories;
     use ProcessTrait;
+    use SoftDeletes;
 
     const categoryClass = ProcessCategory::class;
 

--- a/ProcessMaker/Models/ScreenVersion.php
+++ b/ProcessMaker/Models/ScreenVersion.php
@@ -3,12 +3,14 @@
 namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use ProcessMaker\Contracts\ScreenInterface;
 use ProcessMaker\Traits\HasCategories;
 
 class ScreenVersion extends ProcessMakerModel implements ScreenInterface
 {
     use HasCategories;
+    use SoftDeletes;
 
     const categoryClass = ScreenCategory::class;
 

--- a/ProcessMaker/Models/ScriptVersion.php
+++ b/ProcessMaker/Models/ScriptVersion.php
@@ -3,12 +3,14 @@
 namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use ProcessMaker\Contracts\ScriptInterface;
 use ProcessMaker\Traits\HasCategories;
 
 class ScriptVersion extends ProcessMakerModel implements ScriptInterface
 {
     use HasCategories;
+    use SoftDeletes;
 
     const categoryClass = ScriptCategory::class;
 

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -78,7 +78,7 @@ trait HasVersioning
 
     public function deleteDraft()
     {
-        $this->versions()->draft()->delete();
+        return $this->versions()->draft()->forceDelete();
     }
 
     private function getModelAttributes(): array

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -28,13 +28,7 @@ trait HasVersioning
      */
     public function scopePublished($query)
     {
-        $query->whereHas('versions', function ($query) {
-            // Avoid migration errors when 'draft' column does not exist.
-            $hasDraftColumn = Schema::hasColumn($query->getModel()->getTable(), 'draft');
-            $query->when($hasDraftColumn, function ($query) {
-                $query->where('draft', false);
-            });
-        });
+        return $query->whereHas('versions', fn ($query) => $query->where('draft', false));
     }
 
     /**

--- a/database/migrations/2018_09_07_173804_create_screen_versions_table.php
+++ b/database/migrations/2018_09_07_173804_create_screen_versions_table.php
@@ -23,6 +23,7 @@ return new class extends Migration {
             $table->json('computed')->nullable();
             $table->text('custom_css')->nullable();
             $table->timestamps();
+            $table->softDeletes();
 
             $table->foreign('screen_id')->references('id')->on('screens')->onDelete('cascade');
         });

--- a/database/migrations/2018_09_07_173804_create_screen_versions_table.php
+++ b/database/migrations/2018_09_07_173804_create_screen_versions_table.php
@@ -16,6 +16,7 @@ return new class extends Migration {
             $table->increments('id');
             $table->unsignedInteger('screen_id');
             $table->unsignedInteger('screen_category_id')->nullable();
+            $table->boolean('draft')->default(false);
             $table->text('title');
             $table->text('description');
             $table->string('type', 20)->default('FORM');

--- a/database/migrations/2018_09_07_174703_create_script_versions_table.php
+++ b/database/migrations/2018_09_07_174703_create_script_versions_table.php
@@ -23,6 +23,7 @@ return new class extends Migration {
             $table->text('code')->nullable();
             $table->unsignedInteger('run_as_user_id')->nullable();
             $table->timestamps();
+            $table->softDeletes();
 
             $table->foreign('script_id')->references('id')->on('scripts')->onDelete('cascade');
         });

--- a/database/migrations/2018_09_07_174703_create_script_versions_table.php
+++ b/database/migrations/2018_09_07_174703_create_script_versions_table.php
@@ -15,6 +15,7 @@ return new class extends Migration {
         Schema::create('script_versions', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('script_id');
+            $table->boolean('draft')->default(false);
 
             $table->string('key')->unique()->nullable();
             $table->text('title');

--- a/database/migrations/2018_09_07_175156_create_process_versions_table.php
+++ b/database/migrations/2018_09_07_175156_create_process_versions_table.php
@@ -19,6 +19,7 @@ return new class extends Migration {
             $table->unsignedInteger('process_id');
             $table->unsignedInteger('process_category_id')->nullable();
             $table->unsignedInteger('user_id');
+            $table->boolean('draft')->default(false);
             $table->text('bpmn');
             $table->text('description');
             $table->string('name');

--- a/database/migrations/2020_03_19_155045_create_script_executor_versions_table.php
+++ b/database/migrations/2020_03_19_155045_create_script_executor_versions_table.php
@@ -15,6 +15,7 @@ return new class extends Migration {
         Schema::create('script_executor_versions', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('script_executor_id');
+            $table->boolean('draft')->default(false);
 
             $table->string('title');
             $table->text('description')->nullable();

--- a/database/migrations/2023_02_27_130520_add_draft_column_to_versions_tables.php
+++ b/database/migrations/2023_02_27_130520_add_draft_column_to_versions_tables.php
@@ -12,28 +12,19 @@ return new class extends Migration {
      */
     public function up()
     {
-        if (!Schema::hasColumn('process_versions', 'draft')) {
-            Schema::table('process_versions', function (Blueprint $table) {
-                $table->boolean('draft')->default(false)->after('user_id');
-            });
-        }
+        $tables = [
+            'process_versions',
+            'screen_versions',
+            'script_versions',
+            'script_executor_versions',
+        ];
 
-        if (!Schema::hasColumn('screen_versions', 'draft')) {
-            Schema::table('screen_versions', function (Blueprint $table) {
-                $table->boolean('draft')->default(false)->after('screen_category_id');
-            });
-        }
-
-        if (!Schema::hasColumn('script_versions', 'draft')) {
-            Schema::table('script_versions', function (Blueprint $table) {
-                $table->boolean('draft')->default(false)->after('script_id');
-            });
-        }
-
-        if (!Schema::hasColumn('script_executor_versions', 'draft')) {
-            Schema::table('script_executor_versions', function (Blueprint $table) {
-                $table->boolean('draft')->default(false)->after('script_executor_id');
-            });
+        foreach ($tables as $table) {
+            if (!Schema::hasColumn($table, 'draft')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->boolean('draft')->default(false);
+                });
+            }
         }
     }
 
@@ -44,17 +35,17 @@ return new class extends Migration {
      */
     public function down()
     {
-        Schema::table('process_versions', function (Blueprint $table) {
-            $table->dropColumn('draft');
-        });
-        Schema::table('screen_versions', function (Blueprint $table) {
-            $table->dropColumn('draft');
-        });
-        Schema::table('script_versions', function (Blueprint $table) {
-            $table->dropColumn('draft');
-        });
-        Schema::table('script_executor_versions', function (Blueprint $table) {
-            $table->dropColumn('draft');
-        });
+        $tables = [
+            'process_versions',
+            'screen_versions',
+            'script_versions',
+            'script_executor_versions',
+        ];
+
+        foreach ($tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->dropColumn('draft');
+            });
+        }
     }
 };

--- a/database/migrations/2023_02_27_130520_add_draft_column_to_versions_tables.php
+++ b/database/migrations/2023_02_27_130520_add_draft_column_to_versions_tables.php
@@ -12,18 +12,29 @@ return new class extends Migration {
      */
     public function up()
     {
-        Schema::table('process_versions', function (Blueprint $table) {
-            $table->boolean('draft')->default(false)->after('user_id');
-        });
-        Schema::table('screen_versions', function (Blueprint $table) {
-            $table->boolean('draft')->default(false)->after('screen_category_id');
-        });
-        Schema::table('script_versions', function (Blueprint $table) {
-            $table->boolean('draft')->default(false)->after('script_id');
-        });
-        Schema::table('script_executor_versions', function (Blueprint $table) {
-            $table->boolean('draft')->default(false)->after('script_executor_id');
-        });
+        if (!Schema::hasColumn('process_versions', 'draft')) {
+            Schema::table('process_versions', function (Blueprint $table) {
+                $table->boolean('draft')->default(false)->after('user_id');
+            });
+        }
+
+        if (!Schema::hasColumn('screen_versions', 'draft')) {
+            Schema::table('screen_versions', function (Blueprint $table) {
+                $table->boolean('draft')->default(false)->after('screen_category_id');
+            });
+        }
+
+        if (!Schema::hasColumn('script_versions', 'draft')) {
+            Schema::table('script_versions', function (Blueprint $table) {
+                $table->boolean('draft')->default(false)->after('script_id');
+            });
+        }
+
+        if (!Schema::hasColumn('script_executor_versions', 'draft')) {
+            Schema::table('script_executor_versions', function (Blueprint $table) {
+                $table->boolean('draft')->default(false)->after('script_executor_id');
+            });
+        }
     }
 
     /**

--- a/database/migrations/2023_11_16_171022_add_soft_deletes_to_screen_versions_table.php
+++ b/database/migrations/2023_11_16_171022_add_soft_deletes_to_screen_versions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('screen_versions', function (Blueprint $table) {
+            if (!Schema::hasColumn('screen_versions', 'deleted_at')) {
+                $table->softDeletes()->after('updated_at');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('screen_versions', function (Blueprint $table) {
+            if (Schema::hasColumn('screen_versions', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+        });
+    }
+};

--- a/database/migrations/2023_11_16_171031_add_soft_deletes_to_script_versions_table.php
+++ b/database/migrations/2023_11_16_171031_add_soft_deletes_to_script_versions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('script_versions', function (Blueprint $table) {
+            if (!Schema::hasColumn('script_versions', 'deleted_at')) {
+                $table->softDeletes()->after('updated_at');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('script_versions', function (Blueprint $table) {
+            if (Schema::hasColumn('script_versions', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently, the '*_versions' tables in our database do not support soft deletes. 

1. Create a record in `process_versions` table.
2. Delete the record.
3. It's permanently deleted.

## Solution
- Implement the soft delete functionality in all 'Versions' models, ensuring that records are not permanently deleted, but marked as deleted and can be recovered if required.
  - Only draft records will be permanently deleted to maintain the same behavior.

## How to Test
- All tests must pass.
- You can follow the reproduction steps manually.

## Related Tickets & Packages
- [FOUR-12442](https://processmaker.atlassian.net/browse/FOUR-12442)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12442]: https://processmaker.atlassian.net/browse/FOUR-12442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ