### PR TITLE
Fix Unauthorized Error for Users with Only Project Permissions on Data Source Endpoint Creation

### DIFF
--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -66,7 +66,6 @@ class AuthServiceProvider extends ServiceProvider
 
         try {
             $permissions = Permission::select('name')->get();
-
             // Define the Gate permissions
             $permissions->each(function ($permission) {
                 Gate::define($permission->name, function (User $user, ...$params) use ($permission) {
@@ -132,9 +131,27 @@ class AuthServiceProvider extends ServiceProvider
 
     private function handleUpdateDeleteOperations($permission, $modelClass)
     {
-        $asset = Str::snake(class_basename($modelClass));
+        $asset = $this->getAssetName($modelClass);
 
         return $this->checkPermissionForAsset($permission, $asset);
+    }
+
+    /**
+     * Get the asset name based on the model class.
+     *
+     * @param string $modelClass
+     * @return string
+     */
+    private function getAssetName($modelClass)
+    {
+        $asset = Str::snake(class_basename($modelClass));
+
+        // Adjust asset name for DataSource class
+        if ($modelClass === 'DataSource') {
+            $asset = 'data-source';
+        }
+
+        return $asset;
     }
 
     private function checkForListCreateOperations($permission)

--- a/ProcessMaker/Traits/ProjectAssetTrait.php
+++ b/ProcessMaker/Traits/ProjectAssetTrait.php
@@ -14,35 +14,57 @@ trait ProjectAssetTrait
 
     public function syncProjectAsset($requestOrInteger, $assetModelClass)
     {
-        if (class_exists(self::PROJECT_ASSET_MODEL_CLASS)) {
-            $projectIds = [];
-
-            if ($requestOrInteger instanceof Request && $requestOrInteger->has('projects')) {
-                $projectIds = $requestOrInteger->input('projects', '');
-            } elseif (is_int($requestOrInteger)) {
-                $projectIds = $requestOrInteger;
-            }
-
-            if (!empty($projectIds)) {
-                // Check if the string is in the JSON array format
-                $decodedProjects = json_decode($projectIds, true);
-                if (is_array($decodedProjects)) {
-                    $projectIds = implode(',', array_column($decodedProjects, 'id'));
-                } else {
-                    $projectIds = trim($projectIds, ',');
-                }
-
-                // Explode the comma-separated string, filter, and convert to integers
-                $projectIds = array_map('intval', array_filter(explode(',', $projectIds)));
-            }
-
-            try {
-                // Sync the project assets with the prepared project IDs
-                $this->projectAssets()->syncWithPivotValues($projectIds, ['asset_type' => $assetModelClass]);
-            } catch (Exception $e) {
-                throw new ProjectAssetSyncException('Error syncing project assets: ' . $e->getMessage());
-            }
+        if (!class_exists(self::PROJECT_ASSET_MODEL_CLASS)) {
+            return;
         }
+
+        $projectIds = $this->extractProjectIds($requestOrInteger);
+
+        try {
+            // Sync the project assets with the prepared project IDs
+            $this->projectAssets()->syncWithPivotValues($projectIds, ['asset_type' => $assetModelClass]);
+        } catch (Exception $e) {
+            throw new ProjectAssetSyncException('Error syncing project assets: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Extract project IDs from the provided input.
+     *
+     * @param mixed $input
+     * @return array
+     */
+    private function extractProjectIds($input)
+    {
+        if ($input instanceof Request && $input->has('projects')) {
+            $projectIds = $input->input('projects', '');
+        } elseif (is_int($input)) {
+            $projectIds = $input;
+        } else {
+            return [];
+        }
+
+        if (is_string($projectIds)) {
+            $projectIds = $this->convertStringToArray($projectIds);
+        }
+
+        return array_map('intval', array_filter($projectIds));
+    }
+
+    /**
+     * Convert a string to an array, handling JSON decoding.
+     *
+     * @param string $input
+     * @return array
+     */
+    private function convertStringToArray($input)
+    {
+        $decodedProjects = json_decode($input, true);
+        if (is_array($decodedProjects)) {
+            return array_column($decodedProjects, 'id');
+        }
+
+        return array_map('intval', array_filter(explode(',', trim($input, ','))));
     }
 
     public function getProjectsAttribute()

--- a/ProcessMaker/Traits/ProjectAssetTrait.php
+++ b/ProcessMaker/Traits/ProjectAssetTrait.php
@@ -48,7 +48,7 @@ trait ProjectAssetTrait
             $projectIds = $this->convertStringToArray($projectIds);
         }
 
-        return array_map('intval', array_filter($projectIds));
+        return $projectIds;
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves an issue where users with only Project Permissions received an unauthorized 403 error when creating a new endpoint in data sources. The problem stemmed from inconsistencies in how the modal names were being returned, as well as a 500 error when running the `syncProjectAssets` method during data source updates.

## Solution
- Updated the modal name for the 'DataSource' modal to accommodate inconsistent naming conventions.
- Refactored the `syncProjectAssets` method for better clarity and manageability.
- In the `syncProjectAssets` method, handled extracting the project IDs for arrays and strings.

## How to Test

1. Ensure you have a user with only Project permissions enabled.
2. Log in as that user.
3. Navigate to Designer > Projects.
4. Create a project.
5. Within the project navigate to '+ Assets'
6. Create a new Data Source
7. Create a new endpoint within the data source.
8. Verify that no unauthorized 403 errors occur during the process.
9. Update the data source.
10. Ensure that the update process does not result in a 500 error.

## Related Tickets & Packages
- [FOUR-12749](https://processmaker.atlassian.net/browse/FOUR-12749)
- [Data Source PR](https://github.com/ProcessMaker/package-data-sources/pull/343)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12749]: https://processmaker.atlassian.net/browse/FOUR-12749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ