### PR TITLE
Fix Visibility Issue of 'Add to Project' Action in Assets Ellipsis Menu

### DIFF
--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -54,6 +54,7 @@ export default {
           value: "add-to-project",
           content: "Add to Project",
           icon: "fas fa-folder-plus",
+          permission: 'create-projects',
         },
         {
           value: "edit-item",

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -45,7 +45,7 @@
             status="{{ $config->status }}"
             v-on:edit="edit"
             v-on:reload="reload"
-            :permission="{{ \Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks') }}"
+            :permission="{{ \Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects') }}"
             :current-user-id="{{ \Auth::user()->id }}"
             is-documenter-installed="{{\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()}}"
         ></processes-listing>

--- a/resources/views/processes/screens/list.blade.php
+++ b/resources/views/processes/screens/list.blade.php
@@ -34,7 +34,7 @@
 
         <screen-listing ref="screenListing"
                         :filter="filter"
-                        :permission="{{ \Auth::user()->hasPermissionsFor('screens') }}"
+                        :permission="{{ \Auth::user()->hasPermissionsFor('screens', 'projects') }}"
                         v-on:reload="reload">
         </screen-listing>
     </div>

--- a/resources/views/processes/scripts/list.blade.php
+++ b/resources/views/processes/scripts/list.blade.php
@@ -24,7 +24,7 @@
         <div class="container-fluid">
             <script-listing :filter="filter"
                             :script-executors='@json($config->scriptExecutors)'
-                            :permission="{{ \Auth::user()->hasPermissionsFor('scripts') }}"
+                            :permission="{{ \Auth::user()->hasPermissionsFor('scripts', 'projects') }}"
                             ref="listScript"
                             @delete="deleteScript">
             </script-listing>


### PR DESCRIPTION
This PR resolves an issue where the 'Add to Project' action in the assets' ellipsis menu was hidden, even with the correct permissions enabled. 

The problem stemmed from the lack of project permissions being included in the permissions variable, resulting in the action being hidden from the user. To fix this, 'projects' was added to the `hasPermissionsFor` check in each of the assets listing components.

## Solution
- Added 'projects' to the `hasPermissionsFor` check in the assets listing components to ensure proper visibility of the 'Add to Project' action.

## How to Test

1. Ensure you have the 'create-projects' permission enabled under Projects.
2. Navigate to Processes, Screens, Scripts, Data Sources, Decision Tables assets, and select the ellipsis menu.
3. Confirm that the 'Add to Projects' action is visible.
4. Ensure that the 'Add to Projects' modal works as expected.

## Related Tickets & Packages
- [FOUR-12739](https://processmaker.atlassian.net/browse/FOUR-12739)

ci:next
ci:package-data-sources:observation/FOUR-12739
ci:package-decision-engine:observation/FOUR-12739

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12739]: https://processmaker.atlassian.net/browse/FOUR-12739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ