### PR TITLE
bugfix/FOUR-13338: There is not clear option in the search engine for templates

### DIFF
--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -8,6 +8,15 @@
           </b-btn>
         </b-input-group-prepend>
         <b-form-input v-model="filter" id="search-box" class="pl-0" :placeholder="$t('Search Templates')"></b-form-input>
+        <b-input-group-append v-if="filter">
+          <b-btn
+            class="px-1"
+            variant="outline-secondary"
+            @click="clearSearch()"
+          >
+            <b-icon icon="x" />
+          </b-btn>
+        </b-input-group-append>
       </b-input-group>
     </div>
     <div class="cards-container" :class="type !== 'wizard' ? 'fixed-height' : '' ">
@@ -208,6 +217,10 @@ export default {
         .finally(() => {
           this.loading = false;
         });
+    },
+    clearSearch() {
+      this.filter = "";
+      this.fetch();
     },
     showDetails($event = null) {
       if (!$event) {


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to Reproduce**

1. Go to Launch Pad
2. Click on Guided templates 
3. Click on Search engine of templates

**Current Behavior**
There is not clear option in the search engine for templates


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13338

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy