### PR TITLE
FOUR-13910 block duplicate session in device restriction only works when the initial browser has the session open

### DIFF
--- a/ProcessMaker/Http/Middleware/SessionControlBlock.php
+++ b/ProcessMaker/Http/Middleware/SessionControlBlock.php
@@ -99,7 +99,10 @@ class SessionControlBlock
         $ip = $request->getClientIp() ?? $request->ip();
         // Get the active user sessions
         $sessions = $user->sessions()
-            ->where('is_active', true)
+            ->where([
+                ['is_active', true],
+                ['expired_date', null],
+            ])
             ->orderBy('created_at', 'desc')
             ->get();
 

--- a/ProcessMaker/Http/Middleware/SessionControlBlock.php
+++ b/ProcessMaker/Http/Middleware/SessionControlBlock.php
@@ -97,21 +97,25 @@ class SessionControlBlock
         $requestDevice = $this->formatDeviceInfo($agentDevice, $agent->deviceType(), $agent->platform());
         // Get the user's current IP address
         $ip = $request->getClientIp() ?? $request->ip();
-        // Get the user's most recent session
-        $session = $user->sessions()
+        // Get the active user sessions
+        $sessions = $user->sessions()
             ->where('is_active', true)
             ->orderBy('created_at', 'desc')
-            ->first();
+            ->get();
 
-        if ($session) {
+        $openSessions = $sessions->reduce(function ($carry, $session) use ($requestDevice, $ip) {
             $sessionDevice = $this->formatDeviceInfo(
                 $session->device_name, $session->device_type, $session->device_platform
             );
 
-            return $requestDevice !== $sessionDevice || $session->ip_address !== $ip;
-        }
+            if ($requestDevice !== $sessionDevice || $session->ip_address !== $ip) {
+                return $carry + 1;
+            } else {
+                return $carry - 1;
+            }
+        }, 0);
 
-        return false;
+        return $openSessions > 0;
     }
 
     private function formatDeviceInfo(string $deviceName, string $deviceType, string $devicePlatform): string

--- a/ProcessMaker/Http/Middleware/SessionControlKill.php
+++ b/ProcessMaker/Http/Middleware/SessionControlKill.php
@@ -34,13 +34,17 @@ class SessionControlKill
 
             $session = $this->getActiveSession($user, $userSession);
 
-            // Checks if the session has expired based on the IP address
-            if ($session && $configIP === '2' && $this->isSessionExpiredByIP($session, $request)) {
-                return $this->killSessionAndRedirect($session);
-            }
-            // Checks if the session has expired based on the device
-            if ($session && $configDevice === '2' && $this->isSessionExpiredByDevice($session)) {
-                return $this->killSessionAndRedirect($session);
+            if ($session) {
+                // Checks if the session has expired based on the IP address
+                $isSessionExpiredByIP = $configIP === '2' && $this->isSessionExpiredByIP($session, $request);
+                // Checks if the session has expired based on the device
+                $isSessionExpiredByDevice = $configDevice === '2' && $this->isSessionExpiredByDevice($session);
+                // Checks if the session has expired except the one within the active device
+                $isAnyRestrictionEnabled = $configIP === '1' || $configDevice === '1';
+
+                if ($isSessionExpiredByIP || $isSessionExpiredByDevice || $isAnyRestrictionEnabled) {
+                    return $this->killSessionAndRedirect($session);
+                }
             }
         }
 

--- a/ProcessMaker/Models/UserSession.php
+++ b/ProcessMaker/Models/UserSession.php
@@ -38,16 +38,15 @@ class UserSession extends ProcessMakerModel
     {
         $usersActiveIP = [];
         self::where('is_active', true)
-            ->where('expired_date', null)
-            ->orderBy('id', 'desc')
+            ->whereNull('expired_date')
+            ->orderBy('user_id', 'asc')
+            ->orderBy('created_at', 'desc')
             ->chunk(100, function ($sessions) use (&$usersActiveIP) {
                 foreach ($sessions as $session) {
-                    $key = $session->user_id . '.' . $session->ip_address;
-                    if (!isset($usersActiveIP[$session->user_id])) {
-                        $usersActiveIP[$session->user_id] = $key;
-                    }
-                    // expire all sessions except the ones within the active IP
-                    if ($usersActiveIP[$session->user_id] !== $key) {
+                    if (!array_key_exists($session->user_id, $usersActiveIP)) {
+                        $usersActiveIP[$session->user_id] = $session->user_id;
+                    } else {
+                        // expire all sessions except the ones within the active IP
                         $session->update(['expired_date' => now()]);
                     }
                 }
@@ -61,19 +60,15 @@ class UserSession extends ProcessMakerModel
     {
         $usersActiveDevice = [];
         self::where('is_active', true)
-            ->where('expired_date', null)
-            ->orderBy('id', 'desc')
+            ->whereNull('expired_date')
+            ->orderBy('user_id', 'asc')
+            ->orderBy('created_at', 'desc')
             ->chunk(100, function ($sessions) use (&$usersActiveDevice) {
                 foreach ($sessions as $session) {
-                    $key = $session->user_id . '.' .
-                        $session->device_name . '.' .
-                        $session->device_type . '.' .
-                        $session->device_platform;
-                    if (!isset($usersActiveDevice[$session->user_id])) {
-                        $usersActiveDevice[$session->user_id] = $key;
-                    }
-                    // expire all sessions except the ones within the active device
-                    if ($usersActiveDevice[$session->user_id] !== $key) {
+                    if (!array_key_exists($session->user_id, $usersActiveDevice)) {
+                        $usersActiveDevice[$session->user_id] = $session->user_id;
+                    } else {
+                        // expire all sessions except the ones within the active device
                         $session->update(['expired_date' => now()]);
                     }
                 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The application is only logged in again when we log in with browser 1, which was the one that had the session.

## Solution
Check all active sessions in block session by device

## How to Test
1. login with a user with device 1 
2. have the "Block duplicate session" option in device restriction enabled
3. I will open another device 2
4. try to log in with the same username from the other browser (this is correct)
5. We go to device 1 and log out
6. We return to device 2 and try to log in again

## Related Tickets & Packages
[FOUR-13910](https://processmaker.atlassian.net/browse/FOUR-13910)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy



[FOUR-13910]: https://processmaker.atlassian.net/browse/FOUR-13910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ