### PR TITLE
Resolve BuildScriptExecutor Errors During Process Import with Multiple Custom Script Executors

### DIFF
--- a/ProcessMaker/Jobs/BuildScriptExecutor.php
+++ b/ProcessMaker/Jobs/BuildScriptExecutor.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
 
 class BuildScriptExecutor implements ShouldQueue
@@ -18,7 +19,7 @@ class BuildScriptExecutor implements ShouldQueue
     protected $userId;
 
     // Do not retry this job if it fails
-    public $tries = 1;
+    public $tries = 20;
 
     // Building can take some time
     public $timeout = 600;
@@ -42,5 +43,13 @@ class BuildScriptExecutor implements ShouldQueue
     public function handle()
     {
         \Artisan::call('processmaker:build-script-executor ' . $this->lang . ' ' . $this->userId . ' --rebuild');
+    }
+
+    /**
+     * Prevent job overlaps
+     */
+    public function middleware(): array
+    {
+        return [(new WithoutOverlapping())->releaseAfter(10)];
     }
 }


### PR DESCRIPTION
This PR addresses BuildScriptExecutor errors encountered when importing a process containing multiple custom script executors. The issue stemmed from building the imported script executors simultaneously, leading to Docker errors such as `error 137` and the `/generator container already running` error upon the second attempt to build the script executor.

The solution involves implementing [Laravel's WithoutOverlapping middleware](https://laravel.com/docs/10.x/queues#preventing-job-overlaps) to the BuildScriptExecutor Job. This middleware prevents jobs from overlapping and ensures they run consecutively, resolving the errors encountered during the process import.


## Solution
- List the changes you've introduced to solve the issue.

## How to Test

1. Import the provided process template containing multiple custom script executors. 
[Test_Template.json.txt](https://github.com/ProcessMaker/processmaker/files/14349199/Test_Template.json.txt)

2. Create a new process from the imported template.
3. Monitor the Admin -> Queue Management for Pending, Completed, and Failed Jobs.
4. Verify that the BuildScriptExecutor job successfully completes without errors.

## Related Tickets & Packages
- [FOUR-14202](https://processmaker.atlassian.net/browse/FOUR-14202)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14202]: https://processmaker.atlassian.net/browse/FOUR-14202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ