### PR TITLE
FOUR-12667 Multi-Instance (Parallel) not routing the request when the parallel tasks are completed

### DIFF
--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -140,7 +140,6 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
         // Get complementary information
         $version = $instance->process_version_id;
         $userId = $this->getCurrentUserId();
-        $state = $this->serializeState($instance);
 
         // Dispatch complete task action
         $this->dispatchAction([
@@ -152,7 +151,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
                 'element_id' => $token->element_id,
                 'data' => $data,
             ],
-            'state' => $state,
+            'collaboration_uuid' => $instance->collaboration_uuid,
             'session' => [
                 'user_id' => $userId,
             ],
@@ -556,7 +555,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
     /**
      * Retrieves IDs of all instances collaborating with the given instance.
      *
-     * This function compiles a list of IDs from execution instances associated 
+     * This function compiles a list of IDs from execution instances associated
      * with the same process as the input instance, including the instance itself.
      *
      * @param ProcessRequest $instance The instance to find collaborators for.


### PR DESCRIPTION
## Issue & Reproduction Steps
When a process have a Multi-Instance task, sometimes the request is not routed to the next task. The video attached to the ticket in JIRA show the incorrect behavior.

## Solution
`state` value currently is not necessary and is outdated in some situations, send the `collaboration_uuid` is enough for `nayra service` to get the last state of the request

## How to Test
Create a process with a Multi-Instance task and try to route to the next task the most faster possible.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-12667

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
