### PR TITLE
FOUR-13473: Fix overflow string in the alertBox when the message is too long

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -698,6 +698,8 @@ h1.page-title {
 
 .alertBox {
   width: 100%;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .avatar-circle-list {


### PR DESCRIPTION
## Issue & Reproduction Steps
When dealing with flash messages and the string is too long, it's causing it to overflow the container and display the content outside of the alertBox.

## Solution
-  Include `word-wrap: break-word` and `overflow-wrap: break-word` within the `.flash-message` to ensure that long words are broken and wrapped to the next line. 

## How to Test
- Create a project with a long name and without spaces.
- Open the project
- Add an asset to the Project
Please ensure that the message within the alert box does NOT overflow the container.

## Related Tickets & Packages
- Ticket: [FOUR-13473](https://processmaker.atlassian.net/browse/FOUR-13473)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13473]: https://processmaker.atlassian.net/browse/FOUR-13473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ