### PR TITLE
feature/FOUR-13073: There are not options in elipssis menu for launch pad

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessMap.vue
+++ b/resources/js/processes-catalogue/components/ProcessMap.vue
@@ -14,6 +14,7 @@
         </h4>
         <span class="border bg-white rounded-circle d-flex align-items-center p-0 ellipsis-border">
           <ellipsis-menu
+            v-if="showEllipsis"
             :actions="processLaunchpadActions"
             :permission="permission"
             :data="process"
@@ -110,10 +111,12 @@ export default {
       optionsData: {},
       largeDescription: false,
       readActivated: false,
+      showEllipsis: false
     };
   },
   mounted() {
     this.getActions();
+    this.checkShowEllipsis();
     this.optionsData = {
       id: this.process.id.toString(),
       type: "Process",
@@ -155,6 +158,20 @@ export default {
         conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)",
       };
       this.processLaunchpadActions = this.processLaunchpadActions.map((action) => (action.value !== "archive-item" ? action : newAction));
+    },
+    checkShowEllipsis() {
+      const permissionsNeeded = [
+        "archive-processes",
+        "view-additional-asset-actions",
+        "export-processes",
+        "view-processes",
+        "edit-processes",
+        "create-projects",
+        "create-pm-blocks",
+        "create-process-templates",
+        "view-projects",
+      ];
+      this.showEllipsis = this.permission.some( (permission) => permissionsNeeded.includes(permission));
     },
     /**
      * Return a process cards from process info


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to Reproduce**

1. Create a user with permission in process catalog and project
2. Login with the user-created
3. Go to Process catalog

**Current Behavior** 

The are no options in ellipsis menu Launch Pad for users wihout full permission 
![image-20240103-233116](https://github.com/ProcessMaker/processmaker/assets/123644082/a22dbbc1-3563-49f6-b280-b7863a8e7448)



## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13073

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy