### PR TITLE
QA Observation Bugfix/FOUR-13324: The Select Chart title has a little separation than the other controls

### DIFF
--- a/resources/js/components/shared/ModalSaveVersion.vue
+++ b/resources/js/components/shared/ModalSaveVersion.vue
@@ -45,7 +45,7 @@
                     </label>
                     <icon-dropdown ref="icon-dropdown" />
                     <label class="mt-2">{{ $t("Chart") }}</label>
-                    <div class="dropdown mt-2">
+                    <div class="dropdown">
                       <button
                         id="statusDropdown"
                         class="btn dropdown-toggle dropdown-style w-100 d-flex justify-content-between align-items-center btn-custom"
@@ -849,6 +849,9 @@ $multiselect-height: 38px;
 
 .custom-dropdown {
   width: 100%;
+  max-height: 200px;
+  overflow-y: auto;
+  transform: none;
 }
 
 .error-message {


### PR DESCRIPTION
## Solution
- Extra space between dropdown and title FIXED
- Select Chart Dropdown has an internal scrollbar in case of too many charts

## How to Test
- Create many SAved Search Charts
- Go to Process Launchpad
- Open in Launchpad
- Check "Chart List"

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13324

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next