### PR TITLE
It is not possible to select script executor with the same configuration

### DIFF
--- a/resources/js/processes/scripts/components/LanguageScript.vue
+++ b/resources/js/processes/scripts/components/LanguageScript.vue
@@ -9,7 +9,7 @@
       >
         <b-card
           :key="index"
-          :ref="`${lang.title}`"
+          :ref="`${lang.title}-${index}`"
           class="mt-2"
           @click="selectLanguage(lang, index)"
         >
@@ -62,7 +62,7 @@ export default {
      * Check the language selected and emit to modal
      */
     selectLanguage(lang, index) {
-      this.selectedLang(lang);
+      this.selectedLang(lang, index);
       this.select(index);
     },
     /**
@@ -84,11 +84,11 @@ export default {
     /**
      * Add the border to the item selected
      */
-    selectedLang(lang) {
+    selectedLang(lang, index) {
       for (const item in this.$refs) {
         this.$refs[item][0].className = "card mb-2 card-lang";
       }
-      this.$refs[lang.title][0].className = "card mb-2 card-lang selected";
+      this.$refs[lang.title + '-' + index][0].className = "card mb-2 card-lang selected";
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
The names of the list Script Executors have the same identifier

## Solution
- Change identifier for the executors items.

## How to Test
Have executors created with the same name.
create a script and select an executor script.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-12883](FOUR-12883)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
