### PR TITLE
Feature/four-11537: Process Launchpad - Start Web Entry Links

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessOptions.vue
+++ b/resources/js/processes-catalogue/components/ProcessOptions.vue
@@ -11,7 +11,7 @@
     </button>
     <div class="dropdown-menu scrollable-menu p-3 pb-0 mt-2">
       <p
-        class="font-weight-bold px-1"
+        class="font-weight-bold px-1 text-uppercase"
         style="font-size: 14px"
       >
         {{ $t('Starting events') }}


### PR DESCRIPTION
## Issue & Reproduction Steps
As a user, I want a direct link url for copying, including those from web entries so it is easier for me to access.
![image-20231130-153039](https://github.com/ProcessMaker/processmaker/assets/123644082/f44f15b9-e998-4385-9d67-fe1172ed9f63)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11537

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy