### PR TITLE
FOUR-12716: PMQL "lower" function is not working correctly

### DIFF
--- a/tests/Feature/ExtendedPMQLTest.php
+++ b/tests/Feature/ExtendedPMQLTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Carbon\Carbon;
-use DB;
 use Faker\Factory;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -59,7 +58,7 @@ class ExtendedPMQLTest extends TestCase
         // Instantiate Faker
         $faker = Factory::create();
 
-        //Generate fake data
+        // Generate fake data
         $data = [
             'first_name' => $faker->firstName(),
             'last_name' => $faker->lastName(),
@@ -151,5 +150,22 @@ class ExtendedPMQLTest extends TestCase
         $result = $this->apiCall('GET', $url);
         $requesterId = $result->json()['data'][0]['user_id'];
         $this->assertEquals($requesterId, $user->id);
+    }
+
+    public function testLowerFunction()
+    {
+        ProcessRequest::factory()->create([
+            'data' => ['YQP_CLIENT_NAME' => 'Teresa Roldan HC'],
+        ]);
+
+        $pmqlSearch = 'lower(data.YQP_CLIENT_NAME) LIKE "%teresa roldan hc%"';
+        $route = route('api.requests.index', [
+            'include' => 'data',
+            'pmql' => $pmqlSearch,
+        ]);
+        $response = $this->apiCall('GET', $route);
+
+        $response->assertStatus(200);
+        $this->assertCount(1, $response->json()['data']);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

The pmql should support the use of the function Lower.

1. Create a new PHP script
2. Use the attached PHP script (see JIRA ticket).
3. Execute the script.

After running the script the error displayed is “SERVER ERROR“. Only if you remove the lower function the pmql works.

## Solution

When using a JSON field (`data.example`) and applying the lower function, the following error occurs:

```
An object of the Illuminate\Database\Query\Expression class cannot be converted to a string.
```

This happens because Expression is an object that cannot be directly converted into a string.

This issue likely emerged due to the version upgrade from Laravel 8 to Laravel 10. In Laravel 8, the `__toString()` method existed, but in Laravel 10,this method was removed. Now, to access the value, it is necessary to use the getValue($grammar) method.

Documentation for Laravel 10 and 8:
- [Laravel 10 Documentation](https://laravel.com/api/10.x/Illuminate/Database/Query/Expression.html)
- [Laravel 8 Documentation](https://laravel.com/api/8.x/Illuminate/Database/Query/Expression.html)

## How to Test
Run `php artisan test --filter ExtendedPMQLTest::testLowerFunction`.

## Related Tickets & Packages
- [FOUR-12716](https://processmaker.atlassian.net/browse/FOUR-12716)
- [PQML PR](https://github.com/ProcessMaker/pmql/pull/36)

ci:pmql:bug/FOUR-12716


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12716]: https://processmaker.atlassian.net/browse/FOUR-12716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ