### PR TITLE
FOUR-13245 Fix It is not possible to create a process from a template

### DIFF
--- a/resources/js/templates/assets.js
+++ b/resources/js/templates/assets.js
@@ -11,6 +11,7 @@ new Vue({
       name: "",
       responseId: null,
       request: {},
+      redirectTo: null,
     };
   },
   mounted() {


### PR DESCRIPTION
## Issue & Reproduction Steps
It is not possible to create a process from a template

## Solution
- Add missing varible definition.

## How to Test
Create a new process from any template.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
