### PR TITLE
FOUR-12770 | ”This Action Is Unauthorized" Message for Users Who Are Non-Admin w/ Process Creation Permissions

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -131,7 +131,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('processes', [ProcessController::class, 'store'])->name('processes.store')->middleware('can:create-processes');
     Route::put('processes/{process}', [ProcessController::class, 'update'])->name('processes.update')->middleware('can:edit-processes,process');
     Route::put('processes/{process}/update-bpmn', [ProcessController::class, 'updateBpmn'])->name('processes.update_bpmn')->middleware('can:edit-processes,process');
-    Route::put('processes/{process}/draft', [ProcessController::class, 'updateDraft'])->name('processes.update_draft')->middleware('can:edit-screens,process');
+    Route::put('processes/{process}/draft', [ProcessController::class, 'updateDraft'])->name('processes.update_draft')->middleware('can:edit-processes,process');
     Route::post('processes/{process}/close', [ProcessController::class, 'close'])->name('processes.close')->middleware('can:edit-processes');
     Route::delete('processes/{process}', [ProcessController::class, 'destroy'])->name('processes.destroy')->middleware('can:archive-processes,process');
     Route::put('processes/{process}/restore', [ProcessController::class, 'restore'])->name('processes.restore')->middleware('can:archive-processes,process');


### PR DESCRIPTION
# Issue

Ticket: [FOUR-12770](https://processmaker.atlassian.net/browse/FOUR-12770)

When a non-admin user is working in the Process Modeler, a "This Action is Unauthorized" error is shown when attempting to hit the `processes/{process}/draft` api endpoint.

# Solution
Update the 'update draft' process route permission. The permission was `edit-screens` and needed to be updated to `edit-processes`.

# How to Test
1. Go to branch `observation/FOUR-12770` in `processmaker`.
2. Login to ProcessMaker. Open a Process and the Network Panel.
3. Make a change to the Process. Wait a few seconds.
4. When the 'draft' endpoint is hit, there should be no errors displayed on the screen.

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-12770]: https://processmaker.atlassian.net/browse/FOUR-12770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ