### PR TITLE
FOUR-12665 the interstitial screen in the start event stops working

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -89,8 +89,15 @@ class RequestController extends Controller
                         ->where('status', 'ACTIVE')
                         ->orderBy('id')->first();
 
+                    // If the interstitial is enabled on the start event, then use it as the task
+                    if ($active) {
+                        $task = $allowInterstitial ? $startEvent : $active;
+                    } else {
+                        $task = $startEvent;
+                    }
+
                     return redirect(route('tasks.edit', [
-                        'task' => $active ? $active->getKey() : $startEvent->getKey()
+                        'task' => $task->getKey(),
                     ]));
                 }
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently, if the interstitial screen is configured in the start event, it never shows up and the request’s task is shown directly. 

## Solution
- fix the logic for task redirection

## Related Tickets & Packages
[FOUR-12665](https://processmaker.atlassian.net/browse/FOUR-12665)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy


[FOUR-12665]: https://processmaker.atlassian.net/browse/FOUR-12665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ