### PR TITLE
FOUR-12757 | Non-Admin User With Project Permissions Cannot Create a PM Block from a Process Within Their Project

### DIFF
--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -78,6 +78,8 @@ class AuthServiceProvider extends ServiceProvider
                     // Users that ONLY have 'create-projects' permission are allowed to access specific endpoints
                     $isAllowedEndpoint = $this->checkAllowedEndpoints(request()->path());
 
+                    // dd($isAllowedEndpoint);
+
                     if ($user->hasPermission('create-projects') && $isAllowedEndpoint) {
                         return $this->isProjectAsset($permission, $params);
                     }
@@ -156,7 +158,7 @@ class AuthServiceProvider extends ServiceProvider
 
     private function checkForListCreateOperations($permission)
     {
-        $projectAssetTypes = ['process', 'screen', 'script', 'data-source', 'decision_table'];
+        $projectAssetTypes = ['process', 'screen', 'script', 'data-source', 'decision_table', 'pm-block'];
 
         foreach ($projectAssetTypes as $asset) {
             if (Str::contains($permission->name, $asset)) {

--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -78,8 +78,6 @@ class AuthServiceProvider extends ServiceProvider
                     // Users that ONLY have 'create-projects' permission are allowed to access specific endpoints
                     $isAllowedEndpoint = $this->checkAllowedEndpoints(request()->path());
 
-                    // dd($isAllowedEndpoint);
-
                     if ($user->hasPermission('create-projects') && $isAllowedEndpoint) {
                         return $this->isProjectAsset($permission, $params);
                     }

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -46,13 +46,13 @@ export default {
         {
           value: "create-template",
           content: "Save as Template",
-          permission: ["create-process-templates", "view-additional-asset-actions"],
+          permission: ["create-process-templates"],
           icon: "fas fa-layer-group",
         },
         {
           value: "create-pm-block",
           content: "Save as PM Block",
-          permission: ["create-pm-blocks", "view-additional-asset-actions"],
+          permission: ["create-pm-blocks"],
           icon: "fas nav-icon fa-cube",
         },
         {


### PR DESCRIPTION
# Issue
Ticket: [FOUR-12757](https://processmaker.atlassian.net/browse/FOUR-12757)

Users that only have Project permissions should not be able to see the 'Save as Template' or 'Save as PM Block' options in the Process Asset Ellipsis Menu within a Project. However, they should still be able to use PM Blocks and Templates within their projects.

# Solution
- Remove `view-additional-asset-actions` from the 'Save as Template' and 'Save as PM Block' actions in the Process Ellipsis Menu.
- Add `pm-block` to the projectAssetTypes array in the `checkForListCreateOperations()` function of the Auth Service Provider. This ensures that users who only have Project permissions will not experience errors when working with PM Blocks in Modeler.

# How to Test
1. Go to branch `observation/FOUR-12757` in `processmaker`.
2. Create a non-admin User who only has Project permissions.
3. Log in as the user. Create or open a Project.
4. Add a Process to the Project.
5. From the Asset Listing, open the Process Ellipsis Menu.
	- There should not be options to 'Save as Template' or 'Save as PM Block'.
6. Open the Process in the Modeler. Open your Console.
7. Add a PM Block to the canvas.
	- There should be no errors in the console when a PM Block is added or removed from the canvas.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-12757]: https://processmaker.atlassian.net/browse/FOUR-12757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ