### PR TITLE
Fix Project Title Filter Population Issue on Initial Load

### DIFF
--- a/resources/js/components/shared/PmqlInputFilters.vue
+++ b/resources/js/components/shared/PmqlInputFilters.vue
@@ -696,6 +696,9 @@ export default {
 
         const { data } = await ProcessMaker.apiClient.get("/projects/search?type=project_all");
 
+        if (data.projects) {
+          this.projectOptions = data.projects;
+        }
         if (data.members?.users) {
           const usersWithMappedNames = data.members.users
             .filter(user => !!user)


### PR DESCRIPTION
This PR resolves issues where the Project title filter was not populated on the initial load of the projects page. The solution involved setting the projectOptions variable to the response project data when initially loading the projects page.

## Solution
- Updated the logic to ensure the Project title filter is populated with available project titles on the initial load of the projects page.

## How to Test

1. Ensure that projects are properly configured in the system.
2. Load the projects listing page.
3. Select the 'Filters' option.
4. Choose the project title filter.
5. Confirm that the available project titles are listed before typing in the search bar.
6. While searching, ensure that the project titles are properly listed and that the filter functions as expected.

## Related Tickets & Packages
- [FOUR-12255](https://processmaker.atlassian.net/browse/FOUR-12255)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12255]: https://processmaker.atlassian.net/browse/FOUR-12255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ