### PR TITLE
Implement link generation for triggering guided template modals

### DIFF
--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -143,7 +143,7 @@ export default {
   },
   computed: {
     hasGuidedTemplateParams() {
-      return window.location.search.includes('?guided_templates=true&template=') ? true : false;
+      return window.location.search.includes('?guided_templates=true&template=');
     }
   },
   watch: {
@@ -227,7 +227,7 @@ export default {
             url.searchParams.append('template', $event.template.id);
             history.pushState(null, '', url); // Update the URL without triggering a page reload
           }
-          
+
           // Direct selection of a wizard template card
           this.loadTemplateDetails($event.template.id);
         } else {

--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -141,6 +141,11 @@ export default {
       showWizardTemplateDetails: false,
     };
   },
+  computed: {
+    hasGuidedTemplateParams() {
+      return window.location.search.includes('?guided_templates=true&template=') ? true : false;
+    }
+  },
   watch: {
     currentPage() {
       this.fetch();
@@ -150,72 +155,109 @@ export default {
     },
   },
   methods: {
-    showDetails($event) {
-      if ($event.type === "wizard") {
-        this.template = $event.template;
-        this.showWizardTemplateDetails = true;
-        this.$nextTick(() => {
-          this.$refs.wizardTemplateDetails.show();
-        });
-      } else {
-        this.$emit('show-details', {
-          'id': $event.template.id, 
-          'name': $event.template.name, 
-          'description': $event.template.description,
-          'category_id': $event.template.process_category_id,
-          'version' : $event.template.version,
-        });
-        this.template = $event.template;
+    async loadData() {
+      await this.fetch();
+
+      // After fetch is completed, check if guided template params exist in the URL.
+      // This is used when the URL is directly loaded, and we need to target the specified template to show.
+      if (this.hasGuidedTemplateParams) {
+        this.showDetails();
       }
     },
-    fetch() {
-        this.loading = true;
-        this.apiDataLoading = true;
-        this.orderBy = this.orderBy === "__slot:name" ? "name" : this.orderBy;
+    async fetch() {
+      this.loading = true;
+      this.apiDataLoading = true;
+      this.orderBy = this.orderBy === "__slot:name" ? "name" : this.orderBy;
 
-        let url =
-            this.status === null || this.status === "" || this.status === undefined
-                ? "templates/" + this.type.toLowerCase() +"?"
-                : "templates/" + this.type.toLowerCase() + "?status=" + this.status + "&";
+      let url =
+          this.status === null || this.status === "" || this.status === undefined
+              ? "templates/" + this.type.toLowerCase() +"?"
+              : "templates/" + this.type.toLowerCase() + "?status=" + this.status + "&";
 
-        // If the type is 'wizard', override the URL to fetch guided templates
-        if (this.type === 'wizard') {
-          url = 'wizard-templates?';
+      // If the type is 'wizard', override the URL to fetch guided templates
+      if (this.type === 'wizard') {
+        url = 'wizard-templates?';
+      }
+      // Load from our api client
+      await ProcessMaker.apiClient
+        .get(
+            url +
+            "page=" +
+            this.currentPage +
+            "&per_page=" +
+            this.perPage + 
+            "&filter=" +
+            this.filter +
+            "&order_by=" +
+            this.orderBy +
+            "&order_direction=" +
+            this.orderDirection +
+            "&include=user,categories,category"
+        )
+        .then(response => {
+          if(response.data.data.length === 0) {
+            this.noResults = true;
+          } else {
+            this.templates = response.data.data;
+            this.totalRow = response.data.meta.total;
+            this.apiDataLoading = false;
+            this.apiNoResults = false;
+            this.noResults = false;
+            }
+        })
+        .finally(() => {
+          this.loading = false;
+        });
+    },
+    showDetails($event = null) {
+      if (!$event) {
+        // Load details directly from the URL template parameter
+        const params = new URL(window.location).searchParams;
+        const templateId = Number(params.get("template"));
+
+        if (templateId) {
+          this.loadTemplateDetails(templateId);
         }
-        // Load from our api client
-        ProcessMaker.apiClient
-            .get(
-                url +
-                "page=" +
-                this.currentPage +
-                "&per_page=" +
-                this.perPage + 
-                "&filter=" +
-                this.filter +
-                "&order_by=" +
-                this.orderBy +
-                "&order_direction=" +
-                this.orderDirection +
-                "&include=user,categories,category"
-            )
-            .then(response => {
-              if(response.data.data.length === 0) {
-                this.noResults = true;
-              } else {
-                this.templates = response.data.data;
-                this.totalRow = response.data.meta.total;
-                this.apiDataLoading = false;
-                this.apiNoResults = false;
-                this.noResults = false;
-                }
-            })
-            .finally(() => {
-              this.loading = false;
-            });
+      } else {
+        // Handle different scenarios based on $event type
+        if ($event.type === "wizard") {
+          // Add template parameter to the URL if guided templates are selected
+          let url = new URL(window.location.href);
+          if (url.search.includes('?guided_templates=true')) {
+            url.searchParams.append('template', $event.template.id);
+            history.pushState(null, '', url); // Update the URL without triggering a page reload
+          }
+          
+          // Direct selection of a wizard template card
+          this.loadTemplateDetails($event.template.id);
+        } else {
+          // Direct selection of a default template card
+          this.emitTemplateDetails($event.template);
         }
+      }
+    },
+    loadTemplateDetails(templateId) {
+      this.template = this.templates.find(template => template.id === templateId);
+      this.showWizardTemplateDetails = true;
+
+      this.$nextTick(() => {
+        this.$refs.wizardTemplateDetails.show();
+      });
+    },
+    emitTemplateDetails(template) {
+      this.$emit('show-details', {
+        'id': template.id,
+        'name': template.name,
+        'description': template.description,
+        'category_id': template.process_category_id,
+        'version': template.version,
+      });
+
+      this.template = template;
+    }
   },
-  mounted() {
-    this.fetch();
+  beforeMount() {
+    this.loadData();
   }
 };
 </script>

--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -218,22 +218,19 @@ export default {
         if (templateId) {
           this.loadTemplateDetails(templateId);
         }
-      } else {
-        // Handle different scenarios based on $event type
-        if ($event.type === "wizard") {
-          // Add template parameter to the URL if guided templates are selected
-          let url = new URL(window.location.href);
-          if (url.search.includes('?guided_templates=true')) {
-            url.searchParams.append('template', $event.template.id);
-            history.pushState(null, '', url); // Update the URL without triggering a page reload
-          }
-
-          // Direct selection of a wizard template card
-          this.loadTemplateDetails($event.template.id);
-        } else {
-          // Direct selection of a default template card
-          this.emitTemplateDetails($event.template);
+      } else if ($event && $event.type === "wizard") {  // Handle different scenarios based on $event type 
+        // Add template parameter to the URL if guided templates are selected
+        let url = new URL(window.location.href);
+        if (url.search.includes('?guided_templates=true')) {
+          url.searchParams.append('template', $event.template.id);
+          history.pushState(null, '', url); // Update the URL without triggering a page reload
         }
+
+        // Direct selection of a wizard template card
+        this.loadTemplateDetails($event.template.id);
+      } else {
+        // Direct selection of a default template card
+        this.emitTemplateDetails($event.template);
       }
     },
     loadTemplateDetails(templateId) {

--- a/resources/js/components/templates/WizardTemplateDetails.vue
+++ b/resources/js/components/templates/WizardTemplateDetails.vue
@@ -93,8 +93,16 @@ export default {
     },
     close() {
       this.$bvModal.hide("wizardTemplateDetails");
+      
+      // Remove template parameter from the URL
+      let url = new URL(window.location.href);
+      if (url.search.includes('?guided_templates=true&template=')) {
+        url.searchParams.delete('template');
+        history.pushState(null, '', url); // Update the URL without triggering a page reload
+      }
+      
+      // Cancels the associated process request to prevent orphaned processes.
       if (this.showHelperProcess) {
-        // Cancels the associated process request to prevent orphaned processes.
         this.cancelHelperProcessRequest();
       }
     },

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -97,10 +97,21 @@ export default {
       fromProcessList: false,
     };
   },
+  computed: {
+    hasGuidedTemplateParams() {
+      return window.location.search.includes('?guided_templates=true') ? true : false;
+    },
+  },
   mounted() {
-    this.showDefaultCategory = true;
-    this.getCategories();
-    this.checkSelectedProcess();
+    if (this.hasGuidedTemplateParams) {
+      // Loaded from URL with guided template parameters to show guided templates
+      // Dynamically load the component
+      this.wizardTemplatesSelected(true);
+    } else {
+      this.showDefaultCategory = true;
+      this.getCategories();
+      this.checkSelectedProcess();
+    }
   },
   methods: {
     /**
@@ -168,17 +179,37 @@ export default {
       if (this.category === value) {
         this.key += 1;
       }
+
       this.category = value;
       this.selectedProcess = null;
       this.showCardProcesses = true;
       this.guidedTemplates = false;
       this.showWizardTemplates = false;
+      
+      // Remove guided_templates and template parameters from the URL
+      let url = new URL(window.location.href);
+      if (url.search.includes('?guided_templates=true')) {
+        url.searchParams.delete('guided_templates');
+        url.searchParams.delete('template');
+        history.pushState(null, '', url); // Update the URL without triggering a page reload
+      }
+
       this.showProcess = false;
     },
     /**
      * Select a wizard templates and show display
      */
-    wizardTemplatesSelected() {
+    wizardTemplatesSelected(hasUrlParams = false) {
+      if (!hasUrlParams) {
+        // Add the params if the guided template link was selected
+        let url = new URL(window.location.href);
+        if (!url.search.includes('?guided_templates=true')) {
+          url.searchParams.append('guided_templates', true);
+          history.pushState(null, '', url); // Update the URL without triggering a page reload
+        }
+      }
+
+      // Update state variables
       this.showWizardTemplates = true;
       this.guidedTemplates = true;
       this.showCardProcesses = false;

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -99,7 +99,7 @@ export default {
   },
   computed: {
     hasGuidedTemplateParams() {
-      return window.location.search.includes('?guided_templates=true') ? true : false;
+      return window.location.search.includes('?guided_templates=true');
     },
   },
   mounted() {


### PR DESCRIPTION
This PR introduces link generation for triggering guided template modals. The PLG team can access the modal either within the UI by navigating to the targeted guided template or via URL generation methods. 

Two URL parameters are added to facilitate this functionality: 
1. `/processes-catalogue?guided_templates=true` is used to navigate directly to the guided templates section
2. `/processes-catalogue?guided_templates=true&template=[TEMPLATE_ID]` is utilized to open a specific guided template modal. 
example `/processes-catalogue?guided_templates=true&template=1`

## How to Test

1. Ensure guided templates are synced in your environment `php artisan processmaker:sync-wizard-templates`.
2. Navigate to the Processes section.
3. Note the URL.
4. Select 'Guided Templates.'
5. Verify that the URL is updated with the `?guided_templates=true` parameter.
6. Select a guided template card.
7. Confirm that the modal appears, and the URL is updated to `?guided_template=true&template=[TEMPLATE_ID]`.
8. Copy the URL.
9. Open a new browser tab.
10. Paste the URL.
11. Ensure the modal appears for the targeted guided template.
12. When closing the modal, verify that the `template=` parameter is removed.
13. When navigating to other areas in the processes catalogue, ensure both parameters `guided_template` and `template` are removed from the URL.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13190

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
