### PR TITLE
FOUR-13248:Processes marked as favorites keep the same label in tooltip

### DIFF
--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -10,7 +10,7 @@
         <i
           :ref="`bookmark-${process.id}`"
           v-b-tooltip.hover
-          :title="$t('Add to Favorites')"
+          :title="$t(labelTooltip)"
           :class="bookmarkIcon()"
           @click="checkBookmark(process)"
         />
@@ -36,6 +36,7 @@ export default {
   data() {
     return {
       labelIcon: "Default Icon",
+      labelTooltip: "",
     };
   },
   methods: {
@@ -64,8 +65,10 @@ export default {
      */
     bookmarkIcon() {
       if (this.process.bookmark_id !== 0) {
+        this.labelTooltip = "Remove from favorites";
         return "fas fa-bookmark marked";
       }
+      this.labelTooltip = "Add to Favorites";
       return "far fa-bookmark";
     },
     /**

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1255,6 +1255,7 @@
   "Regular Button": "Regular Button",
   "Remember me": "Remember me",
   "Remove from Group": "Remove from Group",
+  "Remove from favorites": "Remove from favorites",
   "Remove the .env file to perform a new installation.": "Remove the .env file to perform a new installation.",
   "Remove": "Remove",
   "Render HTML from a Variable": "Render HTML from a Variable",


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Have to process
2. Go to Launch Pad
3. Open a process from cards
4. Marked as Favorite
5. Go to the Favorite category
6. Hover in a process marked as favorite
7. Check the title of tooltip

**Current Behavior**
The title for the process in favorite category is incorrect, because these already marked as favorites 

## Solution
[recording.webm](https://github.com/ProcessMaker/processmaker/assets/5005237/8ba33c31-4b22-4964-8538-134507f27acd)


## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-13248](https://processmaker.atlassian.net/browse/FOUR-13248)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-13248]: https://processmaker.atlassian.net/browse/FOUR-13248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ