### PR TITLE
bugfix/FOUR-13260: Favorite category disappears between searches

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -72,7 +72,8 @@ export default {
   props: ["permission", "isDocumenterInstalled", "currentUserId", "process", "currentUser"],
   data() {
     return {
-      listCategories: [{
+      listCategories: [],
+      favorite: [{
         id: 0,
         name: "Favorites",
         status: "ACTIVE",
@@ -139,6 +140,9 @@ export default {
             + `&per_page=${this.numCategories}`
             + `&filter=${this.filter}`)
           .then((response) => {
+            if (this.listCategories[0] !== this.favorite[0]) {
+              this.listCategories = [...this.favorite, ...this.listCategories];
+            }
             this.listCategories = [...this.listCategories, ...response.data.data];
             this.totalPages = response.data.meta.total_pages !== 0 ? response.data.meta.total_pages : 1;
 


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to Reproduce**

1. Have to process
2. Go to process launch pad
3. ON the searcher category search one category exe. Uncategorized
4. Clear the searcher
5. Search Favorite category

**Current Behavior** 
The Favorite category disappears after searching a category 

**Expected Behavior** 
Favorite should not disappear from top categories in LaunchPad 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13260

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy