### PR TITLE
Bugfix/FOUR-12440: When using AI in script it is displayed simultaneously in different scripts

### DIFF
--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -638,6 +638,10 @@ export default {
             return;
           }
 
+          if (response.data.nonce !== this.currentNonce) {
+            return;
+          }
+
           if (this.cancelledJobs.some((element) => element === response.data.nonce)) {
             return;
           }


### PR DESCRIPTION
## Issue & Reproduction Steps
1.Create a script in PHP language
2.Create a B script Javascript language
3.the last script B use the AI with a simple description
4.Click on Generate
5.Go to first script A


**Current Behavior:**
What was generated with AI is also shown in script A that is using another language (in this case PHP)

**Expected Behavior:**
AI in script should not show what it generates in a script that uses another language.

## Solution
- Verify if nonce is the same as the request after update the progress or the script

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/6bcf2359-eaf8-41f3-8e38-7351cb3a866b


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-12440](https://processmaker.atlassian.net/browse/FOUR-12440)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12440]: https://processmaker.atlassian.net/browse/FOUR-12440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ