### PR TITLE
Resolve Issue with Deprecated Guided Template Names

### DIFF
--- a/ProcessMaker/Jobs/SyncWizardTemplates.php
+++ b/ProcessMaker/Jobs/SyncWizardTemplates.php
@@ -83,6 +83,10 @@ class SyncWizardTemplates implements ShouldQueue
                 }
 
                 try {
+                    // Remove deprecated templates that are not in the index.json file.
+                    $this->removeDeprecatedTemplates($wizardTemplates);
+
+                    // Import templates from the index.json file.
                     foreach ($wizardTemplates as $template) {
                         $this->importTemplate($template, $config, $wizardTemplateCategoryId);
                     }
@@ -93,6 +97,18 @@ class SyncWizardTemplates implements ShouldQueue
         } catch (Exception $e) {
             Log::error("Error Syncing Guided Templates: {$e->getMessage()}");
         }
+    }
+
+    // Since the wizard templates are not tracked by a specific ID, we need to track them by the template name.
+    // If the template name has changed, we need to remove the deprecated template name from the database.
+    private function removeDeprecatedTemplates($wizardTemplates)
+    {
+        $templateNames = array_map(function ($template) {
+            return $template['template_details']['card-title'];
+        }, $wizardTemplates);
+
+        // Remove templates that are no longer present in the provided wizard templates.
+        WizardTemplate::whereNotIn('name', $templateNames)->delete();
     }
 
     /**


### PR DESCRIPTION
This PR addresses an issue where, if a guided template name was changed, the deprecated template name would still exist within the instance. To fix this, the PR introduces a check during the syncing process to remove any templates that are not part of the index.json file generated within the wizard templates repo. This ensures that only the templates listed in the latest index.json file are present in the instance.


## How to Test

1. Test this in your local environment.
2. Ensure you already have the old 'Invoice Approval' template in your instance.
3. Run the command php artisan processmaker:sync-wizard-templates.
4. View the guided templates.
5. Confirm that only one guided template is present, and its name is updated to 'Guided Invoice Approval'.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13201

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
