### PR TITLE
FOUR-13378:Recent Assets Section for Designer Welcome Screen

### DIFF
--- a/resources/js/processes/designer/RecentAssets.vue
+++ b/resources/js/processes/designer/RecentAssets.vue
@@ -2,7 +2,7 @@
   <div class="project">
     <b-navbar type="faded">
       <b-navbar-brand class="text-uppercase">
-        {{ $t("Recent Assets from my Projects") }}
+        {{ $t("RECENT ASSETS") }}
       </b-navbar-brand>
       <div class="d-flex" align="end">
         <div class="dropdown">


### PR DESCRIPTION
## Issue & Reproduction Steps
The Title should change from RECENT ASSETS FROM MY PROJECTS to RECENT ASSETS
The Recent Assets section should show all the recent Assets edited by the user not only the Assets of the Projects

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-13378](https://processmaker.atlassian.net/browse/FOUR-13378)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-13378]: https://processmaker.atlassian.net/browse/FOUR-13378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ