### PR TITLE
bugfix/FOUR-13250: Action Unauthorized: when the user does not have permission to start a Request

### DIFF
--- a/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
@@ -94,11 +94,17 @@ export default {
           }
         })
         .catch(err => {
-          this.havelessOneStartEvent = true;
-          this.processEvents = [];
-          this.startEvent = 0;
+          this.disableButton();
           ProcessMaker.alert(err, "danger");
         });
+    },
+    /** 
+     * Disable Start Button
+     */
+    disableButton() {
+      this.havelessOneStartEvent = true;
+      this.processEvents = [];
+      this.startEvent = 0;
     },
     /**
      * Start new request

--- a/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
@@ -82,7 +82,7 @@ export default {
     getStartEvents() {
       this.processEvents = [];
       ProcessMaker.apiClient
-        .get(`processes/${this.process.id}/start_events`)
+        .get(`process_bookmarks/processes/${this.process.id}/start_events`)
         .then((response) => {
           this.processEvents = response.data.data;
           if (this.processEvents.length <= 1) {
@@ -92,6 +92,12 @@ export default {
               this.startEvent = event.id ?? 0;
             }
           }
+        })
+        .catch(err => {
+          this.havelessOneStartEvent = true;
+          this.processEvents = [];
+          this.startEvent = 0;
+          ProcessMaker.alert(err, "danger");
         });
     },
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -125,10 +125,6 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     // Processes
     Route::get('processes', [ProcessController::class, 'index'])->name('processes.index')->middleware('can:view-processes');
     Route::get('processes/{process}', [ProcessController::class, 'show'])->name('processes.show')->middleware('can:view-processes,process');
-    Route::get('processes/{process}/start_events',
-        [ProcessController::class, 'startEvents'])
-        ->name('processes.start.events')
-        ->middleware('can:view-processes,process');
     Route::post('processes/{process}/export', [ProcessController::class, 'export'])->name('processes.export')->middleware('can:export-processes,process');
     Route::get('processes/{process}/bpmn', [ProcessController::class, 'downloadBpmn'])->name('processes.export.bpmn')->middleware('can:view-processes,process');
     Route::post('processes/import', [ProcessController::class, 'import'])->name('processes.import')->middleware('can:import-processes');
@@ -146,6 +142,10 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
 
     // Process Bookmark
     $middlewareCatalog = 'can:view-process-catalog';
+    Route::get('process_bookmarks/processes/{process}/start_events',
+        [ProcessController::class, 'startEvents'])
+        ->name('processes.start.events')
+        ->middleware($middlewareCatalog);
     Route::get('process_bookmarks/processes', [ProcessController::class, 'index'])
     ->name('bookmarks.processes.index')->middleware($middlewareCatalog);
     Route::get('process_bookmarks/categories', [ProcessCategoryController::class, 'index'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -142,10 +142,10 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
 
     // Process Bookmark
     $middlewareCatalog = 'can:view-process-catalog';
-    Route::get('process_bookmarks/processes/{process}/start_events',
-        [ProcessController::class, 'startEvents'])
-        ->name('processes.start.events')
-        ->middleware($middlewareCatalog);
+    Route::get(
+        'process_bookmarks/processes/{process}/start_events',
+        [ProcessController::class, 'startEvents']
+    )->name('processes.start.events')->middleware($middlewareCatalog);
     Route::get('process_bookmarks/processes', [ProcessController::class, 'index'])
     ->name('bookmarks.processes.index')->middleware($middlewareCatalog);
     Route::get('process_bookmarks/categories', [ProcessCategoryController::class, 'index'])


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps**

1. Create a new user
2. Login with this user
3. Go to Lauchpad and open the process

**Current behavior**
The following error apears
![Screenshot from 2024-01-15 11-15-24](https://github.com/ProcessMaker/processmaker/assets/123644082/570e56cf-d762-44a6-9693-de5aaf22dda4)

**Expected behavior**
when the user does not have permission to start a case the button needs to disable
## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy