### PR TITLE
Making Screen Builder export globally available, the right way

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -78,7 +78,7 @@ if (!document.head.querySelector("meta[name=\"is-horizon\"]")) {
 }
 window.VueMonaco = require("vue-monaco");
 
-window.ScreenBuilder = ScreenBuilder;
+window.ScreenBuilder = require("@processmaker/screen-builder");
 window.VueFormElements = require("@processmaker/vue-form-elements");
 
 window.VueRouter = Router;


### PR DESCRIPTION
## Issue & Reproduction Steps
Screen Builder exports wasn't available when using an external package.

## Solution
- Requiring the whole screen builder package instead of the default export

### Ticket
- https://processmaker.atlassian.net/browse/FOUR-13932

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy