### PR TITLE
Resolve missing new process options in New Process modal

### DIFF
--- a/resources/js/components/templates/SelectTemplateModal.vue
+++ b/resources/js/components/templates/SelectTemplateModal.vue
@@ -22,6 +22,7 @@
       <template-search :type="type" :component="currentComponent" @show-details="updateModal($event)" 
         @blank-process-button-clicked="createBlankProcess()"
         @ai-process-button-clicked="createAiProcess()"
+        :showTemplateOptionsActionBar="true"
         :package-ai="packageAi" />
     </modal>
     <create-process-modal ref="create-process-modal" 


### PR DESCRIPTION
This PR resolves the issue of the missing create process option bar from the New Process modal by adding the new attribute `showTemplateOptionsActionBar` to the template search component. The addition of this attribute provides more granular control over which components are displayed when utilizing the Template Search component in different areas of the platform.

## Solution
- Added the `showTemplateOptionsActionBar` attribute to the template search component for better control over component display.

## How to Test

1. Navigate to Designer > Processes.
2. Select the '+ Process' button.
3. Ensure that when the modal appears, the options to 'Build your Own,' 'Generate from Text,' etc., are displayed above the Process Template options.
4. In the top navigation menu, navigate to Processes > Wizard Templates.
5. Confirm that the 'Build your Own,' 'Generate from Text,' etc., options are NOT displayed above the templates in this context.

## Related Tickets & Packages
[FOUR-12668](https://processmaker.atlassian.net/browse/FOUR-12668)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12668]: https://processmaker.atlassian.net/browse/FOUR-12668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ