### PR TITLE
FOUR-13601: Settings not returning after clearing filter

### DIFF
--- a/resources/js/admin/settings/components/SettingText.vue
+++ b/resources/js/admin/settings/components/SettingText.vue
@@ -83,13 +83,14 @@ export default {
       return '•'.repeat(this.input.length);
     },
     state() {
-      if (this.setting.ui?.isNotEmpty) {
+      if (this.setting?.ui?.isNotEmpty) {
         return this.transformed !== '' && this.transformed !== null;
       }
+
       return true;
     },
     invalidFeedback() {
-      if (this.setting.ui?.isNotEmpty && (this.transformed === '' || this.transformed === null)) {
+      if (this.setting?.ui?.isNotEmpty && (this.transformed === '' || this.transformed === null)) {
         return this.$t("The current value is empty but a value is required. Please provide a valid value.");
       }
     }

--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="settings-listing data-table">
-    <pmql-input 
+    <pmql-input
       class="mb-2"
       :search-type="'settings'"
       :value="pmql"
@@ -125,20 +125,20 @@
               </span>
 
               <span v-b-tooltip.hover v-else-if="!['boolean', 'object', 'button'].includes(row.item.format) && !disabledDeleteSetting(row)" :title="$t('Clear')">
-                <b-button 
+                <b-button
                   :aria-label="$t('Clear')"
                   v-uni-aria-describedby="row.item.id.toString()"
-                  :disabled="disableClear(row.item)" 
-                  @click="onClear(row)" 
-                  variant="link" 
+                  :disabled="disableClear(row.item)"
+                  @click="onClear(row)"
+                  variant="link"
                   class="settings-listing-button"
                   >
                   <i class="fa-lg fas fa-trash-alt settings-listing-button"></i>
                 </b-button>
               </span>
               <span v-else class="invisible">
-                <b-button 
-                  variant="link" 
+                <b-button
+                  variant="link"
                   class="settings-listing-button"
                   v-uni-aria-describedby="row.item.id.toString()">
                   <i class="fas fa-trash-alt settings-listing-button"></i>
@@ -279,12 +279,12 @@ export default {
       sortable: false,
       tdClass: "align-middle settings-listing-td3",
     });
-    
+
     ProcessMaker.EventBus.$on('setting-added-from-modal', () => {
       this.shouldDisplayNoDataMessage = false;
       this.$nextTick(() => {
         this.$emit('refresh-all');
-      });  
+      });
     });
   },
   methods: {
@@ -354,7 +354,7 @@ export default {
         if (!this.shouldDisplayNoDataMessage) {
           this.settings = otherSettings; // Use the other settings
         }
-        
+
         this.totalRows = response.data.meta.total;
         this.from = response.data.meta.from;
         this.to = response.data.meta.to;
@@ -366,9 +366,7 @@ export default {
         }
         this.orderByPrevious = this.orderBy;
         this.orderDescPrevious = this.orderDesc;
-        this.$nextTick(() => {
-          callback(this.settings);
-        });
+        this.$nextTick(() => callback(this.settings));
       });
     },
     separateSettings(settings) {
@@ -386,13 +384,14 @@ export default {
       return { noDataSettings, otherSettings };
     },
     shouldDisplayNoData(noDataSettings, allSettings) {
+      // All settings are 'no-data' settings
       if (noDataSettings.length === allSettings.length) {
-        return true; // All settings are 'no-data' settings
-      } else if (noDataSettings.length > 0) {
-        return false; // Some settings are 'no-data' settings
-      } else {
-        return false; // No 'no-data' settings found, display all configured settings
+        // and noDataSettings has a value
+        return noDataSettings.length > 0;
       }
+
+      // No 'no-data' settings found, display all configured settings
+      return false;
     },
     getTooltip(row) {
       if (row.item.readonly) {
@@ -560,7 +559,7 @@ export default {
       if (showAuthAccBtn) {
         // Returns all 'top' position buttons except the '+ Mail Server' button for email server tabs
         return btn.ui.props.position === 'top' && !btn.key.includes('EMAIL_CONNECTOR_ADD_MAIL_SERVER_');
-      } 
+      }
       // Returns all 'top' position buttons except the 'Authorize Account' button for email default settings tab
       return btn.ui.props.position === 'top' && !btn.key.includes('EMAIL_CONNECTOR_AUTHORIZE_ACCOUNT');
     },
@@ -568,7 +567,7 @@ export default {
       const authMethod = groupData.find(data => data.key.includes("abe_imap_auth_method"));
       const selectedAuthMethod = authMethod ? authMethod.ui.options[authMethod.config] : null;
       const showAuthAccBtn = selectedAuthMethod && selectedAuthMethod !== 'standard' ? true : false;
-      
+
       if (showAuthAccBtn) {
         // Returns all 'top' position buttons
         return btn.ui.props.position === 'top';


### PR DESCRIPTION
## Issue
After filtering any of the settings tables, when you attempt to clear the filter, the settings do not return. Instead, multiple  exceptions are thrown due to properties being called which don't exist, halting the entire components functionality.

## Reproduction Steps
1. Set core to this branch `bugfix/FOUR-13601` (and all enterprise packages set to their `next` branch)
2. Set package-auth to [`bugfix/FOUR-13601`](https://github.com/ProcessMaker/package-auth/pull/96)
3. Log in as an administrator and navigate to the settings page
4. Click on any of the tabs and attempt to filter with a string of text which yields no results (e.g. `asdadfkj`) and hit enter
5. Attempt to clear the filter to reset the settings
6. Notice the settings do not return and multiple exceptions are thrown

## Solution
- Tweaking the logic of when to show a custom "No Data" message to ensure it has a value set
- Adding optional chaining operators to properties which may or may not exist on a given object to prevent exceptions from being thrown

## How to Test
You should be able to fully filter settings and clear them as normal.

## Related Tickets & Packages
- [FOUR-13601](https://processmaker.atlassian.net/browse/FOUR-13601)
- [Related package-auth PR](https://github.com/ProcessMaker/package-auth/compare/bugfix/FOUR-13601)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13601]: https://processmaker.atlassian.net/browse/FOUR-13601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ