### PR TITLE
Feature/four 11713:Open Launchpad: Apply filter by category

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -10,7 +10,7 @@
       <b-col cols="2">
         <span class="pl-3 menu-title"> {{ $t('Processes Browser') }} </span>
         <MenuCatologue
-          ref="category-list"
+          ref="categoryList"
           title="Available Processes"
           preicon="fas fa-play-circle"
           class="mt-3"
@@ -86,6 +86,7 @@ export default {
       key: 0,
       totalPages: 1,
       filter: "",
+      markCategorie: false,
     };
   },
   mounted() {
@@ -123,6 +124,12 @@ export default {
           .then((response) => {
             this.listCategories = [...this.listCategories, ...response.data.data];
             this.totalPages = response.data.meta.total_pages;
+
+            if (this.markCategorie) {
+              const indexUncategorized = this.listCategories.findIndex((category) => category.name === this.category.name);
+              this.$refs.categoryList.selectProcessItem(this.listCategories[indexUncategorized]);
+              this.showDefaultCategory = false;
+            }
           });
       }
     },
@@ -138,6 +145,8 @@ export default {
           .get(`process_bookmarks/${categoryId}`)
           .then((response) => {
             this.category = response.data;
+            this.markCategorie = true;
+            this.filterCategories(this.category.name);
           });
       }
     },

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -17,8 +17,8 @@
           show-bookmark="true"
           :data="listCategories"
           :select="selectCategorie"
+          :filter-categories="filterCategories"
           @wizardLinkSelect="wizardTemplatesSelected"
-          @addCategories="addCategories"
         />
       </b-col>
       <b-col cols="10">
@@ -85,6 +85,7 @@ export default {
       page: 1,
       key: 0,
       totalPages: 1,
+      filter: "",
     };
   },
   mounted() {
@@ -95,8 +96,17 @@ export default {
     /**
      * Add new page of categories
      */
-    addCategories() {
+    addCategories(pmql = "") {
       this.page += 1;
+      this.getCategories();
+    },
+    /**
+     * Filter categories
+     */
+     filterCategories(filter = "") {
+      this.page = 1;
+      this.listCategories = [];
+      this.filter = filter;
       this.getCategories();
     },
     /**
@@ -105,7 +115,11 @@ export default {
     getCategories() {
       if (this.page <= this.totalPages) {
         ProcessMaker.apiClient
-          .get(`process_bookmarks/categories?status=active&page=${this.page}&per_page=${this.numCategories}`)
+          .get(`process_bookmarks/categories?status=active
+            &page=${this.page}
+            &per_page=${this.numCategories}
+            &filter=${this.filter}`
+            )
           .then((response) => {
             this.listCategories = [...this.listCategories, ...response.data.data];
             this.totalPages = response.data.meta.total_pages;

--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -1,5 +1,8 @@
 <template>
   <div>
+    <SearchCategories
+      :filter-pmql="onFilter"
+    />
     <div
       v-b-toggle.category-menu
       block
@@ -74,8 +77,13 @@
 </template>
 
 <script>
+import SearchCategories from "./utils/SearchCategories.vue";
+
 export default {
-  props: ["data", "select", "title", "preicon"],
+  components: {
+    SearchCategories,
+  },
+  props: ["data", "select", "title", "preicon", "filterCategories"],
   data() {
     return {
       showCatalogue: false,
@@ -89,6 +97,7 @@ export default {
         },
       ],
       showDefaultCategory: false,
+      pmql: '',
     };
   },
   mounted() {
@@ -112,7 +121,7 @@ export default {
      * Adding categories
      */
     loadMore() {
-      this.$emit("addCategories");
+      this.addCategories(this.pmql);
     },
     selectProcessItem(item) {
       this.selectedProcessItem = item;
@@ -136,6 +145,12 @@ export default {
     },
     onToggleTemplates() {
       this.showGuidedTemplates = !this.showGuidedTemplates;
+    },
+    /**
+     * Filter categories
+     */
+    onFilter(value) {
+      this.filterCategories(value);
     },
   },
 };

--- a/resources/js/processes-catalogue/components/utils/SearchCategories.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCategories.vue
@@ -1,0 +1,58 @@
+<template>
+  <div>
+    <b-input-group>
+      <b-input-group-prepend>
+        <b-btn
+          class="px-1"
+          variant="outline-secondary"
+          :title="$t('Search Categories')"
+          @click="fetch()"
+        >
+          <i class="fas fa-search search-icon" />
+        </b-btn>
+      </b-input-group-prepend>
+      <b-form-input
+        id="search-box"
+        v-model="filter"
+        :placeholder="$t('Search Categories')"
+        @keyup.enter="fetch()"
+      />
+    </b-input-group>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ["filterPmql"],
+  data() {
+    return {
+      filter: "",
+    };
+  },
+  methods: {
+    fetch() {
+      this.filterPmql(this.filter);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.btn-outline-secondary {
+  font-size: 16px;
+}
+.btn-outline-secondary,
+#search-box {
+  border: none;
+  background-color: #f7f9fb;
+}
+#search-box {
+  color: #B9B9B9;
+  padding-left: 4px;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 32.077px;
+  letter-spacing: -0.38px;
+}
+</style>


### PR DESCRIPTION
## Issue & Reproduction Steps

- Add a search tool box “Search categories“
- When a process Launchap was open from Process List, apply this filter in order to select the category related

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11713

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next