### PR TITLE
Fix URL Parameters for Guided Template Modals

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -202,8 +202,8 @@ export default {
       this.showWizardTemplates = false;
 
       // Remove guided_templates and template parameters from the URL
-      const url = new URL(window.location.href);
-      if (url.search.includes("?guided_templates=true")) {
+      if (value !== undefined) {
+        const url = new URL(window.location.href);
         url.searchParams.delete("guided_templates");
         url.searchParams.delete("template");
         history.pushState(null, "", url); // Update the URL without triggering a page reload


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR resolves issues with directing to the guided template modal via URL parameters. The parameters were being removed from the URL when loading, preventing the modal from appearing. The removal of the parameters was due to an outdated conditional that ran on deprecated code.

## Solution
The solution is to update the conditional to only remove the parameters when the 'selectCategory' method has an 'undefined' value. This undefined value indicates that the user manually accessed the guided templates and did not load it directly from a URL.

## How to Test

1. Navigate to Processes > Guided Templates.
2. Select a template.
3. Copy the URL.
4. Open a new tab/window.
5. Paste the copied URL.
6. Ensure the selected guided template modal appears.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-13963](https://processmaker.atlassian.net/browse/FOUR-13963)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13963]: https://processmaker.atlassian.net/browse/FOUR-13963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ