### PR TITLE
QA Observation Bugfix/FOUR-13202: Search category container border and padding not the same as Figma

### DIFF
--- a/resources/js/processes-catalogue/components/utils/SearchCategories.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCategories.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <b-input-group>
+    <b-input-group class="ml-3">
       <b-input-group-prepend>
         <b-btn
           class="px-1"


### PR DESCRIPTION
## How to Test
- Log in to PM4
- Go to Process LaunchPad
- Check the border and padding to the container to search category 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13202

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next