### PR TITLE
Symfony Mailer does not use setAuthMode

### DIFF
--- a/ProcessMaker/Managers/OauthMailManager.php
+++ b/ProcessMaker/Managers/OauthMailManager.php
@@ -63,15 +63,13 @@ class OauthMailManager extends MailManager
             case 'google':
                 $accessToken = $this->checkForExpiredAccessToken();
                 // Update Authentication Mode
-                $transport->setAuthMode('XOAUTH2')
-                ->setUsername($this->fromAddress)
+                $transport->setUsername($this->fromAddress)
                 ->setPassword($accessToken);
                 break;
             case 'office365':
                 $accessToken = $this->checkForExpiredAccessToken();
                 // Update Authentication Mode
-                $transport->setAuthMode('XOAUTH2')
-                ->setUsername($this->fromAddress)
+                $transport->setUsername($this->fromAddress)
                 ->setPassword($accessToken);
                 break;
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
Email sent fail when using google oauth mail client.

## Solution
- Since Laravel 10 the mail service use Symfony Mailer, it does not have the method `setAuthMode` but does not need to use it anymore. This PR removes the use of this function.

## How to Test
- Setup a google auth mail configuration. To enable Gmail SMTP OAuth in email server settings, follow these steps:

  1. Create a new email server configuration.
  2. Click the SMTP Authentication Method setting and select the "google" option.
  3. Save the settings.
  4. Click the Edit icon for the Use Secure Connection setting and select the "tls" option.
  5. Save the settings.
  6. Click the Edit icon for the Server Port setting and enter "587".
  7. Save the settings.
  8. Click the Edit icon for the Server Host setting and enter "smtp.gmail.com".
  9. Save the settings.
  10. Copy the redirect URI from the Gmail Redirect URI setting for creating the Gmail SMTP OAuth integration.
  11. Create Google credentials for the email server's OAuth client.

- Test the email sent

Once fixed in the dish.com server the email could be sent:

![image](https://github.com/ProcessMaker/processmaker/assets/8028650/2da5cb56-2996-4387-a27c-eabbfabdcd41)


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12532

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
