### PR TITLE
FOUR-12886: The list of process per category needs to return if the process was bookmarked

### DIFF
--- a/ProcessMaker/Models/Bookmark.php
+++ b/ProcessMaker/Models/Bookmark.php
@@ -36,4 +36,12 @@ class Bookmark extends ProcessMakerModel
     {
         return $this->hasMany(User::class, 'id');
     }
+
+    /**
+     * Scope check if the process was bookmarked
+     */
+    public function scopeIsBookmarked($query, $proId, $userId)
+    {
+        return $query->where('process_id', $proId)->where('user_id', $userId)->count();
+    }
 }

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -570,14 +570,15 @@ class ProcessTest extends TestCase
 
         // This will return with bookmark
         $user = Auth::user();
-        Bookmark::factory()->count(5)->create([
+        $process = Process::factory()->create();
+        Bookmark::factory()->create([
+            'process_id' => $process->id,
             'user_id' => $user->id
         ]);
         $response = $this->apiCall('GET',
-            route('api.processes.index',['per_page' => 5, 'page' => 1, 'bookmark' => 1])
+            route('api.processes.index',['per_page' => 5, 'page' => 1, 'bookmark' => true])
         );
         $response->assertJsonCount(5, 'data');
-        $this->assertEquals(1, $response->json()['data'][0]['bookmark']);
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
The list of process per category needs to return if the process was bookmarked

## Solution
add a new filter bookmark like:
- `GET /processes?page=1&per_page=10&bookmark=true`
this will return if the process was bookmarked for the user logged

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12886

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next