### PR TITLE
FOUR-14010 | Fix Cancel Button for Selecting Existing Imported Assets 

### DIFF
--- a/resources/js/components/templates/AssetLoadingModal.vue
+++ b/resources/js/components/templates/AssetLoadingModal.vue
@@ -9,7 +9,7 @@
       :setCustomButtons="true"
       :customButtons="customModalButtons"
       @onSubmit="onSubmit"
-      @hidden="close"
+      @close="close"
     >
       <div>
         <p class="mt-1">Are you sure you want to proceed with your selection?</p>
@@ -41,8 +41,8 @@ export default {
     return {
       loading: false,
       customModalButtons: [
-        {"content": "Cancel", "action": "close", "variant": "outline-secondary", "disabled": false, "hidden": false},
-        {"content": "Yes", "action": "onSubmit", "variant": "primary", "disabled": false, "hidden": false},
+        {"content": "Cancel", "action": "close", "variant": "outline-secondary"},
+        {"content": "Yes", "action": "onSubmit", "variant": "primary"},
       ],
     }
   },
@@ -63,8 +63,6 @@ export default {
       this.$emit("submitAssets");
     },
   },
-  mounted() {
-  }
 };
 </script>
 


### PR DESCRIPTION
# Issue
Ticket: [FOUR-14010](https://processmaker.atlassian.net/browse/FOUR-14010)

The Cancel button in the AssetLoadingModal is not working.

# Solution

- Change the `@hidden` property on the modal to `@close`.

# How to Test
1. Go to branch `observation/FOUR-14010` in `processmaker`.
2. Go to Designer → Processes. Create a Process from a Template.
3. Create another Process from the same Template so that you are taken to `/template/assets`.
4. Select 'Continue'.
5. Select 'Cancel' in the Confirmation modal.
	- The modal should close when 'Cancel' is selected.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-14010]: https://processmaker.atlassian.net/browse/FOUR-14010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ