### PR TITLE
Fix Missing Category Dropdown in Create Script Modal for Project Assets

### DIFF
--- a/resources/js/processes/scripts/components/CreateScriptModal.vue
+++ b/resources/js/processes/scripts/components/CreateScriptModal.vue
@@ -81,7 +81,6 @@
               :project-id="projectId"
             />
             <category-select
-              v-show="!projectAsset"
               v-model="script_category_id"
               :errors="addError.script_category_id"
               :label="$t('Category')"


### PR DESCRIPTION
This PR resolves the issue of the missing category select dropdown when creating a script from within a project. The problem was caused by a `v-show` attribute on the `category-select` component in the `create-script-modal` component, which hid the dropdown if the asset being created was a project asset.

## Solution
-  Remove the `v-show` attribute to ensure the visibility of the category dropdown for project assets.

## How to Test

1. Navigate to Designer > Projects.
2. Create a project.
3. Within the project, select the '+ Asset' button.
4. Create a new script.
5. Ensure the category dropdown is visible in the Create Script Modal.

## Related Tickets & Packages
- [FOUR-12756](https://processmaker.atlassian.net/browse/FOUR-12756)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12756]: https://processmaker.atlassian.net/browse/FOUR-12756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

.