### PR TITLE
Feature/four 12636: Update the label "Edit Process" of process options

### DIFF
--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -28,8 +28,8 @@ export default {
           icon: "fas fa-file-export",
         },
         {
-          value: "edit-designer",
-          content: "Edit Process",
+          value: "open-in-modeler",
+          content: "Open in Modeler",
           link: true,
           href: "/modeler/{{id}}",
           permission: ["edit-processes", "create-projects", "view-projects"],

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1133,6 +1133,7 @@
   "Provide Values": "Provide Values",
   "Provider": "Provider",
   "Publish Template": "Publish Template",
+  "Open in Modeler": "Open in Modeler",
   "Queue Management": "Queue Management",
   "QueueManagementAccessed": "Queue Management Accessed",
   "Radio Button Group": "Radio Button Group",


### PR DESCRIPTION
## Issue & Reproduction Steps
The actual option "Edit Process" in the ellipsis menu should change the name to "Open in Modeler".

 In the ellipsis menu add a "Edit Launchpad" The action related to this will work in the ticket FOUR-12634

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12636

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy