### PR TITLE
FOUR-10278: Display and parse correct date/time for "Last Login" user column

### DIFF
--- a/ProcessMaker/Listeners/LoginListener.php
+++ b/ProcessMaker/Listeners/LoginListener.php
@@ -8,7 +8,7 @@ use Illuminate\Auth\Events\Login;
 class LoginListener
 {
     /**
-     * Updated the user's loggedin_at attribute
+     * Updated the user "loggedin_at" attribute
      *
      * @param  \Illuminate\Auth\Events\Login  $event
      *
@@ -21,6 +21,8 @@ class LoginListener
         if (!$user instanceof User) {
             return;
         }
+
+        $user->timestamps = false;
 
         $user->setAttribute('loggedin_at', now());
         $user->save();

--- a/ProcessMaker/Listeners/LoginListener.php
+++ b/ProcessMaker/Listeners/LoginListener.php
@@ -2,24 +2,27 @@
 
 namespace ProcessMaker\Listeners;
 
-use Carbon\Carbon;
+use ProcessMaker\Models\User;
 use Illuminate\Auth\Events\Login;
 
 class LoginListener
 {
     /**
-     * Handle the event.
+     * Updated the user's loggedin_at attribute
      *
-     * @param  Illuminate\Auth\Events\Login  $user
+     * @param  \Illuminate\Auth\Events\Login  $event
+     *
      * @return void
      */
-    public function handle(Login $event)
+    public function handle(Login $event): void
     {
-        // Grab our user that was logged in
         $user = $event->user;
-        // Update the last_login
-        $user->timestamps = false;
-        $user->loggedin_at = Carbon::now();
+
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $user->setAttribute('loggedin_at', now());
         $user->save();
     }
 }

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -137,6 +137,7 @@ class User extends Authenticatable implements HasMedia
         'is_administrator' => 'bool',
         'meta' => 'object',
         'active_at' => 'datetime',
+        'loggedin_at' => 'datetime',
         'schedule' => 'array',
         'preferences_2fa' => 'array',
     ];


### PR DESCRIPTION
## Issue
The "Last Login" column for the user list found in the admin dashboard was incorrectly parsing the datetime causing it to show a different date and time than when the user actually logged in.

## Reproduction Steps
1. Log in to the admin dashboard (be sure your user account has permissions to view all users).
2. Update your timezone in your user profile to be non-UTC +0 timezone.
3. Log out and log back in.
4. Navigate to the user list in the admin dashboard.
5. Sort by last logged in.
6. Notice the date/time differences between when you logged in and the date/time it displays.

## Solution
The `loggedin_at` attribute had to be cast to `datetime` in the `ProcessMaker\Models\User` model.

## How to Test
With the fix, the correct date and time should now display for the "Last Login" column in the user listing.

#### CICD
ci:deploy
ci:next

## Related Tickets & Packages
[FOUR-10278](https://processmaker.atlassian.net/browse/FOUR-10278)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10278]: https://processmaker.atlassian.net/browse/FOUR-10278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ