### PR TITLE
Fix url for script assets

### DIFF
--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -482,7 +482,7 @@ ProcessMaker.EventBus.$on(
     });
     event.registerPreview({
       url: '/designer/scripts/preview',
-      assetUrl: (nodeData) => nodeData.scriptRef ? `/designer/screen-builder/${nodeData.scriptRef}/edit` : null,
+      assetUrl: (nodeData) => nodeData.scriptRef ? `/designer/scripts/${nodeData.scriptRef}/builder` : null,
       receivingParams: ['scriptRef'],
       matcher: (nodeData) => nodeData?.$type === 'bpmn:ScriptTask',
     });


### PR DESCRIPTION
## Issue & Reproduction Steps
    Create a process
    Add Script Task
    Assign a script
    Click on Preview
    Click on external link

Current Behavior 
Link Script redirection not working in Script Task 

## Solution
Fixed the URL for scripts.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-12443

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
