### PR TITLE
Feature/FOUR-13024: Default option when user opens launchpad

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessCategoryController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessCategoryController.php
@@ -81,7 +81,7 @@ class ProcessCategoryController extends Controller
             $query->where('status', 'like', $request->input('status'));
         }
         $query->orderBy(
-            $request->input('order_by', 'name'),
+            $request->input('order_by', 'id'),
             $request->input('order_direction', 'asc')
         );
         $response = $query->paginate($request->input('per_page', 10));

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -116,6 +116,10 @@ export default {
           .then((response) => {
             this.category = response.data;
           });
+      } else {
+        const indexUncategorized = this.listCategories.findIndex((category) => category.name === "Uncategorized");
+        console.log(this.listCategories, indexUncategorized);
+        this.$refs["category-list"].selectItem(this.listCategories[indexUncategorized]);
       }
     },
     /**

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -116,10 +116,6 @@ export default {
           .then((response) => {
             this.category = response.data;
           });
-      } else {
-        const indexUncategorized = this.listCategories.findIndex((category) => category.name === "Uncategorized");
-        console.log(this.listCategories, indexUncategorized);
-        this.$refs["category-list"].selectItem(this.listCategories[indexUncategorized]);
       }
     },
     /**

--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -59,13 +59,26 @@
 <script>
 export default {
   props: ["data", "select", "title", "preicon"],
+  data() {
+    return {
+      showDefaultCategory: false,
+    };
+  },
   mounted() {
+    this.showDefaultCategory = true;
     const listElm = document.querySelector("#infinite-list");
     listElm.addEventListener("scroll", () => {
       if (listElm.scrollTop + listElm.clientHeight >= listElm.scrollHeight) {
         this.loadMore();
       }
     });
+  },
+  updated() {
+    if(this.showDefaultCategory) {
+      const indexUncategorized = this.data.findIndex((category) => category.name === "Uncategorized");
+      this.selectItem(this.data[indexUncategorized]);
+      this.showDefaultCategory = false;
+    }
   },
   methods: {
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
As Participant/ Designer when open the Lauchpad, it will direct to the Uncategorized option of the menu. 

This is because is needed that user could see the avilable process.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13024

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next