### PR TITLE
FOUR-12933 - Fix the content of the email type screen is not displayed in the body of the message

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -220,4 +220,6 @@ return [
     ],
 
     'queue_imports' => env('QUEUE_IMPORTS', true),
+
+    'node_bin_path' => env('NODE_BIN_PATH', '/usr/bin/node'),
 ];


### PR DESCRIPTION
## Issue & Reproduction Steps
The email body is sent empty.

This happens when the laravel configuration is cached.

![image](https://github.com/ProcessMaker/processmaker/assets/8028650/a36338b4-bcb0-466c-897e-2db311c7f561)

## Solution
- Use config to cache variable NODE_BIN_PATH

With the fix:
![image](https://github.com/ProcessMaker/processmaker/assets/8028650/a64bff4d-0c01-4204-886b-96e39e0dce75)

## How to Test
Create a process with a send email task to send an screen type email.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12933

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:connector-send-email:bugfix/FOUR-12933
