### PR TITLE
FOUR-12885: Add additional enum values to status column for users

### DIFF
--- a/database/migrations/2023_12_20_180946_add_new_status_values_to_users_table.php
+++ b/database/migrations/2023_12_20_180946_add_new_status_values_to_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE users MODIFY COLUMN status ENUM('ACTIVE', 'INACTIVE', 'OUT_OF_OFFICE', 'SCHEDULED') NOT NULL DEFAULT 'ACTIVE'");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE users MODIFY COLUMN status ENUM('ACTIVE', 'INACTIVE') NOT NULL DEFAULT 'ACTIVE'");
+    }
+};


### PR DESCRIPTION
## Issue
Two additional values were added in the UI to updates the `status` column in the `users` table. This particular column has an `enum()` value type with only `ACTIVE` and `INACTIVE` as the available values. These values were never added to the actual column in the database and as such, this feature fails to update since the enum will reject any values which don't match it's set.

## Reproduction Steps

1. Log in with admin user
2. Create a user
3. Go to profile of new user
4. Go to admin tab
5. Search new user and edit

**First scenario:**
1. Go to Settings 
2. Select Out of Office in Status list
3. Click on Save button
4. Reload page

**Second scenario:**
1. Go to Settings 
2. Select Scheduled in Status list
3. Click on Save button
4. Reload page

## Solution
- Add a database migration to add the enum values

## How to Test
The reproduction steps should not reproduce the issue.

## Related Tickets & Packages
- [FOUR-12885](https://processmaker.atlassian.net/browse/FOUR-12885)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12885]: https://processmaker.atlassian.net/browse/FOUR-12885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ