### PR TITLE
feature/FOUR-11476

### DIFF
--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -96,6 +96,9 @@ export default {
   margin-right: 1rem;
   border-radius: 16px;
 }
+.card-body {
+  padding: 32px;
+}
 .card-img {
   border-radius: 16px;
 }
@@ -106,17 +109,20 @@ export default {
 .card-bookmark:hover {
   cursor: pointer;
 }
+.card-text {
+  height: 100%;
+}
 .card-info {
   cursor: pointer;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: baseline;
-  padding-top: 15%;
+  justify-content: end;
 }
 .icon-process {
   width: 75px;
-  height: 75px;;
-  padding-left: 0.5rem;
+  height: 75px;
   margin-bottom: 1rem;
 }
 .marked {
@@ -125,14 +131,15 @@ export default {
 .title-process {
   color: #556271;
   font-family: Poppins, sans-serif;
-  font-size: 20px;
+  font-size: 17px;
   font-style: normal;
   font-weight: 700;
-  line-height: normal;
+  line-height: 23.15px;
   letter-spacing: -0.4px;
   text-transform: uppercase;
-  -webkit-line-clamp: 2;
   display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
   word-break: break-all;

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -131,7 +131,7 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: baseline;
-  justify-content: end;
+  justify-content: flex-end;
 }
 .icon-process {
   width: 75px;

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -24,7 +24,20 @@
           :src="getIconProcess()"
           :alt="$t(labelIcon)"
         >
-        <span class="title-process">{{ process.name }}</span>
+        <span
+          :id="`title-${process.id}`"
+          class="title-process"
+        >
+          {{ process.name }}
+        </span>
+        <b-popover
+          v-if="process.name.length > 120"
+          :target="`title-${process.id}`"
+          placement="bottom"
+          triggers="hover focus"
+          :content="process.name"
+          variant="custom"
+        />
       </div>
     </b-card-text>
   </b-card>
@@ -143,5 +156,18 @@ export default {
   -webkit-box-orient: vertical;
   overflow: hidden;
   word-break: break-all;
+}
+.b-popover-custom.popover {
+  background-color: #F6F9FB;
+  border-radius: 4px;
+  border: 1px solid #CDDDEE;
+  box-shadow: 0px 10px 20px 4px #00000021;
+  font-family: Open Sans;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 22px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  padding: 20px;
 }
 </style>

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -162,7 +162,7 @@ export default {
   border-radius: 4px;
   border: 1px solid #CDDDEE;
   box-shadow: 0px 10px 20px 4px #00000021;
-  font-family: 'Open Sans';
+  font-family: 'Open Sans', sans-serif;
   font-size: 16px;
   font-weight: 400;
   line-height: 22px;

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -162,7 +162,7 @@ export default {
   border-radius: 4px;
   border: 1px solid #CDDDEE;
   box-shadow: 0px 10px 20px 4px #00000021;
-  font-family: Open Sans;
+  font-family: 'Open Sans';
   font-size: 16px;
   font-weight: 400;
   line-height: 22px;


### PR DESCRIPTION
## Issue & Reproduction Steps
The Long process names should not overflow the cards in LaunchPad, when we have a long name it should be shown as max in three lines inside the card. (Enginnering tean can suggest a number of characters to consider as a restriction, taking a count the font type and size)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13806

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next