### PR TITLE
FOUR-13214: Adding unit test for the new api

### DIFF
--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -1293,4 +1293,28 @@ class ProcessTest extends TestCase
 
         $this->assertDatabaseMissing('media', ['id' => $mediaImagen->id]);
     }
+
+    /**
+     * Test the start events
+     */
+    public function testProcessBookmarksStartEvents()
+    {
+        // We create a user that isn't administrator
+        $user = Auth::user();
+
+        // Add process permission to user
+        $this->user->permissions()->attach(Permission::byName('view-processes'));
+
+        // Create some processes
+        $bpmn = trim(Process::getProcessTemplate('SingleTask.bpmn'));
+        $process = Process::factory()->create(['bpmn' => $bpmn]);
+        $process->usersCanStart('StartEventUID')->attach($user->id);
+
+        $url = route('api.processes.start.events', $process);
+        $params = [
+            'id' => $process->id,
+        ];
+        $response = $this->apiCall('GET', $url, $params);
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Adding unit test for the new api

## How to Test
`phpunit  --testsuite Unit tests/Feature/Api/ProcessTest.php `

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13214

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next