### PR TITLE
feature/FOUR-12811: If some process has more than one category the cards related are not listing

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -457,7 +457,9 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
      */
     public function scopeProcessCategory($query, int $id)
     {
-        return $query->where('processes.process_category_id', $id);
+        return $query->whereHas('categories', function ($query) use ($id) {
+            $query->where('process_categories.id', $id);
+        });
     }
 
     public function getCollaborations()


### PR DESCRIPTION
## Issue & Reproduction Steps
 If some process has more than one category the cards related are not listing

## Solution
- Solve the QA observations

## How to Test

- Create process categories
- Create process and assign in more than one category
- Go to Processes

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12811

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next