### PR TITLE
FOUR-12889 add middleware and listeners for saml authentication

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -49,6 +49,7 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except(['logout', 'beforeLogout', 'keepAlive']);
+        $this->middleware('saml_request')->only('showLoginForm');
         $this->maxAttempts = (int) config('password-policies.login_attempts', 5);
     }
 
@@ -272,6 +273,27 @@ class LoginController extends Controller
         if ($this->attemptLogin($request)) {
             if ($request->hasSession()) {
                 $request->session()->put('auth.password_confirmed_at', time());
+            }
+
+            // Check if the user needs to change the password
+            if ($request->filled(['SAMLRequest', 'RelayState']) && $user->force_change_password === 1) {
+                // Store the SAMLRequest and RelayState in a cookie
+                Cookie::queue(
+                    'saml_request',
+                    json_encode([
+                        'SAMLRequest' => $request->get('SAMLRequest'),
+                        'RelayState' => $request->get('RelayState'),
+                    ]),
+                    10,
+                    null,
+                    null,
+                    true,
+                    true,
+                    false,
+                    'none',
+                );
+
+                return redirect()->route('password.change');
             }
 
             return $this->sendLoginResponse($request);

--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -75,6 +75,7 @@ class Kernel extends HttpKernel
         'client' => \Laravel\Passport\Http\Middleware\CheckClientCredentials::class,
         'template-authorization' => \ProcessMaker\Http\Middleware\TemplateAuthorization::class,
         'edit_username_password' => \ProcessMaker\Http\Middleware\ValidateEditUserAndPasswordPermission::class,
+        'saml_request' => \ProcessMaker\Http\Middleware\SamlRequest::class,
     ];
 
     /**

--- a/ProcessMaker/Http/Middleware/SamlRequest.php
+++ b/ProcessMaker/Http/Middleware/SamlRequest.php
@@ -28,19 +28,20 @@ class SamlRequest
                 'RelayState' => $relayState,
             ]);
 
-            // Build the query string and set it
-            $queryString = http_build_query($request->query());
-            $request->server->set('QUERY_STRING', $queryString);
-
-            $allowedUrls = env('APP_URL');
-            $url = $request->url();
+            // Check if the current URL is allowed
+            $allowedUrls = [env('APP_URL')];
+            $url = $request->getSchemeAndHttpHost();
 
             if (in_array($url, $allowedUrls)) {
                 // Remove saml_request cookie
                 Cookie::queue(Cookie::forget('saml_request'));
 
+                // Build the query string and set it
+                $queryString = http_build_query($request->query());
+                $request->server->set('QUERY_STRING', $queryString);
+
                 // To redirect with the new query string, you can use the following:
-                return redirect($url . '?' . $queryString);
+                return redirect($request->url() . '?' . $queryString);
             }
         }
 

--- a/ProcessMaker/Http/Middleware/SamlRequest.php
+++ b/ProcessMaker/Http/Middleware/SamlRequest.php
@@ -29,10 +29,11 @@ class SamlRequest
             ]);
 
             // Check if the current URL is allowed
-            $allowedUrls = [env('APP_URL')];
-            $url = $request->getSchemeAndHttpHost();
+            $appUrl = config('app.url');
+            $allowedRedirectUrls = [$appUrl . '/login'];
+            $url = $request->url();
 
-            if (in_array($url, $allowedUrls)) {
+            if (in_array($url, $allowedRedirectUrls)) {
                 // Remove saml_request cookie
                 Cookie::queue(Cookie::forget('saml_request'));
 
@@ -41,7 +42,7 @@ class SamlRequest
                 $request->server->set('QUERY_STRING', $queryString);
 
                 // To redirect with the new query string, you can use the following:
-                return redirect($request->url() . '?' . $queryString);
+                return redirect($url . '?' . $queryString);
             }
         }
 

--- a/ProcessMaker/Http/Middleware/SamlRequest.php
+++ b/ProcessMaker/Http/Middleware/SamlRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Symfony\Component\HttpFoundation\Response;
+
+class SamlRequest
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->hasCookie('saml_request') && !$request->filled(['SAMLRequest', 'RelayState'])) {
+            // Get the SAMLRequest and RelayState from the cookie
+            $samlRequestCookie = json_decode($request->cookie('saml_request'), true);
+            $saml_Request = $samlRequestCookie['SAMLRequest'];
+            $relay_state = $samlRequestCookie['RelayState'];
+
+            // Add SAMLRequest and RelayState to the query string
+            $request->query->add([
+                'SAMLRequest' => $saml_Request,
+                'RelayState' => $relay_state,
+            ]);
+
+            // Build the query string and set it
+            $queryString = http_build_query($request->query());
+            $request->server->set('QUERY_STRING', $queryString);
+
+            // Remove saml_request cookie
+            Cookie::queue(Cookie::forget('saml_request'));
+
+            // To redirect with the new query string, you can use the following:
+            return redirect($request->url() . '?' . $queryString);
+        }
+
+        return $next($request);
+    }
+}

--- a/ProcessMaker/Listeners/SamlAuthenticated.php
+++ b/ProcessMaker/Listeners/SamlAuthenticated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ProcessMaker\Listeners;
+
+use Illuminate\Auth\Events\Authenticated;
+use CodeGreenCreative\SamlIdp\Jobs\SamlSso;
+
+class SamlAuthenticated
+{
+    /**
+     * Listen for the Authenticated event
+     *
+     * @param  Authenticated $event [description]
+     * @return [type]               [description]
+     */
+    public function handle(Authenticated $event)
+    {
+        if (
+            in_array($event->guard, config('samlidp.guards')) &&
+            request()->filled('SAMLRequest') &&
+            !request()->is('saml/logout') &&
+            request()->isMethod('get') &&
+            $event->user->force_change_password === 0
+        ) {
+            abort(response(SamlSso::dispatchSync($event->guard), 302));
+        }
+    }
+}

--- a/ProcessMaker/Listeners/SamlLogin.php
+++ b/ProcessMaker/Listeners/SamlLogin.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ProcessMaker\Listeners;
+
+use CodeGreenCreative\SamlIdp\Jobs\SamlSso;
+use Illuminate\Auth\Events\Login;
+
+class SamlLogin
+{
+    /**
+     * Listen for the Authenticated event
+     *
+     * @param  Authenticated $event [description]
+     * @return [type]               [description]
+     */
+    public function handle(Login $event): void
+    {
+        if (
+            in_array($event->guard, config('samlidp.guards')) &&
+            request()->filled('SAMLRequest') &&
+            !request()->is('saml/logout') &&
+            $event->user->force_change_password === 0
+        ) {
+            abort(response(SamlSso::dispatchSync($event->guard), 302));
+        }
+    }
+}

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -60,8 +60,8 @@ return [
     'events' => [
         'CodeGreenCreative\SamlIdp\Events\Assertion' => [],
         'Illuminate\Auth\Events\Logout' => ['CodeGreenCreative\SamlIdp\Listeners\SamlLogout'],
-        'Illuminate\Auth\Events\Authenticated' => ['CodeGreenCreative\SamlIdp\Listeners\SamlAuthenticated'],
-        'Illuminate\Auth\Events\Login' => ['CodeGreenCreative\SamlIdp\Listeners\SamlLogin'],
+        'Illuminate\Auth\Events\Authenticated' => ['ProcessMaker\Listeners\SamlAuthenticated'],
+        'Illuminate\Auth\Events\Login' => ['ProcessMaker\Listeners\SamlLogin'],
     ],
 
     // List of guards saml idp will catch Authenticated, Login and Logout events


### PR DESCRIPTION
## Issue & Reproduction Steps
The modal to change a user's password is not shown before creating an account in keycloak

## Solution
- Extend SAML library listeners and add a new middleware to preserve the SAML request

## How to Test
1. Log in with the admin user
2. Create a new user
3. Go to the profile of the new user
4. Go to the admin tab
5. Search for new users and edit
6. Enable User must change password at the next login checkbox
7. Click on the save button
8. Go to https://keycloak.processmaker.net/realms/pm4-next/account/#/
9. Click on Sign in
10. Click on Cool Customer Application

## Related Tickets & Packages
[FOUR-12889](https://processmaker.atlassian.net/browse/FOUR-12889)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:SAML_SP_DESTINATION=https://keycloak.processmaker.net/realms/pm4-next/broker/pm4-saml/endpoint


[FOUR-12889]: https://processmaker.atlassian.net/browse/FOUR-12889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ