### PR TITLE
Observation/FOUR-13181: UI the process list needs to take up the entire screen size at the bottom

### DIFF
--- a/resources/js/components/shared/FilterTable.vue
+++ b/resources/js/components/shared/FilterTable.vue
@@ -242,7 +242,6 @@ export default {
 <style>
 .pm-table-container {
   overflow-x: auto;
-  max-height: 400px;
   overflow-y: auto;
   border-left: 1px solid rgba(0, 0, 0, 0.125);
   border-right: 1px solid rgba(0, 0, 0, 0.125);

--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -11,7 +11,7 @@
             <filter-table
               :headers="fields"
               :data="data"
-              style="height: 450px;"
+              style="height: calc(100vh - 350px);"
             >
             <template v-for="(row, rowIndex) in data.data" v-slot:[`row-${rowIndex}`]>
               <td

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -11,7 +11,7 @@
       <filter-table
         :headers="fields"
         :data="data"
-        style="height: 450px;"
+        style="height: calc(100vh - 350px);"
       >
         <!-- Slot Table Body -->
         <template v-for="(row, rowIndex) in data.data" v-slot:[`row-${rowIndex}`]>

--- a/resources/js/templates/components/ProcessTemplatesListing.vue
+++ b/resources/js/templates/components/ProcessTemplatesListing.vue
@@ -11,7 +11,7 @@
         <filter-table
           :headers="fields"
           :data="data"
-          style="height: 450px;"
+          style="height: calc(100vh - 350px);"
         >
         <template v-for="(row, rowIndex) in data.data" v-slot:[`row-${rowIndex}`]>
           <td


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

- Log in 
- Click on Designer 
- Click on Processes

**Current Behavior:** 
As we see the UI of the list of processes, It is showing with a space at the bottom of the screen
()please see the image attached in the ticket)

## Solution
- Calculate the height based on the viewport height.

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-13181](https://processmaker.atlassian.net/browse/FOUR-13181)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13181]: https://processmaker.atlassian.net/browse/FOUR-13181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ