### PR TITLE
observation/FOUR-13168-B up and down buttons do not reset after selecting the button in another column 

### DIFF
--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -281,6 +281,13 @@
         return bubbleColor[status];
       },
       handleEllipsisClick(categoryColumn) {
+        this.fields.forEach(column => {
+          if (column.field !== categoryColumn.field) {
+            column.direction = "none";
+            column.filterApplied = false;
+          }
+        });
+
         if (categoryColumn.direction === "asc") {
           categoryColumn.direction = "desc";
         } else if (categoryColumn.direction === "desc") {

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -346,13 +346,6 @@ export default {
       return data;
     },
     handleEllipsisClick(processColumn) {
-      this.fields.forEach(column => {
-        if (column.field !== processColumn.field) {
-          column.direction = "none";
-          column.filterApplied = false;
-        }
-      });
-
       if (processColumn.direction === "asc") {
         processColumn.direction = "desc";
       } else if (processColumn.direction === "desc") {

--- a/resources/js/templates/components/ProcessTemplatesListing.vue
+++ b/resources/js/templates/components/ProcessTemplatesListing.vue
@@ -337,6 +337,13 @@
           return data;
         },
         handleEllipsisClick(templateColumn) {
+          this.fields.forEach(column => {
+            if (column.field !== templateColumn.field) {
+              column.direction = "none";
+              column.filterApplied = false;
+            }
+          });
+
           if (templateColumn.direction === "asc") {
             templateColumn.direction = "desc";
           } else if (templateColumn.direction === "desc") {


### PR DESCRIPTION
## Issue & Reproduction Steps
Up and down buttons do not reset after selecting the button in another column

## Solution
reset the up and down buttons properties after another column is selected
We added the solution for the templates and categories tabs, the processes and archived processes tabs solution are on the ticket FOUR-13307 to avoid conflicts


https://processmaker.atlassian.net/browse/FOUR-13168

## Related Tickets & Packages

ci:next