### PR TITLE
observation/FOUR-13907 The status of a task self service is shown as in progress

### DIFF
--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -376,14 +376,15 @@ export default {
     formatStatus(props) {
       let color;
       let label;
+      const isSelfService = props.is_self_service;
 
-      if (props.status === "ACTIVE" && props.isSelfService) {
+      if (props.status === "ACTIVE" && isSelfService) {
         color = "danger";
         label = "Self Service";
-      } if (props.status === "ACTIVE") {
+      } else if (props.status === "ACTIVE") {
         color = "success";
         label = "In Progress";
-      } if (props.status === "CLOSED") {
+      } else if (props.status === "CLOSED") {
         color = "primary";
         label = "Completed";
       }


### PR DESCRIPTION
## Issue & Reproduction Steps
The status of a task self service is shown as in progress

## Solution
Fix the condition for the Self Service status badge badge

## How to Test

Log in 
Have a process that the second task goes to Self Service
Start a new case
Go to tab task
Click on self service option

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13907

ci:deploy
ci:next