### PR TITLE
FOUR-12806 Fix Forms tasks reloading in submission and not moving forward

### DIFF
--- a/ProcessMaker/Nayra/MessageBrokers/ServiceKafka.php
+++ b/ProcessMaker/Nayra/MessageBrokers/ServiceKafka.php
@@ -46,7 +46,11 @@ class ServiceKafka
     public function sendMessage(string $subject, string $collaborationId, mixed $body)
     {
         $producer = Kafka::publishOn($subject)
-            ->withHeaders(['collaborationId' => $collaborationId])
+        ->withConfigOptions([
+            'message.max.bytes' => config('kafka.message_max_bytes', 10000000),
+            'compression.codec' => config('kafka.compression_codec', 'gzip'),
+        ])
+        ->withHeaders(['collaborationId' => $collaborationId])
             ->withBodyKey('body', $body);
 
         // SASL Configuration
@@ -77,6 +81,8 @@ class ServiceKafka
         $heartbeat = config('kafka.heartbeat_interval_ms', 3000);
         $prefix = config('kafka.prefix', '');
         $consumer = Kafka::createConsumer([$prefix . self::QUEUE_NAME])
+            ->withOption('fetch.message.max.bytes', config('kafka.message_max_bytes', 10000000))
+            ->withOption('compression.codec', config('kafka.compression_codec', 'gzip'))
             ->withOption('heartbeat.interval.ms', $heartbeat)
             ->withOption('session.timeout.ms', $heartbeat * 10);
 

--- a/config/kafka.php
+++ b/config/kafka.php
@@ -73,4 +73,10 @@ return [
     'sasl_username' => env('KAFKA_SASL_USERNAME'),
     'sasl_mechanisms' => env('KAFKA_SASL_MECHANISMS', 'SCRAM-SHA-256'),
     'security_protocol' => env('KAFKA_SECURITY_PROTOCOL', 'SASL_PLAINTEXT'),
+
+    /*
+     | Message max bytes and max message bytes
+     */
+    'message_max_bytes' => env('KAFKA_MESSAGE_MAX_BYTES', 10000000),
+    'compression_codec' => env('KAFKA_COMPRESSION_CODEC', 'gzip'),
 ];


### PR DESCRIPTION
## Issue & Reproduction Steps
Forms tasks reloading in submission and not moving forward. This was caused because the message size exceded the default maximum kafka message size.

## Solution
- Add environment variables to configure message max size and compression
- Set default max size to 10mb
- Set gzip as default compression

## How to Test
- Create a process with a Screen with a text area.
- Run the process
- Fill the textarea with a large content. E.g. 2mb of a character like `"`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12806

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
