### PR TITLE
Observation/FOUR-13323: Category is displayed without the correct permission

### DIFF
--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -357,7 +357,9 @@
             }
             Vue.set(this, 'selectedPermissions', this.selectedPermissions.filter((v, i, arr) => arr.indexOf(v) === i));
 
-            this.checkProcessCategoryView(sibling, self);
+            if (sibling.includes('processes') || self.includes('processes')) {
+              this.checkProcessCategoryView(sibling, self);
+            }
           },
           checkEdit(sibling, $event) {
             let self = $event.target.value;

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -355,11 +355,10 @@
             if (this.selectedPermissions.includes(self)) {
               this.selectedPermissions.push(sibling);
             }
-            Vue.set(this, 'selectedPermissions', this.selectedPermissions.filter((v, i, arr) => arr.indexOf(v) === i));
-
             if (sibling.includes('processes') || self.includes('processes')) {
               this.checkProcessCategoryView(sibling, self);
             }
+            Vue.set(this, 'selectedPermissions', this.selectedPermissions.filter((v, i, arr) => arr.indexOf(v) === i));
           },
           checkEdit(sibling, $event) {
             let self = $event.target.value;

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -356,12 +356,30 @@
               this.selectedPermissions.push(sibling);
             }
             Vue.set(this, 'selectedPermissions', this.selectedPermissions.filter((v, i, arr) => arr.indexOf(v) === i));
+
+            this.checkProcessCategoryView(sibling, self);
           },
           checkEdit(sibling, $event) {
             let self = $event.target.value;
             if (!this.selectedPermissions.includes(self)) {
               this.selectedPermissions = this.selectedPermissions.filter(function (el) {
                 return el !== sibling;
+              });
+            }
+            if (sibling.includes('processes') || self.includes('processes')) {
+              this.checkProcessCategoryView(sibling, self);
+            }
+            Vue.set(this, 'selectedPermissions', this.selectedPermissions.filter((v, i, arr) => arr.indexOf(v) === i));
+          },
+          checkProcessCategoryView(sibling, self) {
+            const viewProcessCategoriesPermission = 'view-process-categories';
+            if (this.selectedPermissions.includes(self)) {
+              this.selectedPermissions.push(viewProcessCategoriesPermission);
+            }
+
+            if (!this.selectedPermissions.includes(self) && !this.selectedPermissions.includes(sibling)) {
+              this.selectedPermissions = this.selectedPermissions.filter(function (el) {
+                return el !== viewProcessCategoriesPermission;
               });
             }
             Vue.set(this, 'selectedPermissions', this.selectedPermissions.filter((v, i, arr) => arr.indexOf(v) === i));

--- a/resources/views/components/categorized_resource.blade.php
+++ b/resources/views/components/categorized_resource.blade.php
@@ -51,15 +51,15 @@
             <li class="nav-item">
                 <a class="{{$secondTab}}" id="nav-categories-tab" data-toggle="tab" href="#nav-categories"
                 role="tab" onclick="loadCategory()" aria-controls="nav-categories" aria-selected="true">
-                    {{ $tabs[1] ?? __('Categories') }}
+                    {{ $tabs[2] ?? __('Categories') }}
                 </a>
             </li>
             @endif
-            @isset($tabs[2])
+            @isset($tabs[3])
                 <li class="nav-item">
                     <a class="nav-item nav-link" id="nav-archived-tab" data-toggle="tab" href="#nav-archived"
                     role="tab" onclick="loadArchivedProcess()" aria-controls="nav-archived" aria-selected="true">
-                        {{ $tabs[2] ?? __('Archived Processes') }}
+                        {{ $tabs[3] ?? __('Archived Processes') }}
                     </a>
                 </li>
             @endisset


### PR DESCRIPTION
## Issue & Reproduction Steps
- login in the server https://next-qa.processmaker.net/
- Create a normal user
- Assign these permissions to normal user
- Create Processes
- Edit Processes
- View Processes
- Login with the new user
- Go to Designer > Processes
- Open the Categies tab

### Note 
After sync with Claudia Iriarte, an user that have access to create/edit a process should view process categories.

I noticed two issues: 

The tabs in the top are getting the wrong labels because a problem with the indexes of the tabs after introduce the Templates feature (notice that you didn’t added permissions for templates, and you can see a Templates tab, but after clicking the templates tab, the list showing is the list of Categories instead of Templates. The same happens with the Categories tab, that should be Archived processes tab. After clicking the wrong categories tab the list showed is the list of archived processes)

The second issue is related to the permissions assignation in the permissions tab under user edit section. When selecting the Create/Edit Process permission we should activate the View categories automatically, in the same way it happens when Create Process permission is selected, the Edit Process permission also gets selected automatically. I have synchronized with Claudia Iriarte to fix both issues.


## Solution
- Fix indexes in tabs for processes.
- Fix behavior when selecting create and edit process permission to auto activate view process categories 

**Working videos**

https://github.com/ProcessMaker/processmaker/assets/90727999/79f3286a-ab08-4f2c-b1ec-55d95de5c421



https://github.com/ProcessMaker/processmaker/assets/90727999/f363ade6-aad5-46a9-a7fb-ea6b57d5737b


## How to Test
Scenario fix 1
- Assign permission create, edit and view process permission
- Go to Process list
- Verify you can see the tabs Processes, Categories and Archived processes


Scenario fix 2
- Go to user permissions
- Enable create OR edit process permission, view process categories permission should be activated
- Disable both create AND edit process permission, view process categories permission should be deactivated

## Related Tickets & Packages
- [FOUR-13323](https://processmaker.atlassian.net/browse/FOUR-13323)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13323]: https://processmaker.atlassian.net/browse/FOUR-13323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ