### PR TITLE
FOUR-12003: Modeler now detects if process was generated by AI

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -74,6 +74,7 @@ class ModelerController extends Controller
             'countScreenCategories' => $countScreenCategories,
             'countScriptCategories' => $countScriptCategories,
             'isProjectsInstalled' => $isProjectsInstalled,
+            'isAiGenerated' => request()->query('ai'),
         ]);
     }
 

--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -115,7 +115,8 @@
       "categoryType", 
       "callFromAiModeler",
       "isProjectSelectionRequired",
-      "projectId"
+      "projectId",
+      "isAiGenerated"
     ],
     data: function() {
       return {
@@ -286,7 +287,10 @@
             const url = `/package-ai/processes/create/${response.data.id}`;
             this.$emit("process-created-from-modeler", url, response.data.id, response.data.name);
           } else {
-            window.location = `/modeler/${response.data.id}`;
+            console.log('wut', this.isAiGenerated, response.data.id);
+            this.isAiGenerated
+              ? window.location = "/modeler/" + response.data.id + "?ai=1"
+              : window.location = "/modeler/" + response.data.id;
           }
         })
         .catch(error => {

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -87,6 +87,7 @@ div.main {
     screenTypes: @json($screenTypes),
     scriptExecutors: @json($scriptExecutors),
     isProjectsInstalled: @json($isProjectsInstalled),
+    isAiGenerated: @json($isAiGenerated)
   }
   const warnings = @json($process->warnings);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The new features for AI Unified Generation need a way to detect if a process was made by AI so that it may suggest to create assets for the new process on Modeler.

## Solution
- Introduced a query string to communicate if the process was generated by the AI Generation tool.
- Used `window.ProcessMaker.modeler `global variable to reach the Modeler project and have easy access to the check.

## Related Tickets & Packages
- [FOUR-12003](https://processmaker.atlassian.net/browse/FOUR-12003)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
