### PR TITLE
FOUR-12665 The interstitial screen in the start event stops working

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -250,7 +250,7 @@ class ProcessController extends Controller
         $apiRequest = new ApiProcessController();
         $response = $apiRequest->triggerStartEvent($process, $request);
 
-        return redirect('/requests/' . $response->id)->cookie('fromTriggerStartEvent', true, 1);
+        return redirect('/requests/' . $response->id . '?fromTriggerStartEvent=');
     }
 
     private function checkAuth()

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -78,14 +78,14 @@ class RequestController extends Controller
                 if (isset($definition['allowInterstitial'])) {
                     $allowInterstitial = filter_var($definition['allowInterstitial'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                 }
-                if ($allowInterstitial && $request->user_id == Auth::id() && request()->cookie('fromTriggerStartEvent')) {
+                if ($allowInterstitial && $request->user_id == Auth::id() && request()->has('fromTriggerStartEvent')) {
                     $active = $request->tokens()
                         ->where('user_id', Auth::id())
                         ->where('element_type', 'task')
                         ->where('status', 'ACTIVE')
                         ->orderBy('id')->first();
 
-                    return redirect(route('tasks.edit', ['task' => $active ? $active->getKey() : $startEvent->getKey()]))->withoutCookie('fromTriggerStartEvent');
+                    return redirect(route('tasks.edit', ['task' => $active ? $active->getKey() : $startEvent->getKey()]));
                 }
             }
         }

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -76,7 +76,11 @@ class RequestController extends Controller
                 $definition = $startEvent->getDefinition();
                 $allowInterstitial = false;
                 if (isset($definition['allowInterstitial'])) {
-                    $allowInterstitial = filter_var($definition['allowInterstitial'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                    $allowInterstitial = filter_var(
+                        $definition['allowInterstitial'],
+                        FILTER_VALIDATE_BOOLEAN,
+                        FILTER_NULL_ON_FAILURE
+                    );
                 }
                 if ($allowInterstitial && $request->user_id == Auth::id() && request()->has('fromTriggerStartEvent')) {
                     $active = $request->tokens()
@@ -85,7 +89,9 @@ class RequestController extends Controller
                         ->where('status', 'ACTIVE')
                         ->orderBy('id')->first();
 
-                    return redirect(route('tasks.edit', ['task' => $active ? $active->getKey() : $startEvent->getKey()]));
+                    return redirect(route('tasks.edit', [
+                        'task' => $active ? $active->getKey() : $startEvent->getKey()
+                    ]));
                 }
             }
         }

--- a/resources/js/components/requests/card.vue
+++ b/resources/js/components/requests/card.vue
@@ -79,11 +79,10 @@ export default {
         .then(response => {
           this.spin = 0;
           let instance = response.data;
-          this.$cookies.set('fromTriggerStartEvent', true, '1min');
           if (this.$cookies.get("isMobile") === "true") {
             window.location = "/requests/mobile/" + instance.id;
           } else {
-            window.location = "/requests/" + instance.id;
+            window.location = `/requests/${instance.id}?fromTriggerStartEvent=`;
           }
         }).catch((err) => {
           this.disabled = false;


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently, if the interstitial screen is configured in the start event, it never shows up and the request’s task is shown directly. We have noticed that this happens with a process with more than 50 elements (meaning tasks, events, lines, pools, etc.) at the beginning you will see this behavior intermittently but if you increase the number of elements (>50) you will see it permanently. 
If you reduce the number of elements you will see that the interstitial works normally.

## Solution
Replace the `fromTriggerStartEvent` cookie with a query param

## Related Tickets & Packages
[FOUR-12665](https://processmaker.atlassian.net/browse/FOUR-12665)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12665]: https://processmaker.atlassian.net/browse/FOUR-12665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ