### PR TITLE
Observation/FOUR-12695: 35992 Screens in anonymous web entry tasks are not being translated

### DIFF
--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -229,9 +229,9 @@ class ProcessTranslation
             $targetLanguage = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
         }
 
-        $targetLanguage = in_array($targetLanguage, Languages::ALL) ? $targetLanguage : 'en';
+        $targetLanguage = array_key_exists($targetLanguage, Languages::ALL) ? $targetLanguage : 'en';
 
-        if (Auth::user()) {
+        if (Auth::user() && Auth::user()->username !== '_pm4_anon_user') {
             $targetLanguage = Auth::user()->language;
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
- Import attached process
- Confirm Spanish translation is set for Step 1 and 2 screens
- Click on web entry and copy URL
- Task is an anonymous web entry one, no need to set users.
- Open the URL in an Spanish browser (so ProcessMaker picks the language)
- Submit screen

At this point you will see that although the screen in the web entry was correctly shown in Spanish (from the browser), the one in the task didn’t, English labels were shown.


## Solution
- Fix an issue searching the key in the array of languages.
- Fix an issue validating there are not user (when user is not logged in, anonymous user is used instead)

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/dfd4763e-0198-4ecf-868b-95baf5643771


## How to Test
- Follow steps above
- When a user is logged (or WE is authenticated) it should use the language configured in the user profile
- When not logged (WE is anonymous) it should use the language configured in the browser

## Related Tickets & Packages
- [FOUR-12695](https://processmaker.atlassian.net/browse/FOUR-12695)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-12695]: https://processmaker.atlassian.net/browse/FOUR-12695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ