### PR TITLE
FOUR-14069: Create a script to correct the broken links related to the Web Entry

### DIFF
--- a/upgrades/2024_02_07_113706_web_entry_url_fixer.php
+++ b/upgrades/2024_02_07_113706_web_entry_url_fixer.php
@@ -1,0 +1,75 @@
+<?php
+
+use ProcessMaker\ImportExport\Utils;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class WebEntryUrlFixer extends Upgrade
+{
+    /**
+     * Run any validations/pre-run checks to ensure the environment, settings,
+     * packages installed, etc. are right correct to run this upgrade.
+     *
+     * Throw a \RuntimeException if the conditions are *NOT* correct for this
+     * upgrade migration to run. If this is not a required upgrade, then it
+     * will be skipped. Otherwise the exception thrown will be caught, noted,
+     * and will prevent the remaining migrations from continuing to run.
+     *
+     * Returning void or null denotes the checks were successful.
+     *
+     * @throws RuntimeException
+     */
+    public function preflightChecks(): void
+    {
+        //
+    }
+
+    /**
+     * Run the upgrade migration.
+     */
+    public function up(): void
+    {
+        $appUrl = config('app.url');
+        $chunkSize = 50;
+        Process::chunk($chunkSize, function ($processes) use ($appUrl) {
+            foreach ($processes as $process) {
+                $this->updateWebEntryUrl($process, $appUrl);
+            }
+        });
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     */
+    public function down(): void
+    {
+        // No down migration needed.
+    }
+
+    /**
+     * Updates the web entry URL for a given process.
+     */
+    private function updateWebEntryUrl(Process $process, string $appUrl): void
+    {
+        $definitions = $process->getDefinitions(true);
+        $elements = Utils::getElementByMultipleTags($definitions, [
+            'bpmn:task',
+            'bpmn:startEvent',
+        ]);
+        foreach ($elements as $element) {
+            $config = $element->getAttribute('pm:config') ?? '[]';
+            $decodedConfig = json_decode($config, true);
+            $entryUrl = Arr::get($decodedConfig, 'web_entry.webentryRouteConfig.entryUrl');
+
+            // If the entry URL is not a valid URL, then update it.
+            if ($entryUrl && !filter_var($entryUrl, FILTER_VALIDATE_URL)) {
+                $newEntryUrl = rtrim($appUrl, '/') . '/' . ltrim($entryUrl, '/');
+                Arr::set($decodedConfig, 'web_entry.webentryRouteConfig.entryUrl', $newEntryUrl);
+                $element->setAttribute('pm:config', json_encode($decodedConfig));
+            }
+        }
+
+        $process->bpmn = $definitions->saveXml();
+        $process->save();
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps

Previously, when a process was created from a template, the import process incorrectly generated the web entry URL, as it omitted the application URL. This issue was due to the use of `getenv('APP_URL')` instead of `config('app.url')`.

This PR resolves instances where the web entry URL does not include the application URL.

1. Have a process with web entry imported or created from a previous version.
2. Review the link `webentryRouteConfig.entryUrl`.  
3. For backward compatibilities is important to create a script to correct the entryUrl for all processes.

## Solution
- An upgrade script has been developed to modify the web entry URL for all affected processes, but only when necessary, i.e., when the current web entry URL is not a valid URL.

## How to Test
Run the script.
Review in process-catalogue.

Before upgrade:

https://github.com/ProcessMaker/processmaker/assets/90741874/11cb87b8-c7e3-42cc-8d4d-2064655af0f9

After upgrade:

https://github.com/ProcessMaker/processmaker/assets/90741874/a9b3338a-82e9-404f-b0d1-fa0b231b02ab

## Related Tickets & Packages
- [FOUR-14069](https://processmaker.atlassian.net/browse/FOUR-14069)

[FOUR-14069]: https://processmaker.atlassian.net/browse/FOUR-14069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ