### PR TITLE
FOUR-14004 Fix Query of Saved Search Chart doesn't update correctly

### DIFF
--- a/resources/js/components/shared/PmqlInput.vue
+++ b/resources/js/components/shared/PmqlInput.vue
@@ -260,8 +260,8 @@ export default {
       this.calcInputHeight();
     },
     value() {
-      if (!this.query || this.query === "") {
-        this.query = this.value;
+      if (this.query !== this.value) {
+        this.query = this.value || "";
       }
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
The `pmql` field at Saved search inspector in screen builder is not being updated.

## Solution
- Fix the reactivity of the inspector property and the pmql input control.

https://github.com/ProcessMaker/processmaker/assets/8028650/bc2dff70-5593-4b1b-8c73-a8f567bebba1

## How to Test
- Create a display screen and add a couple of Saved Search Charts
- Setup the pmql for each chart.
- Check that the pmql defined is stored for each control.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14004

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:package-savedsearch:bugfix/FOUR-14004
