### PR TITLE
Tasks of the multiple task parallel type with self service do not reach the self service tray

### DIFF
--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -333,7 +333,7 @@
         this.$set(this.node, "assignmentRules", JSON.stringify(value));
       },
       assignmentSupportsSelfService (assignmentType) {
-        return ['process_variable', 'user_group', 'rule_expression'].includes(assignmentType);
+        return ['user_group', 'rule_expression'].includes(assignmentType);
       },
     },
     watch: {

--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -333,7 +333,11 @@
         this.$set(this.node, "assignmentRules", JSON.stringify(value));
       },
       assignmentSupportsSelfService (assignmentType) {
-        return ['user_group', 'rule_expression'].includes(assignmentType);
+        let options = ['process_variable', 'user_group', 'rule_expression'];
+        if (_.get(this.node, "loopCharacteristics") !== 'undefined') {
+          options = ['user_group', 'rule_expression'];
+        }
+        return options.includes(assignmentType);
       },
     },
     watch: {


### PR DESCRIPTION
## Issue & Reproduction Steps
When we want to configure a multi parallel task, and put an assignment of the Process Variable type with the SelfService option.

## Solution
- remove SelfService of option process_variable

## How to Test
When we want to configure a multiparallel task, and put an assignment of type Process Variable, the selfservice option should not be seen.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-13994](FOUR-13994)

![image](https://github.com/ProcessMaker/processmaker/assets/1747025/bc05461c-600a-4517-89a6-5c1a77f813ae)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:processmaker:observation/FOUR-13994
