### PR TITLE
FOUR-13091 enable kill existing session is not working with different browsers

### DIFF
--- a/ProcessMaker/Http/Middleware/SessionControlBlock.php
+++ b/ProcessMaker/Http/Middleware/SessionControlBlock.php
@@ -32,7 +32,7 @@ class SessionControlBlock
                 return $this->redirectToLogin();
             }
             // Check if the user's session should be blocked based on device restriction
-            if ($this->blockedByDevice($user)) {
+            if ($this->blockedByDevice($user, $request)) {
                 return $this->redirectToLogin();
             }
         }
@@ -56,9 +56,10 @@ class SessionControlBlock
         return Setting::configByKey(self::IP_RESTRICTION_KEY) === '1' && $this->blockSessionByIp($user, $request);
     }
 
-    private function blockedByDevice(User $user): bool
+    private function blockedByDevice(User $user, Request $request): bool
     {
-        return Setting::configByKey(self::DEVICE_RESTRICTION_KEY) === '1' && $this->blockSessionByDevice($user);
+        return Setting::configByKey(self::DEVICE_RESTRICTION_KEY) === '1'
+            && $this->blockSessionByDevice($user, $request);
     }
 
     /**
@@ -83,21 +84,24 @@ class SessionControlBlock
      * Checks if the user's current session device matches the device used in the request
      *
      * @param User user
+     * @param Request request
      *
      * @return bool
      */
-    private function blockSessionByDevice(User $user): bool
+    private function blockSessionByDevice(User $user, Request $request): bool
     {
         $agent = new Agent();
         // Get the device details from the request
         $requestDevice = $this->formatDeviceInfo($agent->device(), $agent->deviceType(), $agent->platform());
+        // Get the user's current IP address
+        $ip = $request->getClientIp() ?? $request->ip();
         // Get the user's most recent session
         $session = $user->sessions->sortByDesc('created_at')->first();
         $sessionDevice = $this->formatDeviceInfo(
             $session->device_name, $session->device_type, $session->device_platform
         );
 
-        return $requestDevice !== $sessionDevice;
+        return $requestDevice !== $sessionDevice || $session->ip_address !== $ip;
     }
 
     private function formatDeviceInfo(string $deviceName, string $deviceType, string $devicePlatform): string

--- a/ProcessMaker/Http/Middleware/SessionControlKill.php
+++ b/ProcessMaker/Http/Middleware/SessionControlKill.php
@@ -48,7 +48,13 @@ class SessionControlKill
 
     private function getActiveSession(User $user, string $userSession): ?UserSession
     {
-        return $user->sessions()->where('is_active', true)->where('token', $userSession)->first();
+        return $user->sessions()
+            ->where([
+                ['is_active', true],
+                ['token', $userSession],
+                ['expired_date', '!=', null]
+            ])
+            ->first();
     }
 
     /**

--- a/ProcessMaker/Listeners/UserSession.php
+++ b/ProcessMaker/Listeners/UserSession.php
@@ -34,12 +34,12 @@ class UserSession
         $agentDevice = $agent->device();
         $agentDeviceType = $agent->deviceType();
         $agentPlatform = $agent->platform();
-
-        // if block session by IP or Device is enabled, then mark all active sessions as inactive
+        // if block session by Device is enabled, then mark all active sessions as inactive
         if ($configDevice === '1') {
             $user->sessions()
-                ->where('is_active', true)
                 ->where([
+                    ['is_active', true],
+                    ['ip_address', '!=', $ip],
                     ['device_name', $agentDevice],
                     ['device_type', $agentDeviceType],
                     ['device_platform', $agentPlatform],
@@ -56,11 +56,14 @@ class UserSession
 
         if ($configDevice === '2') {
             $user->sessions()
-                ->where('is_active', true)
-                ->where(function (Builder $query) use ($agentDevice, $agentDeviceType, $agentPlatform) {
+                ->where([
+                    ['is_active', true],
+                ])
+                ->where(function (Builder $query) use ($agentDevice, $agentDeviceType, $agentPlatform, $ip) {
                     $query->where('device_name', '!=', $agentDevice)
                         ->orWhere('device_type', '!=', $agentDeviceType)
-                        ->orWhere('device_platform', '!=', $agentPlatform);
+                        ->orWhere('device_platform', '!=', $agentPlatform)
+                        ->orWhere('ip_address', '!=', $ip);
                 })
                 ->update(['expired_date' => now()]);
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
The user remains logged in in the different browsers

## Solution
- Include IP address check into session control and kill logic 

## How to Test
1. Log in 
2. Create a new user
3. From admin user configure IP Restriction
    a. Go to Admin tab
    b. Go to settings option in sidebar menu
    c. Go to Session Control tab
    d. Go to IP Restriction and edit
    e. Enable Kill existing session
    f. Click on save button
4. Login with a new user in different browsers (in the same IP same device)

## Related Tickets & Packages
[FOUR-13091](https://processmaker.atlassian.net/browse/FOUR-13091)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy

[FOUR-13091]: https://processmaker.atlassian.net/browse/FOUR-13091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ