### PR TITLE
Set Admin User as Default run_as_user_id When Importing Scripts

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
@@ -36,14 +36,9 @@ class ScriptExporter extends ExporterBase
 
         foreach ($this->getDependents('user', true) as $dependent) {
             $scriptUser = $dependent->model;
-            if (!is_null($scriptUser->id)) {
-                // Assign the user ID to run the script
-                $this->model->run_as_user_id = $scriptUser->id;
-            } else {
-                // If the user is not set in the dependent modal, default to the admin user
-                $adminUser = User::where('is_administrator', true)->first();
-                $this->model->run_as_user_id = $adminUser->id;
-            }
+            // Assign the user ID to run the script
+            // If the user is not set in the dependent modal, default to the admin user
+            $this->model->run_as_user_id = $scriptUser?->id ?? User::where('is_administrator', true)->first()->id;
         }
 
         foreach ($this->getDependents('executor', true) as $dependent) {

--- a/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScriptExporter.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\ImportExport\Exporters;
 use ProcessMaker\ImportExport\DependentType;
 use ProcessMaker\Models\EnvironmentVariable;
 use ProcessMaker\Models\ScriptCategory;
+use ProcessMaker\Models\User;
 
 class ScriptExporter extends ExporterBase
 {
@@ -35,7 +36,14 @@ class ScriptExporter extends ExporterBase
 
         foreach ($this->getDependents('user', true) as $dependent) {
             $scriptUser = $dependent->model;
-            $this->model->run_as_user_id = $scriptUser->id;
+            if (!is_null($scriptUser->id)) {
+                // Assign the user ID to run the script
+                $this->model->run_as_user_id = $scriptUser->id;
+            } else {
+                // If the user is not set in the dependent modal, default to the admin user
+                $adminUser = User::where('is_administrator', true)->first();
+                $this->model->run_as_user_id = $adminUser->id;
+            }
         }
 
         foreach ($this->getDependents('executor', true) as $dependent) {


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses an issue discovered during the import of scripts from Guided Templates where scripts lacking a `run_as_user_id` caused a `A user is required to run scripts`. error when running the Re-run Wizard process. To resolve this, the PR implements setting the admin user as the default `run_as_user_id` when importing such scripts.


## How to Test

1. Ensure your environment has the latest Guided Templates synced `php artisan processmaker:sync-guided-templates`.
2. Create a process from the Guided Template.
3. Navigate to that process's Launchpad.
4. Select "Re-run Wizard."
5. Complete the wizard.
6. Navigate to "Requests -> All Requests."
7. Select the recently completed request (the status may initially show as "cancelled").
8. View the summary data.
9. Ensure no errors such as `_configuration_error_node_212` are present.

Example Error that was previously returned:

![unnamed](https://github.com/ProcessMaker/processmaker/assets/52755494/554fef0b-7a69-440f-a3f3-be3bc1d17bd3)



## Related Tickets & Packages
- [FOUR-14144](https://processmaker.atlassian.net/browse/FOUR-14144)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14144]: https://processmaker.atlassian.net/browse/FOUR-14144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ