### PR TITLE
FOUR-13478 | Add a New Tab Labeled “My Templates” in the Screen Section

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScreenController.php
@@ -56,7 +56,11 @@ class ScreenController extends Controller
             'countCategories' => ScreenCategory::where(['status' => 'ACTIVE', 'is_system' => false])->count(),
         ];
 
-        return view('processes.screens.index', compact('listConfig', 'catConfig'));
+        $myScreenTemplates = (object) [
+
+        ];
+
+        return view('processes.screens.index', compact('listConfig', 'catConfig', 'myScreenTemplates'));
     }
 
     /**

--- a/resources/views/components/categorized_resource.blade.php
+++ b/resources/views/components/categorized_resource.blade.php
@@ -46,6 +46,21 @@
                     </a>
                 </li>
             @endisset
+        @elseif (isset($myScreenTemplates))
+            @if ($catConfig->permissions['view'])
+                <li class="nav-item">
+                    <a class="nav-item nav-link" id="nav-categories-tab" data-toggle="tab" href="#nav-categories"
+                    role="tab" onclick="loadCategory()" aria-controls="nav-categories" aria-selected="true">
+                        {{ $tabs[1] ?? __('Categories') }}
+                    </a>
+                </li>
+            @endif
+            <li class="nav-item">
+                <a class="{{$secondTab}}" id="nav-myTemplates-tab" data-toggle="tab" href="#nav-myTemplates"
+                role="tab" onclick="loadMyTemplates()" aria-controls="nav-myTemplates" aria-selected="true">
+                    {{ $tabs[2] ?? __('My Templates') }}
+                </a>
+            </li>
         @else
             @if ($catConfig->permissions['view'] && $catConfig->routes->itemsIndexWeb !== "data-sources.index")
             <li class="nav-item">
@@ -105,10 +120,15 @@
                     </div>
                 </div>
                 @endcan
-                <div class="{{$secondContent}}" id="nav-categories" role="tabpanel" aria-labelledby="nav-categories-tab">
-                <div class="card card-body p-3 border-top-0">
-                    {{ $categoryList }}
-                </div>
+                <div
+                    class="{{$secondContent}}"
+                    id="nav-categories"
+                    role="tabpanel"
+                    aria-labelledby="nav-categories-tab"
+                >
+                    <div class="card card-body p-3 border-top-0">
+                        {{ $categoryList }}
+                    </div>
                 </div>
                 @isset($tabs[3])
                     <div class="tab-pane fade" id="nav-archived" role="tabpanel" aria-labelledby="nav-archived-tab">
@@ -117,8 +137,31 @@
                         </div>
                     </div>
                 @endisset
+            @elseif(isset($myScreenTemplates))
+                <div
+                    class="{{$secondContent}}"
+                    id="nav-categories"
+                    role="tabpanel"
+                    aria-labelledby="nav-categories-tab"
+                >
+                    <div class="card card-body p-3 border-top-0">
+                        {{ $categoryList }}
+                    </div>
+                </div>
+                @isset($tabs[3])
+                <div class="tab-pane fade" id="nav-myTemplates" role="tabpanel" aria-labelledby="nav-myTemplates-tab">
+                    <div class="card card-body p-3 border-top-0">
+                        {{ $myTemplatesList }}
+                    </div>
+                </div>
+                @endisset
             @else
-                <div class="{{$secondContent}}" id="nav-categories" role="tabpanel" aria-labelledby="nav-categories-tab">
+                <div
+                    class="{{$secondContent}}"
+                    id="nav-categories"
+                    role="tabpanel"
+                    aria-labelledby="nav-categories-tab"
+                >
                     <div class="card card-body p-3 border-top-0">
                         {{ $categoryList }}
                     </div>

--- a/resources/views/processes/screens/index.blade.php
+++ b/resources/views/processes/screens/index.blade.php
@@ -20,9 +20,11 @@
             'tabs' => [
             __('Screens'),
             __('Categories'),
+            __('My Templates'),
         ],
         'listConfig' => $listConfig,
-        'catConfig' => $catConfig
+        'catConfig' => $catConfig,
+        'myScreenTemplates' => $myScreenTemplates,
     ])
         @slot('itemList')
             @component('processes.screens.list', ['config' => $listConfig])
@@ -31,6 +33,11 @@
 
         @slot('categoryList')
             @component('categories.list', ['config' => $catConfig])
+            @endcomponent
+        @endslot
+
+        @slot('myTemplatesList')
+            @component('processes.screens.myTemplates', ['config' => $myScreenTemplates])
             @endcomponent
         @endslot
     @endcomponent


### PR DESCRIPTION
# Feature
Ticket: [FOUR-13478](https://processmaker.atlassian.net/browse/FOUR-13478)

As a user, I want to find a Screen Template option in the Screen section via the following flow:

  - Login as Designer
  - Navigate to the Designer section
  - Find the Screen option
  - Find the following new tab: **My Templates**

# How to Test
1. Go to branch `task/FOUR-13478` in `processmaker`.
2. Go to Designer → Screens.
3. The 'My Templates' tab should display.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13478]: https://processmaker.atlassian.net/browse/FOUR-13478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ