### PR TITLE
FOUR-12992: The permission View Process Catalog, needs to enable per Default for the new users

### DIFF
--- a/ProcessMaker/Observers/UserObserver.php
+++ b/ProcessMaker/Observers/UserObserver.php
@@ -35,8 +35,10 @@ class UserObserver
      */
     public function created(User $user): void
     {
-        if ($permission = Permission::where('name', 'view-process-catalog')->first()) {
-            $user->permissions()->attach($permission->id);
-        }
+        $perList = [
+            'view-process-catalog'
+        ];
+        $permissionIds = Permission::whereIn('name', $perList)->pluck('id')->toArray();
+        $user->permissions()->attach($permissionIds);
     }
 }

--- a/ProcessMaker/Observers/UserObserver.php
+++ b/ProcessMaker/Observers/UserObserver.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Observers;
 
 use ProcessMaker\Exception\ReferentialIntegrityException;
 use ProcessMaker\Models\Comment;
+use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\User;
 
@@ -27,5 +28,15 @@ class UserObserver
         Comment::query()
             ->where('user_id', $user->id)
             ->delete();
+    }
+
+    /**
+     * Handle the user "created" event.
+     */
+    public function created(User $user): void
+    {
+        if ($permission = Permission::where('name', 'view-process-catalog')->first()) {
+            $user->permissions()->attach($permission->id);
+        }
     }
 }

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -111,6 +111,9 @@ class PermissionSeeder extends Seeder
             'edit-signals',
             'delete-signals',
         ],
+        'Process Catalog' => [
+            'view-process-catalog',
+        ],
     ];
 
     public function run($seedUser = null)

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -111,9 +111,6 @@ class PermissionSeeder extends Seeder
             'edit-signals',
             'delete-signals',
         ],
-        'Process Catalog' => [
-            'view-process-catalog',
-        ],
     ];
 
     public function run($seedUser = null)

--- a/tests/Feature/Api/PermissionsTest.php
+++ b/tests/Feature/Api/PermissionsTest.php
@@ -104,6 +104,13 @@ class PermissionsTest extends TestCase
 
     public function testSetPermissionsViewProcessCatalogForUser()
     {
+        Permission::updateOrCreate([
+            'name' => 'view-process-catalog',
+        ], [
+            'title' => 'View Process Catalog',
+            'name' => 'view-process-catalog',
+            'group' => 'Process Catalog',
+        ]);
         $testUser = User::updateOrCreate([
             'username' => 'will',
             'is_administrator' => true,
@@ -116,6 +123,8 @@ class PermissionsTest extends TestCase
         ]);
         // Assert that the permissions has been set
         $this->assertTrue($testUser->hasPermission('view-process-catalog'));
+        // Clean
+        session(['permissions' => null]);
     }
 
     public function testCategoryPermission()

--- a/tests/Feature/Api/PermissionsTest.php
+++ b/tests/Feature/Api/PermissionsTest.php
@@ -102,6 +102,22 @@ class PermissionsTest extends TestCase
         $this->assertEquals($testUser->permissions->first()->id, $testPermission->id);
     }
 
+    public function testSetPermissionsViewProcessCatalogForUser()
+    {
+        $testUser = User::updateOrCreate([
+            'username' => 'will',
+            'is_administrator' => true,
+        ], [
+            'username' => 'will',
+            'password' => 'Sample123+',
+            'email' => 'will@gmail.com',
+            'firstname' => 'will',
+            'lastname' => 'will',
+        ]);
+        // Assert that the permissions has been set
+        $this->assertTrue($testUser->hasPermission('view-process-catalog'));
+    }
+
     public function testCategoryPermission()
     {
         $context = function ($type, $class) {

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -176,7 +176,7 @@ class UsersTest extends TestCase
             'lastname' => $faker->lastName(),
             'email' => $faker->email(),
             'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
-            'password' => $faker->password(8) . 'A' . '1',
+            'password' => $faker->password(8) . 'A' . '1' . '+',
             'datetime_format' => $dateFormat,
         ]);
 

--- a/upgrades/2023_12_21_142322_create_permission_view_process_catalog.php
+++ b/upgrades/2023_12_21_142322_create_permission_view_process_catalog.php
@@ -10,13 +10,13 @@ class CreatePermissionViewProcessCatalog extends Upgrade
      */
     public function up(): void
     {
-        if (!Permission::where('name', 'view-process-catalog')->first()) {
-            Permission::factory()->create([
-                'title' => 'View Process Catalog',
-                'name' => 'view-process-catalog',
-                'group' => 'Process Catalog',
-            ]);
-        }
+        Permission::updateOrCreate([
+            'name' => 'view-process-catalog',
+        ], [
+            'title' => 'View Process Catalog',
+            'name' => 'view-process-catalog',
+            'group' => 'Process Catalog',
+        ]);
     }
 
     /**
@@ -24,8 +24,6 @@ class CreatePermissionViewProcessCatalog extends Upgrade
      */
     public function down(): void
     {
-        if ($permission = Permission::where('name', 'view-process-catalog')->first()) {
-            $permission->delete();
-        }
+        Permission::where('name', 'view-process-catalog')->delete();
     }
 }

--- a/upgrades/2023_12_21_142322_create_permission_view_process_catalog.php
+++ b/upgrades/2023_12_21_142322_create_permission_view_process_catalog.php
@@ -1,0 +1,31 @@
+<?php
+
+use ProcessMaker\Models\Permission;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class CreatePermissionViewProcessCatalog extends Upgrade
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Permission::where('name', 'view-process-catalog')->first()) {
+            Permission::factory()->create([
+                'title' => 'View Process Catalog',
+                'name' => 'view-process-catalog',
+                'group' => 'Process Catalog',
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if ($permission = Permission::where('name', 'view-process-catalog')->first()) {
+            $permission->delete();
+        }
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
The permission View Process Catalog, needs to enable per Default for the new users

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12992

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next