### PR TITLE
FOUR-12885: Added migration to convert status column from enum to varchar

### DIFF
--- a/database/migrations/2023_12_18_104245_check_fix_status_at_users_table.php
+++ b/database/migrations/2023_12_18_104245_check_fix_status_at_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $isMysql = DB::getDriverName() === 'mysql';
+        if (!$isMysql) {
+            return;
+        }
+        // check if the column status is of type enum
+        $column = DB::selectOne('SHOW COLUMNS FROM users WHERE Field = "status"');
+        $isEnum = substr($column->Type, 0, 4) === 'enum';
+        if (!$isEnum) {
+            return;
+        }
+        // change the column status to varchar
+        DB::statement('ALTER TABLE users MODIFY COLUMN status VARCHAR(255) NOT NULL DEFAULT "ACTIVE"');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
## Issue
The `status` column in the `users` table is sometimes registered as an `enum()` when is should be a `varchar`. This PR converts that column to `varchar` if it finds it that way.

## Reproduction Steps
1. Log in with admin user
2. Create a user
3. Go to profile of new user
4. Go to admin tab
5. Search new user and edit

**First scenario:**
1. Go to Settings 
2. Select Out of Office in Status list
3. Click on Save button
4. Reload page

**Second scenario:**
1. Go to Settings 
2. Select Scheduled in Status list
3. Click on Save button
4. Reload page

## Solution
- Add a database migration to convert the status column to varchar

## How to Test
The reproduction steps should not reproduce the issue.

## Related Tickets & Packages
- [FOUR-12885](https://processmaker.atlassian.net/browse/FOUR-12885)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12885]: https://processmaker.atlassian.net/browse/FOUR-12885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ