### PR TITLE
Adjust Spacing Between Category List and Guided Templates

### DIFF
--- a/resources/js/components/templates/WizardTemplateCard.vue
+++ b/resources/js/components/templates/WizardTemplateCard.vue
@@ -45,7 +45,8 @@ export default {
   border-radius: 16px;
   border: 1px solid #CDDDEE;
   background-size: cover;
-  height: 243px;
+  width: 350px;
+  height: 240px;
   overflow: hidden;
   &.hover {
     box-shadow: 0px 10px 20px 4px #00000021;

--- a/resources/js/processes-catalogue/components/WizardTemplates.vue
+++ b/resources/js/processes-catalogue/components/WizardTemplates.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container wizard-template-container">
+  <div class="wizard-template-container">
     <template-search
       id="wizard-search"
       type="wizard"


### PR DESCRIPTION
This PR reduces the space between the Category List and Guided Templates to align with the spacing of Available Processes.

## How to Test

1. Navigate to Processes > Guided Templates.
2. Observe the spacing between the Category List and Guided Templates.
3. Confirm that the space is reduced to match the spacing with Available Processes.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13175

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
