### PR TITLE
FOUR-12686: Restart `processmaker:consume` command(s) when config changes

### DIFF
--- a/ProcessMaker/Jobs/RefreshArtisanCaches.php
+++ b/ProcessMaker/Jobs/RefreshArtisanCaches.php
@@ -40,6 +40,10 @@ class RefreshArtisanCaches implements ShouldQueue
             Artisan::call('config:cache', $options);
         } else {
             Artisan::call('queue:restart', $options);
+
+            // We call this manually here since this job is dispatched
+            // automatically when the config *is* cached
+            RestartKafkaConsumers::dispatchSync();
         }
     }
 }

--- a/ProcessMaker/Jobs/RefreshArtisanCaches.php
+++ b/ProcessMaker/Jobs/RefreshArtisanCaches.php
@@ -43,7 +43,7 @@ class RefreshArtisanCaches implements ShouldQueue
 
             // We call this manually here since this job is dispatched
             // automatically when the config *is* cached
-            RestartKafkaConsumers::dispatchSync();
+            RestartMessageConsumers::dispatchSync();
         }
     }
 }

--- a/ProcessMaker/Jobs/RestartKafkaConsumers.php
+++ b/ProcessMaker/Jobs/RestartKafkaConsumers.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Support\Str;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
+
+class RestartKafkaConsumers implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    /**
+     * Number of tries to run this job
+     *
+     * @var int
+     */
+    public $tries = 1;
+
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(): void
+    {
+        if (Str::lower(config('app.message_broker_driver')) !== 'kafka') {
+            return;
+        }
+
+        $exitCode = Artisan::call('kafka:restart-consumers', [
+            '--no-interaction' => true,
+        ]);
+
+        Log::info('Kafka Consumer(s) Restart Attempted', [
+            'exit_code' => $exitCode,
+            'command_output' => Artisan::output(),
+        ]);
+    }
+}

--- a/ProcessMaker/Jobs/RestartMessageConsumers.php
+++ b/ProcessMaker/Jobs/RestartMessageConsumers.php
@@ -2,15 +2,15 @@
 
 namespace ProcessMaker\Jobs;
 
-use Illuminate\Support\Str;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
-class RestartKafkaConsumers implements ShouldQueue
+class RestartMessageConsumers implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
@@ -33,6 +33,8 @@ class RestartKafkaConsumers implements ShouldQueue
      */
     public function handle(): void
     {
+        // For now, we;re only addressing the restart of the kafka consumer(s)
+        // and we will address the rabbitmq consumer(s) in another PR
         if (Str::lower(config('app.message_broker_driver')) !== 'kafka') {
             return;
         }

--- a/ProcessMaker/Providers/SettingServiceProvider.php
+++ b/ProcessMaker/Providers/SettingServiceProvider.php
@@ -54,8 +54,8 @@ class SettingServiceProvider extends ServiceProvider
         });
 
         // When the config:cache command is run, we need to restart
-        // horizon and the kafka consumer to ensure they use the
-        // latest version of the cached configuration
+        // horizon and the message consumer(s) to ensure they use
+        // the latest version of the cached configuration
         $this->app['events']->listen(CommandFinished::class, function ($event) {
             if ($this->isCacheConfigCommand($event)) {
                 $this->restartMessageConsumers();

--- a/ProcessMaker/Providers/SettingServiceProvider.php
+++ b/ProcessMaker/Providers/SettingServiceProvider.php
@@ -2,12 +2,12 @@
 
 namespace ProcessMaker\Providers;
 
-use ProcessMaker\Jobs\RestartKafkaConsumers;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Support\ServiceProvider;
 use ProcessMaker\Events\MarkArtisanCachesAsInvalid;
 use ProcessMaker\Jobs\RefreshArtisanCaches;
+use ProcessMaker\Jobs\RestartMessageConsumers;
 use ProcessMaker\Jobs\TerminateHorizon;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Repositories\ConfigRepository;
@@ -133,7 +133,7 @@ class SettingServiceProvider extends ServiceProvider
         // then we don't need to queue another. The job itself checks if
         // Kafka is set at the MESSAGE_BROKER_DRIVER, so no need to
         // check beforehand
-        if (!job_pending($job = RestartKafkaConsumers::class)) {
+        if (!job_pending($job = RestartMessageConsumers::class)) {
             $job::dispatch();
         }
     }

--- a/ProcessMaker/Providers/SettingServiceProvider.php
+++ b/ProcessMaker/Providers/SettingServiceProvider.php
@@ -58,7 +58,7 @@ class SettingServiceProvider extends ServiceProvider
         // latest version of the cached configuration
         $this->app['events']->listen(CommandFinished::class, function ($event) {
             if ($this->isCacheConfigCommand($event)) {
-                $this->restartKafkaConsumers();
+                $this->restartMessageConsumers();
                 $this->restartHorizon();
             }
         });
@@ -127,12 +127,12 @@ class SettingServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function restartKafkaConsumers(): void
+    public function restartMessageConsumers(): void
     {
-        // If there's already a job pending to restart the kafka consumers,
-        // then we don't need to queue another. The job itself checks if
-        // Kafka is set at the MESSAGE_BROKER_DRIVER, so no need to
-        // check beforehand
+        // If there's already a job pending to restart the message consumers,
+        // then we don't need to queue another. The job itself checks which
+        // messaging service is configured and will restart the consumer for
+        // it appropriately
         if (!job_pending($job = RestartMessageConsumers::class)) {
             $job::dispatch();
         }


### PR DESCRIPTION
## Issue
All ProcessMaker settings are persisted in the database, but are also set in the laravel `config()`. When the config is cached, it is stored in `bootstrap/cache/config.php`, which each instance of the app uses when booting up.

Currently, we restart the job queue by listening for config changes since it is a long-running command (`php artisan horizon`) and only reads from `bootstrap/cache/config.php` once when it starts.

When testing an Actions By Email feature, the settings changes which were made were not picked up by the (more recent) `processmaker:consume` artisan command, which is also long-running. This caused an exception to be thrown in the `processmaker:consume` command's process when the ABE email was attempted to be sent.

## Solution
Call the `kafka:restart-consumers` command to restart all running commands to pick up the new configuration change.

## Reproduction Steps
1. Using the latest version of ProcessMaker, install all enterprise packages
2. Ensure the nayra microservice is setup, connected, and functioning properly
3. Cache the configuration (`php artisan config:cache`)
4. Configure Actions by Email in the settings UI and ensure they are correct
5. Create a process which uses a simple ABE node or use [this one](https://github.com/ProcessMaker/processmaker/files/13551067/abe.json.zip)
6. Start a new request with this process
7. Notice the ABE email never arrives
8. Check the logs of the `processmaker:consume` command and notice the errors

## How to Test
Run through the reproduction steps 3-6 and ensure the `processmaker:consume` command is restarted

## Related Tickets & Packages
- [FOUR-12686](https://processmaker.atlassian.net/browse/FOUR-12686)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12686]: https://processmaker.atlassian.net/browse/FOUR-12686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ