### PR TITLE
FOUR-13219 | The Processes Created From a Template Are Being Created With the Uncategorized Category

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -213,12 +213,12 @@ abstract class ExporterBase implements ExporterInterface
         }
     }
 
-    public function runImport($existingAssetInDatabase = null)
+    public function runImport($existingAssetInDatabase = null, $importingFromTemplate = false)
     {
         $extensions = app()->make(Extension::class);
         $extensions->runExtensions($this, 'preImport', $this->logger);
         $this->logger->log('Running Import ' . static::class);
-        $this->import($existingAssetInDatabase);
+        $this->import($existingAssetInDatabase, $importingFromTemplate);
         $extensions->runExtensions($this, 'postImport', $this->logger);
     }
 

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -75,7 +75,7 @@ class ProcessExporter extends ExporterBase
         $this->exportSubprocesses();
     }
 
-    public function import($existingAssetInDatabase = null) : bool
+    public function import($existingAssetInDatabase = null, $importingFromTemplate = false) : bool
     {
         if ($existingAssetInDatabase) {
             $this->model = Process::where('id', $existingAssetInDatabase)->first();
@@ -90,7 +90,11 @@ class ProcessExporter extends ExporterBase
             $process->manager_id = $dependent->model->id;
         }
 
-        $this->associateCategories(ProcessCategory::class, 'process_category_id');
+        // Avoid associating the category from the manifest with processes imported from templates.
+        // Use the user-selected category instead.
+        if (!$importingFromTemplate) {
+            $this->associateCategories(ProcessCategory::class, 'process_category_id');
+        }
 
         $this->importSignals();
 

--- a/ProcessMaker/ImportExport/Importer.php
+++ b/ProcessMaker/ImportExport/Importer.php
@@ -39,10 +39,10 @@ class Importer
         return Manifest::fromArray($this->payload['export'], $this->options, $this->logger);
     }
 
-    public function doImport($existingAssetInDatabase = null)
+    public function doImport($existingAssetInDatabase = null, $importingFromTemplate = false)
     {
         $this->logger->log('Starting Transaction');
-        DB::transaction(function () use ($existingAssetInDatabase) {
+        DB::transaction(function () use ($existingAssetInDatabase, $importingFromTemplate) {
             // First, we save the model so we have IDs set for all assets
             Schema::disableForeignKeyConstraints();
 
@@ -90,7 +90,7 @@ class Importer
             foreach ($this->manifest->all() as $exporter) {
                 if ($exporter->mode !== 'discard') {
                     $this->logger->log('Associating ' . get_class($exporter->model));
-                    $exporter->runImport($existingAssetInDatabase);
+                    $exporter->runImport($existingAssetInDatabase, $importingFromTemplate);
                 }
             }
 

--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -270,7 +270,9 @@ class ProcessTemplate implements TemplateInterface
         $options = new Options($postOptions);
 
         $importer = new Importer($payload, $options);
-        $manifest = $importer->doImport();
+        $existingAssetsInDatabase = null;
+        $importingFromTemplate = true;
+        $manifest = $importer->doImport($existingAssetsInDatabase, $importingFromTemplate);
         $rootLog = $manifest[$payload['root']]->log;
         $processId = $rootLog['newId'];
 


### PR DESCRIPTION
# Issue
Ticket: [FOUR-13219](https://processmaker.atlassian.net/browse/FOUR-13219)

When creating a process from a template, the category assigned in the modal, 'Default Templates', is not assigned when the process is created.

# Solution
Ensure that the user's selected category is not overwritten by the template manifest's category when the process is created from a template.

# How to Test
1. Go to branch `observation/FOUR-13219` in `processmaker`.
2. Go to Designer → Processes. 
3. Create a Process from a Template. Take note of the selected category.
4. Go to the Processes listing and view your created process.
5. The category associated with the Process should be the category that was selected in the Create Process Modal.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13219]: https://processmaker.atlassian.net/browse/FOUR-13219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ