### PR TITLE
FOUR-13040 | Update Breadcrumbs When User Clicks on Guided Templates

### DIFF
--- a/resources/js/processes-catalogue/components/Breadcrumbs.vue
+++ b/resources/js/processes-catalogue/components/Breadcrumbs.vue
@@ -22,6 +22,10 @@
       <li v-if="process" class="breadcrumb-item">
         {{ process }}
       </li>
+
+      <li v-if="template" class="breadcrumb-item">
+        {{ template }}
+      </li>
     </ol>
   </nav>
 </template>
@@ -29,7 +33,7 @@
 <script>
 export default {
   router: window.ProcessMaker.Router,
-  props: ["process", "category"],
+  props: ["process", "category", "template"],
   data() {
     return {
     };

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -4,6 +4,7 @@
       ref="breadcrumb"
       :category="category ? category.name : ''"
       :process="selectedProcess ? selectedProcess.name : ''"
+      :template="guidedTemplates ? 'Guided Templates' : ''"
     />
     <b-row>
       <b-col cols="2">
@@ -16,7 +17,7 @@
           show-bookmark="true"
           :data="listCategories"
           :select="selectCategorie"
-          @wizardLinkSelect="showWizardTemplates = 'true'"
+          @wizardLinkSelect="wizardTemplatesSelected"
           @addCategories="addCategories"
         />
       </b-col>
@@ -43,6 +44,7 @@
           />
           <wizard-templates
             v-if="showWizardTemplates"
+            :template="guidedTemplates"
           />
         </div>
       </b-col>
@@ -77,6 +79,7 @@ export default {
       showProcess: false,
       category: null,
       selectedProcess: null,
+      guidedTemplates: false,
       numCategories: 15,
       page: 1,
     };
@@ -125,6 +128,7 @@ export default {
       this.category = value;
       this.selectedProcess = null;
       this.showCardProcesses = true;
+      this.guidedTemplates = false;
       this.showWizardTemplates = false;
       this.showProcess = false;
     },
@@ -133,14 +137,18 @@ export default {
      */
     wizardTemplatesSelected() {
       this.showWizardTemplates = true;
+      this.guidedTemplates = true;
       this.showCardProcesses = false;
       this.showProcess = false;
+      this.selectedProcess = null;
+      this.category = null;
     },
     /**
      * Select a process and show display
      */
     openProcess(process) {
       this.showCardProcesses = false;
+      this.guidedTemplates = false;
       this.showProcess = true;
       this.selectedProcess = process;
     },

--- a/resources/js/processes-catalogue/components/WizardTemplates.vue
+++ b/resources/js/processes-catalogue/components/WizardTemplates.vue
@@ -15,6 +15,7 @@ import TemplateSearch from "../../components/templates/TemplateSearch.vue";
 
 export default {
   components: { TemplateSearch },
+  props: ["template"],
   data() {
     return {
       currentComponent: "template-select-card",


### PR DESCRIPTION
# Issue
Ticket: [FOUR-13040](https://processmaker.atlassian.net/browse/FOUR-13040)

Currently, when a user clicks on a process from the ‘Available Processes’ dropdown, the process name appears in the breadcrumbs, but this doesn’t update when you click on ‘Guided Templates’.

# Solution
Add Breadcrumb functionality for the Guided Templates option under 'Add From Templates' via the Breadcrumbs component.

# How to Test
1. Go to branch `observation/FOUR-13040` in `processmaker`.
2. Go to Processes → Guided Templates.
	- A breadcrumb should display for 'Guided Templates'.
	- When clicking between 'Guided Templates' and options for 'Available Processes', the breadcrumbs should update accordingly.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13040]: https://processmaker.atlassian.net/browse/FOUR-13040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ