### PR TITLE
FOUR-12714: Reorder the menu

### DIFF
--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -29,17 +29,17 @@ class GenerateMenus
                     )->active('home/*');
                 });
             }
-            $menu->group(['prefix' => 'requests'], function ($request_items) {
-                $request_items->add(
-                    __('Requests'),
-                    ['route' => 'requests.index', 'id' => 'requests']
-                )->active('requests/*');
-            });
             $menu->group(['prefix' => 'processes'], function ($request_items) {
                 $request_items->add(
                     __('Processes'),
                     ['route' => 'processes.catalogue.index', 'id' => 'processes-catalogue']
                 )->active('processes-catalogue/*');
+            });
+            $menu->group(['prefix' => 'requests'], function ($request_items) {
+                $request_items->add(
+                    __('Requests'),
+                    ['route' => 'requests.index', 'id' => 'requests']
+                )->active('requests/*');
             });
             //@TODO change the index to the correct blade
             $menu->group(['prefix' => 'tasks'], function ($request_items) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Reorder the menu, the Processes show after Home
![image](https://github.com/ProcessMaker/processmaker/assets/42388723/6ad50934-5ad1-41ec-921c-e6754120dc3b)

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Login and review the order like:
Home - Processes - Request - Task  - Analytics - Designer - Admin

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12714

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next