### PR TITLE
Use advanced filter for defaults and fix translations

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -70,7 +70,10 @@ class RequestController extends Controller
                 SavedSearch::KEY_REQUESTS,
             );
             if ($defaultSavedSearch) {
-                $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns, SavedSearch::TYPE_REQUEST);
+                $defaultColumns = SavedSearchController::adjustColumnsOf(
+                    $defaultSavedSearch->columns,
+                    SavedSearch::TYPE_REQUEST
+                );
             } else {
                 $defaultColumns = null;
             }

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -70,7 +70,7 @@ class RequestController extends Controller
                 SavedSearch::KEY_REQUESTS,
             );
             if ($defaultSavedSearch) {
-                $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns);
+                $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns, SavedSearch::TYPE_REQUEST);
             } else {
                 $defaultColumns = null;
             }

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -52,7 +52,10 @@ class TaskController extends Controller
                 SavedSearch::KEY_TASKS,
             );
             if ($defaultSavedSearch) {
-                $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns, SavedSearch::TYPE_TASK);
+                $defaultColumns = SavedSearchController::adjustColumnsOf(
+                    $defaultSavedSearch->columns,
+                    SavedSearch::TYPE_TASK
+                );
             } else {
                 $defaultColumns = null;
             }

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -52,7 +52,7 @@ class TaskController extends Controller
                 SavedSearch::KEY_TASKS,
             );
             if ($defaultSavedSearch) {
-                $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns);
+                $defaultColumns = SavedSearchController::adjustColumnsOf($defaultSavedSearch->columns, SavedSearch::TYPE_TASK);
             } else {
                 $defaultColumns = null;
             }

--- a/resources/js/common/advancedFilterStatusMixin.js
+++ b/resources/js/common/advancedFilterStatusMixin.js
@@ -18,7 +18,7 @@ export default {
       for(const filter of filters) {
         result.push([
           this.formatBadgeSubject(filter),
-          [{name: this.formatBadgeValue(filter), advanced_filter: true}]
+          [{name: filter.value, operator: filter.operator, advanced_filter: true}]
         ]);
 
         if (filter.or && filter.or.length > 0) {
@@ -28,11 +28,6 @@ export default {
     },
     formatBadgeSubject(filter) {
       return get(filter, '_column_label', '');
-    },
-    formatBadgeValue(filter) {
-      let result = filter.operator;
-      result = result + " " + filter.value;
-      return result;
     },
   },
   computed: {

--- a/resources/js/common/setDefaultAdvancedFilterStatus.js
+++ b/resources/js/common/setDefaultAdvancedFilterStatus.js
@@ -5,11 +5,9 @@ export default (status, ignoreSavedFilter = false) => {
   if (ignoreSavedFilter) {
     // Remove any Status filters that might be set by the user
     advancedFilter = advancedFilter.filter(f => f.subject?.type !== "Status");
-  } else {
-    if (advancedFilter.some(f => f.subject?.type === "Status")) {
-      // Already has a status filter set by the user
-      return;
-    }
+  } else if (advancedFilter.some(f => f.subject?.type === "Status")) {
+    // Already has a status filter set by the user
+    return;
   }
   advancedFilter.push({
     subject: {

--- a/resources/js/common/setDefaultAdvancedFilterStatus.js
+++ b/resources/js/common/setDefaultAdvancedFilterStatus.js
@@ -1,0 +1,25 @@
+import { get } from "lodash";
+
+export default (status, ignoreSavedFilter = false) => {
+  let advancedFilter = get(window, 'ProcessMaker.advanced_filter.filters', []);
+  if (ignoreSavedFilter) {
+    // Remove any Status filters that might be set by the user
+    advancedFilter = advancedFilter.filter(f => f.subject?.type !== "Status");
+  } else {
+    if (advancedFilter.some(f => f.subject?.type === "Status")) {
+      // Already has a status filter set by the user
+      return;
+    }
+  }
+  advancedFilter.push({
+    subject: {
+      type: "Status"
+    },
+    operator: "=",
+    value: status,
+    _column_field: "status",
+    _column_label: "Status"
+  });
+  window.ProcessMaker.advanced_filter.filters = advancedFilter;
+
+}

--- a/resources/js/components/shared/PmqlInput.vue
+++ b/resources/js/components/shared/PmqlInput.vue
@@ -153,7 +153,14 @@
           class="selected-filter-item d-flex align-items-center"
         >
           <span class="selected-filter-key mr-1">{{ $t(capitalizeString(filter[0])) }}<template v-if="!get(filter, '1.0.advanced_filter', false)">:</template></span>
-          {{ filter[1][0].name ? filter[1][0].name : filter[1][0].fullname }}
+          {{ filter[1][0].operator ?? '' }}
+          <template v-if="filter[0] === 'Status'">
+            <!-- translate status label -->
+            {{ $t(filter[1][0].name) }}
+          </template>
+          <template v-else>
+            {{ filter[1][0].name ? filter[1][0].name : filter[1][0].fullname }}
+          </template>
           <span
             v-if="filter[1].length > 1"
             class="badge badge-pill ml-2 filter-counter"

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -14,7 +14,7 @@
         <template v-for="(column, index) in tableHeaders" v-slot:[column.field]>
           <PMColumnFilterIconAsc v-if="column.sortAsc"></PMColumnFilterIconAsc>
           <PMColumnFilterIconDesc v-if="column.sortDesc"></PMColumnFilterIconDesc>
-          <div :key="index" style="display: inline-block;">{{ column.label }}</div>
+          <div :key="index" style="display: inline-block;">{{ $t(column.label) }}</div>
         </template>
         <!-- Slot Table Header filter Button -->
         <template v-for="(column, index) in tableHeaders" v-slot:[`filter-${column.field}`]>
@@ -232,14 +232,14 @@ export default {
       }
       return [
         {
-          label: this.$t("Case #"),
+          label: "Case #",
           field: "case_number",
           sortable: true,
           default: true,
           width: 80,
         },
         {
-          label: this.$t("Case title"),
+          label: "Case title",
           field: "case_title",
           sortable: true,
           default: true,
@@ -247,7 +247,7 @@ export default {
           width: 220,
         },
         {
-          label: this.$t("Process"),
+          label: "Process",
           field: "name",
           sortable: true,
           default: true,
@@ -255,7 +255,7 @@ export default {
           truncate: true,
         },
         {
-          label: this.$t("Task"),
+          label: "Task",
           field: "active_tasks",
           sortable: false,
           default: true,
@@ -264,7 +264,7 @@ export default {
           tooltip: this.$t("This column can not be sorted or filtered."),
         },
         {
-          label: this.$t("Participants"),
+          label: "Participants",
           field: "participants",
           sortable: true,
           default: true,
@@ -274,7 +274,7 @@ export default {
           hideSortingButtons: true,
         },
         {
-          label: this.$t("Status"),
+          label: "Status",
           field: "status",
           sortable: true,
           default: true,
@@ -282,7 +282,7 @@ export default {
           filter_subject: { type: 'Status' },
         },
         {
-          label: this.$t("Started"),
+          label: "Started",
           field: "initiated_at",
           format: "datetime",
           sortable: true,
@@ -290,7 +290,7 @@ export default {
           width: 160,
         },
         {
-          label: this.$t("Completed"),
+          label: "Completed",
           field: "completed_at",
           format: "datetime",
           sortable: true,

--- a/resources/js/requests/index.js
+++ b/resources/js/requests/index.js
@@ -3,6 +3,7 @@ import CounterCard from "./components/CounterCard";
 import CounterCardGroup from "./components/CounterCardGroup";
 import RequestsListing from "./components/RequestsListing";
 import AvatarImage from "../components/AvatarImage";
+import setDefaultAdvancedFilterStatus from "../common/setDefaultAdvancedFilterStatus";
 
 Vue.component("AvatarImage", AvatarImage);
 
@@ -39,18 +40,8 @@ new Vue({
     }
 
     if (status) {
-      this.status.push({
-        name: status,
-        value: status,
-      });
+      setDefaultAdvancedFilterStatus(status, true);
     }
-
-    // translate status labels when available
-    window.ProcessMaker.i18nPromise.then(() => {
-      this.status.forEach((item) => {
-        item.name = this.$t(item.name);
-      });
-    });
 
     const urlParams = new URLSearchParams(window.location.search);
     this.urlPmql = urlParams.get("pmql");

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -17,7 +17,7 @@
         <template v-for="(column, index) in tableHeaders" v-slot:[column.field]>
           <PMColumnFilterIconAsc v-if="column.sortAsc"></PMColumnFilterIconAsc>
           <PMColumnFilterIconDesc v-if="column.sortDesc"></PMColumnFilterIconDesc>
-          <div :key="index" style="display: inline-block;">{{ column.label }}</div>
+          <div :key="index" style="display: inline-block;">{{ $t(column.label) }}</div>
         </template>
         <!-- Slot Table Header filter Button -->
         <template v-for="(column, index) in tableHeaders" v-slot:[`filter-${column.field}`]>
@@ -313,7 +313,7 @@ export default {
       const isStatusCompletedList = window.location.search.includes("status=CLOSED");
       const columns = [
         {
-          label: this.$t("Case #"),
+          label: "Case #",
           field: "case_number",
           sortable: true,
           default: true,
@@ -322,7 +322,7 @@ export default {
           order_column: 'process_requests.case_number',
         },
         {
-          label: this.$t("Case title"),
+          label: "Case title",
           field: "case_title",
           name: "__slot:case_number",
           sortable: true,
@@ -333,7 +333,7 @@ export default {
           order_column: 'process_requests.case_title',
         },
         {
-          label: this.$t("Process"),
+          label: "Process",
           field: "process",
           sortable: true,
           default: true,
@@ -343,7 +343,7 @@ export default {
           order_column: 'process_requests.name',
         },
         {
-          label: this.$t("Task"),
+          label: "Task",
           field: "task_name",
           sortable: true,
           default: true,
@@ -353,15 +353,15 @@ export default {
           order_column: 'element_name',
         },
         {
-          label: this.$t("Status"),
+          label: "Status",
           field: "status",
           sortable: true,
           default: true,
           width: 100,
-          filter_subject: { value: 'Status' },
+          filter_subject: { type: 'Status' },
         },
         {
-          label: this.$t("Due date"),
+          label: "Due date",
           field: "due_at",
           format: "datetime",
           sortable: true,
@@ -371,7 +371,7 @@ export default {
       ];
       if (isStatusCompletedList) {
         columns.push({
-          label: this.$t("Completed"),
+          label: "Completed",
           field: "completed_at",
           format: "datetime",
           sortable: true,

--- a/resources/js/tasks/index.js
+++ b/resources/js/tasks/index.js
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import TasksList from "./components/TasksList";
+import setDefaultAdvancedFilterStatus from "../common/setDefaultAdvancedFilterStatus";
 
 new Vue({
   el: "#tasks",
@@ -38,18 +39,7 @@ new Vue({
         status = "In Progress";
         break;
     }
-
-    this.status.push({
-      name: status,
-      value: status,
-    });
-
-    // translate status labels when available
-    window.ProcessMaker.i18nPromise.then(() => {
-      this.status.forEach((item) => {
-        item.name = this.$t(item.name);
-      });
-    });
+    setDefaultAdvancedFilterStatus(status);
 
     if (this.urlPmql && this.urlPmql !== "") {
       this.onSearch();

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2088,5 +2088,8 @@
   "Google Places": "Google Places",
   "Add an action to submit your form or update a field": "Add an action to submit your form or update a field",
   "Add special buttons that link between subpages within this Form": "Add special buttons that link between subpages within this Form",
-  "input": "input"
+  "input": "input",
+  "Case #": "Case #",
+  "Case title": "Case title",
+  "Case Title": "Case Title"
 }


### PR DESCRIPTION
This PR fixes several issues
- It uses advanced filters instead of PMQL for the default status for requests and tasks pages. Fixes [13931](https://processmaker.atlassian.net/browse/FOUR-13931)

These other issues were found and fixed:
- Fixes an problem where column sorting broke when a default task and request pages are converted to system saved searches
- Fixes translations by only translating when the string is displayed

Requires: https://github.com/ProcessMaker/package-savedsearch/pull/415

ci:next