### PR TITLE
Observation/FOUR-13209: Save button is not working when create a AI Script

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -64,7 +64,7 @@ class ModelerController extends Controller
             $process->fill($draft->only(['svg', 'bpmn']));
         }
 
-        $runAsUserDefault = User::where('username', 'admin')->first();
+        $runAsUserDefault = User::where('is_administrator', true)->first();
 
         return view('processes.modeler.index', [
             'process' => $process->append('notifications', 'task_notifications'),

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -15,6 +15,7 @@ use ProcessMaker\Models\ScreenCategory;
 use ProcessMaker\Models\ScreenType;
 use ProcessMaker\Models\ScriptCategory;
 use ProcessMaker\Models\ScriptExecutor;
+use ProcessMaker\Models\User;
 use ProcessMaker\Package\Cdata\Http\Controllers\Api\CdataController;
 use ProcessMaker\Package\PackagePmBlocks\Http\Controllers\Api\PmBlockController;
 use ProcessMaker\PackageHelper;
@@ -63,6 +64,8 @@ class ModelerController extends Controller
             $process->fill($draft->only(['svg', 'bpmn']));
         }
 
+        $runAsUserDefault = User::where('username', 'admin')->first();
+
         return view('processes.modeler.index', [
             'process' => $process->append('notifications', 'task_notifications'),
             'manager' => $manager,
@@ -80,6 +83,7 @@ class ModelerController extends Controller
             'isProjectsInstalled' => $isProjectsInstalled,
             'isPackageAiInstalled' => $isPackageAiInstalled,
             'isAiGenerated' => request()->query('ai'),
+            'runAsUserDefault' => $runAsUserDefault,
         ]);
     }
 

--- a/ProcessMaker/Http/Controllers/Process/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScriptController.php
@@ -50,7 +50,7 @@ class ScriptController extends Controller
             'countCategories' => ScriptCategory::where(['status' => 'ACTIVE', 'is_system' => false])->count(),
         ];
 
-        $runAsUserDefault = User::where('username', 'admin')->first();
+        $runAsUserDefault = User::where('is_administrator', true)->first();
 
         return view('processes.scripts.index', compact('listConfig', 'catConfig', 'runAsUserDefault'));
     }

--- a/resources/js/processes/scripts/components/CreateScriptModal.vue
+++ b/resources/js/processes/scripts/components/CreateScriptModal.vue
@@ -345,7 +345,9 @@ export default {
     },
   },
   mounted() {
-    this.selectedUser = this.runAsUserDefault ? this.runAsUserDefault : null;
+    this.$nextTick(() => {
+      this.selectedUser = this.runAsUserDefault ? this.runAsUserDefault : null;
+    });
   },
   methods: {
     show() {

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -89,7 +89,8 @@ div.main {
     scriptExecutors: @json($scriptExecutors),
     isProjectsInstalled: @json($isProjectsInstalled),
     isPackageAiInstalled: @json($isPackageAiInstalled),
-    isAiGenerated: @json($isAiGenerated)
+    isAiGenerated: @json($isAiGenerated),
+    runAsUserDefault: @json($runAsUserDefault),
   }
   const warnings = @json($process->warnings);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduce:**

- Login as admin
- Go to Designer
- Click on Processes menu
- Click on +Process
- Click Build Your Own
- Set the information and Save
- Drag and Drop the AI Generated control
- Select the Script From Text option for the control
- Set the information required and click on Save

**Current behavior:**
Nothing happens, there is no action to save and continue, but if opens the Advanced Options menu it displays that the Run Script As option is required

**Expected behavior:**
The option Run Script As should be displayed out of the Advanced Options as it is required

## Solution
- Add default user in run as default in modeler AI Script Generation

## How to Test
Follow steps above

## Related Tickets & Packages
- [FOUR-13209](https://processmaker.atlassian.net/browse/FOUR-13209)
- [package-ai PR
](https://github.com/ProcessMaker/package-ai/pull/69)
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13209]: https://processmaker.atlassian.net/browse/FOUR-13209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

.