### PR TITLE
QA Observation Bugfix/FOUR-12975: The search engine is not cleared when changing categories

### DIFF
--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -152,6 +152,7 @@ export default {
       this.$emit("wizardLinkSelect");
     },
     isSelectedProcess(item) {
+      this.clearSearch();
       return this.selectedProcessItem === item;
     },
     isSelectedTemplate(index) {
@@ -162,6 +163,9 @@ export default {
     },
     onToggleTemplates() {
       this.showGuidedTemplates = !this.showGuidedTemplates;
+    },
+    clearSearch() {
+      this.$root.$emit("clearSearch");
     },
     /**
      * Filter categories

--- a/resources/js/processes-catalogue/components/utils/SearchCards.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCards.vue
@@ -31,6 +31,11 @@ export default {
       filter: "",
     };
   },
+  mounted () {
+    this.$root.$on("clearSearch", () => {
+      this.filter = "";
+    });
+  },
   methods: {
     fetch() {
       this.filterPmql(this.filter);


### PR DESCRIPTION
## How to Test
- Have a process 
- Have categories with process
- Go to Launchpad
- Type in the search engine “some criteria“
- Click on the search button
- Click on another category
- Search input should be empty

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-12975

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next
