### PR TITLE
FOUR-13013 | Slider Image Needs to Be Centered Next to Text

### DIFF
--- a/resources/js/components/templates/WizardTemplateDetails.vue
+++ b/resources/js/components/templates/WizardTemplateDetails.vue
@@ -32,8 +32,12 @@
           </div>
         </b-col>
         <b-col>
-          <b-carousel fade :interval="slideInterval">
-            <b-carousel-slide v-for="(image, index) in templateSlides" :key="index" :img-src="image"/>
+          <b-carousel class="d-flex align-items-center justify-content-center h-100 w-100" fade :interval="slideInterval">
+            <b-carousel-slide
+              v-for="(image, index) in templateSlides"
+              :key="index"
+              :img-src="image"
+            />
           </b-carousel>
         </b-col>
       </b-row>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-13013](https://processmaker.atlassian.net/browse/FOUR-13013)

Within the Wizard Template Details modal, the slide images need to be vertically centered in comparison to the text on the left of the slide.
# Previous UI
![Screen Shot 2023-12-21 at 12 25 53 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/1684d21c-f696-4565-9149-aa1de59e0087)

# Updated UI
![Screen Shot 2023-12-21 at 12 26 10 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/04f34b1b-c3ec-4ca2-ab4e-278e367b48fa)

# How to Test
1. Go to branch `observation/FOUR-13013` in `processmaker`.
2. Go to Processes → Guided Templates.
3. Select the Invoice Approval template.
4. In the modal that opens, the images on the right should be vertically centered with the text on the left.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13013]: https://processmaker.atlassian.net/browse/FOUR-13013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ