### PR TITLE
FOUR-12505:Other script executor does not have an icon on the modal script list

### DIFF
--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -154,7 +154,10 @@ class ScriptExecutor extends ProcessMakerModel
         }
 
         foreach ($executors->get() as $executor) {
-            $list[$executor->id] = $executor->language;
+            $list[$executor->id] = [
+                'language' => $executor->language,
+                'title' => $executor->title,
+            ];
         }
 
         return $list;

--- a/resources/js/processes/scripts/components/LanguageScript.vue
+++ b/resources/js/processes/scripts/components/LanguageScript.vue
@@ -9,17 +9,17 @@
       >
         <b-card
           :key="index"
-          :ref="`${lang}`"
+          :ref="`${lang.title}`"
           class="mt-2"
           @click="selectLanguage(lang, index)"
         >
           <b-card-text>
             <img
               :src="getImage(lang)"
-              :alt="lang"
+              :alt="lang.title"
             >
             <span class="text-uppercase ml-2">
-              {{ lang }}
+              {{ lang.language }}
             </span>
           </b-card-text>
         </b-card>
@@ -59,7 +59,17 @@ export default {
      * Get the Icon of the language
      */
     getImage(lang) {
-      return `/img/script_lang/${lang}.svg`;
+      let srcImage = "";
+      switch (lang.language) {
+        case "php":
+        case "javascript":
+        case "lua":
+          srcImage = `/img/script_lang/${lang.language}.svg`;
+          break;
+        default:
+          srcImage = "/img/script_lang/default.svg";
+      }
+      return srcImage;
     },
     /**
      * Add the border to the item selected
@@ -68,7 +78,7 @@ export default {
       for (const item in this.$refs) {
         this.$refs[item][0].className = "card mb-2 card-lang";
       }
-      this.$refs[lang][0].className = "card mb-2 card-lang selected";
+      this.$refs[lang.title][0].className = "card mb-2 card-lang selected";
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-12505](https://processmaker.atlassian.net/browse/FOUR-12505)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-12505]: https://processmaker.atlassian.net/browse/FOUR-12505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ