### PR TITLE
FOUR-12450: Filter only the Projects that belong to the User

### DIFF
--- a/resources/js/components/shared/PmqlInputFilters.vue
+++ b/resources/js/components/shared/PmqlInputFilters.vue
@@ -695,10 +695,12 @@ export default {
         this.allLoading(true);
 
         const { data } = await ProcessMaker.apiClient.get("/projects/search?type=project_all");
-
-        if (data.projects) {
-          this.projectOptions = data.projects;
+        const projectsFilter = await ProcessMaker.apiClient.get("/projects?status=all&per_page=100");
+        
+        if (projectsFilter.data.data) {
+          this.projectOptions = projectsFilter.data.data;
         }
+
         if (data.members?.users) {
           const usersWithMappedNames = data.members.users
             .filter(user => !!user)

--- a/resources/js/components/shared/PmqlInputFilters.vue
+++ b/resources/js/components/shared/PmqlInputFilters.vue
@@ -695,12 +695,9 @@ export default {
         this.allLoading(true);
 
         const { data } = await ProcessMaker.apiClient.get("/projects/search?type=project_all");
-        const projectsFilter = await ProcessMaker.apiClient.get("/projects?status=all&per_page=100");
         
-        if (projectsFilter.data.data) {
-          this.projectOptions = projectsFilter.data.data;
-        }
-
+        this.projectOptions = data.projects ? data.projects : [];
+        
         if (data.members?.users) {
           const usersWithMappedNames = data.members.users
             .filter(user => !!user)


### PR DESCRIPTION
## Issue & Reproduction Steps
Users without Project ownership can view all projects in the filter.

**Steps to Reproduce:**
1. Log in with the admin user.
2. Create several projects with the admin user.
3. Log out.
4. Log in with a different user.
5. Create additional projects with the second user.
7. Click on "Projects."
8. Notice that all projects are visible, not just the ones created by the first user.
9. Click on the project filter.

**Current Behavior:**
All created projects are displayed in the project filter, regardless of ownership.

**Expected Behavior:**
The filter should only display projects that belong to the logged-in user.

## Solution
- Modify the filter to show only the projects that belong to the currently logged-in user.

## How to Test
1. Follow the reproduction steps.
2. Ensure that the project filter exclusively displays projects associated with the logged-in user.

## Related Tickets & Packages
- Observation [FOUR-12450](https://processmaker.atlassian.net/browse/FOUR-12450)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12450]: https://processmaker.atlassian.net/browse/FOUR-12450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ