### PR TITLE
Trigger global signals dispatched by Nayra Service

### DIFF
--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -554,6 +554,24 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
     }
 
     /**
+     * Retrieves IDs of all instances collaborating with the given instance.
+     *
+     * This function compiles a list of IDs from execution instances associated 
+     * with the same process as the input instance, including the instance itself.
+     *
+     * @param ProcessRequest $instance The instance to find collaborators for.
+     * @return int[] Array of collaborating instance IDs.
+     */
+    protected function getCollaboratingInstanceIds($instance)
+    {
+        $ids = ProcessRequest::
+            where('process_collaboration_id', $instance->process_collaboration_id)
+            ->pluck('id')
+            ->toArray();
+        return $ids;
+    }
+
+    /**
      * Build a state object.
      *
      * @param ProcessRequest $instance

--- a/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
@@ -108,6 +108,9 @@ class PersistenceHandler
                 case 'start_event_triggered':
                     $this->persistStartEventTriggered($transaction);
                     break;
+                case 'throw_global_signal_event':
+                    $this->throwGlobalSignalEvent($transaction);
+                    break;
                 case 'event_based_gateway_activated':
                     $this->persistEventBasedGatewayActivated($transaction);
                     break;

--- a/ProcessMaker/Nayra/Repositories/PersistenceTokenTrait.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceTokenTrait.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Nayra\Repositories;
 
 use Illuminate\Support\Facades\Cache;
+use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Listeners\BpmnSubscriber;
 use ProcessMaker\Listeners\CommentsSubscriber;
 use ProcessMaker\Nayra\Bpmn\Events\ActivityActivatedEvent;
@@ -297,5 +298,13 @@ trait PersistenceTokenTrait
         $version = $aboutInfo['version'];
         error_log("Microservice $name version $version is running.");
         Cache::put(self::$aboutCacheKey, $aboutInfo, 60);
+    }
+
+    public function throwGlobalSignalEvent(array $transaction)
+    {
+        $throwElement = $this->deserializer->unserializeEntity($transaction['throw_element']);
+        $token = $transaction['token'] ? $this->deserializer->unserializeToken($transaction['token']) : null;
+        $eventDefinition = $throwElement->getEventDefinitions()->item(0);
+        WorkflowManager::throwSignalEventDefinition($eventDefinition, $token);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Global signal were not being triggered when Nayra trigger them.

## Solution
- Listen for the event throw_global_signal_event to trigger the signal event.

## How to Test

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12555
- https://github.com/ProcessMaker/nayra-docker/pull/36

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
