### PR TITLE
Fix Access Issue for Users with Only Project Permissions on Screen and Script Configuration Pages

### DIFF
--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -107,6 +107,8 @@ class AuthServiceProvider extends ServiceProvider
             'modeler/',
             'script/',
             'designer/scripts',
+            'designer/screens',
+            'processes/',
             'designer/decision-tables',
             'designer/data-sources',
         ];


### PR DESCRIPTION
This PR resolves an issue where users with only Project permissions were unable to access the configuration page of a screen or script. 

## Solution
- The endpoints `'designer/screen'` and `'designer/scripts/'` were included in the `allowedEndpoints` array for those users.

## How to Test

1. Ensure you have a user with only Project permissions enabled.
2. Log in as that user.
3. Navigate to Designer > Projects.
4. Create a project.
5. Within the project, create a new script and screen via the '+ Asset' button.
6. Navigate back to the project.
7. For each of the created assets, select the Ellipsis menu and navigate to 'Configure.'
8. Verify the configuration page loads as expected with no errors.

## Related Tickets & Packages
-[FOUR-12758](https://processmaker.atlassian.net/browse/FOUR-12758)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12758]: https://processmaker.atlassian.net/browse/FOUR-12758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ