### PR TITLE
FOUR-13125 UI: The filter Section should close when we click elsewher…

### DIFF
--- a/resources/js/components/PMColumnFilterPopover/PMColumnFilterPopover.vue
+++ b/resources/js/components/PMColumnFilterPopover/PMColumnFilterPopover.vue
@@ -53,6 +53,7 @@
       onShown() {
         let cancel = this.$refs.pmColumnFilterForm.$el.getElementsByClassName("pm-filter-form-button-cancel");
         cancel[0].focus();
+        this.closeOnBlur();
       },
       onShow() {
         this.$root.$emit("bv::hide::popover");
@@ -72,6 +73,15 @@
       onCancel() {
         this.popoverShow = false;
         this.$emit("onCancel");
+      },
+      closeOnBlur() {
+        let area = this.$refs.pmColumnFilterForm.$el.parentNode;
+        area.addEventListener('mouseenter', () => {
+          window.removeEventListener('click', this.onCancel);
+        });
+        area.addEventListener('mouseleave', () => {
+          window.addEventListener('click', this.onCancel);
+        });
       }
     }
   };


### PR DESCRIPTION
…e in the screen, not only using the Cancel button

## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
