### PR TITLE
FOUR- 13061 Fix The case number is not displayed in the Case Title column in a process with web entry.

### DIFF
--- a/ProcessMaker/Managers/DataManager.php
+++ b/ProcessMaker/Managers/DataManager.php
@@ -133,7 +133,7 @@ class DataManager
         // Magic Variable: _request
         $request = $token->getInstance() ?: $token->processRequest;
         if (!(isset($data['not_override_request']) && $data['not_override_request'] === true)) {
-            $data['_request'] = $request->attributesToArray();
+            $data = $this->updateRequestMagicVariable($data, $request);
         }
 
         // Magic Variable: _parent
@@ -173,6 +173,21 @@ class DataManager
         $data['numberOfInstances'] = $activity->getLoopCharacteristics()->getLoopInstanceProperty($token, 'numberOfInstances', 0);
         $data['numberOfActiveInstances'] = $activity->getLoopCharacteristics()->getLoopInstanceProperty($token, 'numberOfActiveInstances', 0);
         $data['numberOfCompletedInstances'] = $activity->getLoopCharacteristics()->getLoopInstanceProperty($token, 'numberOfCompletedInstances', 0);
+
+        return $data;
+    }
+
+    public function updateRequestMagicVariable(array $data, ProcessRequest $request)
+    {
+        // Magic Variable: _request
+        $data['_request'] = $request->attributesToArray();
+        $startEventToken = $request
+            ->tokens()
+            ->select('element_id', 'element_name')
+            ->where('element_type', 'startEvent')
+            ->first();
+        $data['_request']['startEventId'] = $startEventToken?->element_id;
+        $data['_request']['startEventName'] = $startEventToken?->element_name;
 
         return $data;
     }

--- a/ProcessMaker/Observers/ProcessRequestObserver.php
+++ b/ProcessMaker/Observers/ProcessRequestObserver.php
@@ -67,6 +67,7 @@ class ProcessRequestObserver
         if ($request->isDirty('data')) {
             $dm = new DataManager();
             $data = $dm->getRequestData($request);
+            $data = $dm->updateRequestMagicVariable($data, $request);
             // If request is a parent process, inherit the case title to the child requests
             if (!$request->parent_request_id) {
                 $mustacheTitle = $request->getCaseTitleFromProcess();


### PR DESCRIPTION
## Issue & Reproduction Steps
The case number is not displayed in the Case Title column in a process with web entry.

## Solution
- Update magic variable `_request` always to calculate `case_title`

## How to Test

- Import attached process 
- Copy web entry URL
- search process and edit
- Click on web entry 
- Go to configuration
- Click on web entry 
- Copy web entry URL

First scenario: Request in progress 
- Open web entry
- Open new browser
- Paste Url
- Fill any value in New Input field
- Click on submit button
- Go to PM4
- Click on Request tab
- Go to All request page

Second scenario: Request completed
- Open web entry
- Open new browser
- Paste Url
- Fill any value in New Input field
- Click on submit button
- Go to PM4
- Search last request of process
- Click on Form task
- Click on submit button
- Click on Request tab
- Go to All request page

Attachment:
[weprocess.zip](https://github.com/ProcessMaker/processmaker/files/13822385/weprocess.zip)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13061
- https://processmaker.atlassian.net/browse/FOUR-13062

https://github.com/ProcessMaker/processmaker/assets/8028650/161d14d8-dfda-413e-970d-f1f3d001c2f5

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
