### PR TITLE
QA Observation Bugfix/FOUR-14061: Saved search custom date columns showing wrong date/time

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "processmaker/processmaker",
-    "version": "4.9.1",
+    "version": "4.9.2+nightly-20240207",
     "description": "BPM PHP Software",
     "keywords": [
         "php bpm processmaker"
@@ -102,7 +102,7 @@
             "Gmail"
         ],
         "processmaker": {
-            "build": "e9f8891c",
+            "build": "2b72f777",
             "custom": {
                 "package-ellucian-ethos": "1.15.1",
                 "package-plaid": "1.5.0",
@@ -177,7 +177,7 @@
             "microservices": {
                 "pmai": "fall-2023"
             },
-            "release": "Winter 2024"
+            "release": "Winter 2024 Pre-Release"
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22b568d7ccfb6f6bdff936451b0cdd8f",
+    "content-hash": "c09f7bdf02186f5fd6eb58fba336eeb0",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@processmaker/processmaker",
-    "version": "4.9.1",
+    "version": "4.9.2+nightly-20240207",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@processmaker/processmaker",
-            "version": "4.9.1",
+            "version": "4.9.2+nightly-20240207",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
@@ -9054,7 +9054,7 @@
             "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
             "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
@@ -9857,7 +9857,7 @@
                 "node": ">=16"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
@@ -15698,7 +15698,7 @@
                 "lib0": "^0.2.31"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "peerDependencies": {
@@ -15717,7 +15717,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "peerDependencies": {
@@ -15738,7 +15738,7 @@
                 "y-websocket-server": "bin/server.js"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "optionalDependencies": {
@@ -15938,7 +15938,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@processmaker/processmaker",
-    "version": "4.9.1",
+    "version": "4.9.2+nightly-20240207",
     "description": "ProcessMaker 4",
     "author": "DevOps <devops@processmaker.com>",
     "license": "ISC",

--- a/resources/js/components/shared/FilterTableBodyMixin.js
+++ b/resources/js/components/shared/FilterTableBodyMixin.js
@@ -50,5 +50,42 @@ export default {
     getNestedPropertyValue(obj, path) {
       return get(obj, path);
     },
+    format(value, format, column, datax) {
+      let config = "";
+      if (format === "datetime") {
+        config = ProcessMaker.user.datetime_format;
+        value = this.checkCustomColumnData(column, datax, config, value);
+      }
+      if (format === "date") {
+        config = ProcessMaker.user.datetime_format.replace(/[\sHh:msaAzZ]/g, "");
+        value = this.checkCustomColumnData(column, datax, config, value);
+      }
+      return value;
+    },
+    convertUTCToLocal(value, config) {
+      if (value) {
+        if (moment(value).isValid()) {
+          return window.moment(value)
+            .format(config);
+        }
+        return value;
+      }
+      return "-";
+    },
+    checkCustomColumnData(columnName, dataColumn, config, originValue) {
+      let columnValue = "";
+      if (columnName.startsWith("data.")) {
+        columnName = columnName.substring("data.".length);
+        for (const key in dataColumn) {
+          if (key === columnName) {
+            columnValue = dataColumn[key];
+            return this.convertUTCToLocal(columnValue, config);
+          }
+        }
+      }
+      else{
+        return originValue;
+      }
+    }
   },
 };

--- a/resources/js/components/shared/FilterTableBodyMixin.js
+++ b/resources/js/components/shared/FilterTableBodyMixin.js
@@ -47,18 +47,18 @@ export default {
     formatCategory(categories) {
       return categories.map(item => item.name).join(', ');
     },
-    getNestedPropertyValue(obj, path) {
-      return get(obj, path);
+    getNestedPropertyValue(obj, header) {
+      return this.format(get(obj, header.field), header);
     },
-    format(value, format, column, datax) {
+    format(value, header) {
       let config = "";
-      if (format === "datetime") {
+      if (header.format === "datetime") {
         config = ProcessMaker.user.datetime_format;
-        value = this.checkCustomColumnData(column, datax, config, value);
+        value = this.convertUTCToLocal(value, config)
       }
-      if (format === "date") {
+      if (header.format === "date") {
         config = ProcessMaker.user.datetime_format.replace(/[\sHh:msaAzZ]/g, "");
-        value = this.checkCustomColumnData(column, datax, config, value);
+        value = this.convertUTCToLocal(value, config)
       }
       return value;
     },
@@ -72,20 +72,5 @@ export default {
       }
       return "-";
     },
-    checkCustomColumnData(columnName, dataColumn, config, originValue) {
-      let columnValue = "";
-      if (columnName.startsWith("data.")) {
-        columnName = columnName.substring("data.".length);
-        for (const key in dataColumn) {
-          if (key === columnName) {
-            columnValue = dataColumn[key];
-            return this.convertUTCToLocal(columnValue, config);
-          }
-        }
-      }
-      else{
-        return originValue;
-      }
-    }
   },
 };

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -42,20 +42,20 @@
             v-for="(header, colIndex) in tableHeaders"
             :key="colIndex"
           >
-            <template v-if="containsHTML(getNestedPropertyValue(row, header.field))">
+            <template v-if="containsHTML(getNestedPropertyValue(row, header))">
               <div
                 :id="`element-${rowIndex}-${colIndex}`"
                 :class="{ 'pm-table-truncate': header.truncate }"
                 :style="{ maxWidth: header.width + 'px' }"
               >
-                <span v-html="sanitize(getNestedPropertyValue(row, header.field))"></span>
+                <span v-html="sanitize(getNestedPropertyValue(row, header))"></span>
               </div>
               <b-tooltip
                 v-if="header.truncate"
                 :target="`element-${rowIndex}-${colIndex}`"
                 custom-class="pm-table-tooltip"
               >
-                {{ sanitizeTooltip(getNestedPropertyValue(row, header.field)) }}
+                {{ sanitizeTooltip(getNestedPropertyValue(row, header)) }}
               </b-tooltip>
             </template>
             <template v-else>
@@ -72,13 +72,13 @@
                   :class="{ 'pm-table-truncate': header.truncate }"
                   :style="{ maxWidth: header.width + 'px' }"
                 >
-                  {{ format(getNestedPropertyValue(row, header.field), header.format, header.field, row.data) }}
+                  {{ getNestedPropertyValue(row, header) }}
                   <b-tooltip
                     v-if="header.truncate"
                     :target="`element-${rowIndex}-${colIndex}`"
                     custom-class="pm-table-tooltip"
                   >
-                    {{ format(getNestedPropertyValue(row, header.field), header.format, header.field, row.data) }}
+                    {{ getNestedPropertyValue(row, header) }}
                   </b-tooltip>
                 </div>
               </template>

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -72,13 +72,13 @@
                   :class="{ 'pm-table-truncate': header.truncate }"
                   :style="{ maxWidth: header.width + 'px' }"
                 >
-                  {{ getNestedPropertyValue(row, header.field) }}
+                  {{ format(getNestedPropertyValue(row, header.field), header.format, header.field, row.data) }}
                   <b-tooltip
                     v-if="header.truncate"
                     :target="`element-${rowIndex}-${colIndex}`"
                     custom-class="pm-table-tooltip"
                   >
-                    {{ getNestedPropertyValue(row, header.field) }}
+                    {{ format(getNestedPropertyValue(row, header.field), header.format, header.field, row.data) }}
                   </b-tooltip>
                 </div>
               </template>

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -44,20 +44,20 @@
             v-for="(header, colIndex) in tableHeaders"
             :key="colIndex"
           >
-            <template v-if="containsHTML(getNestedPropertyValue(row, header.field))">
+            <template v-if="containsHTML(getNestedPropertyValue(row, header))">
               <div
                 :id="`element-${rowIndex}-${colIndex}`"
                 :class="{ 'pm-table-truncate': header.truncate }"
                 :style="{ maxWidth: header.width + 'px' }"
                   >
-                <span v-html="sanitize(getNestedPropertyValue(row, header.field))"></span>
+                <span v-html="sanitize(getNestedPropertyValue(row, header))"></span>
               </div>
               <b-tooltip
                 v-if="header.truncate"
                 :target="`element-${rowIndex}-${colIndex}`"
                 custom-class="pm-table-tooltip"
               >
-                {{ sanitizeTooltip(getNestedPropertyValue(row, header.field)) }}
+                {{ sanitizeTooltip(getNestedPropertyValue(row, header)) }}
               </b-tooltip>
             </template>
             <template v-else>
@@ -71,7 +71,7 @@
               <template v-else>
                 <template v-if="header.field === 'due_at'">
                   <span :class="['badge', 'badge-'+row['color_badge'], 'due-'+row['color_badge']]">
-                    {{ formatRemainingTime(getNestedPropertyValue(row, header.field)) }}
+                    {{ formatRemainingTime(getNestedPropertyValue(row, header)) }}
                   </span>
                   <span>{{ row["due_date"] }}</span>
                 </template>
@@ -81,13 +81,13 @@
                     :class="{ 'pm-table-truncate': header.truncate }"
                     :style="{ maxWidth: header.width + 'px' }"
                   >
-                    {{ format(getNestedPropertyValue(row, header.field), header.format, header.field, row.data) }}
+                    {{ getNestedPropertyValue(row, header) }}
                     <b-tooltip
                       v-if="header.truncate"
                       :target="`element-${rowIndex}-${colIndex}`"
                       custom-class="pm-table-tooltip"
                     >
-                      {{ format(getNestedPropertyValue(row, header.field), header.format, header.field, row.data) }}
+                      {{ getNestedPropertyValue(row, header) }}
                     </b-tooltip>
                   </div>
                 </template>

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -81,13 +81,13 @@
                     :class="{ 'pm-table-truncate': header.truncate }"
                     :style="{ maxWidth: header.width + 'px' }"
                   >
-                    {{ getNestedPropertyValue(row, header.field) }}
+                    {{ format(getNestedPropertyValue(row, header.field), header.format, header.field, row.data) }}
                     <b-tooltip
                       v-if="header.truncate"
                       :target="`element-${rowIndex}-${colIndex}`"
                       custom-class="pm-table-tooltip"
                     >
-                      {{ getNestedPropertyValue(row, header.field) }}
+                      {{ format(getNestedPropertyValue(row, header.field), header.format, header.field, row.data) }}
                     </b-tooltip>
                   </div>
                 </template>


### PR DESCRIPTION
## Solution
- Filters with UTC vonversion were applied to custom columns with datetime and date data type

## How to Test
- Complete a process with date and datetime fields in the screen
- Add custom date and datetime columns to a saved search.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14061

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next