### PR TITLE
FOUR-12672 Defaulting to the prop Types

### DIFF
--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -78,7 +78,7 @@
           v-if="isProjectsInstalled"
           v-model="formData.projects"
           :errors="errors.projects"
-          :projectId="projectId"
+          :project-id="projectId"
           :label="$t('Project')"
           :required="isProjectSelectionRequired"
           api-get="projects"
@@ -161,13 +161,13 @@ export default {
     this.resetFormData();
     this.resetErrors();
     if (this.isQuickCreate === true) {
-      this.screenTypes = filterScreenType();
+      this.screenTypes = filterScreenType() ?? this.types;
       // in any case the screenType if the only one, default to the first value
       if (Object.keys(this.screenTypes).length === 1) this.formData.type = Object.keys(this.screenTypes)[0];
     }
     if (this.callFromAiModeler === true) {
       this.screenTypes = this.types;
-    } 
+    }
   },
   methods: {
     show() {
@@ -193,10 +193,10 @@ export default {
       this.resetErrors();
     },
     close() {
-      this.$bvModal.hide('createScreen');
+      this.$bvModal.hide("createScreen");
       this.disabled = false;
-      this.$emit('reload');
-    },  
+      this.$emit("reload");
+    },
     onSubmit() {
       this.resetErrors();
       // single click

--- a/resources/js/utils/filterScreenType.js
+++ b/resources/js/utils/filterScreenType.js
@@ -2,6 +2,7 @@ import { ScreenTypes } from "../models/screens";
 
 /**
  * Filter the screen types based on the task
+ * @return {?Object};
  */
 export function filterScreenType() {
   const screen = new URLSearchParams(window.location.search).get("screenType")?.split(",");

--- a/resources/js/utils/filterScreenType.js
+++ b/resources/js/utils/filterScreenType.js
@@ -4,6 +4,7 @@ import { ScreenTypes } from "../models/screens";
  * Filter the screen types based on the task
  */
 export function filterScreenType() {
-  const screen = new URLSearchParams(window.location.search).get("screenType").split(",");
+  const screen = new URLSearchParams(window.location.search).get("screenType")?.split(",");
+  if (!screen) return;
   return Object.fromEntries(Object.entries(ScreenTypes).filter(([key]) => screen.includes(key)));
 }


### PR DESCRIPTION
## Issue & Reproduction Steps


## Solution
- Added a check if the `filterScreenTypes` function returns undefined to default to `this.types`

## How to Test
You can try to create a screen, no errors should appear in the Developer Tools.
Just out of curiosity, try to test creating using the Asset Quick Create

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12672

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
