### PR TITLE
Feature/four 12708: Process Launchpad - Click on Card need to open the process Launch

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -4,6 +4,7 @@
       v-for="process in processList"
       :key="process.id"
       class="card-process"
+      @click="openProcessInfo(process.id)"
     >
       <b-card-text>
         <img
@@ -36,12 +37,14 @@ export default {
   methods: {
     loadCard() {
       /* TODO complete the new API */
-      console.log(this.category.name);
       ProcessMaker.apiClient
         .get("processes")
         .then((response) => {
           this.processList = response.data.data;
         });
+    },
+    openProcessInfo(process) {
+      window.location = `/processes-catalogue/${process}`;
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
Go to Processes

Click one process (card) and open the corresponding Process launchpad

Example:
![image-20231204-181100](https://github.com/ProcessMaker/processmaker/assets/123644082/d6475a77-3941-4ecb-ae85-d09c2a2fc521)
![image-20231204-181119](https://github.com/ProcessMaker/processmaker/assets/123644082/e2266511-c308-4d58-9c5b-bb623621c9ac)


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12708

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy