### PR TITLE
QA Observation bugfix/FOUR-13111 : CSS import in ListChart.vue forces the user / developer to have installed the package saved-search

### DIFF
--- a/resources/js/processes-catalogue/components/charts/ListChart.vue
+++ b/resources/js/processes-catalogue/components/charts/ListChart.vue
@@ -469,7 +469,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import "../../../../../vendor/processmaker/package-savedsearch/resources/sass/_variables.scss";
+// @import "../../../../../vendor/processmaker/package-savedsearch/resources/sass/_variables.scss";
 $animationLength: 500ms;
 $footerHeight: 35px;
 
@@ -635,9 +635,9 @@ $listChartDark: #212529 !important;
   .b-pagination {
     .page-item {
       .page-link {
-        background-color: lighten($secondary, 44%);
+        background-color: gray;
         border-radius: 2px;
-        color: $secondary;
+        color: grey;
         cursor: pointer;
         font-size: 12px;
         height: 29px;
@@ -649,24 +649,24 @@ $listChartDark: #212529 !important;
       }
       &:hover {
         .page-link {
-          background-color: lighten($secondary, 40%);
+          background-color: #c3c3c3;
         }
       }
       &.disabled {
         cursor: not-allowed;
         opacity: 0.5;
         .page-link {
-          background-color: lighten($secondary, 44%);
+          background-color: #c4c4c4;
         }
       }
       &.active {
         .page-link {
-          background-color: lighten($secondary, 15%);
+          background-color: #c2c2c2;
           color: white;
         }
         &:hover {
           .page-link {
-            background-color: lighten($secondary, 11%);
+            background-color: #c1c1c1;
           }
         }
       }

--- a/resources/js/processes-catalogue/components/charts/ListChart.vue
+++ b/resources/js/processes-catalogue/components/charts/ListChart.vue
@@ -469,7 +469,6 @@ export default {
 </script>
 
 <style lang="scss">
-// @import "../../../../../vendor/processmaker/package-savedsearch/resources/sass/_variables.scss";
 $animationLength: 500ms;
 $footerHeight: 35px;
 


### PR DESCRIPTION
## Solution
The imported savedsearch library was removed

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13111

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next