### PR TITLE
Observation/FOUR-13960: Server error when using sort ascending or descending in taps, process categories, templates

### DIFF
--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -16,6 +16,8 @@
          <!-- Slot Table Header filter Button -->
             <template v-for="(column, index) in fields" v-slot:[`filter-${column.field}`]>
               <div
+                v-if="column.sortable"
+                :key="index"
                 @click="handleEllipsisClick(column)"
               >
                 <i

--- a/resources/js/templates/components/ProcessTemplatesListing.vue
+++ b/resources/js/templates/components/ProcessTemplatesListing.vue
@@ -16,6 +16,8 @@
           <!-- Slot Table Header filter Button -->
           <template v-for="(column, index) in fields" v-slot:[`filter-${column.field}`]>
             <div
+              v-if="column.sortable"
+              :key="index"
               @click="handleEllipsisClick(column)"
             >
             <i


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduced:** 

- Go to processes
- Click on template tab
- Sort a column ascendingly or descendingly
- Click on option to sort ascending or descending of the unlabeled column.

**Current Behavior:**
The option option to sort ascending or descending is displayed and when you click it, a server error is displayed.

**Expected Behavior:**
This ascendingly or descendingly option should not be displayed in this column.

## Solution
- Check if column is sortable in templates and categories.

## How to Test
Follow steps above

## Related Tickets & Packages
- [FOUR-13960](https://processmaker.atlassian.net/browse/FOUR-13960)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13960]: https://processmaker.atlassian.net/browse/FOUR-13960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:next
ci:deploy