### PR TITLE
FOUR-12550 Notification Empty when a Translation is added in a Process

### DIFF
--- a/ProcessMaker/Notifications/ProcessTranslationReady.php
+++ b/ProcessMaker/Notifications/ProcessTranslationReady.php
@@ -47,7 +47,13 @@ class ProcessTranslationReady extends Notification
      */
     public function toArray($notifiable)
     {
+        $data = [
+            'humanLanguage' => $this->targetLanguage['humanLanguage'],
+            'processName' => $this->process->name
+        ];
+        $message = __('Process translation to :humanLanguage completed for process: :processName', $data);
         return [
+            'message' => $message,
             'code' => $this->code,
             'name' => __('Process translated'),
             'processId' => $this->process->id ?? '',


### PR DESCRIPTION
**Steps to Reproduce:**

1. Login https://ci-997eeda9bb.eng.processmaker.net/
2. Create a Process
3. Open the Process Configuration
4. Press + Translation button
5. Select a Lenguage
6. Press Translate process button
7. Wait for the notification

**Current Behavior:**
The notification is empty 

**Expected Behavior:**
When a translation is added in a process, the notification should have the correct message.
