### PR TITLE
Remove Deprecated Code for Reassociating Data Source Scripts

### DIFF
--- a/ProcessMaker/ImportExport/Importer.php
+++ b/ProcessMaker/ImportExport/Importer.php
@@ -48,38 +48,13 @@ class Importer
 
             $count = count(Arr::where($this->manifest->all(), fn ($exporter) => $exporter->mode !== 'discard'));
             $this->logger->log("Importing $count assets");
-
             foreach ($this->manifest->all() as $exporter) {
                 if ($exporter->mode !== 'discard') {
                     $this->logger->log('Importing ' . get_class($exporter->model));
                     if ($exporter->disableEventsWhenImporting) {
                         $exporter->model->saveQuietly();
                     } else {
-                        $exporterClass = get_class($exporter->model);
-                        if ($exporterClass === 'ProcessMaker\Packages\Connectors\DataSources\Models\Script') {
-                            switch ($exporter->mode) {
-                                case 'copy':
-                                    $exporter->model->script_id = $this->newScriptId;
-                                    break;
-                                case 'update':
-                                    $script = Script::find($exporter->model->script_id);
-                                    if ($script) {
-                                        $script->fill($exporter->model->getAttributes());
-                                        $script->save();
-                                    }
-                                    break;
-
-                                default:
-                                    // code...
-                                    break;
-                            }
-                        }
-
                         $exporter->model->save();
-
-                        if ($exporterClass === 'ProcessMaker\Models\Script') {
-                            $this->newScriptId = $exporter->model->id;
-                        }
                     }
                     $exporter->log('newId', $exporter->model->id);
                 }


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR removes deprecated code responsible for reassociating data source scripts with the imported script. The deprecated code caused a 'Duplicate entry` error when associating the data_source_scripts from the guided template. The reassociation functionality is now handled in the data source ProcessExporterExtension file.

## How to Test

1. Ensure your instance has Guided Templates synced `php artisan processmaker:sync-guided-templates`
2. Select the guided template and run the process
3. Upon first completion of the guided template, you will be redirected to the launchpad, but to trigger the error you will need to run the guided template again to create another process
4. Upon completion of the second guided template, you will be navigated to the 'existing assets' page.
5. Select 'Continue'
6. Select 'Yes'
7. Ensure no errors appear and the process is successfully created and you are redirected to the process launchpad.

## Related Tickets & Packages
- [FOUR-14098](https://processmaker.atlassian.net/browse/FOUR-14098)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14098]: https://processmaker.atlassian.net/browse/FOUR-14098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ