### PR TITLE
FOUR-13115:UI: the Process Browser is  very close to the breadcrumb

### DIFF
--- a/resources/js/processes-catalogue/components/Breadcrumbs.vue
+++ b/resources/js/processes-catalogue/components/Breadcrumbs.vue
@@ -1,29 +1,44 @@
 <template>
   <nav aria-label="breadcrumb">
-    <ol class="breadcrumb bg-transparent p-0 mb-3">
+    <ol class="breadcrumb bg-transparent p-0 mb-4">
       <li class="breadcrumb-item">
-        <a href="/" :aria-label="$t('Home')">
+        <a
+          href="/"
+          :aria-label="$t('Home')"
+        >
           <i class="fas fa-home" />
         </a>
       </li>
 
       <li class="breadcrumb-item">
-        <a href="/processes-catalogue" :aria-label="$t('Home')">
+        <a
+          href="/processes-catalogue"
+          :aria-label="$t('Home')"
+        >
           {{ $t('Processes') }}
         </a>
       </li>
 
-      <li v-if="category" class="breadcrumb-item">
+      <li
+        v-if="category"
+        class="breadcrumb-item"
+      >
         <a :aria-label="category">
           {{ category }}
         </a>
       </li>
 
-      <li v-if="process" class="breadcrumb-item">
+      <li
+        v-if="process"
+        class="breadcrumb-item"
+      >
         {{ process }}
       </li>
 
-      <li v-if="template" class="breadcrumb-item">
+      <li
+        v-if="template"
+        class="breadcrumb-item"
+      >
         {{ template }}
       </li>
     </ol>


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-13115](https://processmaker.atlassian.net/browse/FOUR-13115)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-13115]: https://processmaker.atlassian.net/browse/FOUR-13115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ