### PR TITLE
FOUR-13166: filter option are not working correctly

### DIFF
--- a/ProcessMaker/Filters/Filter.php
+++ b/ProcessMaker/Filters/Filter.php
@@ -100,6 +100,10 @@ class Filter
             return 'like';
         }
 
+        if ($this->operator === 'regex') {
+            $this->operator = 'REGEXP';
+        }
+        
         return $this->operator;
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Go to server https://ci-2d99bcfae6.engk8s.processmaker.net/
2. Go to Requests page
3. Select Regex option in the filter modal
4. Press apply button

**Current Behavior:**
The table is displayed empty

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-13166](https://processmaker.atlassian.net/browse/FOUR-13166)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-13166]: https://processmaker.atlassian.net/browse/FOUR-13166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ