### PR TITLE
Fix failing 'ScriptExecutorsTest' 

### DIFF
--- a/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
@@ -114,6 +114,7 @@ class ScriptExporterTest extends TestCase
 
     public function testNoMatchingRunAsUser()
     {
+        $admin_user = User::factory()->create(['is_administrator' => true]);
         DB::beginTransaction();
         $user = User::factory()->create(['username' => 'test']);
         $script = Script::factory()->create(['title' => 'test', 'run_as_user_id' => $user->id]);
@@ -124,7 +125,7 @@ class ScriptExporterTest extends TestCase
         $this->import($payload);
 
         $script = Script::where('title', 'test')->firstOrFail();
-        $this->assertNull($script->run_as_user_id);
+        $this->assertEquals($script->run_as_user_id, $admin_user->id);
     }
 
     public function testRunAsUserIdNull()

--- a/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
@@ -126,6 +126,7 @@ class ScriptExporterTest extends TestCase
 
         $script = Script::where('title', 'test')->firstOrFail();
         $this->assertEquals($script->run_as_user_id, $admin_user->id);
+        $admin_user->delete();
     }
 
     public function testRunAsUserIdNull()


### PR DESCRIPTION
This PR resolves a failing 'ScriptExecutorTest'. The error occurred due to the admin user now being set as the default run_script_as_user when importing scripts. The solution was to update the tests to ensure an admin user was created in the database as well as asserting the run_script_as_user matched that of the admin user.

## How to Test

1. Run the test `phpunit tests/Feature/ImportExport/Exporters/ScriptExecutorTest.php`.
2. Ensure all tests pass without errors.

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
