### PR TITLE
feature/FOUR-12238: Process Launchpad: API to save and get Bookmarks

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/BookmarkController.php
+++ b/ProcessMaker/Http/Controllers/Api/BookmarkController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Http\Resources\ProcessCollection;
+use ProcessMaker\Models\Bookmark;
+use ProcessMaker\Models\Process;
+
+class BookmarkController extends Controller
+{
+    public function index(Request $request)
+    {
+        // Get the user
+        $user = Auth::user();
+        // Get the order by to apply
+        $orderBy = $this->getRequestSortBy($request, 'name');
+        // Get the processes  active
+        $processes = Process::nonSystem()->active();
+        // Filter pmql
+        $pmql = $request->input('pmql', '');
+        if (!empty($pmql)) {
+            try {
+                $processes->pmql($pmql);
+            } catch (\ProcessMaker\Query\SyntaxError $e) {
+                return response(['error' => 'PMQL error'], 400);
+            }
+        }
+        // Get the processes
+        $processes = $processes
+            ->select('processes.*')
+            ->leftJoin('user_process_bookmarks as bookmark', 'bookmark.process_id', '=', 'processes.id')
+            ->where('bookmark.user_id', $user->id)
+            ->orderBy(...$orderBy)
+            ->get()
+            ->collect();
+
+        return new ProcessCollection($processes);
+    }
+
+    public function store(Request $request, Process $process)
+    {
+        $bookmark = new Bookmark();
+        $bookmark->fill([
+            'process_id' => $process->id,
+            'user_id' => Auth::user()->id
+        ]);
+        try {
+            $bookmark->saveOrFail();
+        } catch (\Exception $e) {
+            return response()->json(['error' => $e->getMessage()], 400);
+        }
+    }
+
+    public function destroy(Request $request, Process $process)
+    {
+        // Get the user
+        $user = Auth::user();
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/BookmarkController.php
+++ b/ProcessMaker/Http/Controllers/Api/BookmarkController.php
@@ -31,6 +31,7 @@ class BookmarkController extends Controller
         $processes = $processes
             ->select('processes.*', 'bookmark.id as bookmark_id')
             ->leftJoin('user_process_bookmarks as bookmark', 'bookmark.process_id', '=', 'processes.id')
+            ->leftJoin('users as user', 'processes.user_id', '=', 'user.id') // Required for the pmql
             ->where('bookmark.user_id', $user->id)
             ->orderBy('processes.name', 'asc')
             ->get()

--- a/ProcessMaker/Models/Bookmark.php
+++ b/ProcessMaker/Models/Bookmark.php
@@ -4,6 +4,8 @@ namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use ProcessMaker\Models\ProcessMakerModel;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\User;
 
 class Bookmark extends ProcessMakerModel
 {
@@ -22,4 +24,17 @@ class Bookmark extends ProcessMakerModel
         'user_id',
         'process_id',
     ];
+
+    public static function rules(): array
+    {
+        return [
+            'user_id' => 'required',
+            'process_id' => 'required',
+        ];
+    }
+
+    public function users()
+    {
+        return $this->hasMany(User::class, 'id');
+    }
 }

--- a/ProcessMaker/Models/Bookmark.php
+++ b/ProcessMaker/Models/Bookmark.php
@@ -4,7 +4,6 @@ namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use ProcessMaker\Models\ProcessMakerModel;
-use ProcessMaker\Models\Process;
 use ProcessMaker\Models\User;
 
 class Bookmark extends ProcessMakerModel

--- a/database/factories/ProcessMaker/Models/BookmarkFactory.php
+++ b/database/factories/ProcessMaker/Models/BookmarkFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories\ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\User;
+
+/**
+ * Bookmark factory
+ */
+class BookmarkFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => function () {
+                return User::factory()->create()->getKey();
+            },
+            'process_id' => function () {
+                return Process::factory()->create()->getKey();
+            },
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use ProcessMaker\Http\Controllers\Api\BookmarkController;
 use ProcessMaker\Http\Controllers\Api\ChangePasswordController;
 use ProcessMaker\Http\Controllers\Api\CommentController;
 use ProcessMaker\Http\Controllers\Api\CssOverrideController;
@@ -135,6 +136,11 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::delete('processes/{process}', [ProcessController::class, 'destroy'])->name('processes.destroy')->middleware('can:archive-processes,process');
     Route::put('processes/{process}/restore', [ProcessController::class, 'restore'])->name('processes.restore')->middleware('can:archive-processes,process');
     Route::put('processes/{process}/duplicate', [ProcessController::class, 'duplicate'])->name('processes.duplicate')->middleware('can:create-processes,process');
+
+    // Process Bookmark
+    Route::get('process_bookmarks', [BookmarkController::class, 'index'])->name('process_bookmarks.index')->middleware('can:view-processes');
+    Route::post('process_bookmarks/{process}', [BookmarkController::class, 'store'])->name('process_bookmarks.store')->middleware('can:edit-processes');
+    Route::delete('process_bookmarks/{process}', [BookmarkController::class, 'destroy'])->name('process_bookmarks.destroy')->middleware('can:edit-processes');
 
     // Process Categories
     Route::get('process_categories', [ProcessCategoryController::class, 'index'])->name('process_categories.index')->middleware('can:view-process-categories');

--- a/routes/api.php
+++ b/routes/api.php
@@ -140,7 +140,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     // Process Bookmark
     Route::get('process_bookmarks', [BookmarkController::class, 'index'])->name('process_bookmarks.index')->middleware('can:view-processes');
     Route::post('process_bookmarks/{process}', [BookmarkController::class, 'store'])->name('process_bookmarks.store')->middleware('can:edit-processes');
-    Route::delete('process_bookmarks/{process}', [BookmarkController::class, 'destroy'])->name('process_bookmarks.destroy')->middleware('can:edit-processes');
+    Route::delete('process_bookmarks/{bookmark}', [BookmarkController::class, 'destroy'])->name('process_bookmarks.destroy')->middleware('can:edit-processes');
 
     // Process Categories
     Route::get('process_categories', [ProcessCategoryController::class, 'index'])->name('process_categories.index')->middleware('can:view-process-categories');

--- a/tests/Feature/Api/BookmarkTest.php
+++ b/tests/Feature/Api/BookmarkTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Models\Bookmark;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\User;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class BookmarkTest extends TestCase
+{
+    use RequestHelper;
+
+    const API_TEST_URL = '/process_bookmarks';
+
+    const STRUCTURE = [
+        'id',
+        'user_id',
+        'process_id',
+        'updated_at',
+        'created_at',
+    ];
+
+    /**
+     * Test get bookmarks
+     */
+    public function testGetBookmark()
+    {
+        // Create a fake
+        $bookmark = Bookmark::factory()->count(10)->create();
+        $user = User::factory()->create();
+        // Call the api GET
+        $response = $this->apiCall('GET', self::API_TEST_URL);
+        // Validate the header status code
+        $response->assertStatus(200);
+    }
+
+    /**
+     * Test store bookmarks
+     */
+    public function testStoreBookmark()
+    {
+        // Create a fake
+        $process = Process::factory()->create();
+        // Call the api POST
+        $response = $this->apiCall('POST', self::API_TEST_URL .'/'. $process->id, []);
+        // Validate the header status code
+        $response->assertStatus(201);
+    }
+
+    /**
+     * Test delete bookmark with error 403
+     */
+    public function testDeleteBookmark403()
+    {
+        // Create a fake
+        $process = Process::factory()->create();
+        // Call the api DELETE
+        $response = $this->apiCall('DELETE', self::API_TEST_URL .'/'. $process->id, []);
+        // Validate the header status code
+        $response->assertStatus(403);
+    }
+
+
+    /**
+     * Test delete bookmark
+     */
+    public function testDeleteBookmark()
+    {
+        // Create a fake
+        $process = Process::factory()->create();
+        $user = User::factory()->create();
+        Auth::login($user);
+        // Call the api POST
+        $this->apiCall('POST', self::API_TEST_URL .'/'. $process->id, []);
+        // Call the api DELETE
+        $response = $this->apiCall('DELETE', self::API_TEST_URL .'/'. $process->id, [
+            'user_id' => $user->id
+        ]);
+        // Validate the header status code
+        $response->assertStatus(204);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Process Launchpad: API to save and get Bookmarks

## Solution
- Implement a new API in order to get, store and delete a bookmark

## How to Test
Tes the new API's to get, save and delete a bookmark
```
GET /process_bookmarks
POST  /process_bookmarks/{process}
DELETE  /process_bookmarks/{process}
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12238

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next