### PR TITLE
FOUR-12567 - Problem with the in-flight map of a request

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -67,7 +67,7 @@ class ModelerController extends Controller
             'manager' => $manager,
             'signalPermissions' => SignalManager::permissions($request->user()),
             'autoSaveDelay' => config('versions.delay.process', 5000),
-            'isVersionsInstalled' => PackageHelper::isPackageInstalled('ProcessMaker\Package\Versions\PluginServiceProvider'),
+            'isVersionsInstalled' => PackageHelper::isPmPackageVersionsInstalled(),
             'isDraft' => $draft !== null,
             'pmBlockList' => $pmBlockList,
             'externalIntegrationsList' => $externalIntegrationsList,
@@ -132,7 +132,13 @@ class ModelerController extends Controller
             $requestIdleNodes = $nodeIds->diff($filteredCompletedNodes)->diff($requestInProgressNodes)->values();
 
             // Add completed sequence flow to the list of completed nodes.
-            $sequenceFlowNodes = $this->getCompletedSequenceFlow($xml, $filteredCompletedNodes->implode(' '), $requestInProgressNodes->implode(' '), $matchingNodes->implode(' '));
+            $sequenceFlowNodes = $this->getCompletedSequenceFlow(
+                $xml,
+                $processRequest,
+                $filteredCompletedNodes->implode(' '),
+                $requestInProgressNodes->implode(' '),
+                $matchingNodes->implode(' ')
+            );
             $filteredCompletedNodes = $filteredCompletedNodes->merge($sequenceFlowNodes);
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Due to the fact that the status of the sequence flow is not recorded in the `process_request_tokens` table, difficulties arise in determining whether a flow sequence has been completed or not.

- To replicate this problem, import the attached process.

## Solution
- It is suggested to evaluate the condition of the sequence flow using the process data to determine if a flow sequence has been traversed.
  - Possibly, with more time and approval, another viable solution would be to record the states of the sequence flow in the database, similar to how it is handled with other nodes. This way, it would be much easier to identify if that route has been traversed.

## How to Test
- Follow the reproduction steps of above.

## Related Tickets & Packages
- [FOUR-12567](https://processmaker.atlassian.net/browse/FOUR-12567)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12567]: https://processmaker.atlassian.net/browse/FOUR-12567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ