### PR TITLE
FOUR-12828: Save changes modified to suit AI asset generation

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -170,8 +170,8 @@ export default {
     ProcessMaker.$modeler = this.$refs.modeler;
     window.ProcessMaker.EventBus.$emit("modeler-app-init", this);
 
-    window.ProcessMaker.EventBus.$on("modeler-save", (redirectUrl, nodeId, onSuccess, onError) => {
-      this.saveProcess(onSuccess, onError, redirectUrl, nodeId);
+    window.ProcessMaker.EventBus.$on("modeler-save", (redirectUrl, nodeId, generatingAssets, onSuccess, onError) => {
+      this.saveProcess(onSuccess, onError, redirectUrl, nodeId, generatingAssets);
     });
     window.ProcessMaker.EventBus.$on("modeler-change", () => {
       window.ProcessMaker.EventBus.$emit("new-changes");
@@ -231,16 +231,16 @@ export default {
       return notifications;
     },
     emitSaveEvent({
-      xml, svg, redirectUrl = null, nodeId = null,
+      xml, svg, redirectUrl = null, nodeId = null, generatingAssets = false,
     }) {
       this.dataXmlSvg.xml = xml;
       this.dataXmlSvg.svg = svg;
 
       if (this.externalEmit.includes("open-modal-versions")) {
-        window.ProcessMaker.EventBus.$emit("open-modal-versions", redirectUrl, nodeId);
+        window.ProcessMaker.EventBus.$emit("open-modal-versions", redirectUrl, nodeId, generatingAssets);
         return;
       }
-      window.ProcessMaker.EventBus.$emit("modeler-save", redirectUrl, nodeId);
+      window.ProcessMaker.EventBus.$emit("modeler-save", redirectUrl, nodeId, generatingAssets);
     },
     emitDiscardEvent() {
       if (this.externalEmit.includes("open-versions-discard-modal")) {
@@ -256,7 +256,7 @@ export default {
           window.location.reload();
         });
     },
-    saveProcess(onSuccess, onError, redirectUrl = null, nodeId = null) {
+    saveProcess(onSuccess, onError, redirectUrl = null, nodeId = null, generatingAssets = false) {
       const data = {
         name: this.process.name,
         description: this.process.description,
@@ -280,7 +280,7 @@ export default {
         if (response.data.warnings && response.data.warnings.length > 0) {
           window.ProcessMaker.EventBus.$emit("save-changes-activate-autovalidate");
         }
-        window.ProcessMaker.EventBus.$emit("save-changes", redirectUrl, nodeId);
+        window.ProcessMaker.EventBus.$emit("save-changes", redirectUrl, nodeId, generatingAssets);
         if (!redirectUrl) {
           window.ProcessMaker.EventBus.$emit("redirect");
         }


### PR DESCRIPTION
## Description
AI Unified project requires that the generated assets be shown on a reload to the Modeler project so that the bpmn has every assets in order and avoid a regeneration of screens and scripts already associated to the process's tasks.

## Solution
- On core, modify the save-changes event to let the generateAssets() function on modeler be executed on a successful save of the process.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12828

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
