### PR TITLE
FOUR-13229 Change settings helper

### DIFF
--- a/upgrades/2023_12_06_182508_add_session_control_settings.php
+++ b/upgrades/2023_12_06_182508_add_session_control_settings.php
@@ -21,7 +21,7 @@ class AddSessionControlSettings extends Upgrade
                     'format' => 'choice',
                     'config' => 0,
                     'name' => 'IP restriction',
-                    'helper' => 'Restricts logins made by the same user from different IPs.',
+                    'helper' => 'Restrict logins made by the same user from the same IP.',
                     'group' => Setting::SESSION_CONTROL_GROUP,
                     'hidden' => false,
                     'ui' => [


### PR DESCRIPTION
## Issue & Reproduction Steps
Helper is not consistent with PRD.

## Solution
- Change helper to: Restrict logins made by the same user from the same IP.

![image](https://github.com/ProcessMaker/processmaker/assets/8028650/84a9d970-8adf-4e5c-aa9e-264ffbbaaa88)


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13229

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
