### PR TITLE
FOUR-12868: Create an API to get the total request per process

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -187,6 +187,14 @@ class ProcessRequestController extends Controller
         return new ApiCollection($response, $total);
     }
 
+    public function getCount(Request $request, $process)
+    {
+        $query = ProcessRequest::select();
+        $query->where('process_id', $process);
+
+        return ['meta' => ['total' => $query->count()]];
+    }
+
     /**
      * Display the specified resource.
      *

--- a/routes/api.php
+++ b/routes/api.php
@@ -162,6 +162,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
 
     // Requests
     Route::get('requests', [ProcessRequestController::class, 'index'])->name('requests.index'); // Already filtered in controller
+    Route::get('requests/{process}/count', [ProcessRequestController::class, 'getCount'])->name('requests.count');
     Route::get('requests/{request}', [ProcessRequestController::class, 'show'])->name('requests.show')->middleware('can:view,request');
     Route::put('requests/{request}', [ProcessRequestController::class, 'update'])->name('requests.update')->middleware('can:update,request');
     Route::put('requests/{request}/retry', [ProcessRequestController::class, 'retry'])->name('requests.retry')->middleware('can:update,request');

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -69,6 +69,31 @@ class ProcessRequestsTest extends TestCase
     }
 
     /**
+     * Count the total of request per process
+     */
+    public function testCountRequest()
+    {
+        ProcessRequest::query()->delete();
+        $process = Process::factory()->create();
+        ProcessRequest::factory()->count(10)->create([
+            'process_id' => $process->id
+        ]);
+
+        $response = $this->apiCall('GET', self::API_TEST_URL . '/'. $process->id . '/count');
+
+        // Validate the header status code
+        $response->assertStatus(200);
+
+        // Verify structure
+        $response->assertJsonStructure([
+            'meta',
+        ]);
+
+        // Verify count
+        $this->assertEquals(10, $response->json()['meta']['total']);
+    }
+
+    /**
      * Test to verify that the list dates are in the correct format (yyyy-mm-dd H:i+GMT)
      */
     public function testScreenListDates()


### PR DESCRIPTION
## Issue & Reproduction Steps
Create an API to get the total request per process

## Solution
- `GET 'requests/{process}/count'`

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12868

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next