### PR TITLE
feature/FOUR-12794: The show me the templates button does not show the available templates

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -21,7 +21,10 @@
       @onPageChanged="onPageChanged"
     />
 
-    <CatalogueEmpty v-if="processList.length === 0" />
+    <CatalogueEmpty
+      v-if="processList.length === 0"
+      @wizardLinkSelect="wizardLinkSelected"
+    />
   </div>
 </template>
 
@@ -71,6 +74,12 @@ export default {
           this.totalRow = response.data.meta.total;
           this.totalPages = response.data.meta.total_pages;
         });
+    },
+    /**
+     * go to wizard templates section
+     */
+    wizardLinkSelected() {
+      this.$emit("wizardLinkSelect");
     },
     /**
      * Build URL for Process Cards

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -76,7 +76,7 @@ export default {
         });
     },
     /**
-     * go to wizard templates section
+     * Go to wizard templates section
      */
     wizardLinkSelected() {
       this.$emit("wizardLinkSelect");

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -39,6 +39,7 @@
             :key="key"
             :category="category"
             @openProcess="openProcess"
+            @wizardLinkSelect="wizardTemplatesSelected"
           />
           <ProcessInfo
             v-if="showProcess && !showWizardTemplates && !showCardProcesses"


### PR DESCRIPTION
## Issue & Reproduction Steps
The show me the templates button does not show the available templates
1. Log in 
2. Clcik on processes 
3. Click on “Show Me  The templates“

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-12794

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:deploy