### PR TITLE
FOUR-13012 | When a Process is Clicked and Then a Templates is Clicked, the Process Shows at the Bottom of the Template Page

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -36,22 +36,26 @@
           v-if="!showWizardTemplates && !showCardProcesses && !showProcess"
           class="d-flex justify-content-center py-5"
         >
-          <CatalogueEmpty v-if="!showWizardTemplates && !fields.length" />
+          <CatalogueEmpty />
         </div>
-        <wizard-templates v-if="showWizardTemplates" />
-        <CardProcess
-          v-if="showCardProcesses"
-          :category="category"
-          @openProcess="openProcess"
-        />
-        <ProcessInfo
-          v-if="showProcess"
-          :process="selectedProcess"
-          :current-user-id="currentUserId"
-          :permission="permission"
-          :is-documenter-installed="isDocumenterInstalled"
-          @goBackCategory="returnedFromInfo"
-        />
+        <div v-else>
+          <CardProcess
+            v-if="showCardProcesses && !showWizardTemplates"
+            :category="category"
+            @openProcess="openProcess"
+          />
+          <ProcessInfo
+            v-if="showProcess && !showWizardTemplates"
+            :process="selectedProcess"
+            :current-user-id="currentUserId"
+            :permission="permission"
+            :is-documenter-installed="isDocumenterInstalled"
+            @goBackCategory="returnedFromInfo"
+          />
+          <wizard-templates
+            v-if="showWizardTemplates"
+          />
+        </div>
       </b-col>
     </b-row>
   </div>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-13012](https://processmaker.atlassian.net/browse/FOUR-13012)

From the Processes Page, if you click on the Guided Template option, then on a Process option, and go back to Guided Templates, the Process Info will display under the Guided Templates.

# Solution
Update the handling of the Catalogue Empty, CardProcess, ProcessInfo, and WizardTemplates components in relation to one another.

# How to Test
1. Go to branch `observation/FOUR-13012` in `processmaker`.
2. Go to Processes → Guided Templates.
3. Next, select an Available Process.
4. Selected Guided Templates again.
	- There should be no Process info under the Guided Templates.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13012]: https://processmaker.atlassian.net/browse/FOUR-13012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ