### PR TITLE
bugfix/FOUR-12857: Process with category inactive could start a reques by Launch Pad

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -106,7 +106,7 @@ export default {
      */
     getCategories() {
       ProcessMaker.apiClient
-        .get(`process_categories?page=${this.page}&per_page=${this.numCategories}`)
+        .get(`process_categories?status=active&page=${this.page}&per_page=${this.numCategories}`)
         .then((response) => {
           this.listCategories = [...this.listCategories, ...response.data.data];
         });


### PR DESCRIPTION
## Issue & Reproduction Steps
Process with category inactive could start a reques by Launch Pad

## Solution
- apply filter by status = active

## How to Test

1. Create a category for process
2. Create a process
3. Assign the process to category created 
4. Inactive the category
5. Go to requests 
6. Search the process with the inactive category (The process does not appear in the list of requests)
7. Go to launch pad
8. Try to start a request of the process with inactive category

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12857

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next