### PR TITLE
FOUR-12638: Introduce customized optimize:clear

### DIFF
--- a/ProcessMaker/Console/Commands/OptimizeClearCommand.php
+++ b/ProcessMaker/Console/Commands/OptimizeClearCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'optimize:clear')]
+class OptimizeClearCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'optimize:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove the cached bootstrap files';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->components->info('Clearing cached bootstrap files.');
+
+        collect([
+            'events' => fn () => $this->callSilent('event:clear') == 0,
+            'views' => fn () => $this->callSilent('view:clear') == 0,
+            'route' => fn () => $this->callSilent('route:clear') == 0,
+        ])->each(fn ($task, $description) => $this->components->task($description, $task));
+
+        $this->newLine();
+    }
+}


### PR DESCRIPTION
## Issue
In production, we use the `bootstrap/cache/packages.php` file as a cached store of licensed packages which we would like to be loaded. In the case that the `php artisan optimize:clear` command is run, this flushes that file (which is generated with a separate command) and causes the framework to regenerate the file with all packages discovered, regardless of licensing.

## Reproduction Steps
1. Install all custom and enterprise packages using `develop`
2. Run the `php artisan license:update {pathToLicenseJsonFile}` command to generate the package manifest.
3. Interact with the platform and notice everything working as intended
4. Now run `php artisan optimize:clear`
5. Check the platform again (e.g. the `/requests` page). Notice the errors/multiple menu items added, etc. This is because there are multiple additional `ServiceProviders` from the custom packages which are not supposed to be loaded.

## Solution
- Introduce our own `optimize:clear` command to override the framework's and remove the subcommands which alter the cached package manifest.

## How to Test
Run through the reproduction steps and it should now not flush the package manifest.

## Related Tickets & Packages
- For this PR: [FOUR-12638](https://processmaker.atlassian.net/browse/FOUR-12638)
- For licensing feature: [FOUR-11055](https://processmaker.atlassian.net/browse/FOUR-11055)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12638]: https://processmaker.atlassian.net/browse/FOUR-12638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ