### PR TITLE
feature/FOUR-13059: Add project options is not present in menu options of Launch Pad

### DIFF
--- a/resources/views/processes-catalogue/index.blade.php
+++ b/resources/views/processes-catalogue/index.blade.php
@@ -13,7 +13,7 @@
     <processes-catalogue
       :process="{{$process ?? 0}}"
       :current-user-id="{{ \Auth::user()->id }}"
-      :permission="{{ \Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks') }}"
+      :permission="{{ \Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects') }}"
       :current-user="{{ \Auth::user() }}"
       is-documenter-installed="{{\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()}}"
     >


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to Reproduce**

- Go to Launch pad menu
- Click on a process
- Click on the ELipsis menu
- Check Add Project option

**Current Behavior** 

There si not option Add project option
![image-20240102-221511](https://github.com/ProcessMaker/processmaker/assets/123644082/99a75dec-ac69-490f-afae-378b8f87fc1a)


**Expected Behavior** 

The Add project option should be present in options menu to launch pad as figma 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13059

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy