### PR TITLE
feature/FOUR-12318: Add the redirect to launchpad

### DIFF
--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -23,7 +23,7 @@ export default {
           value: "open-launchpad",
           content: "Open Launchpad",
           link: true,
-          href: "/processes/", //TO DO: Add path to Launchpad View when it's ready
+          href: "/processes-catalogue/",
           permission: ["edit-processes", "create-projects", "view-projects"],
           icon: "fas fa-file-export",
         },


### PR DESCRIPTION
## Issue & Reproduction Steps
The open Launchpad need to redirect the the Menu Process
![image-20231115-160644](https://github.com/ProcessMaker/processmaker/assets/123644082/1f54e06b-c128-4fff-a03a-e52a87fdb099)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12318

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next