### PR TITLE
Resolve OpenAI Endpoint Error in PMQL Input Component

### DIFF
--- a/resources/js/components/shared/PmqlInput.vue
+++ b/resources/js/components/shared/PmqlInput.vue
@@ -364,7 +364,7 @@ export default {
       this.aiLoading = true;
 
       ProcessMaker.apiClient
-        .post("/openai/nlq-to-pmql", params)
+        .post("/package-ai/nlqToPmql", params)
         .then((response) => {
           this.pmql = response.data.result;
           this.usage = response.data.usage;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses an issue with the PMQL input component encountering an error related to the OpenAI endpoint. The problem stemmed from the component utilizing a deprecated endpoint `openai/nlq-to-pmql`. This PR resolves the issue by updating the endpoint to the new one.

## Solution
- Update deprecated endpoint in favor of new endpoint

## How to Test

1. Create a new screen.
2. Add a select list component.
3. Configure the select list to utilize either a data source or collection.
4. In the PMQL input field, enter a command such as where.
5. Press Enter.
6. Verify that no errors are displayed.

## Related Tickets & Packages
[FOUR-14058](https://processmaker.atlassian.net/browse/FOUR-14058)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14058]: https://processmaker.atlassian.net/browse/FOUR-14058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ