### PR TITLE
Observation/FOUR-14044: The Log option is showing the categories of data connectors, and the categories tab is not present in the options

### DIFF
--- a/resources/views/components/categorized_resource.blade.php
+++ b/resources/views/components/categorized_resource.blade.php
@@ -47,11 +47,35 @@
                 </li>
             @endisset
         @else
-            @if ($catConfig->permissions['view'])
+            @if ($catConfig->permissions['view'] && $catConfig->routes->itemsIndexWeb !== "data-sources.index")
             <li class="nav-item">
                 <a class="{{$secondTab}}" id="nav-categories-tab" data-toggle="tab" href="#nav-categories"
                 role="tab" onclick="loadCategory()" aria-controls="nav-categories" aria-selected="true">
                     {{ $tabs[2] ?? __('Categories') }}
+                </a>
+            </li>
+            @endif
+            @if (
+                array_key_exists('view', $catConfig->permissions) &&
+                $catConfig->permissions['view'] &&
+                $catConfig->routes->itemsIndexWeb === "data-sources.index"
+            )
+            <li class="nav-item">
+                <a class="{{$secondTab}}" id="nav-categories-tab" data-toggle="tab" href="#nav-categories"
+                role="tab" onclick="loadCategory()" aria-controls="nav-categories" aria-selected="true">
+                    {{ $tabs[1] ?? __('Categories') }}
+                </a>
+            </li>
+            @endif
+            @if (
+                array_key_exists('view-data-sources', $catConfig->permissions) &&
+                $catConfig->permissions['view-data-sources'] &&
+                $catConfig->routes->itemsIndexWeb === "data-sources.index"
+            )
+            <li class="nav-item">
+                <a class="nav-item nav-link" id="nav-archived-tab" data-toggle="tab" href="#nav-archived"
+                role="tab" onclick="loadArchivedProcess()" aria-controls="nav-archived" aria-selected="true">
+                    {{ $tabs[2] ?? __('Logs') }}
                 </a>
             </li>
             @endif


### PR DESCRIPTION
## Issue & Reproduction Steps

- Log in
- Go to Designer 
- Click on Data Connectors
- Click on Log options

**Current Behavior:** 
The categories tab in data connectors is not present, and when entering the Logs tab the categories of data connectors are being displayed

**Expected Behavior:**
The categories tab should be shown in the data options connectors, and the Logs tab should show the logs, not the categories.

## Solution
- Verify permissions and route for data connector and show the correct tags

## How to Test
- Follow steps above.
- Use different permissions for the user to activate/deactivate different tabs

## Related Tickets & Packages
- [FOUR-14044](https://processmaker.atlassian.net/browse/FOUR-14044)
- [package-data-sources PR](https://github.com/ProcessMaker/package-data-sources/pull/349)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14044]: https://processmaker.atlassian.net/browse/FOUR-14044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ