### PR TITLE
feature/FOUR-12652: Create table and column to save the Launchpad Settings and bookmarks

### DIFF
--- a/ProcessMaker/Models/Bookmark.php
+++ b/ProcessMaker/Models/Bookmark.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use ProcessMaker\Models\ProcessMakerModel;
+
+class Bookmark extends ProcessMakerModel
+{
+    use HasFactory;
+
+    protected $connection = 'processmaker';
+
+    protected $table = 'user_process_bookmarks';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'user_id',
+        'process_id',
+        'bookmark_type',
+    ];
+}

--- a/database/migrations/2023_11_30_165723_add_launchpad_properties_at_processes.php
+++ b/database/migrations/2023_11_30_165723_add_launchpad_properties_at_processes.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('processes', function (Blueprint $table) {
+            $table->json('launchpad_properties')->nullable();
+        });
+        Schema::table('process_versions', function (Blueprint $table) {
+            $table->json('launchpad_properties')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('processes', function (Blueprint $table) {
+            $table->dropColumn(['launchpad_properties']);
+        });
+        Schema::table('process_versions', function (Blueprint $table) {
+            $table->dropColumn(['launchpad_properties']);
+        });
+    }
+};

--- a/database/migrations/2023_11_30_170839_create_user_process_bookmarks_table.php
+++ b/database/migrations/2023_11_30_170839_create_user_process_bookmarks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_process_bookmarks', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedInteger('process_id');
+            $table->timestamps();
+
+            // Foreign keys
+            $table->foreign('process_id')->references('id')->on('processes')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_process_bookmarks');
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
Create table and column to save the Launchpad Settings and bookmarks

## Solution
- A new table was created `user_process_bookmarks`
- A new column was added `processes.launchpad_properties`

## How to Test
`artisan migrate --force`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12652

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next