### PR TITLE
FOUR-13922 Configurable Requests and Tasks columns

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -64,7 +64,7 @@ class RequestController extends Controller
         $userFilter = SaveSession::getConfigFilter('requestFilter', Auth::user());
 
         // Get default Saved search config
-        if (!class_exists(SavedSearch::class)) {
+        if (class_exists(SavedSearch::class)) {
             $defaultSavedSearch = SavedSearch::firstSystemSearchFor(
                 Auth::user(),
                 SavedSearch::KEY_REQUESTS,

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -64,12 +64,16 @@ class RequestController extends Controller
         $userFilter = SaveSession::getConfigFilter('requestFilter', Auth::user());
 
         // Get default Saved search config
-        $defaultSavedSearch = SavedSearch::firstSystemSearchFor(
-            Auth::user(),
-            SavedSearch::KEY_REQUESTS,
-        );
-        if ($defaultSavedSearch) {
-            $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns);
+        if (!class_exists(SavedSearch::class)) {
+            $defaultSavedSearch = SavedSearch::firstSystemSearchFor(
+                Auth::user(),
+                SavedSearch::KEY_REQUESTS,
+            );
+            if ($defaultSavedSearch) {
+                $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns);
+            } else {
+                $defaultColumns = null;
+            }
         } else {
             $defaultColumns = null;
         }

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -46,7 +46,7 @@ class TaskController extends Controller
         $userFilter = SaveSession::getConfigFilter('taskFilter', Auth::user());
 
         // Get default Saved search config
-        if (!class_exists(SavedSearch::class)) {
+        if (class_exists(SavedSearch::class)) {
             $defaultSavedSearch = SavedSearch::firstSystemSearchFor(
                 Auth::user(),
                 SavedSearch::KEY_TASKS,

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -46,12 +46,16 @@ class TaskController extends Controller
         $userFilter = SaveSession::getConfigFilter('taskFilter', Auth::user());
 
         // Get default Saved search config
-        $defaultSavedSearch = SavedSearch::firstSystemSearchFor(
-            Auth::user(),
-            SavedSearch::KEY_TASKS,
-        );
-        if ($defaultSavedSearch) {
-            $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns);
+        if (!class_exists(SavedSearch::class)) {
+            $defaultSavedSearch = SavedSearch::firstSystemSearchFor(
+                Auth::user(),
+                SavedSearch::KEY_TASKS,
+            );
+            if ($defaultSavedSearch) {
+                $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns);
+            } else {
+                $defaultColumns = null;
+            }
         } else {
             $defaultColumns = null;
         }

--- a/resources/views/requests/index.blade.php
+++ b/resources/views/requests/index.blade.php
@@ -90,7 +90,10 @@
                                     </template>
 
                                     <template v-slot:right-buttons>
-                                        @if(Route::has('package.savedsearch.defaults.edit'))
+                                        @if((
+                                            Auth::user()->is_administrator ||
+                                            Auth::user()->hasPermission('edit-screens')
+                                          ) && Route::has('package.savedsearch.defaults.edit'))
                                         <b-button
                                             class="ml-md-2"
                                             href="{{route(

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -65,7 +65,10 @@
                       </template>
 
                       <template v-slot:right-buttons>
-                          @if(Route::has('package.savedsearch.defaults.edit'))
+                          @if((
+                              Auth::user()->is_administrator ||
+                              Auth::user()->hasPermission('edit-screens')
+                            ) && Route::has('package.savedsearch.defaults.edit'))
                           <b-button
                             class="ml-md-2"
                             href="{{route(


### PR DESCRIPTION
## Configurable Requests and Tasks columns
Use `edit-screens` as permission to setup Requests and Tasks permissions.

## Solution
- Use `edit-screens` as permission to setup Requests and Tasks permissions.

## How to Test

1. Create a user with permissions:
- edit-screens
- view-users
- view-groups
2. Login the that User
3. This User will have enabled a gear to configure the Columns of Requests and Tasks List

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13922

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:package-savedsearch:FOUR-13922

.