### PR TITLE
FOUR-12752 | Processes Generated from AI, Within a Project, Aren’t Being Created With the Project Assignment

### DIFF
--- a/resources/js/components/templates/SelectTemplateModal.vue
+++ b/resources/js/components/templates/SelectTemplateModal.vue
@@ -98,7 +98,7 @@
       },
       createAiProcess() {
         if (this.projectId) {
-          window.location.href = `/package-ai/processes/create/${this.projectId}`;
+          window.location.href = `/package-ai/processes/create?projectId=${this.projectId}`;
         } else {
           window.location.href = "/package-ai/processes/create";
         }

--- a/resources/js/components/templates/SelectTemplateModal.vue
+++ b/resources/js/components/templates/SelectTemplateModal.vue
@@ -97,7 +97,11 @@
         this.$refs["create-process-modal"].show();
       },
       createAiProcess() {
-        window.location.href = "/package-ai/processes/create";
+        if (this.projectId) {
+          window.location.href = `/package-ai/processes/create/${this.projectId}`;
+        } else {
+          window.location.href = "/package-ai/processes/create";
+        }
       },
       useSelectedTemplate() {
         this.selectedTemplate = true;


### PR DESCRIPTION
# Issue
Ticket: [FOUR-12752](https://processmaker.atlassian.net/browse/FOUR-12752)

Within a Project, if a user creates a Process using Generative AI, the Create Process Modal is not automatically filled with the Project that they were working in.

# Solution
Pass the Project ID to the Package AI Process Creation page. From there, pass the Project ID to the Create Process Modal.

# How to Test
1. Go to branch `observation/FOUR-12752` in `processmaker`.
2. Go to branch `observation/FOUR-12752` in `package-ai`.
3. Have a Project Created. Open the Project.
4. Click +ASSET and create a new Process from AI.
	- When taken to the `/package-ai/processes/create` route, there should be a Project ID appended to the end of the link.
5. Generate a Process and select 'Use Model'.
6. In the Create Process modal, the Project field should reflect the Project that the Process was created from.
7. When creating a Process (not from a project), the user should be taken to `/package-ai/processes/create`. There should be no Project ID appended to the end of the link.

ci:next


# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-12752]: https://processmaker.atlassian.net/browse/FOUR-12752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ