### PR TITLE
Cache Storage is throwing a PDOException when the $key already exists

### DIFF
--- a/ProcessMaker/Bpmn/Process.php
+++ b/ProcessMaker/Bpmn/Process.php
@@ -42,6 +42,7 @@ class Process extends ModelsProcess
             $properties = Cache::store('global_variables')->get($key, []);
             $properties[$name] = $value;
             try {
+                Cache::store('global_variables')->forget($key);
                 Cache::store('global_variables')->forever($key, $properties);
             } catch (\Throwable $e) {
                 \Log::error($e->getMessage());


### PR DESCRIPTION
## Issue & Reproduction Steps
Cache Storage is throwing a PDOException when the $key already exists

## Solution
- Remove the $key before to store the new value

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12780

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
