### PR TITLE
FOUR-14056: When launching a process from LaunchPad the insterstitials are not taking the user to the initial screen

### DIFF
--- a/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
@@ -116,7 +116,7 @@ export default {
           this.spin = 0;
           const instance = response.data;
           this.$cookies.set("fromTriggerStartEvent", true, "1min");
-          window.location = `/requests/${instance.id}`;
+          window.location = `/requests/${instance.id}?fromTriggerStartEvent=`;
         }).catch((err) => {
           const { data } = err.response;
           if (data.message) {


### PR DESCRIPTION
## Issue & Reproduction Steps
When launching a process from LaunchPad the insterstitials are not taking the user to the initial screen

## Solution
- When we start a case we need to use the following flag `fromTriggerStartEvent`

## How to Test
- Create a process with a start - insterstitials
- Create a process with a start - without insterstitials
- Both use cases needs to have the same behaviour when you start a Request from the button 
![image](https://github.com/ProcessMaker/processmaker/assets/42388723/6af27c26-7532-45a8-a551-95c3b1d4832c)


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14056

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next