### PR TITLE
FOUR-11745: Screens-Type screen does not show all options

### DIFF
--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -150,7 +150,7 @@ ProcessMaker.EventBus.$on(
         name: "screenRef",
         required: true,
         params: {
-          type: "FORM,CONVERSATIONAL",
+          type: "FORM,CONVERSATIONAL,EMAIL,DISPLAY",
           interactive: true,
         },
       },


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).
Screens-Type screen does not show all options
## Solution
- The list of the available screen types was completed

[scree-types.webm](https://github.com/ProcessMaker/processmaker/assets/1401911/b9fb6ed2-ea0a-4d77-bea2-eeef716b3890)

## How to Test

1. Log In PM
2. Go to designer
3. Create a new process
4. Add a task send email and form task
5. Click on "Create a new screen" of any of the tasks
6. Click on X of create screen
7. Refresh page
8. Click on +Screen
9. Screen types do not show all screen options

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11745

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
