### PR TITLE
FOUR-13223 Validate Cell phone number when 2FA SMS is enabled

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -347,8 +347,8 @@ class UserController extends Controller
     /**
      * Validate the phone number for SMS two-factor authentication.
      *
-     * @param User $user 
-     * @param mixed $number 
+     * @param User $user User to validate
+     * @param mixed $number Number to validate
      */
     private function validateCellPhoneNumber(User $user, $number)
     {

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -18,6 +18,7 @@ use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\Users as UserResource;
 use ProcessMaker\Models\User;
+use ProcessMaker\TwoFactorAuthentication;
 
 class UserController extends Controller
 {
@@ -176,6 +177,12 @@ class UserController extends Controller
         }
 
         $user->fill($fields);
+        if (array_key_exists('cell', $fields)) {
+            $response = $this->validateCellPhoneNumber($user, $fields['cell']);
+            if ($response) {
+                return $response;
+            }
+        }
         $user->setTimezoneAttribute($request->input('timezone', ''));
         $user->saveOrFail();
         // Register the Event
@@ -314,6 +321,12 @@ class UserController extends Controller
         }
         $original = $user->getOriginal();
         $user->fill($fields);
+        if (array_key_exists('cell', $fields)) {
+            $response = $this->validateCellPhoneNumber($user, $fields['cell']);
+            if ($response) {
+                return $response;
+            }
+        }
         if (Auth::user()->is_administrator && $request->has('is_administrator')) {
             // user must be an admin to make another user an admin
             $user->is_administrator = $request->get('is_administrator');
@@ -329,6 +342,34 @@ class UserController extends Controller
         }
 
         return response([], 204);
+    }
+
+    /**
+     * Validate the phone number for SMS two-factor authentication.
+     *
+     * @param User $user 
+     * @param mixed $number 
+     */
+    private function validateCellPhoneNumber(User $user, $number)
+    {
+        $methods = $user->getValid2FAPreferences();
+        $hasSMS2FA = in_array(TwoFactorAuthentication::SMS, $methods);
+        $isValid = !$hasSMS2FA || preg_match('/^[+\.0-9x\)\(\-\s\/]+$/', $number);
+        if (!$isValid) {
+            return response([
+                'message' => __(
+                    'A valid Cell phone number is required for SMS two-factor authentication.'
+                ),
+                'errors' => [
+                    'cell' => [
+                        __(
+                            'A valid Cell phone number is required for SMS two-factor authentication.'
+                        ),
+                    ],
+                ],
+            ], 422);
+        }
+        return false;
     }
 
     /**

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -12,6 +12,7 @@
   "+ Add Page": "+ Seite hinzufügen",
   "72 hours": "72 Stunden",
   "A .env file already exists. Stop the installation procedure, delete the existing .env file, and then restart the installation.": "Es existiert bereits eine .env-Datei. Beenden Sie den Installationsvorgang, löschen Sie die vorhandene .env-Datei und starten Sie die Installation erneut.",
+  "A valid Cell phone number is required for SMS two-factor authentication.": "A valid Cell phone number is required for SMS two-factor authentication.",
   "A variable key name is a symbolic name to reference information.": "Ein Variablenschlüssel ist ein symbolischer Name, der als Referenz dient.",
   "About ProcessMaker": "Über ProcessMaker",
   "About": "Über",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -31,6 +31,7 @@
   "A script selection is required": "A script selection is required",
   "A security code will be sent to all selected methods.": "A security code will be sent to all selected methods.",
   "A user with the username {{username}} and email {{email}} was previously deleted.": "A user with the username :username and email :email was previously deleted.",
+  "A valid Cell phone number is required for SMS two-factor authentication.": "A valid Cell phone number is required for SMS two-factor authentication.",
   "A variable key name is a symbolic name to reference information.": "A variable key name is a symbolic name to reference information.",
   "A variable name is a symbolic name to reference information.": "A variable name is a symbolic name to reference information.",
   "About ProcessMaker": "About ProcessMaker",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -12,6 +12,7 @@
   "+ Add Page": "+ Agregar página",
   "72 hours": "72 horas",
   "A .env file already exists. Stop the installation procedure, delete the existing .env file, and then restart the installation.": "Un archivo .env ya existe. Detenga el procedimiento de instalación, elimine el archivo .env existente y luego reinicie la instalación.",
+  "A valid Cell phone number is required for SMS two-factor authentication.": "Se requiere un número de teléfono celular válido para la autenticación de dos factores de SMS.",
   "A variable key name is a symbolic name to reference information.": "Un nombre de clave variable es un nombre simbólico para hacer referencia a la información.",
   "About ProcessMaker": "Acerca de ProcessMaker",
   "About": "Acerca de",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -12,6 +12,7 @@
   "+ Add Page": "+ Ajouter page",
   "72 hours": "72 heures",
   "A .env file already exists. Stop the installation procedure, delete the existing .env file, and then restart the installation.": "Un fichier .env existe déjà. Arrêtez la procédure d'installation, supprimez le fichier .env existant, puis redémarrez l'installation.",
+  "A valid Cell phone number is required for SMS two-factor authentication.": "A valid Cell phone number is required for SMS two-factor authentication.",
   "A variable key name is a symbolic name to reference information.": "Un nom de clé de variable est un nom symbolique qui permet de référencer l'information.",
   "About ProcessMaker": "À propos de ProcessMaker",
   "About": "À propos",


### PR DESCRIPTION
## Issue & Reproduction Steps
Validation is missing when the user does not have their cell phone number configured correctly and chooses By message to phone number in 2FA.

## Solution
- Add validation for Cell phone number

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13223

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
