### PR TITLE
FOUR-13205 non-admin user cannot edit its password with permission to edit

### DIFF
--- a/ProcessMaker/Http/Middleware/ProcessMakerAuthenticate.php
+++ b/ProcessMaker/Http/Middleware/ProcessMakerAuthenticate.php
@@ -11,6 +11,12 @@ class ProcessMakerAuthenticate extends Authenticate
     {
         $this->addAcceptJsonHeaderIfApiCall($request, $guards);
 
+        // Load permissions into the session
+        if (auth()->check() && !$request->ajax()) {
+            $permissions = $request->user()->loadPermissions();
+            session(['permissions' => $permissions]);
+        }
+
         return parent::authenticate($request, $guards);
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
A non-admin user with permission to edit your password cannot edit it

## Solution
- Refactor has permission handling

## How to Test
1. Login
2. Configure Password Set By User
   1. Go to admin tab
   2. Go to setting option in sidebar menu
   3. Click on Log-In Options
   4. Enable Password Set By User
3. Create an user
4. Assign permission to user
   1. Search user and edit 
   2. Go to permission tab 
   3. Enable "Edit Personal Profile" in Users 
   4. Enable "Edit User And Password" in Username and password 
   5. Click on save button
5. Log in with new user
6. Go to avatar
7. Click on Edit user Profile
8. The user must be able to change their password

## Related Tickets & Packages
[FOUR-13205](https://processmaker.atlassian.net/browse/FOUR-13205)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy



[FOUR-13205]: https://processmaker.atlassian.net/browse/FOUR-13205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ