### PR TITLE
Gracefully handle missing classes and columns when importing

### DIFF
--- a/ProcessMaker/Exception/PackageNotInstalledException.php
+++ b/ProcessMaker/Exception/PackageNotInstalledException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace ProcessMaker\Exception;
-
-use Exception;
-
-class PackageNotInstalledException extends Exception
-{
-}

--- a/ProcessMaker/ImportExport/Logger.php
+++ b/ProcessMaker/ImportExport/Logger.php
@@ -60,7 +60,7 @@ class Logger
             return;
         }
 
-        ImportLog::dispatch($this->userId, $type, $message, $additionalParams);
+        ImportLog::dispatch($this->userId, $type, substr($message, 0, 1000), $additionalParams);
         $this->logToFile($type, $message, $additionalParams);
     }
 

--- a/resources/js/processes/import/components/ImportLog.vue
+++ b/resources/js/processes/import/components/ImportLog.vue
@@ -3,7 +3,7 @@
     <a href="#" class="link" v-if="!visible" @click.stop="visible = !visible">Show debugging info</a>
     <div v-if="visible">
       <div ref="log" class="log card text-left">
-        <div class="entry" v-for="(line, i) in logEntries" :key="i">{{ line.message }}</div>
+        <div class="entry" :class="{ warn: line.type === 'warn' }" v-for="(line, i) in logEntries" :key="i">{{ line.message }}</div>
       </div>
       <div v-if="allowDownloadDebug">
         <a :href="'/import/download-debug?hash=' + $root.hash">Download Debug Data</a>
@@ -63,5 +63,9 @@ export default {
 }
 .link {
   font-size: 12px;
+}
+.warn {
+  background-color: #FFAB00;
+  font-weight: bold;
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-12929

If a column or class is missing, the import fails.

## Solution
- Log a warning and continue importing

## How to Test
Export a simple process from Winter and import it into Fall. The import should complete without errors.

The process table has a new column, `case_title`. Previously, this was causing it to fail

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12929

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy