### PR TITLE
FOUR-13057 queries with case_title and case_number are not recognized in tasks table

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -751,7 +751,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
      *
      * @return callable
      */
-    public function valueAliasName(string $value, Expression $expression): callable
+    public function valueAliasProcess_Name(string $value, Expression $expression): callable
     {
         return function ($query) use ($expression, $value) {
             $query->whereHas('processRequest', function ($query) use ($expression, $value) {

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -17,6 +17,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\MultiInstanceLoopCharacteristicsInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Managers\WorkflowManagerDefault;
 use ProcessMaker\Notifications\ActivityActivatedNotification;
+use ProcessMaker\Query\Expression;
 use ProcessMaker\Traits\ExtendedPMQL;
 use ProcessMaker\Traits\HasUuids;
 use ProcessMaker\Traits\HideSystemResources;
@@ -705,6 +706,40 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     {
         return function ($query) use ($expression, $value) {
             $query->where('process_request_tokens.element_name', $expression->operator, $value);
+        };
+    }
+
+    /**
+     * PMQL value alias for the case number field related to process request
+     *
+     * @param string value
+     * @param ProcessMaker\Query\Expression expression
+     *
+     * @return callable
+     */
+    public function valueAliasCase_Number(string $value, Expression $expression): callable
+    {
+        return function ($query) use ($expression, $value) {
+            $query->whereHas('processRequest', function ($query) use ($expression, $value) {
+                return $query->where('case_number', $expression->operator, $value);
+            });
+        };
+    }
+
+    /**
+     * PMQL value alias for the case title field related to process request
+     *
+     * @param string value
+     * @param ProcessMaker\Query\Expression expression
+     *
+     * @return callable
+     */
+    public function valueAliasCase_Title(string $value, Expression $expression): callable
+    {
+        return function ($query) use ($expression, $value) {
+            $query->whereHas('processRequest', function ($query) use ($expression, $value) {
+                $query->where('case_title', $expression->operator, $value);
+            });
         };
     }
 

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -744,6 +744,23 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     }
 
     /**
+     * PMQL value alias for the process name field related to process request
+     *
+     * @param string value
+     * @param ProcessMaker\Query\Expression expression
+     *
+     * @return callable
+     */
+    public function valueAliasName(string $value, Expression $expression): callable
+    {
+        return function ($query) use ($expression, $value) {
+            $query->whereHas('processRequest', function ($query) use ($expression, $value) {
+                $query->where('name', $expression->operator, $value);
+            });
+        };
+    }
+
+    /**
      * PMQL wildcard for process request & data fields
      *
      * @param string $value


### PR DESCRIPTION
## Issue & Reproduction Steps
Queries with case_title and case_number are not recognized in the tasks table and "PMQL is not valid" message appears

## Solution
- Add support for `case_title`, `case_number` and `process_name` fields in PMQL queries

## How to Test
1. Import attached process
2. Create a new request
3. Fill any Name in New input field (for example test1)
4. Click on the submit button
5. Go to the Tasks tab
6. FIrst scenario:
  a. Type case_title="CASE TITLE" in seach input (for example case_title="test1")
  b. Type enter
7. Second scenario:
  a. Type case_number=CASE#  in search input (for example case_number=41)
  b. Type enter

## Related Tickets & Packages
[FOUR-13057](https://processmaker.atlassian.net/browse/FOUR-13057)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy

[FOUR-13057]: https://processmaker.atlassian.net/browse/FOUR-13057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ