### PR TITLE
Implement HideSystemResources Trait for Guided Template Collection

### DIFF
--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -113,6 +113,8 @@ trait HideSystemResources
                 });
         } elseif (static::class === ScriptExecutor::class) {
             return $query->where('is_system', false);
+        } elseif (static::class === 'ProcessMaker\Plugins\Collections\Models\Collection') {
+            return $query->whereNull('collections.asset_type');
         } else {
             return $query->whereDoesntHave('categories', function ($query) {
                 $query->where('is_system', true);


### PR DESCRIPTION
This PR introduces the HideSystemResources trait for collections, specifically to hide the Guided Template Collection from the UI. This trait ensures that system-related collections, such as the one for guided templates, are not visible in the user interface.

## How to Test

1. Navigate to the Collections section.
2. Verify that the Global Template Collection is not visible in the UI.

## Related Tickets & Packages
-  [FOUR-13197](https://processmaker.atlassian.net/browse/FOUR-13197)
- Collections PR - https://github.com/ProcessMaker/package-collections/pull/375

ci:next
ci:package-collections:observation/FOUR-13197

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13197]: https://processmaker.atlassian.net/browse/FOUR-13197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ