### PR TITLE
FOUR-13919 Importing the screen builder css globally instead of per page

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -28,6 +28,7 @@ import PmqlInput from "./components/shared/PmqlInput.vue";
 import DataTreeToggle from "./components/common/data-tree-toggle.vue";
 import TreeView from "./components/TreeView.vue";
 import FilterTable from "./components/shared/FilterTable.vue";
+import "@processmaker/screen-builder/dist/vue-form-builder.css";
 
 window.__ = translator;
 window._ = require("lodash");

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -323,7 +323,6 @@ import {
   ComputedProperties,
   CustomCSS,
 } from "@processmaker/screen-builder";
-import "@processmaker/screen-builder/dist/vue-form-builder.css";
 import "@processmaker/vue-form-elements/dist/vue-form-elements.css";
 import MonacoEditor from "vue-monaco";
 import _, { cloneDeep, debounce } from "lodash";

--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -55,7 +55,6 @@
 
   import Vue from 'vue'
   import {VueFormRenderer} from '@processmaker/screen-builder';
-  import '@processmaker/screen-builder/dist/vue-form-builder.css';
 
   Vue.component('vue-form-renderer', VueFormRenderer);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The css wasn't being applied when looking at a screen in a process (running)

## Solution
- Importing the CSS globally instead of per page

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13919

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy