### PR TITLE
Add Permission Check for Project Configuration in UserController@show

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -214,7 +214,7 @@ class UserController extends Controller
      */
     public function show(User $user)
     {
-        if (!Auth::user()->can('view', $user)) {
+        if (!Auth::user()->can('view', $user) && !Auth::user()->can('create-projects')) {
             throw new AuthorizationException(__('Not authorized to update this user.'));
         }
 
@@ -644,7 +644,7 @@ class UserController extends Controller
     /**
      * Get filter configuration.
      *
-     * @param String $name
+     * @param string $name
      * @return \Illuminate\Http\Response
      *
      * @OA\Get(
@@ -671,13 +671,14 @@ class UserController extends Controller
     public function getFilterConfiguration(String $name, Request $request)
     {
         $filter = SaveSession::getConfigFilter($name, $request->user());
-        return response(["data" => $filter], 200);
+
+        return response(['data' => $filter], 200);
     }
 
     /**
      * Store filter configuration.
      *
-     * @param String $name
+     * @param string $name
      * @param Request $request
      * @return \Illuminate\Http\Response
      *
@@ -706,6 +707,7 @@ class UserController extends Controller
     {
         $request->json()->all();
         $filter = SaveSession::setConfigFilter($name, $request->user(), $request->json()->all());
-        return response(["data" => $filter], 200);
+
+        return response(['data' => $filter], 200);
     }
 }


### PR DESCRIPTION
This PR includes a check for the 'create-projects' permission when accessing the show method in the UserController. The addition of this permission allows users with Project permissions to configure project members in their projects.

## How to Test

1. Create a user with only Project permissions.
2. Log in as the user.
3. Create a project.
4. Add members to the project.
5. From the ellipsis menu, select 'Configure'.
6. Confirm that no errors appear when opening the configuration modal.
7. Verify that the preselected project members are visible.
8. Add or remove users.
9. Confirm that no errors occur during the process.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13210

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
