### PR TITLE
bugfix/FOUR-13325 : Scroll infinite It's not working up in Launchpad

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -152,7 +152,10 @@ export default {
             + `&per_page=${this.numCategories}`
             + `&filter=${this.filter}`)
           .then((response) => {
-            this.listCategories = [...this.defaultOptions, ...response.data.data];
+            if(!this.checkDefaultOptions()) {
+              this.listCategories = [...this.defaultOptions, ...this.listCategories];
+            }
+            this.listCategories = [...this.listCategories, ...response.data.data];
             this.totalPages = response.data.meta.total_pages !== 0 ? response.data.meta.total_pages : 1;
             this.categoryCount = response.data.meta.total;
             if (this.markCategory) {
@@ -162,6 +165,12 @@ export default {
             }
           });
       }
+    },
+    /**
+     * Check if listCatefgories have the default options
+     */
+    checkDefaultOptions() {
+      return this.defaultOptions.every(v => this.listCategories.includes(v));
     },
     /**
      * Check if there is a pre-selected process


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce
Have many categories in process
Go to Launchpad
Scroll down the categories
Try scrolling up to see the first category

**Current Behavior** 
Scroll infinite It's not working up in Launchpad

**Expected Behavior** 
Infinite scroll should work upwards

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13325

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy