### PR TITLE
FOUR-12755 | Non-Admin User With Project Permissions Can’t Custom Export Processes Within Projects

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -198,9 +198,11 @@ class ProcessController extends Controller
         return redirect()->to(route('modeler'));
     }
 
-    public function export(Process $process)
+    public function export(Request $request, Process $process)
     {
-        return view('processes.export', compact('process'));
+        $projectId = $request->query('project_id');
+
+        return view('processes.export', compact('process', 'projectId'));
     }
 
     public function import(Request $request, Process $process)

--- a/resources/js/processes/export/components/CustomExportView.vue
+++ b/resources/js/processes/export/components/CustomExportView.vue
@@ -8,6 +8,7 @@
             :groups="$root.groups"
             :process-name="$root.rootAsset.name"
             :process-id="processId"
+            :project-id="projectId"
           />
           <!-- TODO: Complete Changelog -->
           <!-- <MainAssetView
@@ -54,6 +55,7 @@ export default {
   props: {
     processName: {},
     processId: {},
+    projectId: null,
   },
   mixins: [],
   data() {

--- a/resources/js/processes/export/components/ExportSuccessModal.vue
+++ b/resources/js/processes/export/components/ExportSuccessModal.vue
@@ -48,7 +48,7 @@ import AssetRedirectMixin from "../../../components/shared/AssetRedirectMixin";
 
 export default {
   components: { Modal },
-  props: ["processId", "processName", "exportInfo", "info"],
+  props: ["processId", "processName", "exportInfo", "info", "projectId"],
   mixins: [ AssetRedirectMixin ],
   data() {
       return {
@@ -85,6 +85,8 @@ export default {
     onClose() {
       if (this.redirectUrl) {
         window.ProcessMaker.EventBus.$emit("redirect");
+      } else if (this.projectId) {
+        window.location = `/designer/projects/${this.projectId}`;
       } else {
         window.location = "/processes";
       }

--- a/resources/js/processes/export/components/MainAssetView.vue
+++ b/resources/js/processes/export/components/MainAssetView.vue
@@ -96,7 +96,7 @@
                 :password-protect="passwordProtect"
             />
             <import-process-modal ref="import-process-modal" :existingAssets="existingAssets" :processName="processName" :userHasEditPermissions="true" @import-new="setCopyAll" @update-process="setUpdateAll"></import-process-modal>                            
-            <export-success-modal ref="export-success-modal" :processName="processName" :processId="processId" :exportInfo="exportInfo" :info="groups"/>
+            <export-success-modal ref="export-success-modal" :processName="processName" :processId="processId" :exportInfo="exportInfo" :info="groups" :projectId="projectId"/>
             <import-log :log-entries="$root.queueLog" :allow-download-debug="$root.allowDownloadDebug"></import-log>
         </div>
     </div>
@@ -118,7 +118,8 @@ export default {
     "processName",
     "groups",
     "processId",
-    "processInfo"
+    "processInfo",
+    "projectId",
     ],
     components: {
         DataCard,

--- a/resources/js/processes/export/index.js
+++ b/resources/js/processes/export/index.js
@@ -9,6 +9,7 @@ import State from './state';
 Vue.component("VuePassword", VuePassword);
 
 const processName = document.head.querySelector('meta[name="export-process-name"]').content;
+const projectId = document.head.querySelector('meta[name="export-project-id"]').content;
 
 const routes = [
     { 
@@ -29,6 +30,7 @@ const routes = [
             routeName: 'export-custom-process',
             processName: processName,
             processId: route.params.processId,
+            projectId: projectId,
           }),
     },
 ];

--- a/resources/views/processes/export.blade.php
+++ b/resources/views/processes/export.blade.php
@@ -7,6 +7,7 @@
 @section('meta')
     <meta name="export-process-name" content="{{ $process->name }}">
     <meta name="export-process-id" content="{{ $process->id }}">
+    <meta name="export-project-id" content="{{ $projectId }}"
 
 @endsection
 


### PR DESCRIPTION
# Issue
Ticket: [FOUR-12755](https://processmaker.atlassian.net/browse/FOUR-12755)

When a non-Admin User with Project permissions attempts a Custom Export of a Process asset within a Project, successful export occurs, but the subsequent redirect to 'designer/processes' results in a 'Not Authorized' page due to the user's lack of Process permissions.

# Solution
After completing a Custom Export of a Process from a Project, the user is redirected back to the Project instead of the Processes Listing page. 

The `projectId` is retrieved from the Export URL (`/processes/{processId}/export?project_id={projectId]`) and passed to the appropriate views. The projectId is then used to return the user back to their Project after Custom Export.

# How to Test
1. Go to branch `observation/FOUR-12755-b` in `processmaker`.
3. Log in with a non-admin user that only has Project permissions.
4. Have a Project created. Open the Project.
5. Have a Process created inside of the Project.
6. Select 'Export' from the Process Ellipsis Menu.
7. Select 'Custom' from the Export Options. Export the Process.
	- After the Process is exported and you select 'Close' on the Process Export Successful modal, you should be redirected back to your Project.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-12755]: https://processmaker.atlassian.net/browse/FOUR-12755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ