### PR TITLE
Observation/FOUR-13815: Ellipsis options are not shown if the screen is reduced in process

### DIFF
--- a/resources/js/components/shared/FilterTable.vue
+++ b/resources/js/components/shared/FilterTable.vue
@@ -377,5 +377,13 @@ export default {
 .pm-table-container::-webkit-scrollbar-thumb {
   background-color: #6C757D;
   border-radius: 20px;
+} 
+.pm-table-container {
+  height: calc(100vh - 150px);
+  min-height: 400px;
+}
+.ellipsis-dropdown-main ul.dropdown-menu.dropdown-menu-right.show {
+  max-height: 250px;
+  overflow-y: auto;
 }
 </style>

--- a/resources/js/components/shared/FilterTable.vue
+++ b/resources/js/components/shared/FilterTable.vue
@@ -238,6 +238,8 @@ export default {
   border-radius: 5px;
   scrollbar-width: 8px;
   scrollbar-color: #6C757D;
+  height: calc(100vh - 150px);
+  min-height: 400px;
 }
 
 .pm-table-container th {
@@ -378,10 +380,6 @@ export default {
   background-color: #6C757D;
   border-radius: 20px;
 } 
-.pm-table-container {
-  height: calc(100vh - 150px);
-  min-height: 400px;
-}
 .ellipsis-dropdown-main ul.dropdown-menu.dropdown-menu-right.show {
   max-height: 250px;
   overflow-y: auto;

--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -11,7 +11,7 @@
           <filter-table
             :headers="fields"
             :data="data"
-            style="height: calc(100vh - 350px);"
+            style="height: calc(100vh - 355px);"
           >
          <!-- Slot Table Header filter Button -->
             <template v-for="(column, index) in fields" v-slot:[`filter-${column.field}`]>

--- a/resources/js/processes/components/ArchivedProcessList.vue
+++ b/resources/js/processes/components/ArchivedProcessList.vue
@@ -15,6 +15,7 @@
       <filter-table
         :headers="fields"
         :data="data"
+        style="height: calc(100vh - 355px);"
       >
         <!-- Slot Table Body -->
         <template

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -15,7 +15,7 @@
       <filter-table
         :headers="fields"
         :data="data"
-        style="height: calc(100vh - 350px);"
+        style="height: calc(100vh - 355px);"
       >
         <!-- Slot Table Header filter Button -->
         <template

--- a/resources/js/templates/components/ProcessTemplatesListing.vue
+++ b/resources/js/templates/components/ProcessTemplatesListing.vue
@@ -11,7 +11,7 @@
         <filter-table
           :headers="fields"
           :data="data"
-          style="height: calc(100vh - 350px);"
+          style="height: calc(100vh - 355px);"
         >
           <!-- Slot Table Header filter Button -->
           <template v-for="(column, index) in fields" v-slot:[`filter-${column.field}`]>


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduced:**
- Go to process
- Click on ellipsis of any process
- Shrink the screen a little
- View the ellipsis options

**Current Behavior:**
You can no longer see all the ellipsis options.

**Expected Behavior:**
You should be able to see all the options even if the screen is reduced.

## Solution
- Added max height and scrollbars to the menu.

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/1800843b-286a-4410-9d15-e57c1325363b

## How to Test
Open the ellipsis menu and verify a scrollbar is added for larger menus

## Related Tickets & Packages
- FOUR-13815

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
