### PR TITLE
FOUR-13159:There is no default icon on the process cards

### DIFF
--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -75,7 +75,7 @@ export default {
     getIconProcess() {
       let icon = "default-icon";
       if (this.process.launchpad_properties) {
-        icon = JSON.parse(this.process.launchpad_properties).icon;
+        icon = JSON.parse(this.process.launchpad_properties).icon || "default-icon";
       }
       return `/img/launchpad-images/icons/${icon}.svg`;
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
There is no default icon on the process cards

## Solution
- Load the default icon or the custom

## How to Test
Create a new process
Does not select any icon in launch pad settings
Save the changes
Go to process-catalogue
Search the process
Check the card

## Related Tickets & Packages
- [FOUR-13159](https://processmaker.atlassian.net/browse/FOUR-13159)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-13159]: https://processmaker.atlassian.net/browse/FOUR-13159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ