### PR TITLE
FOUR-13321: Process in category inactive are listed in All Processes>> Launchpad

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -123,10 +123,7 @@ class ProcessController extends Controller
         }
 
         // Filter by category status
-        $catStatus = $request->input('cat_status', null);
-        if (!empty($catStatus)) {
-            $processes->categoryStatus($catStatus);
-        }
+        $processes->categoryStatus($request->input('cat_status', null));
 
         if (!empty($pmql)) {
             try {

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -122,6 +122,12 @@ class ProcessController extends Controller
             $processes->processCategory($category);
         }
 
+        // Filter by category status
+        $catStatus = $request->input('cat_status', null);
+        if (!empty($catStatus)) {
+            $processes->categoryStatus($catStatus);
+        }
+
         if (!empty($pmql)) {
             try {
                 $processes->pmql($pmql);

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -468,11 +468,13 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
      * Scope a query to include a specific category
      * @param string $status
      */
-    public function scopeCategoryStatus($query, $status = 'ACTIVE')
+    public function scopeCategoryStatus($query, $status)
     {
-        return $query->whereHas('categories', function ($query) use ($status) {
-            $query->where('process_categories.status', $status);
-        });
+        if (!empty($status)) {
+            return $query->whereHas('categories', function ($query) use ($status) {
+                $query->where('process_categories.status', $status);
+            });
+        }
     }
 
     public function getCollaborations()

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -464,6 +464,17 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         });
     }
 
+    /**
+     * Scope a query to include a specific category
+     * @param string $status
+     */
+    public function scopeCategoryStatus($query, $status = 'ACTIVE')
+    {
+        return $query->whereHas('categories', function ($query) use ($status) {
+            $query->where('process_categories.status', $status);
+        });
+    }
+
     public function getCollaborations()
     {
         $this->bpmnDefinitions = app(BpmnDocumentInterface::class, ['process' => $this]);

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -101,6 +101,7 @@ export default {
           + `&per_page=${this.perPage}`
           + `&pmql=${encodeURIComponent(this.pmql)}`
           + "&bookmark=true"
+          + "&cat_status=ACTIVE"
           + "&order_by=name&order_direction=asc";
       }
       if (this.category.id === 0) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Process in category inactive are listed in All Processes>> Launchpad

## Solution
- List only the processes related to the category = ACTIVE

## How to Test
1. Log in PM4
2. Create a process
3. Create a category
4. Assign the process to category
5. Inactive the category created
6. Go to Launchpad
7. Click on All Processes
8. Search the process in category inactive

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13321

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy