### PR TITLE
FOUR-13204:After entering an invalid search the category search engine stops working

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -136,14 +136,13 @@ export default {
     getCategories() {
       if (this.page <= this.totalPages) {
         ProcessMaker.apiClient
-          .get(`process_bookmarks/categories?status=active
-            &page=${this.page}
-            &per_page=${this.numCategories}
-            &filter=${this.filter}`
-            )
+          .get("process_bookmarks/categories?status=active"
+            + `&page=${this.page}`
+            + `&per_page=${this.numCategories}`
+            + `&filter=${this.filter}`)
           .then((response) => {
             this.listCategories = [...this.listCategories, ...response.data.data];
-            this.totalPages = response.data.meta.total_pages;
+            this.totalPages = response.data.meta.total_pages !== 0 ? response.data.meta.total_pages : 1;
 
             if (this.markCategory) {
               const indexUncategorized = this.listCategories.findIndex((category) => category.name === this.category.name);

--- a/resources/js/processes-catalogue/components/utils/SearchCategories.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCategories.vue
@@ -23,7 +23,7 @@
         <b-btn
           class="px-1"
           variant="outline-secondary"
-          @click="clean()"
+          @click="clearFilter()"
         >
           <b-icon icon="x" />
         </b-btn>
@@ -44,13 +44,13 @@ export default {
     fetch() {
       this.filterPmql(this.filter);
     },
-    clean() {
+    clearFilter() {
       this.filter = "";
       this.fetch();
     },
     fillFilter(filter) {
       this.filter = filter;
-    }
+    },
   },
 };
 </script>


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Log in to PM4
2. Go to Process catalogue
3. Enter a process inexistent o invalid search like xxxxxxxxxx
4. Clear the input search
5. Click on search button

After entering an invalid search the category search engine stops working 

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-13204](https://processmaker.atlassian.net/browse/FOUR-13204)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next


[FOUR-13204]: https://processmaker.atlassian.net/browse/FOUR-13204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ