### PR TITLE
QA Observation Bugfix/FOUR-13112: Carousel of images should not be automatic

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCarousel.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCarousel.vue
@@ -33,7 +33,7 @@ export default {
       sliding: null,
       images: [],
       defaultImage: Array(4).fill({ url: "/img/launchpad-images/defaultImage.svg" }),
-      interval: 2000,
+      interval: 0,
     };
   },
   mounted() {


### PR DESCRIPTION
## How to Test
-  Open any Process in Launchpad
- Add Images to Carousel
- Carousel should be stopped and images changes only with click on small Indicators (small horizontal lines over the image)

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13112

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next

