### PR TITLE
FOUR-13942 the kill existing session in device restriction is not working correctly

### DIFF
--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -34,6 +34,7 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \ProcessMaker\Http\Middleware\SessionStarted::class,
             \ProcessMaker\Http\Middleware\AuthenticateSession::class,
+            \ProcessMaker\Http\Middleware\SessionControlKill::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             //\ProcessMaker\Http\Middleware\VerifyCsrfToken::class,
             \ProcessMaker\Http\Middleware\SetLocale::class,       // This is disabled until all routes are handled by our new engine


### PR DESCRIPTION
## Issue & Reproduction Steps
The Kill existing session option in device restriction is not working correctly.
There are times when both browsers are in session, sometimes if the existing session is checked

## Solution
- Run session control kill middleware before the `BROWSER_CACHE` middleware

## How to Test
1. Log in 
2. Go to Admin
3. Click on Settings
4. Enter Session Control
5. In Device Restriction choose the option `Kill existing session`
6. Login in a browser with a user
7. Login with the same user in another browser
8. We return to the first browser
9. We refresh or enter an option in the application

## Related Tickets & Packages
- [FOUR-13942](https://processmaker.atlassian.net/browse/FOUR-13942)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy



[FOUR-13942]: https://processmaker.atlassian.net/browse/FOUR-13942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ