### PR TITLE
Observation/FOUR-13088: Check if package-ai is installed for Ai Unified generation

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -52,6 +52,7 @@ class ModelerController extends Controller
         asort($screenTypes);
         $countScreenCategories = ScreenCategory::where(['status' => 'ACTIVE', 'is_system' => false])->count();
         $isProjectsInstalled = PackageHelper::isPackageInstalled(PackageHelper::PM_PACKAGE_PROJECTS);
+        $isPackageAiInstalled = hasPackage('package-ai');
 
         // For create script modal in modeler
         $scriptExecutors = ScriptExecutor::list();
@@ -77,6 +78,7 @@ class ModelerController extends Controller
             'countScreenCategories' => $countScreenCategories,
             'countScriptCategories' => $countScriptCategories,
             'isProjectsInstalled' => $isProjectsInstalled,
+            'isPackageAiInstalled' => $isPackageAiInstalled,
             'isAiGenerated' => request()->query('ai'),
         ]);
     }

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -88,6 +88,7 @@ div.main {
     screenTypes: @json($screenTypes),
     scriptExecutors: @json($scriptExecutors),
     isProjectsInstalled: @json($isProjectsInstalled),
+    isPackageAiInstalled: @json($isPackageAiInstalled),
     isAiGenerated: @json($isAiGenerated)
   }
   const warnings = @json($process->warnings);


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves https://processmaker.atlassian.net/browse/FOUR-13088
## Solution
- Add to modeler a variable to check if package-ai is installed

## How to Test
- Go to modeler without install package-ai, verify that the AI Assistant icon does not shows.
- Go to modeler after install package-ai, verify that the AI Assistant icon shows.

## Related Tickets & Packages
- [FOUR-13088](https://processmaker.atlassian.net/browse/FOUR-13088) 
- [FOUR-12816](https://processmaker.atlassian.net/browse/FOUR-12816)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/5922)
- [Modeler PR](https://github.com/ProcessMaker/modeler/pull/1775)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13088]: https://processmaker.atlassian.net/browse/FOUR-13088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FOUR-12816]: https://processmaker.atlassian.net/browse/FOUR-12816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:next