### PR TITLE
FOUR-13834 | The Modified Date in Projects Isn’t Updated After Making Changes to the Project

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -14,9 +14,12 @@ use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessTemplates;
 use ProcessMaker\Models\Template;
+use ProcessMaker\Traits\ProjectAssetTrait;
 
 class TemplateController extends Controller
 {
+    use ProjectAssetTrait;
+
     protected array $types = [
         'process' => [Process::class, ProcessTemplate::class, ProcessCategory::class, 'process_category_id', 'process_templates'],
     ];
@@ -142,6 +145,11 @@ class TemplateController extends Controller
                 ];
             } else {
                 $response = $this->template->create($type, $request);
+            }
+            if ($request->has('projects')) {
+                // Update 'updated_at' field for the project
+                $projectIds = explode(',', $request->input('projects'));
+                $this->updateProjectUpdatedAt($projectIds);
             }
         } elseif ($type === 'update-assets') {
             $request['request'] = json_decode($request['request'], true);

--- a/ProcessMaker/Traits/ProjectAssetTrait.php
+++ b/ProcessMaker/Traits/ProjectAssetTrait.php
@@ -23,6 +23,7 @@ trait ProjectAssetTrait
         try {
             // Sync the project assets with the prepared project IDs
             $this->projectAssets()->syncWithPivotValues($projectIds, ['asset_type' => $assetModelClass]);
+            $this->updateProjectUpdatedAt($projectIds);
         } catch (Exception $e) {
             throw new ProjectAssetSyncException('Error syncing project assets: ' . $e->getMessage());
         }
@@ -80,5 +81,26 @@ trait ProjectAssetTrait
         }
 
         return json_encode([]);
+    }
+
+    /**
+     * Update the 'updated_at' field of projects.
+     *
+     * @param array|int $projectIds
+     * @return void
+     */
+    public function updateProjectUpdatedAt($projectIds)
+    {
+        if (!class_exists(self::PROJECT_MODEL_CLASS)) {
+            return;
+        }
+
+        foreach ((array) $projectIds as $projectId) {
+            $project = self::PROJECT_MODEL_CLASS::find($projectId);
+
+            if ($project) {
+                $project->touch();
+            }
+        }
     }
 }


### PR DESCRIPTION
# Issue
Ticket: [FOUR-13834](https://processmaker.atlassian.net/browse/FOUR-13834)

After adding assets to a project, removing assets from a project, or duplicating assets within a project, the 'Modified' date is not updated in the Projects Listing.

# Solution
Add a method to the `ProjectAssetTrait.php` file called `updateProjectUpdatedAt`. This method updates the `updated_at` database field for projects. The method is called within the `syncProjectAssets` function, as many project assets utilize this function when they are updated. For any endpoints where project assets are being updated, but the `syncProjectAssets` method is not being called, the `updateProjectUpdatedAt` method is called directly in that asset's controller.

# How to Test
1. Go to branch `observation/FOUR-13834` in `processmaker`.
2. Go to branch `observation/FOUR-13834` in `package-projects`.
3. Go to branch `observation/FOUR-13834` in `package-ai`.
4. Go to Designer → Projects. Create and open a Project.
5. Add an existing Process to the Project.
	- Ensure that the 'Modified' date updates in the Project Listing.
	- Repeat for all other assets.
6. Create a new Process within the Project.
	- Ensure that the 'Modified' date updates in the Project Listing.
	- Repeat for all other assets.
7. Duplicate a Process within the Project.
	- Ensure that the 'Modified' date updates in the Project Listing.
	- Repeat for all other assets.
8. Delete a Process from the Project.
	- Ensure that the 'Modified' data updates in the Project Listing.
	- Repeat for all other assets.

ci:next
ci:package-projects:observation/FOUR-13834
ci:package-ai:observation/FOUR-13834

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13834]: https://processmaker.atlassian.net/browse/FOUR-13834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ