### PR TITLE
Standard Login option doesn't work in SSO configuration

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -58,14 +58,14 @@ class LoginController extends Controller
     {
         $manager = App::make(LoginManager::class);
         $addons = $manager->list();
-        $existErrorSso = Cache::get('ERROR_SSO', false);
+        $driverSSO = null;
         // Review if we need to redirect the default SSO
-        if (config('app.enable_default_sso') && !$existErrorSso) {
+        if (config('app.enable_default_sso')) {
             $arrayAddons = $addons->toArray();
             $driver = $this->getDefaultSSO($arrayAddons);
             // If a default SSO was defined we will to redirect
             if (!empty($driver)) {
-                return redirect()->route('sso.redirect', ['driver' => $driver]);
+                $driverSSO = $driver;
             }
         }
         $block = $manager->getBlock();
@@ -84,7 +84,7 @@ class LoginController extends Controller
             'none'
         );
         $loginView = empty(config('app.login_view')) ? 'auth.login' : config('app.login_view');
-        $response = response(view($loginView, compact('addons', 'block')));
+        $response = response(view($loginView, compact('addons', 'block', 'driver')));
         $response->withCookie($cookie);
 
         return $response;

--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -6,6 +6,7 @@ use App;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Cookie;
 use ProcessMaker\Events\Logout;
 use ProcessMaker\Http\Controllers\Controller;
@@ -57,8 +58,9 @@ class LoginController extends Controller
     {
         $manager = App::make(LoginManager::class);
         $addons = $manager->list();
+        $existErrorSso = Cache::get('ERROR_SSO', false);
         // Review if we need to redirect the default SSO
-        if (config('app.enable_default_sso')) {
+        if (config('app.enable_default_sso') && !$existErrorSso) {
             $arrayAddons = $addons->toArray();
             $driver = $this->getDefaultSSO($arrayAddons);
             // If a default SSO was defined we will to redirect

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -764,6 +764,7 @@
   "Inclusive Gateway": "Inclusive Gateway",
   "Incoming flows do not join": "Incoming flows do not join",
   "Incomplete import of": "Incomplete import of",
+  "Incorrect Login Configuration. Contact your administrator for assistance." : "Incorrect Login Configuration. Contact your administrator for assistance.",
   "Indexed Search": "Indexed Search",
   "info": "info",
   "Info": "Info",


### PR DESCRIPTION
## Issue & Reproduction Steps
When there is a problem in the SSO configuration, it does not allow you to log in

## Solution
- Add variable Error SSO

## How to Test
Configure SSO login with correct and incorrect configuration
login

## Related Tickets & Packages
- [FOUR-12542](https://processmaker.atlassian.net/browse/FOUR-12542)


Depends
https://github.com/ProcessMaker/package-auth/pull/92

ci:package-auth:bugfix/FOUR-12542
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12542]: https://processmaker.atlassian.net/browse/FOUR-12542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ