### PR TITLE
Reduce Spacing Between Guided Templates

### DIFF
--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -58,7 +58,7 @@
           </p>
         </template>
         <template v-else>
-          <b-card-group id="template-options" deck class="d-flex small-deck-margin template-options">
+          <b-card-group id="template-options" deck class="small-deck-margin template-options" :class="type !== 'wizard' ?  'd-flex' : ''">
             <template-select-card
               v-show="component === 'template-select-card'"
               v-for="(template, index) in templates"

--- a/resources/js/components/templates/TemplateSelectCard.vue
+++ b/resources/js/components/templates/TemplateSelectCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="template-select-card-container" :class="type !== 'wizard' ? 'pb-2' : 'pb-4 col-3'">
+  <div :class="type !== 'wizard' ? 'template-select-card-container pb-2' : 'wizard-select-card-container pb-4'" >
     <wizard-template-card
       v-if="type === 'wizard'"
       :template="template"
@@ -35,5 +35,12 @@ export default {
 <style lang="scss" scoped>
 .template-select-card-container {
   flex: 0 0 33.333333%;
+}
+
+.wizard-select-card-container {
+  height: 240px;
+  margin-right: 1rem;
+  margin-top: 1rem;
+  width: 350px;
 }
 </style>

--- a/resources/js/components/templates/TemplateSelectCard.vue
+++ b/resources/js/components/templates/TemplateSelectCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="template-select-card-container" :class="type !== 'wizard' ? 'pb-2' : 'pb-4'">
+  <div class="template-select-card-container" :class="type !== 'wizard' ? 'pb-2 col-3' : 'pb-4'">
     <wizard-template-card
       v-if="type === 'wizard'"
       :template="template"

--- a/resources/js/components/templates/TemplateSelectCard.vue
+++ b/resources/js/components/templates/TemplateSelectCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="template-select-card-container" :class="type !== 'wizard' ? 'pb-2 col-3' : 'pb-4'">
+  <div class="template-select-card-container" :class="type !== 'wizard' ? 'pb-2' : 'pb-4 col-3'">
     <wizard-template-card
       v-if="type === 'wizard'"
       :template="template"


### PR DESCRIPTION
This PR addresses the extra space between guided templates when multiple templates are listed. The solution involves adding the col-3 class to the template select card container.

## How to Test

1. Navigate to Processes > Guided Templates.
2. Open your inspector panel.
3. Locate the div with the class template-select-card-container.
4. Duplicate the div so that more than one guided template is displayed.
5. Ensure the spacing between the divs matches the spacing in the mockup.


## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-13357](https://processmaker.atlassian.net/browse/FOUR-13357)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
