### PR TITLE
FOUR-11415 Password Policy Configuration

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -38,6 +38,8 @@ class LoginController extends Controller
      */
     protected $redirectTo = '/';
 
+    protected $maxAttempts;
+
     /**
      * Create a new controller instance.
      *
@@ -46,6 +48,7 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except(['logout', 'beforeLogout', 'keepAlive']);
+        $this->maxAttempts = (int) config('password-policies.login_attempts');
     }
 
     /**

--- a/config/password-policies.php
+++ b/config/password-policies.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'minimum_length' => env('PASSWORD_POLICY_MINIMUM_LENGTH', 8),
+    'maximum_length' => env('PASSWORD_POLICY_MAXIMUM_LENGTH', null),
+    'numbers' => env('PASSWORD_POLICY_NUMBERS', true),
+    'uppercase' => env('PASSWORD_POLICY_UPPERCASE', true),
+    'special' => env('PASSWORD_POLICY_SPECIAL', true),
+    //'expiration_days' => env('PASSWORD_POLICY_EXPIRATION_DAYS', 0), // 0 never expires
+    'login_attempts' => env('PASSWORD_POLICY_LOGIN_ATTEMPTS', 5),
+];

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -396,12 +396,6 @@
               delete this.formData.password;
               return true
             }
-            if (this.formData.password.trim().length > 0 && this.formData.password.trim().length < 8) {
-              this.errors.password = ['Password must be at least 8 characters']
-              this.password = ''
-              this.submitted = false
-              return false
-            }
             if (this.formData.password !== this.formData.confPassword) {
               this.errors.password = ['Passwords must match']
               this.password = ''

--- a/resources/views/auth/passwords/change.blade.php
+++ b/resources/views/auth/passwords/change.blade.php
@@ -45,7 +45,7 @@
                                     'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
                                 </div>
                             </vue-password>
-                            <small v-if="errors && errors.password && errors.password.length" class="text-danger">@{{ errors.password[0] }}</small>
+                            <small v-for="(error, index) in errors.password" class="text-danger">@{{ error }}</small>
                         </div>
                         <div class="form-group">
                             {!!Form::label('confpassword', __('Confirm Password'))!!}<small class="ml-1">*</small>
@@ -94,22 +94,11 @@
                 });
             },
             validatePassword() {
-                if (this.$refs.passwordStrength.strength.score < 2) {
-                    this.errors.password = ['Password is too weak']
-                    return false
-                }
-
                 if (!this.formData.password && !this.formData.confpassword) {
                     return false;
                 }
 
                 if (this.formData.password.trim() === '' && this.formData.confpassword.trim() === '') {
-                    return false
-                }
-
-                if (this.formData.password.trim().length > 0 && this.formData.password.trim().length < 8) {
-                    this.errors.password = ['Password must be at least 8 characters']
-                    this.formData.password = ''
                     return false
                 }
 

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -151,12 +151,6 @@
                         delete this.formData.password;
                         return true
                     }
-					if (this.formData.password.trim().length > 0 && this.formData.password.trim().length < 8) {
-						this.errors.password = ['Password must be at least 8 characters']
-                        this.password = ''
-                        this.submitted = false
-                        return false
-					}
                     if (this.formData.password !== this.formData.confPassword) {
                         this.errors.password = ['Passwords must match']
                         this.password = ''

--- a/resources/views/shared/users/sidebar.blade.php
+++ b/resources/views/shared/users/sidebar.blade.php
@@ -54,7 +54,8 @@
                 {!! Form::label('confPassword', __('Confirm Password')) !!}
                 {!! Form::password('confPassword', ['id' => 'confPassword', 'rows' => 4, 'class'=> 'form-control', 'v-model'
                 => 'formData.confPassword', 'autocomplete' => 'new-password', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
-                <div class="invalid-feedback" :style="{display: (errors.password) ? 'block' : 'none' }" role="alert" v-for="(error, index) in errors.password">@{{error}}</div>
+                <div class="invalid-feedback" :style="{display: (errors.password) ? 'block' : 'none' }" role="alert"
+                     v-for="(error, index) in errors.password">@{{error}}</div>
             </div>
             @cannot('edit-user-and-password')
                 <div class="form-group">

--- a/resources/views/shared/users/sidebar.blade.php
+++ b/resources/views/shared/users/sidebar.blade.php
@@ -22,8 +22,8 @@
         </div>
     </div>
     <div class="card card-body mt-3">
-        <fieldset :disabled="{{ \Auth::user()->hasPermission('edit-user-and-password') || \Auth::user()->is_administrator ? 'false' : 'true' }}">  
-            <legend> 
+        <fieldset :disabled="{{ \Auth::user()->hasPermission('edit-user-and-password') || \Auth::user()->is_administrator ? 'false' : 'true' }}">
+            <legend>
                 <h5 class="mb-3 font-weight-bold">{{__('Login Information')}}</h5>
             </legend>
             <div class="form-group">
@@ -54,7 +54,7 @@
                 {!! Form::label('confPassword', __('Confirm Password')) !!}
                 {!! Form::password('confPassword', ['id' => 'confPassword', 'rows' => 4, 'class'=> 'form-control', 'v-model'
                 => 'formData.confPassword', 'autocomplete' => 'new-password', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
-                <div class="invalid-feedback" :style="{display: (errors.password) ? 'block' : 'none' }" role="alert" v-if="errors.password">@{{errors.password[0]}}</div>
+                <div class="invalid-feedback" :style="{display: (errors.password) ? 'block' : 'none' }" role="alert" v-for="(error, index) in errors.password">@{{error}}</div>
             </div>
             @cannot('edit-user-and-password')
                 <div class="form-group">

--- a/tests/Feature/Api/ChangePasswordTest.php
+++ b/tests/Feature/Api/ChangePasswordTest.php
@@ -45,8 +45,9 @@ class ChangePasswordTest extends TestCase
             'confpassword' => 'ProcessMaker',
         ]);
 
-        $response->assertStatus(422)
-                 ->assertSeeText('The password must contain either a number or a special character');
+        $response->assertStatus(422);
+        $json = $response->json();
+        $this->assertTrue(in_array('The Password field must contain at least one symbol.', $json['errors']['password']));
 
         // Validate updated user password changed
         $updatedUser = User::where('id', $user->id)->first();
@@ -72,8 +73,8 @@ class ChangePasswordTest extends TestCase
 
         // Post data with new password
         $response = $this->apiCall('PUT', self::API_TEST_URL, [
-            'password' => 'ProcessMaker1',
-            'confpassword' => 'ProcessMaker1',
+            'password' => 'ProcessMaker1_',
+            'confpassword' => 'ProcessMaker1_',
         ]);
 
         // Validate the header status code

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -61,7 +61,7 @@ class UsersTest extends TestCase
             'timezone' => $faker->timezone(),
             'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
             'birthdate' => $faker->dateTimeThisCentury()->format('Y-m-d'),
-            'password' => $faker->sentence(10),
+            'password' => $faker->sentence(8) . 'A_' . '1',
         ];
     }
 
@@ -100,7 +100,7 @@ class UsersTest extends TestCase
             'lastname' => 'name',
             'email' => $faker->email(),
             'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
-            'password' => $faker->sentence(10),
+            'password' => $faker->password(8) . 'A_' . '1',
         ]);
 
         // Validate the header status code
@@ -602,9 +602,9 @@ class UsersTest extends TestCase
         $response = $this->apiCall('POST', self::API_TEST_URL, $payload);
         $response->assertStatus(422);
         $json = $response->json();
-        $this->assertEquals('The Password field must be at least 8 characters.', $json['errors']['password'][0]);
+        $this->assertTrue(in_array('The Password field must be at least 8 characters.', $json['errors']['password']));
 
-        $payload['password'] = 'Abc12345';
+        $payload['password'] = 'Abc12345_';
         $response = $this->apiCall('POST', self::API_TEST_URL, $payload);
         $response->assertStatus(201);
         $json = $response->json();
@@ -616,9 +616,9 @@ class UsersTest extends TestCase
         $response = $this->apiCall('PUT', route('api.users.update', $userId), $payload);
         $response->assertStatus(422);
         $json = $response->json();
-        $this->assertEquals('The Password field must be at least 8 characters.', $json['errors']['password'][0]);
+        $this->assertTrue(in_array('The Password field must be at least 8 characters.', $json['errors']['password']));
 
-        $payload['password'] = 'Abc12345';
+        $payload['password'] = 'Abc12345_';
         $response = $this->apiCall('PUT', route('api.users.update', $userId), $payload);
         $response->assertStatus(204);
 
@@ -673,7 +673,7 @@ class UsersTest extends TestCase
                 'lastname' => $faker->lastName(),
                 'email' => $faker->email(),
                 'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
-                'password' => $faker->sentence(10),
+                'password' => $faker->sentence(8) . 'A_' . '1',
             ]);
             // Validate the header status code
             $response->assertStatus(201);


### PR DESCRIPTION
## Issue & Reproduction Steps
The passwords policies are not configurable

## Solution
Added validations when the users login to the app

## How to Test
Add in .env the next values:

PASSWORD_POLICY_NUMBERS=TRUE

PASSWORD_POLICY_UPPERCASE=TRUE

PASSWORD_POLICY_SPECIAL=TRUE

PASSWORD_POLICY_MINIMUM_LENGTH=8

PASSWORD_POLICY_MAXIMUM_LENGTH=12

PASSWORD_POLICY_LOGIN_ATTEMPTS=5

And validate when user login to the app

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages
https://processmaker.atlassian.net/browse/FOUR-11415

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
