### PR TITLE
FOUR-12988: UI Observation:  too much space between the Browser manu and process images

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -6,7 +6,7 @@
     />
     <div
       v-if="processList.length > 0"
-      class="container processList"
+      class="processList"
     >
       <Card
         v-for="(process, index) in processList"

--- a/resources/js/processes-catalogue/components/utils/SearchCards.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCards.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div>
     <b-input-group>
       <b-input-group-prepend>
         <b-btn


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-12988](https://processmaker.atlassian.net/browse/FOUR-12988)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-12988]: https://processmaker.atlassian.net/browse/FOUR-12988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ