### PR TITLE
Observation/FOUR-14094: The output in decision preview and output in scripts shows a horizontal scroll

### DIFF
--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -291,7 +291,7 @@
                       <div class="output text-white">
                         <pre
                           v-if="preview.success"
-                          class="text-white"
+                          class="text-white text-pre-wrap"
                         ><samp>{{ preview.output }}</samp></pre>
                         <div v-if="preview.failure">
                           <div class="text-light bg-danger">
@@ -1112,5 +1112,10 @@ export default {
 }
 .cldr.delete-sign.codicon.codicon-diff-remove {
     background: #fbc7c7 !important;
+}
+
+.text-pre-wrap {
+    overflow-x: hidden;
+    white-space: pre-wrap;
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps

FIRST SCENARIO: Decision Preview

- Import attached decision table
- Search table and edit
- Go to Sample input in Preview
- Assign Honda to brand 
- Assign 1900 to year
- Click on run button

SECOND SCENARIO: Scripts

- Create a script
- Go to Designer
- Go to Scripts option in sidebar menu
- Click on +Script button
- Fill name and description fields
- Select one language in executor section
- Click on save button
- Run script
- Write "This car is not available, to reserve for the following month enter the following link https://www.orange.es/" in return 
- Click on run button

**Current behavior:**
The output in decision preview shows a  horizontal scroll

**Expected behavior:**
The result in preview should not show the horizontal scroll

## Solution
- Set overflow to hidden a white-space to pre-wrap

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-14094](https://processmaker.atlassian.net/browse/FOUR-14094)
- [package-decision-engine PR](https://github.com/ProcessMaker/package-decision-engine/pull/98)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
