### PR TITLE
FOUR-14195:Launchpad carosuel does not show correct the image

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCarousel.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCarousel.vue
@@ -74,7 +74,7 @@ export default {
   },
 };
 </script>
-<style lang="scss" scoped>
+<style lang="scss">
 #processes-carousel {
   .carousel-indicators {
     li {

--- a/resources/js/processes-catalogue/components/ProcessesCarousel.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCarousel.vue
@@ -13,8 +13,15 @@
         v-for="(image, index) in images.length > 0 ? images : defaultImage"
         :key="index"
         class="custom-style"
-        :img-src="image.url"
-      />
+      >
+        <template #img>
+          <img
+            :src="image.url"
+            :alt="process.name"
+            class="d-block w-100 img-carousel"
+          >
+        </template>
+      </b-carousel-slide>
     </b-carousel>
   </div>
 </template>
@@ -74,7 +81,7 @@ export default {
   },
 };
 </script>
-<style lang="scss">
+<style lang="scss" scoped>
 #processes-carousel {
   .carousel-indicators {
     li {
@@ -104,7 +111,7 @@ export default {
   width: 100%;
   height: 400px;
 }
-.img-fluid {
+.img-carousel {
   max-width: 100%;
   height: inherit;
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
If we add the scope the style defined does not apply because this is from Boostrap

## Solution
- The component does not resize the image correctly 

## How to Test
Go to Processes

## Related Tickets & Packages
- [FOUR-14195](https://processmaker.atlassian.net/browse/FOUR-14195)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-14195]: https://processmaker.atlassian.net/browse/FOUR-14195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ