### PR TITLE
feature/FOUR-13370: The Avatar is not working correctly as Participant and Designer

### DIFF
--- a/resources/js/processes/screen-builder/typeDisplay.js
+++ b/resources/js/processes/screen-builder/typeDisplay.js
@@ -9,6 +9,7 @@ const TableControl = FormBuilderControls.find((control) => control.rendererBindi
 const RichTextControl = FormBuilderControls.find((control) => control.rendererBinding === "FormHtmlEditor");
 const FormRecordList = FormBuilderControls.find((control) => control.rendererBinding === "FormRecordList");
 const FormImage = FormBuilderControls.find((control) => control.rendererBinding === "FormImage");
+const FormAvatar = FormBuilderControls.find((control) => control.rendererBinding === "FormAvatar");
 const FormLoop = FormBuilderControls.find((control) => control.rendererBinding === "FormLoop");
 const FormNestedScreen = FormBuilderControls.find((control) => control.rendererBinding === "FormNestedScreen");
 const FileDownloadControl = FormBuilderControls.find((control) => control.builderBinding === "FileDownload");
@@ -25,6 +26,7 @@ const controlsDisplay = [
   TableControl,
   FormRecordList,
   FormImage,
+  FormAvatar,
   FormLoop,
   FormNestedScreen,
   FileDownloadControl,

--- a/resources/js/processes/screen-builder/typeForm.js
+++ b/resources/js/processes/screen-builder/typeForm.js
@@ -16,7 +16,7 @@ ProcessMaker.EventBus.$on("screen-builder-init", (manager) => {
   initialControls.forEach((config) => {
     config.control.inspector.push(...globalProperties[0].inspector);
 
-    if (config.control.component !== "FormListTable" && config.control.component !== "FormAnalyticsChart") {
+    if (config.control.component !== "FormListTable" && config.control.component !== "FormAnalyticsChart" && config.control.component !== "FormAvatar") {
       manager.addControl(
         config.control,
         config.rendererComponent,


### PR DESCRIPTION
## Issue & Reproduction Steps

The Avatar is not the same in Home Option and Designer Option, since is the same user that was login.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13370

## PR Package
https://github.com/ProcessMaker/screen-builder/pull/1531

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:screen-builder:feature/FOUR-13370