### PR TITLE
Task/FOUR-12952: Update process translation project to use another model instead of deprecated text-davinci-003

### DIFF
--- a/ProcessMaker/Ai/Handlers/LanguageTranslationHandler.php
+++ b/ProcessMaker/Ai/Handlers/LanguageTranslationHandler.php
@@ -56,6 +56,7 @@ class LanguageTranslationHandler extends OpenAiHandler
             'role' => 'user',
             'content' => $prompt,
         ]];
+
         return $this;
     }
 

--- a/ProcessMaker/Ai/Handlers/NlqToCategoryHandler.php
+++ b/ProcessMaker/Ai/Handlers/NlqToCategoryHandler.php
@@ -10,7 +10,7 @@ class NlqToCategoryHandler extends OpenAiHandler
     {
         parent::__construct();
         $this->config = [
-            'model' => 'text-davinci-003',
+            'model' => 'gpt-3.5-turbo',
             'max_tokens' => 20,
             'temperature' => 0,
             'top_p' => 1,
@@ -34,7 +34,10 @@ class NlqToCategoryHandler extends OpenAiHandler
         $prompt = $this->replaceStopSequence($prompt);
         $prompt = $this->replaceDefaultType($prompt, $type);
 
-        $this->config['prompt'] = $prompt;
+        $this->config['messages'] = [[
+            'role' => 'user',
+            'content' => $prompt,
+        ]];
 
         return $this;
     }
@@ -43,15 +46,17 @@ class NlqToCategoryHandler extends OpenAiHandler
     {
         $client = app(Client::class);
         $response = $client
-            ->completions()
-            ->create(array_merge($this->getConfig()));
-
+            ->chat()
+            ->create(
+                array_merge($this->getConfig()
+                )
+            );
         return $this->formatResponse($response);
     }
 
     private function formatResponse($response)
     {
-        $result = ltrim($response->choices[0]->text);
+        $result = ltrim($response->choices[0]->message->content);
 
         return [strtolower($result), $response->usage, $this->question];
     }

--- a/ProcessMaker/Ai/Handlers/NlqToCategoryHandler.php
+++ b/ProcessMaker/Ai/Handlers/NlqToCategoryHandler.php
@@ -51,6 +51,7 @@ class NlqToCategoryHandler extends OpenAiHandler
                 array_merge($this->getConfig()
                 )
             );
+
         return $this->formatResponse($response);
     }
 

--- a/ProcessMaker/Ai/Handlers/NlqToPmqlHandler.php
+++ b/ProcessMaker/Ai/Handlers/NlqToPmqlHandler.php
@@ -10,7 +10,7 @@ class NlqToPmqlHandler extends OpenAiHandler
     {
         parent::__construct();
         $this->config = [
-            'model' => 'text-davinci-003',
+            'model' => 'gpt-3.5-turbo',
             'max_tokens' => 1900,
             'temperature' => 0,
             'top_p' => 1,
@@ -34,7 +34,10 @@ class NlqToPmqlHandler extends OpenAiHandler
         $prompt = $this->replaceStopSequence($prompt);
         $prompt = $this->replaceWithCurrentYear($prompt);
 
-        $this->config['prompt'] = $prompt;
+        $this->config['messages'] = [[
+            'role' => 'user',
+            'content' => $prompt,
+        ]];
 
         return $this;
     }
@@ -43,15 +46,18 @@ class NlqToPmqlHandler extends OpenAiHandler
     {
         $client = app(Client::class);
         $response = $client
-            ->completions()
-            ->create(array_merge($this->getConfig()));
+            ->chat()
+            ->create(
+                array_merge($this->getConfig()
+                )
+            );
 
         return $this->formatResponse($response);
     }
 
     private function formatResponse($response)
     {
-        $result = ltrim($response->choices[0]->text);
+        $result = ltrim($response->choices[0]->message->content);
         $result = explode('Question:', $result)[0];
         $result = rtrim(rtrim(str_replace("\n", '', $result)));
         $result = str_replace('\'', '', $result);


### PR DESCRIPTION
## Issue & Reproduction Steps
According to the [announcement of OpenAI](https://openai.com/blog/gpt-4-api-general-availability) the model text-davinci-003 are going to be deprecated. We need to update process translations in order to use another model.

## Solution
- Change the model from text-davinci-003 to gpt-3.5-turbo-16k
- Change completion to chat mode required for newest models.

## Related Tickets & Packages
- [FOUR-12952](https://processmaker.atlassian.net/browse/FOUR-12952)

[FOUR-12952]: https://processmaker.atlassian.net/browse/FOUR-12952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy
