### PR TITLE
Observation/FOUR-14185: Pagination does not work if we have a filter with more than one page.

### DIFF
--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -114,19 +114,19 @@ const PMColumnFilterCommonMixin = {
       this.advancedFilter[index] = json;
       this.markStyleWhenColumnSetAFilter();
       this.storeFilterConfiguration();
-      this.fetch();
+      this.fetch(true);
     },
     onClear(index) {
       this.advancedFilter[index] = [];
       this.markStyleWhenColumnSetAFilter();
       this.storeFilterConfiguration();
-      this.fetch();
+      this.fetch(true);
     },
     onChangeSort(value, field) {
       this.setOrderByProps(field, value);
       this.markStyleWhenColumnSetAFilter();
       this.storeFilterConfiguration();
-      this.fetch();
+      this.fetch(true);
     },
     onUpdate(object, index) {
       if (object.$refs.pmColumnFilterForm &&

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -391,7 +391,7 @@ export default {
       }
       return data;
     },
-    fetch() {
+    fetch(navigateToFirstPage = false) {
       Vue.nextTick(() => {
         if (this.cancelToken) {
           this.cancelToken();
@@ -400,7 +400,7 @@ export default {
 
         const CancelToken = ProcessMaker.apiClient.CancelToken;
 
-        const { pmql, filter, advancedFilter } = this.buildPmqlAndFilter();
+        const { pmql, filter, advancedFilter } = this.buildPmqlAndFilter(navigateToFirstPage);
 
         // Load from our api client
         ProcessMaker.apiClient
@@ -443,7 +443,7 @@ export default {
           });
       });
     },
-    buildPmqlAndFilter() {
+    buildPmqlAndFilter(navigateToFirstPage) {
       let pmql = '';
 
       if (this.pmql !== undefined) {
@@ -472,7 +472,8 @@ export default {
       this.previousPmql = pmql;
 
       const advancedFilter = this.getAdvancedFilter();
-      if (this.previousAdvancedFilter !== advancedFilter) {
+
+      if (this.previousAdvancedFilter !== advancedFilter && navigateToFirstPage) {
         this.page = 1;
       }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to reproduced:

- Log in
- Go to request/all
- Select a process/status/start filter
- Perform a search that has more than one page
- Apply the filter
- Click on pagination-button

## Solution
- Add a flag to not go to first page when using navigate

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/fde9526e-8c79-46bc-9237-1663d815293b


## How to Test
- Follow steps above
- Also test it's working the scenario described here: https://processmaker.atlassian.net/browse/FOUR-14155

## Related Tickets & Packages
- [FOUR-14185](https://processmaker.atlassian.net/browse/FOUR-14185)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-14185]: https://processmaker.atlassian.net/browse/FOUR-14185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ