### PR TITLE
FOUR-12710: Create a new permission View Process Catalog in order to see the information

### DIFF
--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -111,6 +111,9 @@ class PermissionSeeder extends Seeder
             'edit-signals',
             'delete-signals',
         ],
+        'Process Catalog' => [
+            'view-process-catalog',
+        ],
     ];
 
     public function run($seedUser = null)

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -42,6 +42,7 @@ export default {
         {
           value: "edit-launchpad",
           content: "Edit in Launchpad",
+          permission: ["edit-processes", "view-additional-asset-actions"],
           icon: "fas fa-edit",
           conditional: "if(status == 'ACTIVE', true, false)"
         },

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -83,7 +83,7 @@ export default {
           + "&bookmark=true"
           + "&order_by=name&order_direction=asc";
       }
-      return `processes?page=${this.currentPage}`
+      return `process_bookmarks/processes?page=${this.currentPage}`
           + `&per_page=${this.perPage}`
           + `&category=${this.category.id}`
           + `&pmql=${encodeURIComponent(this.pmql)}`

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -106,7 +106,7 @@ export default {
      */
     getCategories() {
       ProcessMaker.apiClient
-        .get(`process_categories?status=active&page=${this.page}&per_page=${this.numCategories}`)
+        .get(`process_bookmarks/categories?status=active&page=${this.page}&per_page=${this.numCategories}`)
         .then((response) => {
           this.listCategories = [...this.listCategories, ...response.data.data];
         });
@@ -120,7 +120,7 @@ export default {
         const categories = this.process.process_category_id;
         const categoryId = typeof categories === "string" ? categories.split(",")[0] : categories;
         ProcessMaker.apiClient
-          .get(`process_categories/${categoryId}`)
+          .get(`process_bookmarks/${categoryId}`)
           .then((response) => {
             this.category = response.data;
           });

--- a/routes/api.php
+++ b/routes/api.php
@@ -138,9 +138,19 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::put('processes/{process}/duplicate', [ProcessController::class, 'duplicate'])->name('processes.duplicate')->middleware('can:create-processes,process');
 
     // Process Bookmark
-    Route::get('process_bookmarks', [BookmarkController::class, 'index'])->name('process_bookmarks.index')->middleware('can:view-processes');
-    Route::post('process_bookmarks/{process}', [BookmarkController::class, 'store'])->name('process_bookmarks.store')->middleware('can:edit-processes');
-    Route::delete('process_bookmarks/{bookmark}', [BookmarkController::class, 'destroy'])->name('process_bookmarks.destroy')->middleware('can:edit-processes');
+    $middlewareCatalog = 'can:view-process-catalog';
+    Route::get('process_bookmarks/processes', [ProcessController::class, 'index'])
+    ->name('bookmarks.processes.index')->middleware($middlewareCatalog);
+    Route::get('process_bookmarks/categories', [ProcessCategoryController::class, 'index'])
+    ->name('bookmarks.categories.index')->middleware($middlewareCatalog);
+    Route::get('process_bookmarks/{process_category}', [ProcessCategoryController::class, 'show'])
+    ->name('bookmarks.categories.show')->middleware($middlewareCatalog);
+    Route::get('process_bookmarks', [BookmarkController::class, 'index'])
+    ->name('bookmarks.index')->middleware($middlewareCatalog);
+    Route::post('process_bookmarks/{process}', [BookmarkController::class, 'store'])
+    ->name('bookmarks.store')->middleware($middlewareCatalog);
+    Route::delete('process_bookmarks/{bookmark}', [BookmarkController::class, 'destroy'])
+    ->name('bookmarks.destroy')->middleware($middlewareCatalog);
 
     // Process Categories
     Route::get('process_categories', [ProcessCategoryController::class, 'index'])->name('process_categories.index')->middleware('can:view-process-categories');

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,7 +92,7 @@ Route::middleware('auth', 'sanitize', 'force_change_password')->group(function (
     Route::get('designer/scripts/categories', [ScriptController::class, 'index'])->name('script-categories.index')->middleware('can:view-script-categories');
     Route::get('designer', [DesignerController::class, 'index'])->name('designer.index');
 
-    Route::get('processes-catalogue/{process?}', [ProcessesCatalogueController::class, 'index'])->name('processes.catalogue.index');
+    Route::get('processes-catalogue/{process?}', [ProcessesCatalogueController::class, 'index'])->name('processes.catalogue.index')->middleware('can:view-process-catalog');
     
     Route::get('processes', [ProcessController::class, 'index'])->name('processes.index');
     Route::get('processes/{process}/edit', [ProcessController::class, 'edit'])->name('processes.edit')->middleware('can:edit-processes');


### PR DESCRIPTION
## Issue & Reproduction Steps
Create a new permission View Process Catalog in order to see the information, per default all new usesr will have this permission and all the admin users, this permission will be enable by default.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12710

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next