### PR TITLE
FOUR-13200:There is not separation line on Search category and categories in LaunchPad

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessInfo.vue
@@ -18,8 +18,9 @@
       </b-col>
     </div>
     <b-col cols="12">
-      <process-tab 
-        :current-user="currentUser" 
+      <hr class="my-12">
+      <process-tab
+        :current-user="currentUser"
         :process="process"
       />
     </b-col>
@@ -54,7 +55,9 @@ export default {
     };
   },
   methods: {
-    /** Rerun a process cards */
+    /**
+     * Return a process cards
+     */
     goBackCategory() {
       this.$emit("goBackCategory");
     },

--- a/resources/js/processes-catalogue/components/utils/SearchCategories.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCategories.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="search-categories">
     <b-input-group>
       <b-input-group-prepend>
         <b-btn
@@ -29,6 +29,7 @@
         </b-btn>
       </b-input-group-append>
     </b-input-group>
+    <hr class="my-12">
   </div>
 </template>
 
@@ -72,5 +73,8 @@ export default {
   font-weight: 400;
   line-height: 32.077px;
   letter-spacing: -0.38px;
+}
+.search-categories {
+  padding-left: 1rem;
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
There is no separation line on the Search category and categories in LaunchPad .

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:next