### PR TITLE
FOUR-14089: Assets view displays wrong label in the Screens button

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1923,7 +1923,7 @@
   "View All Decision Tables": "View All Decision Tables",
   "View All Processes": "View All Processes",
   "View All Requests": "View All Requests",
-  "View All Screens": "View All Processes",
+  "View All Screens": "View All Screens",
   "View All Scripts": "View All Scripts",
   "View All Notifications": "View All Notifications",
   "View All Requests": "View All Requests",


### PR DESCRIPTION
## Issue & Reproduction Steps
- Login into PM
- Go to the /designer url
- Hover the Screens button

## Solution
The translations has been fixed

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14089

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
