### PR TITLE
Observation/FOUR-13977: All options are shown in Custom select in the process column in task

### DIFF
--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -123,7 +123,7 @@ const PMColumnFilterCommonMixin = {
       if (column.format) {
         format = column.format;
       }
-      if (column.field === "status" || column.field === "assignee" || column.field === "participants" || column.field === 'process') {
+      if (column.field === "status" || column.field === "assignee" || column.field === "participants") {
         format = "stringSelect";
       }
       return format;
@@ -138,9 +138,6 @@ const PMColumnFilterCommonMixin = {
       }
       if (column.field === "participants") {
         formatRange = this.viewParticipants;
-      }
-      if (column.field === "process") {
-        formatRange = this.viewProcesses;
       }
       return formatRange;
     },

--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -143,7 +143,10 @@ const PMColumnFilterCommonMixin = {
     },
     getOperators(column) {
       let operators = [];
-      if (column.field === "status" || column.field === "assignee" || column.field === "participants" || column.field === 'process') {
+      if (column.field === "case_title" || column.field === "name" || column.field === "process" || column.field === "task_name") {
+        operators = ["=", "in", "contains", "regex"];
+      }
+      if (column.field === "status" || column.field === "assignee" || column.field === "participants") {
         operators = ["=", "in"];
       }
       return operators;

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -535,11 +535,12 @@ export default {
       let type = "Field";
       //The inclusion of the alias in the comparison is necessary to ensure the correct
       //type is obtained when the column has been modified by the method getAliasColumnForFilter().
-      if (value === "case_number" || 
-          value === "case_title" || 
-          value === "processRequest.case_number" || 
+      if (value === "case_number" ||
+          value === "case_title" ||
+          value === "process" ||
+          value === "processRequest.case_number" ||
           value === "processRequest.case_title" ||
-          value === "process") {
+          value === "processRequest.name") {
         type = "Relationship";
       }
       if (value === "status") {

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -538,11 +538,9 @@ export default {
       if (value === "case_number" || 
           value === "case_title" || 
           value === "processRequest.case_number" || 
-          value === "processRequest.case_title") {
+          value === "processRequest.case_title" ||
+          value === "process") {
         type = "Relationship";
-      }
-      if (value === "process") {
-        type = "Process";
       }
       if (value === "status") {
         type = "Status";
@@ -555,6 +553,9 @@ export default {
       }
       if (value === "case_title") {
         value = "processRequest.case_title";
+      }
+      if (value === "process") {
+        value = "processRequest.name";
       }
       if (value === "task_name") {
         value = "element_name";


### PR DESCRIPTION
## Issue & Reproduction Steps

- Go to tasks
- Click on filter button
- Click on the arrows in the filter column

**Current Behavior:**
All process names are displayed, the field it occupies is too much.

**Expected Behavior:**
As in requests or other columns such as case title, a "Type Value" should be displayed

## Solution
- Use a single input instead select list for process name in tasks and use the alias process_request.name for the search

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/4e42e5c5-edad-4823-abb2-b1d88e0f2b7f


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-13977](https://processmaker.atlassian.net/browse/FOUR-13977)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13977]: https://processmaker.atlassian.net/browse/FOUR-13977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ