### PR TITLE
FOUR-12376 signal reference is not reflected in collaborative mode

### DIFF
--- a/resources/js/processes/modeler/components/inspector/SignalPayload.vue
+++ b/resources/js/processes/modeler/components/inspector/SignalPayload.vue
@@ -96,6 +96,12 @@ export default {
           this.node().eventDefinitions.forEach(definition => {
             if(definition.$type === 'bpmn:SignalEventDefinition') {
               definition.config = JSON.stringify(this.config);
+
+              window.ProcessMaker.EventBus.$emit('multiplayer-updateInspectorProperty', {
+                id: this.node().id,
+                key: 'signalPayload',
+                value: JSON.stringify(this.config),
+              });
             }
           }, this)
         }
@@ -106,6 +112,12 @@ export default {
     payloadChange(selectedObject) {
       this.config.payload[0].id = selectedObject.id;
       this.$set(this.node().eventDefinitions[0], "config", JSON.stringify(this.config));
+
+      window.ProcessMaker.EventBus.$emit('multiplayer-updateInspectorProperty', {
+        id: this.node().id,
+        key: 'signalPayload',
+        value: JSON.stringify(this.config),
+      });
     },
     node() {
       const modeler =  this.$root.$children[0].$refs.modeler;
@@ -140,7 +152,7 @@ export default {
   .displayed-expression {
     width: 146px;
   }
-  
+
   .displayed-expression,
   .special-assignment-input {
     font-family: monospace;


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
All changes related to the signal events should be reflected in the other users in collaborative mode

Actual behavior: 
The assignation of the signal reference is not reflected in the other user in collaborative mode 

## Solution
- Add support to the Signal Payload in collaborative mode

## How to Test
Test the steps above
1. Create a process
2. Open the process with two users with different session
3. With one user 
4. Add signal intermediate event
5. Assign a signal reference
6. Saved the changes
7. Go to the modeler of the other users
8. The signal reference must be assigned

## Related Tickets & Packages
[FOUR-12376](https://processmaker.atlassian.net/browse/FOUR-12376)
https://github.com/ProcessMaker/modeler/pull/1739

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12376]: https://processmaker.atlassian.net/browse/FOUR-12376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ