### PR TITLE
FOUR-12755 | Non-Admin User With Project Permissions Can’t Export Processes Within Projects

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -106,7 +106,7 @@ export default {
   components: { PmqlInput },
   filters: { },
   mixins: [],
-  props: ["actions", "permission", "data", "isDocumenterInstalled", "divider", "lauchpad", "customButton", "showProgress", "isPackageInstalled", "searchBar", "variant"],
+  props: ["actions", "permission", "data", "isDocumenterInstalled", "divider", "lauchpad", "customButton", "showProgress", "isPackageInstalled", "searchBar", "variant", "redirectTo", "redirectId"],
   data() {
     return {
       active: false,
@@ -140,6 +140,10 @@ export default {
       this.$emit("navigate", action, data);
     },
     itemLink(action, data) {
+      if (this.redirectTo === "projects") {
+        const href = Mustache.render(action.href, data);
+        return `${href}?project_id=${this.redirectId}`;
+      }
       return Mustache.render(action.href, data);
     },
     onShow() {

--- a/resources/js/processes/export/components/ExportSuccessModal.vue
+++ b/resources/js/processes/export/components/ExportSuccessModal.vue
@@ -44,11 +44,12 @@
 
 <script>
 import Modal from "../../../components/shared/Modal";
+import AssetRedirectMixin from "../../../components/shared/AssetRedirectMixin";
 
 export default {
   components: { Modal },
   props: ["processId", "processName", "exportInfo", "info"],
-  mixins: [],
+  mixins: [ AssetRedirectMixin ],
   data() {
       return {
         disabled: false,
@@ -80,9 +81,13 @@ export default {
     }
   },
 
-  methods: { 
+  methods: {
     onClose() {
+      if (this.redirectUrl) {
+        window.ProcessMaker.EventBus.$emit("redirect");
+      } else {
         window.location = "/processes";
+      }
     },
     show() {
       this.$bvModal.show('exportSuccessModal');


### PR DESCRIPTION
# Issue
Ticket: [FOUR-12755](https://processmaker.atlassian.net/browse/FOUR-12755)

When a non-Admin User with Project permissions attempts to export a Process asset within a Project, successful export occurs, but the subsequent redirect to `/designer/processes` results in a 'Not Authorized' page due to the user's lack of Process permissions.

# Solution
After exporting a Process from a Project, the user is redirected back to the Project instead of the Processes Listing page. The `AssetRedirectMixin` in `core` was utilized to handle this solution.

# How to Test
1. Go to branch `observation/FOUR-12755` in `processmaker`.
2. Go to branch `observation/FOUR-12755` in `package-projects`.
3. Log in with a non-admin user that only has Project permissions.
4. Have a Project created. Open the Project.
5. Have a Process created inside of the Project.
6. Select 'Export' from the Process Ellipsis Menu.
7. Export the Process.
	- After the Process is exported and you select 'Close' on the Process Export Successful modal, you should be redirected back to your Project.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-12755]: https://processmaker.atlassian.net/browse/FOUR-12755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ