### PR TITLE
Bugfix/FOUR-12421: Main Ai Menu is shown on Apply Changes or Cancel

### DIFF
--- a/resources/js/processes/scripts/components/AiTab.vue
+++ b/resources/js/processes/scripts/components/AiTab.vue
@@ -36,7 +36,7 @@
     <b-list-group-item
       class="p-0 border-left-0 border-right-0 border-top-0 mb-0"
     >
-      <b-collapse id="assistant" :visible="showPromptArea">
+      <b-collapse id="assistant" :visible="true">
         <div v-if="!showPromptArea">
           <div class="card-header m-0 d-flex border-0 pb-1 px-2">
             <div class="d-flex w-50 p-2 ai-button-container">
@@ -180,8 +180,8 @@ export default {
       this.prompt = this.defaultPrompt;
     }
 
-    if (this.processId !== 0) {
-      this.showPromptArea = true;
+    if (this.processId === 0) {
+      this.showMenu();
     }
   },
   methods: {

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -544,13 +544,11 @@ export default {
       this.newCode = "";
       this.changesApplied = true;
       this.action = "";
-      this.$refs.aiTab2.showMenu();
     },
     cancelChanges() {
       this.newCode = "";
       this.changesApplied = true;
       this.action = "";
-      this.$refs.aiTab2.showMenu();
     },
     cancelRequest() {
       if (this.currentNonce) {
@@ -559,7 +557,6 @@ export default {
         this.loading = false;
         this.progress.progress = 0;
         this.action = "";
-        this.$refs.aiTab2.showMenu();
       }
     },
     closeExplanation() {


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Login as admin
2. Go to Designer
3. Click on +Process
4. Click on Build Your Own
5. Drag and drop the AI Generated control
6. Select Generate Script From Text
7. Set the information
8. Change if needed the prompt on the Description 
9. Click on Generate
10. Click on Document, Clean or Explain

## Expected Behavior
After apply should display the menu 

## Current Behavior
After apply the changes instead of displaying the menu options it displays the Generate Script From Text is displayed

## Solution
- The variable that toggles the menu is always changed on the `mounted()` hook of `AiTab.vue` so changing it to display the main menu on mount solves the issue.

## Related Tickets & Packages
- [FOUR-12421](https://processmaker.atlassian.net/browse/FOUR-12421)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12421]: https://processmaker.atlassian.net/browse/FOUR-12421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ