### PR TITLE
Implement Temporary Solution for Generating Guided Template Launchpad Carousel Images

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -1721,9 +1721,11 @@ class ProcessController extends Controller
 
     public function getMediaImages(Request $request, Process $process)
     {
-        $media = Process::with(['media'])
-            ->where('id', $process->id)
-            ->get();
+        $media = Process::with(['media' => function ($query) {
+            $query->orderBy('order_column', 'asc');
+        }])
+        ->where('id', $process->id)
+        ->get();
 
         return new ProcessCollection($media);
     }

--- a/ProcessMaker/Jobs/SyncGuidedTemplates.php
+++ b/ProcessMaker/Jobs/SyncGuidedTemplates.php
@@ -229,9 +229,21 @@ class SyncGuidedTemplates implements ShouldQueue
         $this->importMedia($templateIconUrl, 'icon', $mediaCollectionName, $guidedTemplate);
         $this->importMedia($templateCardBackgroundUrl, 'cardBackground', $mediaCollectionName, $guidedTemplate);
 
+        if (!empty($template['assets']['launchpad']['process-card-background'])) {
+            $templateProcessCardBackgroundUrl = $this->buildTemplateUrl($config, $template['assets']['launchpad']['process-card-background']);
+            $this->importMedia($templateProcessCardBackgroundUrl, 'launchpadProcessCardBackground', $mediaCollectionName, $guidedTemplate);
+        }
+
         foreach ($template['assets']['slides'] as $slide) {
             $templateSlideUrl = $this->buildTemplateUrl($config, $slide);
             $this->importMedia($templateSlideUrl, 'slide', $mediaCollectionName, $guidedTemplate);
+        }
+
+        if (!empty($template['assets']['launchpad']['slides'])) {
+            foreach ($template['assets']['launchpad']['slides'] as $slide) {
+                $templateSlideUrl = $this->buildTemplateUrl($config, $slide);
+                $this->importMedia($templateSlideUrl, 'launchpadSlides', $mediaCollectionName, $guidedTemplate);
+            }
         }
     }
 


### PR DESCRIPTION
This PR introduces a temporary solution for generating Guided Template Launchpad carousel images. Due to limitations in the current system where launchpad images are not exported alongside process configurations, this temporary solution utilizes the [wizard-templates GitHub repo](https://github.com/ProcessMaker/wizard-templates/pull/16) to store images related to the guided template. Upon importing the process created from the guided template, the images are synced to the newly imported process.

The changes include updates to the `SyncGuidedTemplates` job to handle storing the launchpad images and modifications to the import method for importing a process from a process template to add the guided template images to the process`image_carousel` media collection.

## How to Test

1. Ensure your environment is configured with the correct wizard-template branch by adding `GUIDED_TEMPLATE_BRANCH=task/FOUR-14171` to your .env file.
2. Run the commands `php artisan optimize` and `php artisan processmaker:sync-guided-templates`.
3. Navigate to Processes -> Guided Templates.
4. Run a guided template.
5. Upon completion and redirection to the newly created process, verify that the carousel images are loaded correctly.
6. Run another guided template to ensure there are no image errors on subsequent process imports.

## Related Tickets & Packages
- [Wizard Templates PR](https://github.com/ProcessMaker/wizard-templates/pull/16)
- [FOUR-14171](https://processmaker.atlassian.net/browse/FOUR-14171)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:wizard-templates:task/FOUR-14171
ci:GUIDED_TEMPLATE_BRANCH="task/FOUR-14171"

[FOUR-14171]: https://processmaker.atlassian.net/browse/FOUR-14171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ