### PR TITLE
FOUR-12621: Create an API to get the processes related to the specific Category

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -107,6 +107,11 @@ class ProcessController extends Controller
         if (!empty($filter)) {
             $processes->filter($filter);
         }
+        // Filter by category
+        $category = $request->input('category', null);
+        if (!empty($category)) {
+            $processes->category($category);
+        }
 
         if (!empty($pmql)) {
             try {

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -450,6 +450,14 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         return $query->where('processes.status', 'ARCHIVED');
     }
 
+    /**
+     * Scope a query to include a specific category
+     */
+    public function scopeCategory($query, int $id)
+    {
+        return $query->where('processes.process_category_id', $id);
+    }
+
     public function getCollaborations()
     {
         $this->bpmnDefinitions = app(BpmnDocumentInterface::class, ['process' => $this]);

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -556,6 +556,29 @@ class ProcessTest extends TestCase
     }
 
     /**
+     * Test filter by Category
+     */
+    public function testFilterCategory()
+    {
+        // Create Category
+        $categoryA = ProcessCategory::factory()->create();
+        $categoryB = ProcessCategory::factory()->create();
+        // Now we create process related to this
+        Process::factory()->count(5)->create([
+            'process_category_id' => $categoryB->id,
+        ]);
+        // Get process without category
+        $response = $this->apiCall('GET', route('api.processes.index', ['per_page' => 5, 'page' => 1]));
+        $response->assertJsonCount(5, 'data');
+        // Get process without category
+        $response = $this->apiCall('GET', route('api.processes.index', ['category' => $categoryA->id]));
+        $response->assertJsonCount(0, 'data');
+        // The first page should have 5 items related to the category
+        $response = $this->apiCall('GET', route('api.processes.index', ['category' => $categoryB->id]));
+        $response->assertJsonCount(5, 'data');
+    }
+
+    /**
      * Test pagination of process list
      */
     public function testPagination()


### PR DESCRIPTION
## Issue & Reproduction Steps
Create an API to get the processes related to the specific Category

## Solution
- A new parameter was added in the api `GET /processes?category={process_category}`

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12621

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next