### PR TITLE
Update Artisan Command and Environment Variables for Guided Templates Sync

### DIFF
--- a/ProcessMaker/Console/Commands/SyncGuidedTemplates.php
+++ b/ProcessMaker/Console/Commands/SyncGuidedTemplates.php
@@ -3,16 +3,16 @@
 namespace ProcessMaker\Console\Commands;
 
 use Illuminate\Console\Command;
-use ProcessMaker\Jobs\SyncWizardTemplates as Job;
+use ProcessMaker\Jobs\SyncGuidedTemplates as Job;
 
-class SyncWizardTemplates extends Command
+class SyncGuidedTemplates extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'processmaker:sync-wizard-templates
+    protected $signature = 'processmaker:sync-guided-templates
                             {--queue : Queue this command to run asynchronously}';
 
     /**
@@ -20,7 +20,7 @@ class SyncWizardTemplates extends Command
      *
      * @var string
      */
-    protected $description = 'Synchronize wizard templates from a central repository';
+    protected $description = 'Synchronize guided templates from a central repository';
 
     /**
      * Create a new command instance.

--- a/ProcessMaker/Console/Kernel.php
+++ b/ProcessMaker/Console/Kernel.php
@@ -36,7 +36,7 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('processmaker:sync-default-templates --queue')->daily();
 
-        $schedule->command('processmaker:sync-wizard-templates --queue')->daily();
+        $schedule->command('processmaker:sync-guided-templates --queue')->daily();
     }
 
     /**

--- a/ProcessMaker/Jobs/SyncGuidedTemplates.php
+++ b/ProcessMaker/Jobs/SyncGuidedTemplates.php
@@ -21,7 +21,7 @@ use ProcessMaker\Models\User;
 use ProcessMaker\Models\WizardTemplate;
 use Storage;
 
-class SyncWizardTemplates implements ShouldQueue
+class SyncGuidedTemplates implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
@@ -47,18 +47,18 @@ class SyncWizardTemplates implements ShouldQueue
     {
         try {
             // Fetch configuration from the environment
-            $config = config('services.wizard_templates_github');
+            $config = config('services.guided_templates_github');
 
-            // Build the URL to fetch the default templates list from GitHub
-            $url = $config['base_url'] . $config['wizard_repo'] . '/' . $config['wizard_branch'] . '/index.json';
+            // Build the URL to fetch the guided templates list from GitHub
+            $url = $config['base_url'] . $config['template_repo'] . '/' . $config['template_branch'] . '/index.json';
 
             // If there are multiple categories of templates defined in the .env, separate them into an array
-            $categories = (strpos($config['wizard_categories'], ',') !== false)
-                ? explode(',', $config['wizard_categories'])
-                : [$config['wizard_categories']];
+            $categories = (strpos($config['template_categories'], ',') !== false)
+                ? explode(',', $config['template_categories'])
+                : [$config['template_categories']];
 
             // Create or get the ID of the 'Guided Templates' category
-            $wizardTemplateCategoryId = ProcessCategory::firstOrCreate([
+            $guidedTemplateCategoryId = ProcessCategory::firstOrCreate([
                 'name' => 'Guided Templates',
             ], [
                 'status' => 'ACTIVE',
@@ -77,18 +77,18 @@ class SyncWizardTemplates implements ShouldQueue
             $data = $response->json();
 
             // Iterate over categories and templates to retrieve them
-            foreach ($data as $templateCategory => $wizardTemplates) {
+            foreach ($data as $templateCategory => $guidedTemplates) {
                 if (!in_array($templateCategory, $categories) && !in_array('all', $categories)) {
                     continue;
                 }
 
                 try {
                     // Remove deprecated templates that are not in the index.json file.
-                    $this->removeDeprecatedTemplates($wizardTemplates);
+                    $this->removeDeprecatedTemplates($guidedTemplates);
 
                     // Import templates from the index.json file.
-                    foreach ($wizardTemplates as $template) {
-                        $this->importTemplate($template, $config, $wizardTemplateCategoryId);
+                    foreach ($guidedTemplates as $template) {
+                        $this->importTemplate($template, $config, $guidedTemplateCategoryId);
                     }
                 } catch (Exception $e) {
                     Log::error("Error Importing Guided Templates: {$e->getMessage()}");
@@ -99,27 +99,27 @@ class SyncWizardTemplates implements ShouldQueue
         }
     }
 
-    // Since the wizard templates are not tracked by a specific ID, we need to track them by the template name.
+    // Since the guided templates are not tracked by a specific ID, we need to track them by the template name.
     // If the template name has changed, we need to remove the deprecated template name from the database.
-    private function removeDeprecatedTemplates($wizardTemplates)
+    private function removeDeprecatedTemplates($guidedTemplates)
     {
         $templateNames = array_map(function ($template) {
             return $template['template_details']['card-title'];
-        }, $wizardTemplates);
+        }, $guidedTemplates);
 
-        // Remove templates that are no longer present in the provided wizard templates.
+        // Remove templates that are no longer present in the provided guided templates.
         WizardTemplate::whereNotIn('name', $templateNames)->delete();
     }
 
     /**
-     * Import a wizard template into the database.
+     * Import a guided template into the database.
      *
      * @param array $template
      * @param array $config
-     * @param int $wizardTemplateCategoryId
+     * @param int $guidedTemplateCategoryId
      * @return void
      */
-    private function importTemplate($template, $config, $wizardTemplateCategoryId)
+    private function importTemplate($template, $config, $guidedTemplateCategoryId)
     {
         // Configure URLs for the helper process, process template
         $helperProcessUrl = $this->buildTemplateUrl($config, $template['helper_process']);
@@ -130,24 +130,24 @@ class SyncWizardTemplates implements ShouldQueue
         $templateProcessPayload = $this->fetchPayload($processTemplateUrl);
 
         // Update process categories for the helper process and process template
-        $this->updateProcessCategories($helperProcessPayload, $templateProcessPayload, $wizardTemplateCategoryId);
+        $this->updateProcessCategories($helperProcessPayload, $templateProcessPayload, $guidedTemplateCategoryId);
 
         // Import the helper process and get the new ID
-        $newHelperProcessId = $this->importProcess($helperProcessPayload, 'WIZARD_HELPER_PROCESS');
+        $newHelperProcessId = $this->importProcess($helperProcessPayload, 'GUIDED_HELPER_PROCESS');
         // Import the process template and get the new ID
-        $newProcessTemplateId = $this->importProcess($templateProcessPayload, 'WIZARD_PROCESS_TEMPLATE');
+        $newProcessTemplateId = $this->importProcess($templateProcessPayload, 'GUIDED_PROCESS_TEMPLATE');
 
-        // Update or create the wizard template in the database
-        $wizardTemplate = $this->updateOrCreateWizardTemplate($template, $newHelperProcessId, $newProcessTemplateId);
+        // Update or create the guided template in the database
+        $guidedTemplate = $this->updateOrCreateGuidedTemplate($template, $newHelperProcessId, $newProcessTemplateId);
 
         // Create a media collection for template assets
-        $mediaCollectionName = $this->createMediaCollection($wizardTemplate);
+        $mediaCollectionName = $this->createMediaCollection($guidedTemplate);
 
         // Import template assets and associate with the media collection
-        $this->importTemplateAssets($template, $config, $mediaCollectionName, $wizardTemplate);
+        $this->importTemplateAssets($template, $config, $mediaCollectionName, $guidedTemplate);
 
-        $wizardTemplate->media_collection = $mediaCollectionName;
-        $wizardTemplate->save();
+        $guidedTemplate->media_collection = $mediaCollectionName;
+        $guidedTemplate->save();
     }
 
     // Helper functions used within importTemplate
@@ -155,8 +155,8 @@ class SyncWizardTemplates implements ShouldQueue
     {
         // Build the URL for a template based on the configuration and template path
         return $config['base_url'] .
-            $config['wizard_repo'] . '/' .
-            $config['wizard_branch'] . '/' .
+            $config['template_repo'] . '/' .
+            $config['template_branch'] . '/' .
             Str::replace('./', '', $templatePath);
     }
 
@@ -166,18 +166,18 @@ class SyncWizardTemplates implements ShouldQueue
         return Http::get($url)->json();
     }
 
-    private function updateProcessCategories(&$helperProcessPayload, &$templateProcessPayload, $wizardTemplateCategoryId)
+    private function updateProcessCategories(&$helperProcessPayload, &$templateProcessPayload, $guidedTemplateCategoryId)
     {
         // Update process categories for both the helper process and process template
         data_set(
             $helperProcessPayload,
             "export.{$helperProcessPayload['root']}.attributes.process_category_id",
-            $wizardTemplateCategoryId
+            $guidedTemplateCategoryId
         );
         data_set(
             $templateProcessPayload,
             "export.{$templateProcessPayload['root']}.attributes.process_category_id",
-            $wizardTemplateCategoryId
+            $guidedTemplateCategoryId
         );
     }
 
@@ -209,9 +209,9 @@ class SyncWizardTemplates implements ShouldQueue
         }
     }
 
-    private function updateOrCreateWizardTemplate($template, $newHelperProcessId, $newProcessTemplateId)
+    private function updateOrCreateGuidedTemplate($template, $newHelperProcessId, $newProcessTemplateId)
     {
-        // Update or create the wizard template in the database
+        // Update or create the guided template in the database
 
         return WizardTemplate::updateOrCreate([
             'name' => $template['template_details']['card-title'],
@@ -224,35 +224,35 @@ class SyncWizardTemplates implements ShouldQueue
         ]);
     }
 
-    private function createMediaCollection($wizardTemplate)
+    private function createMediaCollection($guidedTemplate)
     {
         // Create a media collection for template assets and return the collection name
-        $mediaCollectionName = 'wt-' . $wizardTemplate->uuid . '-media';
-        $wizardTemplate->addMediaCollection($mediaCollectionName);
+        $mediaCollectionName = 'wt-' . $guidedTemplate->uuid . '-media';
+        $guidedTemplate->addMediaCollection($mediaCollectionName);
 
         return $mediaCollectionName;
     }
 
-    private function importTemplateAssets($template, $config, $mediaCollectionName, $wizardTemplate)
+    private function importTemplateAssets($template, $config, $mediaCollectionName, $guidedTemplate)
     {
         // Clear the collection to prevent duplicate images
-        $wizardTemplate->clearMediaCollection($mediaCollectionName);
+        $guidedTemplate->clearMediaCollection($mediaCollectionName);
         // Build asset urls
         $templateIconUrl = $this->buildTemplateUrl($config, $template['assets']['icon']);
         $templateCardBackgroundUrl = $this->buildTemplateUrl($config, $template['assets']['card-background']);
         // Import template assets and associate with the media collection
-        $this->importMedia($templateIconUrl, 'icon', $mediaCollectionName, $wizardTemplate);
-        $this->importMedia($templateCardBackgroundUrl, 'cardBackground', $mediaCollectionName, $wizardTemplate);
+        $this->importMedia($templateIconUrl, 'icon', $mediaCollectionName, $guidedTemplate);
+        $this->importMedia($templateCardBackgroundUrl, 'cardBackground', $mediaCollectionName, $guidedTemplate);
 
         foreach ($template['assets']['slides'] as $slide) {
             $templateSlideUrl = $this->buildTemplateUrl($config, $slide);
-            $this->importMedia($templateSlideUrl, 'slide', $mediaCollectionName, $wizardTemplate);
+            $this->importMedia($templateSlideUrl, 'slide', $mediaCollectionName, $guidedTemplate);
         }
     }
 
-    private function importMedia($assetUrl, $customProperty, $mediaCollectionName, $wizardTemplate)
+    private function importMedia($assetUrl, $customProperty, $mediaCollectionName, $guidedTemplate)
     {
         // Import a media asset and associate it with the media collection
-        $wizardTemplate->addMediaFromUrl($assetUrl)->withCustomProperties(['media_type' => $customProperty])->toMediaCollection($mediaCollectionName);
+        $guidedTemplate->addMediaFromUrl($assetUrl)->withCustomProperties(['media_type' => $customProperty])->toMediaCollection($mediaCollectionName);
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -46,11 +46,11 @@ return [
         'template_categories' => env('DEFAULT_TEMPLATE_CATEGORIES', 'accounting-and-finance,customer-success,human-resources,marketing-and-sales,operations,it'),
     ],
 
-    'wizard_templates_github' => [
+    'guided_templates_github' => [
         'base_url' => 'https://raw.githubusercontent.com/processmaker/',
-        'wizard_repo' => env('WIZARD_TEMPLATE_REPO', 'wizard-templates'),
-        'wizard_branch' => env('WIZARD_TEMPLATE_BRANCH', '2023-winter'),
-        'wizard_categories' => env('WIZARD_TEMPLATE_CATEGORIES', 'all'),
+        'template_repo' => env('GUIDED_TEMPLATE_REPO', 'wizard-templates'),
+        'template_branch' => env('GUIDED_TEMPLATE_BRANCH', '2023-winter'),
+        'template_categories' => env('GUIDED_TEMPLATE_CATEGORIES', 'all'),
     ],
 
 ];


### PR DESCRIPTION
This PR updates the `php artisan processmaker:sync-wizard-templates` command to `php artisan processmaker:sync-guided-templates`. Additionally, it modifies references in `services.php` files and updates variables and methods in the `SyncGuidedTemplate` files from `wizard` to `guided`.

## New Environment Variables

- GUIDED_TEMPLATE_REPO
- GUIDED_TEMPLATE_BRANCH
- GUIDED_TEMPLATE_CATEGORIES
.

## How to Test

1. Ensure you have no guided templates in your database.
2. Run the command `php artisan processmaker:sync-guided-templates`.
3. Ensure the command runs with no errors.
4. Confirm that the guided template is updated in the database.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13259

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
