### PR TITLE
Resolve intermittent 422 error in Guided Templates

### DIFF
--- a/resources/js/components/templates/WizardHelperProcessModal.vue
+++ b/resources/js/components/templates/WizardHelperProcessModal.vue
@@ -17,8 +17,6 @@
                 :user-id="currentUserId"
                 @task-updated="taskUpdated"
                 @submit="submit"
-                @completed="completed"
-                @@error="error"
             ></task>
         </modal>
     </div>

--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -45,7 +45,6 @@ export default {
             }
         },
         async getNextTask(processRequestId) {
-            console.log("getNextTask", processRequestId);
             try {
                 const response = await ProcessMaker.apiClient.get(`tasks`, {
                 params: {
@@ -60,7 +59,6 @@ export default {
                 });
 
                 const taskData = response.data.data;
-                console.log("getNextTask - data", taskData);
                 if (taskData.length > 0) {
                     this.task = taskData[0];
                     this.currentUserId = parseInt(document.head.querySelector('meta[name="user-id"]').content);
@@ -101,18 +99,18 @@ export default {
             }
         },
         taskUpdated(task) {
-            console.log("taskUpdated", task);
             this.task = task;
         },
         async submit(task) {
             const { id: taskId, process_request_id: processRequestId } = task;
-            console.log("submit", task);
+
             try {
-                await ProcessMaker.apiClient.put(`tasks/${taskId}`, {
-                status: "COMPLETED",
-                data: this.formData
-                });
-                console.log("task completed", taskId);
+                if (task.advancedStatus !== 'completed') {
+                    await ProcessMaker.apiClient.put(`tasks/${taskId}`, {
+                        status: "COMPLETED",
+                        data: this.formData
+                     });
+                }
 
                 // Successfully completed task, get the next one
                 await this.getNextTask(processRequestId);
@@ -129,7 +127,6 @@ export default {
             console.error('error', processRequestId);
         },
         async importProcessTemplate() {
-            console.log("template", this.template);
             const response = await ProcessMaker.apiClient.post(`template/create/process/${this.template.process_template_id}`, {
                 name: this.template.name,
                 description: this.template.description,

--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -105,7 +105,7 @@ export default {
             const { id: taskId, process_request_id: processRequestId } = task;
 
             try {
-                if (task.advancedStatus !== 'completed') {
+                if (task.advanceStatus !== 'completed') {
                     await ProcessMaker.apiClient.put(`tasks/${taskId}`, {
                         status: "COMPLETED",
                         data: this.formData

--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -1,4 +1,3 @@
-
 export default {
     data() {
         return {
@@ -8,35 +7,40 @@ export default {
         }
     },
     methods: {
-        async getHelperProcessStartEvent(triggeredBy = null) {
+        getHelperProcessStartEvent(triggeredBy = null) {
             if (triggeredBy === 'wizard-details-modal') {
                 this.startEvents = this.template.process.start_events.filter(event => !event.eventDefinitions || event.eventDefinitions.length === 0);
                 this.helperProcessId = this.template.process.id;
-                
+
                 this.triggerHelperProcessStartEvent();
             } else {
                 if (this.wizardTemplateUuid !== null) {
-                    const response = await ProcessMaker.apiClient.get(`wizard-templates/${this.wizardTemplateUuid}/get-helper-process`);
-                    if (response.data) {
-                        this.helperProcessId = response.data.helper_process_id;
-                        this.startEvents = JSON.parse(response.data.start_events).filter(event => !event.eventDefinitions || event.eventDefinitions.length === 0);
-                        
-                        this.triggerHelperProcessStartEvent();
-                    }
+                    ProcessMaker.apiClient.get(`wizard-templates/${this.wizardTemplateUuid}/get-helper-process`)
+                    .then(response => {
+                        if (response.data) {
+                            this.helperProcessId = response.data.helper_process_id;
+                            this.startEvents = JSON.parse(response.data.start_events).filter(event => !event.eventDefinitions || event.eventDefinitions.length === 0);
+
+                            this.triggerHelperProcessStartEvent();
+                        }
+                    });
                 }
-            }            
+            }
         },
-        async triggerHelperProcessStartEvent() {
+        triggerHelperProcessStartEvent() {
             try {
-                
+
                 const startEventId = this.startEvents[0].id;
                 const url = `/process_events/${this.helperProcessId}?event=${startEventId}`;
 
                 // Start the helper process
-                const response = await window.ProcessMaker.apiClient.post(url);
-                const processRequestId = response.data.id;
+                window.ProcessMaker.apiClient.post(url).then(response => {
+                    const processRequestId = response.data.id;
+                    this.getNextTask(processRequestId);
+                }).catch(error => {
+                    console.error('Error: ', error);
+                })
 
-                this.getNextTask(processRequestId);
             } catch (err) {
                 const data = err.response?.data;
                 if (data && data.message) {
@@ -44,9 +48,9 @@ export default {
                 }
             }
         },
-        async getNextTask(processRequestId) {
+        getNextTask(processRequestId) {
             try {
-                const response = await ProcessMaker.apiClient.get(`tasks`, {
+                ProcessMaker.apiClient.get(`tasks`, {
                 params: {
                     page: 1,
                     include: 'user,assignableUsers',
@@ -56,23 +60,26 @@ export default {
                     order_by: 'due_at',
                     order_direction: 'asc'
                 }
+                }).then(response => {
+                    const taskData = response.data.data;
+                    if (taskData.length > 0) {
+                        this.task = taskData[0];
+                        this.currentUserId = parseInt(document.head.querySelector('meta[name="user-id"]').content);
+                        this.$bvModal.show('processWizard');
+                        this.showHelperProcess = true;
+                    } else {
+                        if (this.shouldImportProcessTemplate) {
+                            this.importProcessTemplate();
+                        } else {
+                            this.showHelperProcess = false;
+                            this.close();
+                        }
+                    }
+
+                }).catch(error => {
+                    console.error(error);
                 });
 
-                const taskData = response.data.data;
-                if (taskData.length > 0) {
-                    this.task = taskData[0];
-                    this.currentUserId = parseInt(document.head.querySelector('meta[name="user-id"]').content);
-                    this.$bvModal.show('processWizard');    
-                    this.showHelperProcess = true;
-                } else {
-                    if (this.shouldImportProcessTemplate) {
-                        this.importProcessTemplate();
-                    } else {
-                        this.showHelperProcess = false;
-                        this.close();
-                    }
-                    
-                }
             } catch (error) {
                 if (error && error.message) {
                     ProcessMaker.alert(error.message, 'danger');
@@ -84,14 +91,15 @@ export default {
             // Cancels the associated process request to prevent orphaned processes.
             this.cancelHelperProcessRequest();
         },
-        async cancelHelperProcessRequest() {
+        cancelHelperProcessRequest() {
             const {process_request_id: processRequestId } = this.task;
 
             try {
-                await ProcessMaker.apiClient.put(`requests/${processRequestId}`, {
+                ProcessMaker.apiClient.put(`requests/${processRequestId}`, {
                     status: "CANCELED"
+                }).then(response => {
+                    this.showHelperProcess = false;
                 });
-                this.showHelperProcess = false;
             } catch (error) {
                 if (data && data.message) {
                     ProcessMaker.alert(data.message, 'danger');
@@ -101,47 +109,51 @@ export default {
         taskUpdated(task) {
             this.task = task;
         },
-        async submit(task) {
+        submit(task) {
             const { id: taskId, process_request_id: processRequestId } = task;
-
             try {
                 if (task.advanceStatus !== 'completed') {
-                    await ProcessMaker.apiClient.put(`tasks/${taskId}`, {
-                        status: "COMPLETED",
-                        data: this.formData
-                     });
+                    ProcessMaker.apiClient.put(`tasks/${taskId}`, {
+                    status: "COMPLETED",
+                    data: this.formData
+                    }).then(response => {
+                        // Successfully completed task, get the next one
+                        this.getNextTask(processRequestId);
+                    }).catch(error => {
+                        console.log('Error: ', error);
+                    });
+                } else {
+                    if (this.shouldImportProcessTemplate) {
+                        this.importProcessTemplate();
+                    } else {
+                        this.showHelperProcess = false;
+                        this.close();
+                    }
                 }
-
-                // Successfully completed task, get the next one
-                await this.getNextTask(processRequestId);
             } catch (error) {
                 if (error && error.message) {
-                ProcessMaker.alert(error.message, 'danger');
+                    ProcessMaker.alert(error.message, 'danger');
                 }
             }
         },
-        completed(processRequestId) {
-            console.log("task completed", processRequestId);
-        },
-        error(processRequestId) {
-            console.error('error', processRequestId);
-        },
-        async importProcessTemplate() {
-            const response = await ProcessMaker.apiClient.post(`template/create/process/${this.template.process_template_id}`, {
+        importProcessTemplate() {
+            ProcessMaker.apiClient.post(`template/create/process/${this.template.process_template_id}`, {
                 name: this.template.name,
                 description: this.template.description,
-                version: '1.0.0', // TODO: Wizards should have a versions property 
+                version: '1.0.0', // TODO: Wizards should have a versions property
                 process_category_id: this.template.process.process_category_id,
                 projects: null,
                 wizardTemplateUuid: this.template.uuid,
+            }).then(response => {
+                if (response.data?.existingAssets) {
+                    this.handleExistingAssets(response.data);
+                } else {
+                    // redirect to the new process launchpad
+                    window.location = `/processes-catalogue/${response.data.processId}`;
+                }
+            }).catch(error => {
+                console.error(error);
             });
-        
-            if (response.data?.existingAssets) {
-                this.handleExistingAssets(response.data);
-            } else {
-                // redirect to the new process launchpad
-                window.location = `/processes-catalogue/${response.data.processId}`;
-            }
         },
         handleExistingAssets(data) {
             const assets = JSON.stringify(data.existingAssets);
@@ -149,17 +161,17 @@ export default {
             const request = JSON.stringify(data.request);
             window.history.pushState(
                 {
-                assets,
-                name: this.template.name,
-                responseId,
-                request,
-                redirectTo: 'process-launchpad',
-                wizardTemplateUuid: this.template.uuid,
+                    assets,
+                    name: this.template.name,
+                    responseId,
+                    request,
+                    redirectTo: 'process-launchpad',
+                    wizardTemplateUuid: this.template.uuid,
                 },
                 "",
                 "/template/assets",
             );
             window.location = "/template/assets";
         }
-   },
+    },
 }

--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -45,6 +45,7 @@ export default {
             }
         },
         async getNextTask(processRequestId) {
+            console.log("getNextTask", processRequestId);
             try {
                 const response = await ProcessMaker.apiClient.get(`tasks`, {
                 params: {
@@ -59,7 +60,7 @@ export default {
                 });
 
                 const taskData = response.data.data;
-
+                console.log("getNextTask - data", taskData);
                 if (taskData.length > 0) {
                     this.task = taskData[0];
                     this.currentUserId = parseInt(document.head.querySelector('meta[name="user-id"]').content);
@@ -100,16 +101,18 @@ export default {
             }
         },
         taskUpdated(task) {
+            console.log("taskUpdated", task);
             this.task = task;
         },
         async submit(task) {
             const { id: taskId, process_request_id: processRequestId } = task;
-
+            console.log("submit", task);
             try {
                 await ProcessMaker.apiClient.put(`tasks/${taskId}`, {
                 status: "COMPLETED",
                 data: this.formData
                 });
+                console.log("task completed", taskId);
 
                 // Successfully completed task, get the next one
                 await this.getNextTask(processRequestId);


### PR DESCRIPTION
This PR resolves an intermittent 422 error that occurred when running a guided template helper process. The issue was caused by attempting to update a task status to 'completed' through an API request when the task had already been completed. 

## Solution:
The solution involves checking the task's `advanceStatus` to ensure that it has not already been marked as completed before making the API request.

## How to Test
Note: The issue was encountered on CI servers and could not be replicated locally. However, to test the resolution:

1. Navigate to Processes -> Guided Templates.
2. Select a guided template.
3. Click on 'Get Started' and run through the process.
4. Ensure that no 422 errors occur.
5. Upon completion of the guided template, run another guided template.
6. Confirm that no 422 errors occur.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13239

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
