### PR TITLE
FOUR-13015 | When ‘Use Now’ is Clicked in the Slide, the Modal Changes Size Before Loading the Next Slide

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -980,6 +980,7 @@ nav {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.29) 0%, rgba(255, 255, 255, 0.62) 100%), var(--borders, #CDDDEE);
   padding: 50px;
   color: #556271;
+  min-height: 450px;
 }
 
 #wizardTemplateDetails___BV_modal_header_,


### PR DESCRIPTION
# Issue
Ticket: [FOUR-13015](https://processmaker.atlassian.net/browse/FOUR-13015)

When 'Use Now' is selected from the Guided Template details modal, the modal changes size when loading the Helper Process.

# Solution
Set a min-height on the modal so that the modal does not visibly change size when the Helper Process is loaded.

# How to Test
1. Go to branch `observation/FOUR-13015` in `processmaker`.
2. Go to Processes → Guided Templates.
3. Select the available Guided Template.
4. When the modal opens, select the 'Use Now' button.
	- The modal should not change size when the Helper Process is loaded.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13015]: https://processmaker.atlassian.net/browse/FOUR-13015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ