### PR TITLE
FOUR-13316: Properly clear the user's avatar when saved

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -312,7 +312,6 @@ class UserController extends Controller
 
         $request->validate(User::rules($user));
         $fields = $request->json()->all();
-
         if (isset($fields['password'])) {
             $fields['password'] = Hash::make($fields['password']);
             $fields['password_changed_at'] = Carbon::now()->toDateTimeString();

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -312,6 +312,7 @@ class UserController extends Controller
 
         $request->validate(User::rules($user));
         $fields = $request->json()->all();
+
         if (isset($fields['password'])) {
             $fields['password'] = Hash::make($fields['password']);
             $fields['password_changed_at'] = Carbon::now()->toDateTimeString();
@@ -536,7 +537,7 @@ class UserController extends Controller
      * @param User $user
      * @param Request $request
      *
-     * @throws \Exception
+     * @throws \Exception|\Throwable
      */
     private function uploadAvatar(User $user, Request $request)
     {
@@ -548,8 +549,13 @@ class UserController extends Controller
             return;
         }
 
+        // A bool value of false here set for the user's avatar indicates we're clearing
+        // the avatar both by deleting the image itself from the filesystem and emptying
+        // the "avatar" column for this user in the database
         if ($data['avatar'] === false) {
             $user->clearMediaCollection(User::COLLECTION_PROFILE);
+            $user->setAttribute('avatar', '');
+            $user->save();
 
             return;
         }


### PR DESCRIPTION
## Issue
When clearing a given user's avatar (whether your own or another user's) after saving, a broken image continued to show everywhere the user's avatar would appear instead of the default initials.

## Reproduction Steps
1. Log in as a user with profile editing permissions
2. Navigate to edit your profile
3. Upload a photo for your avatar and save your profile
4. Notice your avatar update across the site, including on the same page
5. Now go back to edit your profile and clear your avatar and save
6. Notice the broken image(s) appearing everywhere your avatar is. This should be the default of the user's first and last initials as displayed in the preview.

## Solution
The `avatar` column in the `users` table was not being emptied and persisted after the avatar image was removed from the filesystem. The fix was simple, to empty that column and save it in the database to keep everything in sync.

## How to Test
You should now be able to run through the reproduction steps and see the proper initials of the user appear in place of the previously broken avatar image.

## Related Tickets & Packages
- [FOUR-13316](https://processmaker.atlassian.net/browse/FOUR-13316)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13316]: https://processmaker.atlassian.net/browse/FOUR-13316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ