### PR TITLE
FOUR-12978 | Error In Console When Creating a Script Copy With a Non-Admin User

### DIFF
--- a/resources/js/processes/scripts/components/CreateScriptModal.vue
+++ b/resources/js/processes/scripts/components/CreateScriptModal.vue
@@ -351,13 +351,6 @@ export default {
     show() {
       this.$bvModal.show("createScript");
     },
-    getAdminUser() {
-      ProcessMaker.apiClient
-        .get(`/users/${this.userRunScript}`)
-        .then((response) => {
-          this.selectedUser = response.data;
-        });
-    },
     onClose() {
       this.title = "";
       this.language = "";
@@ -370,7 +363,6 @@ export default {
       this.retry_attempts = 0;
       this.retry_wait_time = 5;
       this.addError = {};
-      this.getAdminUser();
       this.projects = [];
       this.close();
     },


### PR DESCRIPTION
# Issue
Ticket: [FOUR-12978](https://processmaker.atlassian.net/browse/FOUR-12978)

When logged in with a non-Admin User, we receive a console error when attempting to create a copy of a Script within a Project.

# Solution
The console error was coming from the `getAdminUser()` method in CreateScriptModal.vue. This method, and it's refereence, were removed in [this PR](https://github.com/ProcessMaker/processmaker/pull/5778) for ticket [FOUR-12744](https://processmaker.atlassian.net/browse/FOUR-12744).

The method was re-added in this [PR](https://github.com/ProcessMaker/processmaker/pull/5836) for [FOUR-12877](https://processmaker.atlassian.net/browse/FOUR-12877). However, the `userRunScript` value was not being passed to the method, which resulted in a console error. 

Because the `runAsUserDefault` prop is being used to handle the Script's 'Run User As' option, the `getAdminUser()` method has been removed.  

# How to Test
1. Go to branch `observation/FOUR-12978` in `processmaker`.
2. Log in with a non-admin user.
3. Have a Project created. Open the Project.
4. Have a Script created inside of the Project.
5. From the Ellipsis Menu of the Script Asset, select the option to 'Copy to Project'.
6. Add info for the Script and click 'SAVE'.
	- There should be no console errors when the Script is saved.
7. Test that [FOUR-12877](https://processmaker.atlassian.net/browse/FOUR-12877) also does not replicate.
	- Create a New Script from the Assets section of the Designer page.
	- Save the Script. The modal window should close and there should be no console errors.
	- Open a Project. Create a new Script from the +ASSET option.
	- Save the Script. The modal window should close and there should be no console errors.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-12978]: https://processmaker.atlassian.net/browse/FOUR-12978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-12744]: https://processmaker.atlassian.net/browse/FOUR-12744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-12877]: https://processmaker.atlassian.net/browse/FOUR-12877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-12877]: https://processmaker.atlassian.net/browse/FOUR-12877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ