### PR TITLE
Implement Global Configuration Collection for Guided Templates

### DIFF
--- a/ProcessMaker/Jobs/SyncWizardTemplates.php
+++ b/ProcessMaker/Jobs/SyncWizardTemplates.php
@@ -118,7 +118,6 @@ class SyncWizardTemplates implements ShouldQueue
 
         // Import the helper process and get the new ID
         $newHelperProcessId = $this->importProcess($helperProcessPayload, 'WIZARD_HELPER_PROCESS');
-
         // Import the process template and get the new ID
         $newProcessTemplateId = $this->importProcess($templateProcessPayload, 'WIZARD_PROCESS_TEMPLATE');
 

--- a/ProcessMaker/Models/WizardTemplate.php
+++ b/ProcessMaker/Models/WizardTemplate.php
@@ -26,7 +26,6 @@ class WizardTemplate extends ProcessMakerModel implements HasMedia
         'description',
         'media_collection',
         'template_details',
-        'config_collection_id',
     ];
 
     protected $appends = [

--- a/config/services.php
+++ b/config/services.php
@@ -49,7 +49,7 @@ return [
     'wizard_templates_github' => [
         'base_url' => 'https://raw.githubusercontent.com/processmaker/',
         'wizard_repo' => env('WIZARD_TEMPLATE_REPO', 'wizard-templates'),
-        'wizard_branch' => env('WIZARD_TEMPLATE_BRANCH', 'main'),
+        'wizard_branch' => env('WIZARD_TEMPLATE_BRANCH', '2023-winter'),
         'wizard_categories' => env('WIZARD_TEMPLATE_CATEGORIES', 'all'),
     ],
 

--- a/database/factories/ProcessMaker/Models/WizardTemplateFactory.php
+++ b/database/factories/ProcessMaker/Models/WizardTemplateFactory.php
@@ -18,7 +18,6 @@ class WizardTemplateFactory extends Factory
             'name' => $this->faker->unique()->name(),
             'description' => $this->faker->unique()->name(),
             'media_collection' => $this->faker->unique()->name(),
-            'config_collection_id' => null,
             'template_details' => '{}',
             'helper_process_id' => Process::factory()->create()->id,
         ];

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -393,8 +393,8 @@ button:focus.navbar-toggler {
 }
 
 .modal .modal-huge {
-  max-width: 947px;
-  width: 947px;
+  max-width: 1250px;
+  width: 100%;
   height: 746px;
 }
 
@@ -980,7 +980,6 @@ nav {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.29) 0%, rgba(255, 255, 255, 0.62) 100%), var(--borders, #CDDDEE);
   padding: 50px;
   color: #556271;
-  height: 450px;
 }
 
 #wizardTemplateDetails___BV_modal_header_,


### PR DESCRIPTION
This PR introduces the Global Configuration Collection for Guided Templates, a crucial step in managing and storing all configured Guided Templates data.


The changes include:

1. Creating a collection seeder to initialize the global collection
2. Removing the deprecated `config_collection_id` column from the `wizard_templates` table via migration
3. Removing deprecated code related to collection imports in the wizard sync job
4. Updating the default branch reference for the `wizard-template` GitHub repo to `2023-winter` 
5. Make UI adjustments for a responsive modal when rendering the helper process.

## How to Test

1. Ensure the php artisan `processmaker:sync-wizard-templates` command has been executed, or run the command manually to sync the wizard templates.
2. Navigate to `Processes > Guided Templates` and confirm the presence of at least one guided template.
3. Verify that the information for the guided template is displayed accurately.
4. Select the guided template and click the "Use Now" button within the modal. Ensure that the helper process's start event is triggered, rendering the task screens in the modal as expected.

## Related Tickets & Packages
- [FOUR-13110](https://processmaker.atlassian.net/browse/FOUR-13110)
- Collections PR - https://github.com/ProcessMaker/package-collections/pull/372
- Wizard Templates REPO PR - https://github.com/ProcessMaker/wizard-templates/pull/13

ci:next
ci:package-collections:task/FOUR-13110

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13110]: https://processmaker.atlassian.net/browse/FOUR-13110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ