### PR TITLE
FOUR-12987:UI observation the line between Processes and Templates is missing

### DIFF
--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -9,7 +9,10 @@
     >
       <div class="d-flex align-items-center justify-content-between pl-3 pr-3">
         <div class="d-flex align-items-center">
-          <i :class="preicon" />
+          <i
+            class="mr-3"
+            :class="preicon"
+          />
           {{ $t(title) }}
         </div>
         <i
@@ -35,6 +38,7 @@
         </b-list-group-item>
       </b-list-group>
     </b-collapse>
+    <hr class="my-12">
     <div
       v-b-toggle.collapse-3
       block
@@ -44,7 +48,11 @@
     >
       <div class="d-flex align-items-center justify-content-between pl-3 pr-3">
         <div class="d-flex align-items-center">
-          <img src="../../../img/template-icon.svg" alt="Template Icon">
+          <img
+            class="mr-3"
+            src="../../../img/template-icon.svg"
+            alt="Template Icon"
+          >
           {{ $t("Add From Templates") }}
         </div>
         <i


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-12987](https://processmaker.atlassian.net/browse/FOUR-12987)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-12987]: https://processmaker.atlassian.net/browse/FOUR-12987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ