### PR TITLE
FOUR-12784:Bullets are not displayed in the rich text component

### DIFF
--- a/resources/js/components/shared/DataTree.vue
+++ b/resources/js/components/shared/DataTree.vue
@@ -25,7 +25,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 ul.tree, ul.tree ul {
   list-style: none;
    margin: 0;

--- a/resources/js/processes/export/components/ExportSuccessModal.vue
+++ b/resources/js/processes/export/components/ExportSuccessModal.vue
@@ -94,7 +94,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 
   ul {
     list-style: none;


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a screen
- Drag and drop the rich text component
- Add some text lines 
- Use the bullet list format 

## Solution
- Add the label **scoped** in the style for the components

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-12784](https://processmaker.atlassian.net/browse/FOUR-12784)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-12784]: https://processmaker.atlassian.net/browse/FOUR-12784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ