### PR TITLE
CData executor appears in list of available executors

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
@@ -347,11 +347,13 @@ class ScriptExecutorController extends Controller
     {
         $languages = [];
         foreach (Script::scriptFormats() as $key => $config) {
-            $languages[] = [
-                'value' => $key,
-                'text' => $config['name'],
-                'initDockerfile' => ScriptExecutor::initDockerfile($key),
-            ];
+            if (!array_key_exists( 'system', $config) || (array_key_exists( 'system', $config) && !$config['system'])) {
+                $languages[] = [
+                    'value' => $key,
+                    'text' => $config['name'],
+                    'initDockerfile' => ScriptExecutor::initDockerfile($key),
+                ];
+            }
         }
 
         return ['languages' => $languages];


### PR DESCRIPTION
## Issue & Reproduction Steps
Cdata appears in the list of languages available.

## Solution
- Do not show system languages.

## How to Test
Create or edit an executor, You shouldn't see the language Cdata.

## Related Tickets & Packages
- [FOUR-12538](https://processmaker.atlassian.net/browse/FOUR-12538)

Depends
ci:docker-executor-cdata:bugfix/FOUR-12538
https://github.com/ProcessMaker/docker-executor-cdata/pull/8
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12538]: https://processmaker.atlassian.net/browse/FOUR-12538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ