### PR TITLE
FOUR-12246 customize artisan command to generate self-signed certificates

### DIFF
--- a/ProcessMaker/Console/Commands/CreateSamlCertificate.php
+++ b/ProcessMaker/Console/Commands/CreateSamlCertificate.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use CodeGreenCreative\SamlIdp\Console\CreateCertificate;
+
+class CreateSamlCertificate extends CreateCertificate
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'samlidp:cert
+                            {--days=7300 : Number of days to add from today as the expiration date}
+                            {--keyname=key.pem : Full name of the certificate key file}
+                            {--certname=cert.pem : Full name to the certificate file}
+                            {--subject= : Set subject of request or cert}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create new certificate and private key for your IdP';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $storagePath = storage_path('samlidp');
+        $days = $this->option('days');
+        $keyName = $this->option('keyname');
+        $certName = $this->option('certname');
+        $subject = $this->option('subject');
+
+        // Create storage/samlidp directory
+        if (!file_exists($storagePath)) {
+            mkdir($storagePath, 0755, true);
+        }
+
+        $key = sprintf('%s/%s', $storagePath, $keyName);
+        $cert = sprintf('%s/%s', $storagePath, $certName);
+        $question = 'The name chosen for the PEM files already exist. Would you like to overwrite existing PEM files?';
+
+        if ((!file_exists($key) && !file_exists($cert)) || $this->confirm($question)) {
+            $command = 'openssl req -x509 -sha256 -nodes -days %s -newkey rsa:2048 -keyout %s -out %s';
+            $args = [$days, $key, $cert];
+
+            if (!is_null($subject)) {
+                $command .= ' -subj "%s"';
+                $args[] = $subject;
+            }
+
+            exec(vsprintf($command, $args));
+        }
+    }
+}

--- a/ProcessMaker/Console/Commands/CreateSamlCertificate.php
+++ b/ProcessMaker/Console/Commands/CreateSamlCertificate.php
@@ -15,7 +15,8 @@ class CreateSamlCertificate extends CreateCertificate
                             {--days=7300 : Number of days to add from today as the expiration date}
                             {--keyname=key.pem : Full name of the certificate key file}
                             {--certname=cert.pem : Full name to the certificate file}
-                            {--subject= : Set subject of request or cert}';
+                            {--subject= : Set subject of request or cert '
+                                . '(e.g. /C=US/ST=New York/L=New York City/O=Example Inc/CN=example.com)}';
 
     /**
      * The console command description.


### PR DESCRIPTION
## Issue & Reproduction Steps
As a Developer, I want to add more options to the artisan command to generate self-signed certificates

## Solution
- add a customized artisan command to generate self-signed certificates for the IDP

## How to Test
1. Run `php artisan -h samlidp:cert`
2. Run `php artisan samlidp:cert --subject "/C=US/ST=New York/L=New York City/O=Example Inc/CN=example.com"`

## Related Tickets & Packages
[FOUR-12246](https://processmaker.atlassian.net/browse/FOUR-12246)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:SAML_SP_DESTINATION=https://keycloak.processmaker.net/realms/pm4-next/broker/pm4-saml/endpoint



[FOUR-12246]: https://processmaker.atlassian.net/browse/FOUR-12246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ