### PR TITLE
FOUR-13253: Query to populate the Case title has the same condition twice

### DIFF
--- a/upgrades/2023_12_14_160541_populate_process_requests_case_number.php
+++ b/upgrades/2023_12_14_160541_populate_process_requests_case_number.php
@@ -97,7 +97,6 @@ class PopulateProcessRequestsCaseNumber extends Upgrade
                     select 1 from category_assignments
                         left join process_categories on category_assignments.category_id = process_categories.id
                     where process_requests.process_id = category_assignments.assignable_id
-                        and process_requests.process_id = category_assignments.assignable_id
                         and category_assignments.assignable_type = \'ProcessMaker\\\\Models\\\\Process\'
                         and process_categories.is_system = 1
                 )


### PR DESCRIPTION
## Issue & Reproduction Steps
Query to populate the Case title has the same condition twice

## Solution
- Remove the condition repeated
`process_requests.process_id = category_assignments.assignable_id`

## How to Test
Run execute upgrade
`nginx php  artisan upgrade --force`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13253

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy