### PR TITLE
observation/FOUR-13368 Server Error when sort option is used in the last column in the Processes page

### DIFF
--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -23,6 +23,7 @@
           #[`filter-${column.field}`]
         >
           <div
+            v-if="column.sortable"
             :key="index"
             @click="handleEllipsisClick(column)"
           >


### PR DESCRIPTION
## Issue & Reproduction Steps
Server Error when sort option is used in the last column in the Processes page

## Solution
Add a sort validation on process list

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13368

ci:deploy
ci:next