### PR TITLE
Add handle Duplicates to EnvironmentVariableExporter and remove duplicate env variables

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/EnvironmentVariableExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/EnvironmentVariableExporter.php
@@ -10,6 +10,8 @@ class EnvironmentVariableExporter extends ExporterBase
 
     public static $fallbackMatchColumn = 'name';
 
+    public $handleDuplicatesByIncrementing = ['name'];
+
     public function export() : void
     {
         $this->addReference(DependentType::ENVIRONMENT_VARIABLE_VALUE, $this->model->value);

--- a/upgrades/2023_12_07_225946_delete_duplicate_environment_variables.php
+++ b/upgrades/2023_12_07_225946_delete_duplicate_environment_variables.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use ProcessMaker\Models\EnvironmentVariable;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class DeleteDuplicateEnvironmentVariables extends Upgrade
+{
+    /**
+     * Run the upgrade migration.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('delete from environment_variables
+                        where id not in ( SELECT * FROM (select max(id)
+                        from environment_variables group by name) AS S);
+                    ');
+        EnvironmentVariable::where('name', 'ess')->delete();
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses a critical issue related to the automatic creation of environment variables with the same name, which was occurring excessively—surpassing the limit of 100 instances. 

The modifications implemented in this PR effectively resolve the problem, ensuring that the generation of environment variables can handle duplicates in increments and remove all the duplicates.

## Solution 
- Add $handleDuplicatesByIncrementing to the EnvironmentVariableExporter Class 
- Add an upgrade migration to delete all the env duplicates.

## How to Test

In this case, we need to run a few tests, the first one is to make sure all duplicate env variables are been incremented and the second test is to make sure all the duplicate env variables have been deleted.

First Test:
Import PM Block:
- Download the [financial-assistant.json](https://github.com/ProcessMaker/processmaker/files/13605873/financial-assistant.json) file.
- Import the attached PM Block into your environment.
- Revisit the database and ensure that duplicates have been appropriately incremented. (`ess #`)
- Confirm that duplicate environment variables now display a unique number appended at the end of their names.
- Now you can Delete the `ess` variables manually 

Second test:
- The second test will need all of the duplicates with out the increment so in this case, please comment out the `$handleDuplicatesByIncrementing` flag within the `EnvironmentVariableExporter` and reimport the file.
- This will give you all the duplicate environment variables again `ess`.
- run  'php artisan upgrade'
- Please ensure that all of the `ess` variables have been successfully removed from the DB.

## Related Tickets & Packages
[FOUR-12763](https://processmaker.atlassian.net/browse/FOUR-12763)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12763]: https://processmaker.atlassian.net/browse/FOUR-12763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ