### PR TITLE
observation/FOUR-14080 The column length becomes blank if the screen size is manipulated.

### DIFF
--- a/resources/js/components/shared/FilterTable.vue
+++ b/resources/js/components/shared/FilterTable.vue
@@ -165,9 +165,16 @@ export default {
       ellipsisColumn.forEach((column) => {
         column.addEventListener("click", this.handleEllipsisClick);
       });
+      window.addEventListener("resize", this.handleWindowResize);
     });
   },
+  beforeDestroy() {
+    window.removeEventListener("resize", this.handleWindowResize);
+  },
   methods: {
+    handleWindowResize() {
+      this.calculateColumnWidth();
+    },
     calculateColumnWidth() {
       this.headers.forEach((headerColumn, index) => {
         if (this.calculateContent(index) !== 0) {


### PR DESCRIPTION
## Issue & Reproduction Steps
The column length becomes blank if the screen size is manipulated.

## Solution
We adjusted the content when the window is resize

## How to Test
Steps to reproduced:

1.Have a process with Case title
2.Create a requests
3.Go to requests/tasks
4.Move window size
5.Click on the column between Case title and process

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14080

ci:deploy
ci:next