### PR TITLE
Update Guided Templates Button Text to 'Get Started'

### DIFF
--- a/resources/js/components/templates/WizardTemplateDetails.vue
+++ b/resources/js/components/templates/WizardTemplateDetails.vue
@@ -26,7 +26,7 @@
               <p class="wizard-details-description">{{ templateDetails['modal-description'] | str_limit(150) }}</p>
               <button class="wizard-details-button text-uppercase"  @click.prevent="getHelperProcessStartEvent('wizard-details-modal')">
                 <i class="fas fa-play-circle mr-1" />
-                {{ $t('Use Now') }}
+                {{ $t('Get Started') }}
               </button>
             </div>
           </div>


### PR DESCRIPTION
This PR modifies the button text for Guided Templates from 'Use Now' to 'Get Started' for improved clarity.

## How to Test

1. Navigate to Processes > Guided Templates.
2. Select a Guided Template.
3. Confirm that the button text now reads 'Get Started'.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13217

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
