### PR TITLE
FOUR-12766 error label in the frame of changing a user's password

### DIFF
--- a/resources/views/auth/passwords/change.blade.php
+++ b/resources/views/auth/passwords/change.blade.php
@@ -45,7 +45,9 @@
                                     'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
                                 </div>
                             </vue-password>
-                            <small v-for="(error, index) in errors.password" class="text-danger">@{{ error }}</small>
+                            <small v-for="(error, index) in errors.password" v-cloak class="text-danger">
+                                @{{ error }}
+                            </small>
                         </div>
                         <div class="form-group">
                             {!!Form::label('confpassword', __('Confirm Password'))!!}<small class="ml-1">*</small>
@@ -134,12 +136,16 @@
 
 @section('css')
   <style media="screen">
+      [v-cloak] {
+          display: none;
+      }
+
       .formContainer {
-          width:504px;
+          width: 504px;
       }
 
       .formContainer .form {
-        margin-top:85px;
+        margin-top: 85px;
         text-align: left
       }
   </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
It shows us the window to change the password, but very quickly it shows us that {{error}} label in red, then it is lost

## How to Test
1. Log in 
2. create a user
3. enable the option "User must change password at next login"
4. Log out
5. and login with the created user

## Related Tickets & Packages
[FOUR-12766](https://processmaker.atlassian.net/browse/FOUR-12766)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy


[FOUR-12766]: https://processmaker.atlassian.net/browse/FOUR-12766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ