### PR TITLE
The pager in templates does not work correctly when you do a non-existent search

### DIFF
--- a/resources/js/processes/components/ProcessMixin.js
+++ b/resources/js/processes/components/ProcessMixin.js
@@ -62,6 +62,18 @@ export default {
           }
         }
 
+        if (this.previousFilter !== filter) {
+          this.page = 1;
+        }
+
+        this.previousFilter = filter;
+
+        if (this.previousPmql !== pmql) {
+          this.page = 1;
+        }
+
+        this.previousPmql = pmql;
+
         // Load from our api client
         ProcessMaker.apiClient
           .get(

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -195,6 +195,8 @@ export default {
       pmBlockName: "",
       assetName: "",
       processData: {},
+      previousFilter: "",
+      previousPmql: "",
       sortOrder: [
         {
           field: "name",

--- a/resources/js/templates/components/ProcessTemplatesListing.vue
+++ b/resources/js/templates/components/ProcessTemplatesListing.vue
@@ -109,7 +109,7 @@
       </div>
     </div>
 </template>
-  
+
 <script>
   Vue.filter('str_limit', function (value, size) {
     if (!value) return '';
@@ -136,6 +136,7 @@
       data() {
         return {
           orderBy: "name",
+          previousFilter: "",
           sortOrder: [
             {
               field: "name",
@@ -297,7 +298,11 @@
               this.status === null || this.status === "" || this.status === undefined
                   ? "templates/process?"
                   : "templates?status=" + this.status + "&";
-  
+          let filter = this.filter;
+          if (this.previousFilter !== filter) {
+            this.page = 1;
+          }
+          this.previousFilter = filter;
           // Load from our api client
           ProcessMaker.apiClient
               .get(


### PR DESCRIPTION
## Issue & Reproduction Steps
When the filter is used, the page stays with the last one that was changed.

## Solution
- Switch to the first page when using the filter.

## How to Test

- Have multiple pages of process templates.
- change to another page other than the first.
- When the search is performed it should change to the first page.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-13247](FOUR-13247)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
