### PR TITLE
[34945] html is being sanitized in PDF connector

### DIFF
--- a/ProcessMaker/SanitizeHelper.php
+++ b/ProcessMaker/SanitizeHelper.php
@@ -237,7 +237,7 @@ class SanitizeHelper
 
     private static function renderHtmlIsEnabled($item, $type, $field)
     {
-        return $item['component'] === 'FormTextArea' && isset($item['config'][$type]) && $item['config'][$field] === true;
+        return isset($item['config']) && $item['component'] === $type && isset($item['config'][$field]) && $item['config'][$field] === true;
     }
 
     public static function sanitizeEmail($email)

--- a/ProcessMaker/SanitizeHelper.php
+++ b/ProcessMaker/SanitizeHelper.php
@@ -194,7 +194,11 @@ class SanitizeHelper
             if (isset($item['items']) && is_array($item['items'])) {
                 // Inside loop ..
                 if ($item['component'] == 'FormLoop') {
-                    self::getRichTextElements($item['items'], $parent . '.' . $item['config']['name'], $elements);
+                    self::getRichTextElements(
+                        $item['items'],
+                        ($parent ? $parent . '.' . $item['config']['name'] : $item['config']['name']),
+                        $elements
+                    );
                 } elseif ($item['component'] == 'FormMultiColumn') {
                     self::getVariableMultiColumn($item, $parent, $elements);
                 } else {

--- a/ProcessMaker/SanitizeHelper.php
+++ b/ProcessMaker/SanitizeHelper.php
@@ -237,7 +237,10 @@ class SanitizeHelper
 
     private static function renderHtmlIsEnabled($item, $type, $field)
     {
-        return isset($item['config']) && $item['component'] === $type && isset($item['config'][$field]) && $item['config'][$field] === true;
+        return isset($item['config'])
+            && $item['component'] === $type
+            && isset($item['config'][$field])
+            && $item['config'][$field] === true;
     }
 
     public static function sanitizeEmail($email)


### PR DESCRIPTION
## Issue & Reproduction Steps
When there are variables containing html in a rich text component, these variables are sanitized.

## Solution
- Review component FormHtmlViewer for variable mustache

## How to Test
steps in ticket

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-12993](FOUR-12993)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
