### PR TITLE
FOUR-12710: Define the permission to enable see the menu Processes

### DIFF
--- a/ProcessMaker/Observers/UserObserver.php
+++ b/ProcessMaker/Observers/UserObserver.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Observers;
 
 use ProcessMaker\Exception\ReferentialIntegrityException;
 use ProcessMaker\Models\Comment;
+use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\User;
 
@@ -27,5 +28,18 @@ class UserObserver
         Comment::query()
             ->where('user_id', $user->id)
             ->delete();
+    }
+
+    /**
+     * Handle the user "created" event.
+     */
+    public function created(User $user): void
+    {
+        $permissionsList = [
+            'view-process-catalog',
+        ];
+
+        $permissionIds = Permission::whereIn('name', $permissionsList)->pluck('id')->toArray();
+        $user->permissions()->attach($permissionIds);
     }
 }

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -20,6 +20,9 @@ class PermissionSeeder extends Seeder
             'edit-process-categories',
             'view-process-categories',
         ],
+        'Process Catalog' => [
+            'view-process-catalog',
+        ],
         'Process Templates' => [
             'delete-process-templates',
             'create-process-templates',

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -42,6 +42,7 @@ export default {
         {
           value: "edit-launchpad",
           content: "Edit in Launchpad",
+          permission: ["edit-processes", "view-additional-asset-actions"],
           icon: "fas fa-edit",
           conditional: "if(status == 'ACTIVE', true, false)"
         },

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,7 +92,7 @@ Route::middleware('auth', 'sanitize', 'force_change_password')->group(function (
     Route::get('designer/scripts/categories', [ScriptController::class, 'index'])->name('script-categories.index')->middleware('can:view-script-categories');
     Route::get('designer', [DesignerController::class, 'index'])->name('designer.index');
 
-    Route::get('processes-catalogue/{process?}', [ProcessesCatalogueController::class, 'index'])->name('processes.catalogue.index');
+    Route::get('processes-catalogue/{process?}', [ProcessesCatalogueController::class, 'index'])->name('processes.catalogue.index')->middleware('can:view-process-catalog');
     
     Route::get('processes', [ProcessController::class, 'index'])->name('processes.index');
     Route::get('processes/{process}/edit', [ProcessController::class, 'edit'])->name('processes.edit')->middleware('can:edit-processes');


### PR DESCRIPTION
## Issue & Reproduction Steps
Define the permission to enable see the menu Processes

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12710

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next