### PR TITLE
Add process_launchpad_id Property to Helper Process Request Data

### DIFF
--- a/resources/js/components/templates/WizardHelperProcessModal.vue
+++ b/resources/js/components/templates/WizardHelperProcessModal.vue
@@ -31,7 +31,7 @@ import wizardHelperProcessModalMixin from "./mixins/wizardHelperProcessModal";
 export default {
     mixins: [wizardHelperProcessModalMixin],
     components: { Modal, Task},
-    props: ["wizardTemplateUuid"],
+    props: ["wizardTemplateUuid", "processLaunchpadId"],
     data() {
         return {
             helperProcessId: null,

--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -30,9 +30,10 @@ export default {
     triggerHelperProcessStartEvent() {
       const startEventId = this.startEvents[0].id;
       const url = `/process_events/${this.helperProcessId}?event=${startEventId}`;
-
       // Start the helper process
-      window.ProcessMaker.apiClient.post(url).then((response) => {
+      window.ProcessMaker.apiClient.post(url, {
+        process_launchpad_id: this.processLaunchpadId ? this.processLaunchpadId : null
+      }).then((response) => {
         const processRequestId = response.data.id;
         this.getFirstTask(processRequestId);
       }).catch((error) => {

--- a/resources/js/processes-catalogue/components/ProcessOptions.vue
+++ b/resources/js/processes-catalogue/components/ProcessOptions.vue
@@ -12,6 +12,7 @@
       v-if="createdFromWizardTemplate"
       id="wizardHelperProcessModal" 
       ref="wizardHelperProcessModal"
+      :processLaunchpadId="process.id"
       :wizardTemplateUuid="wizardTemplateUuid"
     />
   </div>


### PR DESCRIPTION
This PR adds a new property process_launchpad_id in the Helper Process request data object. This property will enable the PLG team to reference the process/launchpad id in which the re-run wizard helper process was initiated.

## Solution
- Add `process_launchpad_id` property to request data for Guided Template Helper Processes

## How to Test

1. Run a Guided Template helper process.
2. Upon completion, select the 'Re-run wizard' link in the launchpad.
3. Close the modal to cancel the request, go to 'Requests -> All Requests'.
4. Locate the recently canceled request.
5. View the summary tab.
6. Ensure the property `process_launchpad_id` is present.
7. In the URL, update the URL to navigate to `/processes-catalogue/[PROCESS_LAUNCHPAD_ID]`.
8. Ensure the id corresponds to the correct launchpad.

## Related Tickets & Packages
[FOUR-14079](https://processmaker.atlassian.net/browse/FOUR-14079)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14079]: https://processmaker.atlassian.net/browse/FOUR-14079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ