### PR TITLE
Add helperProcessRequestId Attribute to Processes Properties

### DIFF
--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -248,9 +248,15 @@ class ProcessTemplate implements TemplateInterface
                 $payload['export'][$key]['attributes']['description'] = $requestData['description'];
                 $payload['export'][$key]['attributes']['process_category_id'] = $requestData['process_category_id'];
                 // Store the wizard template uuid on the process to rerun the helper process
-                if (isset($request->wizardTemplateUuid)) {
+                if (isset($requestData['wizardTemplateUuid'])) {
                     $properties = json_decode($payload['export'][$key]['attributes']['properties'], true);
-                    $properties['wizardTemplateUuid'] = $request->wizardTemplateUuid;
+                    $properties['wizardTemplateUuid'] = $requestData['wizardTemplateUuid'];
+                    $payload['export'][$key]['attributes']['properties'] = json_encode($properties);
+                }
+                // Store the helper process request id that initiated the process creation
+                if (isset($requestData['helperProcessRequestId'])) {
+                    $properties = json_decode($payload['export'][$key]['attributes']['properties'], true);
+                    $properties['helperProcessRequestId'] = $requestData['helperProcessRequestId'];
                     $payload['export'][$key]['attributes']['properties'] = json_encode($properties);
                 }
 

--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -109,6 +109,7 @@ export default {
         process_category_id: this.template.process.process_category_id,
         projects: null,
         wizardTemplateUuid: this.template.uuid,
+        helperProcessRequestId: this.task.process_request_id,
       }).then((response) => {
         if (response.data?.existingAssets) {
           this.handleExistingAssets(response.data);


### PR DESCRIPTION
This PR adds a new attribute helperProcessRequestId to the processes properties object. This attribute will enable the PLG team to reference the helper process request id that initiated the creation of the guided template process.

## How to Test

1. Run a Guided Template helper process.
2. Upon completion, check the database for the newly created process in the `processes` table.
3. Navigate to the `'properties'` column.
4. Ensure in the object a new `helperProcessRequestId` is set.
5. Take note of the newly created process id.
6. In your environment, create a new PHP script.
7. Paste the below provided code snippet.
8. Replace the `[NEW_PROCESS_ID]` placeholder in the `$guzzleApi` variable with the actual newly created process id.
9. Run the script.
10. Ensure the `helperProcessRequestId` is returned.

## Code Snippet:

```
<?php 
$guzzleClient = new \GuzzleHttp\Client(['base_uri'=> $_SERVER['HOST_URL'],'verify' => false]);
$guzzleOptions['headers']['Accept'] = 'application/json';
$guzzleOptions['headers']['Authorization'] = 'Bearer ' . getenv('API_TOKEN');

$processId = $data["_request"]['process_id'];
$guzzleApi = '/api/1.0/processes/[NEW_PROCESS_ID]';

// Get the helper process request ID stored in the process properties
$res = $guzzleClient->request("GET", $guzzleApi, $guzzleOptions);
$process = json_decode($res->getBody(), true);
$helperProcessRequestId = $process['properties']['helperProcessRequestId'];

return ["helperProcessRequestId" => $helperProcessRequestId];
```

## Related Tickets & Packages
[FOUR-14065](https://processmaker.atlassian.net/browse/FOUR-14065) 

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14065]: https://processmaker.atlassian.net/browse/FOUR-14065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ