### PR TITLE
Observation/FOUR-12884: The error message when a language is not selected is not seen

### DIFF
--- a/resources/js/processes/scripts/components/LanguageScript.vue
+++ b/resources/js/processes/scripts/components/LanguageScript.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="container-lang">
+  <div class="container-lang"
+       :class="{'is-invalid': invalid_feedback !== ''}"
+  >
     <label class="choose-lang m-2 text-uppercase">
       {{ $t("Choose an Executor") }}
     </label>
@@ -108,6 +110,9 @@ export default {
     max-height: 450px;
     font-size: 14px;
     overflow-y: auto;
+  }
+  .container-lang.is-invalid {
+    border: 1px solid #E50130;
   }
   .choose-lang {
     color: #6A7888;


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to Reproduce**

- Go to the Script page
- Click on + Script
- Fill all field except the selection of the language 
- Click on Save button
 
**Current Behavior**

If I do not select un executors the error message is not visible 

**Expected Behavior**

The executors box should be painted or have a mark to know that the error is there because we have to scroll down to know about the error

## Solution
- In sync with Franz Villaroel a red border is added when language is not selected

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-12884](https://processmaker.atlassian.net/browse/FOUR-12884)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12884]: https://processmaker.atlassian.net/browse/FOUR-12884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ