### PR TITLE
FOUR-13355: Scroll stops working if Zoom is used in processes

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -10,6 +10,7 @@
     class="ellipsis-dropdown-main"
     @show="onShow"
     @hide="onHide"
+    boundary="viewport"
   >
     <template v-if="customButton" #button-content>
       <i


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- boundary="viewport" property was added to the ellipsis menu component

## How to Test
Describe how to test that this solution works.
1.Go to process
2.Click on ellipsis of the first process
3.Zoom the screen up to 150% or more
4.Click on scroll and move it

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13355

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
