### PR TITLE
Feature/four 12794: The show me the templates button does not show the available templates

### DIFF
--- a/resources/js/processes-catalogue/components/CatalogueEmpty.vue
+++ b/resources/js/processes-catalogue/components/CatalogueEmpty.vue
@@ -17,9 +17,22 @@
       <button
         type="button"
         class="btn btn-primary text-capitalize"
+        @click="wizardLinkSelected"
       >
         {{ $t("Show Me The Templates") }}
       </button>
     </p>
   </div>
 </template>
+<script>
+export default {
+  methods: {
+    /**
+     * go to wizard templates section
+     */
+    wizardLinkSelected() {
+      this.$emit("wizardLinkSelect");
+    },
+  },
+};
+</script>

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -26,7 +26,9 @@
           v-if="!showWizardTemplates && !showCardProcesses && !showProcess"
           class="d-flex justify-content-center py-5"
         >
-          <CatalogueEmpty />
+          <CatalogueEmpty 
+            @wizardLinkSelect="wizardTemplatesSelected"
+          />
         </div>
         <div v-else>
           <CardProcess


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Log in 
2. Clcik on processes 
3. Click on “Show Me  The templates“

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12794

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next