### PR TITLE
FOUR-13995: Incorrect Redirection After Creating ProcessTemplate

### DIFF
--- a/resources/js/components/templates/TemplateAssetsView.vue
+++ b/resources/js/components/templates/TemplateAssetsView.vue
@@ -85,8 +85,8 @@ export default {
       required: true,
     },
     redirectTo: {
-      type: String,
-      required: true,
+      type: [String, null],
+      default: null,
     },
     wizardTemplateUuid: {
       type: String,

--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -253,19 +253,16 @@ export default {
       )
         .then((response) => {
           if (response.data.existingAssets) {
-            const assets = JSON.stringify(response.data.existingAssets);
-            const responseId = response.data.id;
-            const request = JSON.stringify(response.data.request);
-            window.history.pushState(
-              {
-                assets,
-                name: this.templateData.name,
-                responseId,
-                request,
-              },
-              "",
-              "/template/assets",
-            );
+            // Use local storage to pass the data to the assets page.
+            const stateData = {
+              assets: JSON.stringify(response.data.existingAssets),
+              name: this.templateData.name,
+              responseId: response.data.id,
+              request: JSON.stringify(response.data.request),
+              redirectTo: null,
+            };
+            localStorage.setItem("templateAssetsState", JSON.stringify(stateData));
+            // Redirect to the assets page.
             window.location = "/template/assets";
           } else {
             ProcessMaker.alert(this.$t("The process was created."), "success");


### PR DESCRIPTION
## Issue & Reproduction Steps
When initiating a new Process from a Template, if the assets specified in the process already exist within the system, the expected behavior is to redirect the user to the AssetsTable page, where these pre-existing assets should be displayed. Currently, the redirection occurs as expected, but the assets themselves do not appear in the AssetsTable. This issue seems to suggest a loading or retrieval problem where the AssetsTable fails to fetch or render the existing assets in the context of the new Process creation

## Solution
- The problem is related to the use of history.pushState. Redirecting causes these data to be lost.
- The suggested solution is to use localStorage instead.

## How to Test
- Navigate to Designer->Processes 
- Create a Process from a Template
- Navigate back to Designer->Processes 
- Create a new Process from the same Template
When the AssetsTable appears, please ensure that the Assets are been displayed within the table.

## Related Tickets & Packages
- Ticket: [FOUR-13995](https://processmaker.atlassian.net/browse/FOUR-13995)
ci:next


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13995]: https://processmaker.atlassian.net/browse/FOUR-13995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ