### PR TITLE
FOUR-13354: File preview in a second task, with multiple parallel, does not show the uploaded file

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1045,8 +1045,12 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         if (!$isMultiInstance) {
             return '';
         }
-        $loopData = $this->token_properties['data'];
-        $index = $loopData['loopCounter'];
+        $loopData = $this->token_properties['data'] ?? [];
+
+        $index = null;
+        if (array_key_exists('loopCounter', $loopData)) {
+            $index = $loopData['loopCounter'];
+        }
         $definition = $this->getDefinition(true);
         if (!$definition instanceof ActivityInterface) {
             return '';
@@ -1059,7 +1063,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
             return '';
         }
 
-        return $variable . '.' . $index;
+        return $index !== null ?  $variable . '.' . $index : $variable;
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps

- Log in 
- create a process  
- in the first task create a file upload (use a loop with variable name loop_1)
- in the second task create a preview file
- the second task must be configured with multiple parallel (using Request Variable Array = loop_1)
- start a new case
- upload an image in file upload
- add two users for multiple task
-  Open the task

## Solution
- verification of null and array index existence.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13354
ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
