### PR TITLE
FOUR-13251 The selection list for participants is replaced by a text …

### DIFF
--- a/ProcessMaker/Filters/Filter.php
+++ b/ProcessMaker/Filters/Filter.php
@@ -13,6 +13,8 @@ class Filter
 {
     const TYPE_PARTICIPANTS = 'Participants';
 
+    const TYPE_PARTICIPANTS_FULLNAME = 'ParticipantsFullName';
+
     const TYPE_STATUS = 'Status';
 
     const TYPE_FIELD = 'Field';
@@ -194,6 +196,9 @@ class Filter
         switch ($this->subjectType) {
             case self::TYPE_PARTICIPANTS:
                 $method = 'valueAliasParticipant';
+                break;
+            case self::TYPE_PARTICIPANTS_FULLNAME:
+                $method = 'valueAliasParticipantByFullName';
                 break;
             case self::TYPE_STATUS:
                 $method = 'valueAliasStatus';

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -726,6 +726,26 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     }
 
     /**
+     * PMQL value alias for participant field by fullname.
+     * @param string $value
+     * @return callable
+     */
+    public function valueAliasParticipantByFullName($value, $expression)
+    {
+        return function ($query) use ($value, $expression) {
+            $query->whereIn('id', function ($subquery) use ($value, $expression) {
+                $subquery->select('process_request_id')->from('process_request_tokens')
+                    ->whereIn('user_id', function ($subquery) use ($value, $expression) {
+                        $subquery->select('id')
+                            ->from('users')
+                            ->whereRaw("CONCAT(firstname, ' ', lastname) " . $expression->operator . " ?", [$value]);
+                    })
+                    ->whereIn('element_type', ['task', 'userTask', 'startEvent']);
+            });
+        };
+    }
+
+    /**
      * Get the process version used by this request
      *
      * @return ProcessVersion

--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -123,7 +123,7 @@ const PMColumnFilterCommonMixin = {
       if (column.format) {
         format = column.format;
       }
-      if (column.field === "status" || column.field === "assignee" || column.field === "participants" || column.field === 'process') {
+      if (column.field === "status" || column.field === "assignee") {
         format = "stringSelect";
       }
       return format;
@@ -136,17 +136,14 @@ const PMColumnFilterCommonMixin = {
       if (column.field === "assignee") {
         formatRange = this.viewAssignee;
       }
-      if (column.field === "participants") {
-        formatRange = this.viewParticipants;
-      }
-      if (column.field === "process") {
-        formatRange = this.viewProcesses;
-      }
       return formatRange;
     },
     getOperators(column) {
       let operators = [];
-      if (column.field === "status" || column.field === "assignee" || column.field === "participants" || column.field === 'process') {
+      if (column.field === "case_title" || column.field === "name" || column.field === "process" || column.field === "task_name" || column.field === "participants") {
+        operators = ["=", "in", "contains", "regex"];
+      }
+      if (column.field === "status" || column.field === "assignee") {
         operators = ["=", "in"];
       }
       return operators;

--- a/resources/js/components/PMColumnFilterPopover/PMColumnFilterForm.vue
+++ b/resources/js/components/PMColumnFilterPopover/PMColumnFilterForm.vue
@@ -2,7 +2,8 @@
   <div class="pm-filter-form">
     <b-form @submit.prevent="handleSubmit">
       <PMColumnFilterToggleAscDesc v-model="viewSort"
-                                   @onChange="onChangeSort">
+                                   @onChange="onChangeSort"
+                                   v-if="typeof hideSortingButtons === 'boolean' ? !hideSortingButtons : true">
       </PMColumnFilterToggleAscDesc>
 
       <div class="pm-filter-form-area" ref="pmFilterFormArea" data-cy="pmFilterFormArea">
@@ -90,7 +91,7 @@
     components: {
       ...Components
     },
-    props: ["type", "value", "format", "formatRange", "operators", "viewConfig", "sort"],
+    props: ["type", "value", "format", "formatRange", "operators", "viewConfig", "sort", "hideSortingButtons"],
     data() {
       return {
         items: [],

--- a/resources/js/components/PMColumnFilterPopover/PMColumnFilterPopover.vue
+++ b/resources/js/components/PMColumnFilterPopover/PMColumnFilterPopover.vue
@@ -23,6 +23,7 @@
                           :operators="operators"
                           :viewConfig="viewConfig"
                           :sort="sort"
+                          :hideSortingButtons="hideSortingButtons"
                           @onChangeSort="onChangeSort"
                           @onApply="onApply"
                           @onClear="onClear"
@@ -41,7 +42,7 @@
       PMColumnFilterForm,
       PMColumnFilterIconThreeDots
     },
-    props: ["container", "boundary", "id", "type", "value", "format", "formatRange", "operators", "viewConfig", "sort"],
+    props: ["container", "boundary", "id", "type", "value", "format", "formatRange", "operators", "viewConfig", "sort", "hideSortingButtons"],
     data() {
       return {
         popoverShow: false

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -29,6 +29,7 @@
                                    :viewConfig="getViewConfigFilter()"
                                    :container="''"
                                    :boundary="'viewport'"
+                                   :hideSortingButtons="column.hideSortingButtons"
                                    @onChangeSort="onChangeSort($event, column.field)"
                                    @onApply="onApply($event, column.field)"
                                    @onClear="onClear(column.field)"
@@ -266,6 +267,7 @@ export default {
           default: true,
           width: 160,
           truncate: true,
+          hideSortingButtons: true,
         },
         {
           label: this.$t("Status"),
@@ -527,7 +529,7 @@ export default {
         type = "Task";
       }
       if (value === "participants") {
-        type = "Participants";
+        type = "ParticipantsFullName";
       }
       if (value === "status") {
         type = "Status";


### PR DESCRIPTION
The selection list for participants is replaced by a text input that accepts the operators: '=', 'in', 'contains', 'regex'. These operators provide more filtering options; the change is due to a selection list becoming too large when we have many participants. Additionally, we have hidden the sorting buttons for the participants column since a record in the table can have many participants.