### PR TITLE
FOUR-13011 | Display a ‘No Templates’ Image When Searching for a Template

### DIFF
--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -34,13 +34,28 @@
       </b-card-group>
 
       <div class="pb-2 template-container">
-        <template v-if="noResults">
+        <template v-if="noResults && type !== 'wizard'">
           <div class="no-data-icon d-flex d-block justify-content-center pb-2">
             <i class="fas fa-umbrella-beach mt-5" />
           </div>
           <div class="no-data d-block d-flex justify-content-center">
             {{ $t('No Data Available') }}
           </div>
+        </template>
+        <template v-else-if="noResults && type == 'wizard'">
+          <div class="d-flex justify-content-center my-5">
+            <img
+              class="image d-flex"
+              src="/img/processes-catalogue-empty.svg"
+              alt="recent projects"
+            >
+          </div>
+          <h4 class="text-center">
+            {{ $t("Currently, there are no Guided Templates available.") }}
+          </h4>
+          <p class="text-center">
+            {{ $t('Please check back soon.') }}
+          </p>
         </template>
         <template v-else>
           <b-card-group id="template-options" deck class="d-flex small-deck-margin template-options">

--- a/resources/js/processes-catalogue/components/CatalogueEmpty.vue
+++ b/resources/js/processes-catalogue/components/CatalogueEmpty.vue
@@ -8,10 +8,10 @@
       >
     </div>
     <h4 class="text-center">
-      {{ $t('Currently you dont have processes created') }}
+      {{ $t("Currently, you don't have any processes created.") }}
     </h4>
     <p class="text-center">
-      {{ $t('We encourage you to create new processes using our templates') }}
+      {{ $t('We encourage you to create new processes using our templates.') }}
     </p>
     <p class="text-center my-4">
       <button

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -25,22 +25,26 @@
           v-if="!showWizardTemplates && !showCardProcesses && !showProcess"
           class="d-flex justify-content-center py-5"
         >
-          <CatalogueEmpty v-if="!showWizardTemplates && !fields.length" />
+          <CatalogueEmpty />
         </div>
-        <wizard-templates v-if="showWizardTemplates" />
-        <CardProcess
-          v-if="showCardProcesses"
-          :category="category"
-          @openProcess="openProcess"
-        />
-        <ProcessInfo
-          v-if="showProcess"
-          :process="selectedProcess"
-          :current-user-id="currentUserId"
-          :permission="permission"
-          :is-documenter-installed="isDocumenterInstalled"
-          @goBackCategory="returnedFromInfo"
-        />
+        <div v-else>
+          <CardProcess
+            v-if="showCardProcesses && !showWizardTemplates"
+            :category="category"
+            @openProcess="openProcess"
+          />
+          <ProcessInfo
+            v-if="showProcess && !showWizardTemplates"
+            :process="selectedProcess"
+            :current-user-id="currentUserId"
+            :permission="permission"
+            :is-documenter-installed="isDocumenterInstalled"
+            @goBackCategory="returnedFromInfo"
+          />
+          <wizard-templates
+            v-if="showWizardTemplates"
+          />
+        </div>
       </b-col>
     </b-row>
   </div>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-13011](https://processmaker.atlassian.net/browse/FOUR-13011)

If a user does not have any Guided Templates available, a 'No Templates' image should display when searching for templates. This is similar functionality to the 'No Processes' image that displays when there are no Processes available.

# Previous UI
![Screen Shot 2023-12-22 at 18 05 31 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/23a4d8ba-f613-4339-8bf8-1c0004f24980)


# Updated UI
![Screen Shot 2023-12-22 at 18 02 59 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/a6dc64ac-0aab-4919-9450-f03c19f8ace9)


# How to Test
1. Go to branch `observation/FOUR-13011` in `processmaker`.
2. If you have Guided Templates, wipe them from your database.
3. Go to Processes → Guided Templates.
4. An image should appear letting the user know that no Guided Templates are available.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13011]: https://processmaker.atlassian.net/browse/FOUR-13011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ