### PR TITLE
Feature/FOUR-14120b: Backend - Fire job when task is assigned to a user

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -24,8 +24,8 @@ use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\Setting;
-use ProcessMaker\Models\User;
 use ProcessMaker\Models\TaskDraft;
+use ProcessMaker\Models\User;
 use ProcessMaker\Notifications\TaskReassignmentNotification;
 use ProcessMaker\Query\SyntaxError;
 use ProcessMaker\SanitizeHelper;
@@ -380,42 +380,7 @@ class TaskController extends Controller
             return new Resource($task->refresh());
         } elseif (!empty($request->input('user_id'))) {
             $userToAssign = $request->input('user_id');
-            $sendActivityActivatedNotifications = false;
-            $reassingAction = false;
-            if ($task->is_self_service && $userToAssign == Auth::id() && !$task->user_id) {
-                // Claim task
-                $task->is_self_service = 0;
-                $task->user_id = $userToAssign;
-                $task->persistUserData($userToAssign);
-                $sendActivityActivatedNotifications = true;
-            } elseif ($userToAssign === '#manager') {
-                // Reassign to manager
-                $task->authorizeAssigneeEscalateToManager();
-                $userToAssign = $task->escalateToManager();
-                $task->persistUserData($userToAssign);
-                $reassingAction = true;
-            } else {
-                // Validate if user can reassign
-                $task->authorizeReassignment(Auth::user());
-                // Reassign user
-                $task->reassignTo($userToAssign);
-                $task->persistUserData($userToAssign);
-                $reassingAction = true;
-            }
-            $task->save();
-
-            if ($sendActivityActivatedNotifications) {
-                $task->sendActivityActivatedNotifications();
-            }
-            // Register the Event
-            if ($reassingAction) {
-                ActivityReassignment::dispatch($task);
-            }
-
-            // Send a notification to the user
-            $notification = new TaskReassignmentNotification($task);
-            $task->user->notify($notification);
-            event(new ActivityAssigned($task));
+            $task->reassign($userToAssign, $request->user());
 
             return new Resource($task->refresh());
         } else {
@@ -483,10 +448,11 @@ class TaskController extends Controller
 
         return new Resource($newTask);
     }
+
     public function setPriority(Request $request, ProcessRequestToken $task)
     {
         $task->update(['is_priority' => $request->input('is_priority', false)]);
-        return new Resource($task->refresh());
 
+        return new Resource($task->refresh());
     }
 }

--- a/ProcessMaker/InboxRules/ApplyAction.php
+++ b/ProcessMaker/InboxRules/ApplyAction.php
@@ -7,37 +7,33 @@ use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\SanitizeHelper;
-use ProcessMaker\Http\Resources\Task as Resource;
 
 class ApplyAction
 {
     public function applyActionOnTask(ProcessRequestToken $task)
     {
-        $matchingTasks = MatchingTasks::matchingInboxRules($task);
+        $matchingInboxRules = MatchingTasks::matchingInboxRules($task);
 
-        foreach ($matchingTasks as $inputRule) {
-        
+        foreach ($matchingInboxRules as $inputRule) {
+            //Mark as priority
+            if ($inputRule->mark_as_priority === true) {
+                $this->markAsPriority($task);
+            }
+
+            //Reassign to user id
+            if ($inputRule->reassign_to_user_id !== null) {
+                $this->reassignToUserID($task, $inputRule);
+            }
+
             //If $savedSearchId is null For Task Rules only
-            if($inputRule->saved_search_id === null) {
-                
+            if ($inputRule->task) {
                 //Fill and save as draft
-                if($inputRule->fill_data === true) {
+                if ($inputRule->fill_data === true) {
                     //here process for save draft
                 }
                 //Submit the form
-                if($inputRule->submit_data !== null) {
-                   $this->submitForm($task, $inputRule);
-                }
-
-            } else {
-                //Mark as priority
-                if ($inputRule->mark_as_priority === true) {
-                    $this->markAsPriority($inputRule);
-                }
-
-                //Reassign to user id
-                if ($inputRule->reassign_to_user_id !== null) {
-                    $this->reassignToUserID($task, $inputRule);
+                if ($inputRule->submit_data !== null) {
+                    $this->submitForm($task, $inputRule);
                 }
             }
         }
@@ -48,18 +44,11 @@ class ApplyAction
         if ($task->status === 'CLOSED') {
             return abort(422, __('Task already closed'));
         }
-        $data = json_decode($inputRule->submit_data, 1);
-        $data = SanitizeHelper::sanitizeData(
-            $data['data'],
-            null,
-            $task->processRequest->do_not_sanitize ?? []
-        );
+        $data = $inputRule->submit_data;
         // Call the manager to trigger the start event
         $process = $task->process;
         $instance = $task->processRequest;
         WorkflowManager::completeTask($process, $instance, $task, $data);
-
-        return new Resource($task->refresh());
     }
 
     public function reassignToUserID($task, $inputRule)
@@ -71,9 +60,8 @@ class ApplyAction
         $task->save();
     }
 
-    public function markAsPriority($inputRule)
+    public function markAsPriority($task)
     {
-        ProcessRequestToken::where('process_request_token_id', $inputRule->process_request_token_id)
-            ->update(['is_priority' => 1]);
+        $task->update(['is_priority' => true]);
     }
 }

--- a/ProcessMaker/InboxRules/ApplyAction.php
+++ b/ProcessMaker/InboxRules/ApplyAction.php
@@ -11,24 +11,10 @@ use ProcessMaker\Http\Resources\Task as Resource;
 
 class ApplyAction
 {
-    public function applyActionOnTask(ProcessRequestToken $task){
-        $array = [
-                "id" => 14,
-                "name" => "ullam",
-                "user_id" => 56,
-                "active" => 1,
-                "end_date" => null,
-                "saved_search_id" => null,
-                "process_request_token_id" => 10,
-                "mark_as_priority" => 0,
-                "reassign_to_user_id" => null,
-                "fill_data" => 0,
-                "submit_data" => null,
-                "created_at" => "2024-02-20 03:01:41",
-                "updated_at" => "2024-02-20 03:01:41"
-        ];
-        $matchingTasks = MatchingTasks::matchingInboxRules($task);
+    public function applyActionOnTask(ProcessRequestToken $task)
+    {
 
+        $matchingTasks = MatchingTasks::matchingInboxRules($task);
 
         foreach ($matchingTasks as $inputRule) {
         
@@ -37,7 +23,7 @@ class ApplyAction
                 
                 //Fill and save as draft
                 if($inputRule->fill_data === true) {
-                    //here process for draft
+                    //TODO here process for save draft
                 }
                 //Submit the form
                 if($inputRule->submit_data !== null) {
@@ -45,9 +31,9 @@ class ApplyAction
                         return abort(422, __('Task already closed'));
                     }
                     // Skip ConvertEmptyStringsToNull and TrimStrings middlewares
-                    $data = $inputRule->submit_data;
+                    $data = json_decode($inputRule->submit_data, 1);
                     $data = SanitizeHelper::sanitizeData($data['data'], null, $task->processRequest->do_not_sanitize ?? []);
-                    //Call the manager to trigger the start event
+                    // Call the manager to trigger the start event
                     $process = $task->process;
                     $instance = $task->processRequest;
                     WorkflowManager::completeTask($process, $instance, $task, $data);
@@ -72,7 +58,5 @@ class ApplyAction
                 }
             }
         }
-
-
     }
 }

--- a/ProcessMaker/InboxRules/ApplyAction.php
+++ b/ProcessMaker/InboxRules/ApplyAction.php
@@ -69,7 +69,7 @@ class ApplyAction
     }
 
     public function saveAsDraft($task)
-    { 
+    {
         //Only not null or not empty data is going to be stored
         TaskDraft::updateOrCreate(
             ['task_id' => $task->id],

--- a/ProcessMaker/InboxRules/ApplyAction.php
+++ b/ProcessMaker/InboxRules/ApplyAction.php
@@ -31,7 +31,7 @@ class ApplyAction
             if ($inputRule->task) {
                 //Fill and save as draft
                 if ($inputRule->fill_data === true) {
-                    $this->saveAsDraft($task);
+                    $this->saveAsDraft($task, $inputRule);
                 }
                 //Submit the form
                 if ($inputRule->submit_data === true) {
@@ -68,12 +68,12 @@ class ApplyAction
         $task->update(['is_priority' => true]);
     }
 
-    public function saveAsDraft($task)
+    public function saveAsDraft($task, $inputRule)
     {
         //Only not null or not empty data is going to be stored
         TaskDraft::updateOrCreate(
             ['task_id' => $task->id],
-            ['data' => $task->data ?? null]
+            ['data' => $inputRule->data ?? null]
         );
     }
 }

--- a/ProcessMaker/InboxRules/ApplyAction.php
+++ b/ProcessMaker/InboxRules/ApplyAction.php
@@ -31,7 +31,7 @@ class ApplyAction
             if ($inputRule->task) {
                 //Fill and save as draft
                 if ($inputRule->fill_data === true) {
-                    $this->saveAsDraft($task);                    
+                    $this->saveAsDraft($task);
                 }
                 //Submit the form
                 if ($inputRule->submit_data !== null) {
@@ -69,7 +69,7 @@ class ApplyAction
     }
 
     public function saveAsDraft($task)
-    {  
+    { 
         //Only not null or not empty data is going to be stored
         TaskDraft::updateOrCreate(
             ['task_id' => $task->id],

--- a/ProcessMaker/InboxRules/ApplyAction.php
+++ b/ProcessMaker/InboxRules/ApplyAction.php
@@ -34,7 +34,7 @@ class ApplyAction
                     $this->saveAsDraft($task);
                 }
                 //Submit the form
-                if ($inputRule->submit_data !== null) {
+                if ($inputRule->submit_data === true) {
                     $this->submitForm($task, $inputRule);
                 }
             }
@@ -46,7 +46,7 @@ class ApplyAction
         if ($task->status === 'CLOSED') {
             return abort(422, __('Task already closed'));
         }
-        $data = $inputRule->submit_data;
+        $data = $inputRule->data;
         // Call the manager to trigger the start event
         $process = $task->process;
         $instance = $task->processRequest;

--- a/ProcessMaker/InboxRules/ApplyAction.php
+++ b/ProcessMaker/InboxRules/ApplyAction.php
@@ -2,6 +2,77 @@
 
 namespace ProcessMaker\InboxRules;
 
+use Facades\ProcessMaker\InboxRules\MatchingTasks;
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\SanitizeHelper;
+use ProcessMaker\Http\Resources\Task as Resource;
+
 class ApplyAction
 {
+    public function applyActionOnTask(ProcessRequestToken $task){
+        $array = [
+                "id" => 14,
+                "name" => "ullam",
+                "user_id" => 56,
+                "active" => 1,
+                "end_date" => null,
+                "saved_search_id" => null,
+                "process_request_token_id" => 10,
+                "mark_as_priority" => 0,
+                "reassign_to_user_id" => null,
+                "fill_data" => 0,
+                "submit_data" => null,
+                "created_at" => "2024-02-20 03:01:41",
+                "updated_at" => "2024-02-20 03:01:41"
+        ];
+        $matchingTasks = MatchingTasks::matchingInboxRules($task);
+
+
+        foreach ($matchingTasks as $inputRule) {
+        
+            //If $savedSearchId is null For Task Rules only
+            if($inputRule->saved_search_id === null) {
+                
+                //Fill and save as draft
+                if($inputRule->fill_data === true) {
+                    //here process for draft
+                }
+                //Submit the form
+                if($inputRule->submit_data !== null) {
+                    if ($task->status === 'CLOSED') {
+                        return abort(422, __('Task already closed'));
+                    }
+                    // Skip ConvertEmptyStringsToNull and TrimStrings middlewares
+                    $data = $inputRule->submit_data;
+                    $data = SanitizeHelper::sanitizeData($data['data'], null, $task->processRequest->do_not_sanitize ?? []);
+                    //Call the manager to trigger the start event
+                    $process = $task->process;
+                    $instance = $task->processRequest;
+                    WorkflowManager::completeTask($process, $instance, $task, $data);
+        
+                    return new Resource($task->refresh());
+                }
+
+            } else {
+                //Mark as priority
+                if ($inputRule->mark_as_priority === true) {
+                    ProcessRequestToken::where('process_request_token_id', $inputRule->process_request_token_id)
+                    ->update(['is_priority' => 1]);
+                }
+
+                //Reassign to user id
+                if ($inputRule->reassign_to_user_id !== null) {
+                    $task->authorizeReassignment(Auth::user());
+                    // Reassign user
+                    $task->reassignTo($inputRule->reassign_to_user_id);
+                    $task->persistUserData($inputRule->reassign_to_user_id);
+                    $task->save();
+                }
+            }
+        }
+
+
+    }
 }

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -20,7 +20,6 @@ class MatchingTasks
 
         $matchingInboxRules = [];
 
-        if ($task && $task->user_id) {
             //The Foreach has only inbox rules ACTIVE=true and user_id = $task->user_id
             foreach ($this->queryInboxRules($task) as $rule) {
                 if ($this->isEndDatePast($rule)) {
@@ -36,9 +35,6 @@ class MatchingTasks
                 }
             }
             return $matchingInboxRules;
-        } else {
-            return [];
-        }
     }
 
     public function shouldSkipRule($rule): bool

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -2,13 +2,14 @@
 
 namespace ProcessMaker\InboxRules;
 
+use Carbon\Carbon;
 use ProcessMaker\Models\InboxRule;
 use ProcessMaker\Models\ProcessRequestToken;
 
 /**
  * This Class is used in 2 ways
  * 1. After a task is assigned, it checks to see if it matches any active InboxRules in the system and returns the InboxRule models.
- * 2. The `get` method returns all tasks th  at match a given InboxRule
+ * 2. The `get` method returns all tasks that match a given InboxRule
  */
 class MatchingTasks
 {
@@ -19,7 +20,7 @@ class MatchingTasks
         if ($task && $task->user_id) {
             //The Foreach has only inbox rules ACTIVE=true and user_id = $task->user_id
             foreach ($this->queryInboxRules($task) as $rule) {
-                if ($rule->end_date && $rule->end_date->isPast()) {
+                if ($rule->end_date && Carbon::parse($rule->end_date)->isPast()) {
                     continue;
                 }
 

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -31,11 +31,7 @@ class MatchingTasks
                     $matchingInboxRules[] = $rule;
                 }
 
-                if (
-                    $rule->process_request_token_id !== null &&
-                    $task->process_id == $rule->task->process_id &&
-                    $task->element_id == $rule->task->element_id
-                ) {
+                if ($this->matchesProcessToken($rule, $task)) {
                     $matchingInboxRules[] = $rule;
                 }
             }
@@ -50,11 +46,18 @@ class MatchingTasks
         return $this->isEndDatePast($rule);
     }
 
-    private function matchesSavedSearch($rule, $task): bool
+    public function matchesSavedSearch($rule, $task): bool
     {
         return $rule->saved_search_id !== null && $this->matchesResultInSavedSearch($rule, $task);
     }
-    
+
+    public function matchesProcessToken($rule, $task): bool
+    {
+        return $rule->process_request_token_id !== null
+            && $task->process_id == $rule->task->process_id
+            && $task->element_id == $rule->task->element_id;
+    }
+
     public function get(InboxRule $inboxRule) : array
     {
         if ($savedSearch = $inboxRule->savedSearch) {

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -2,8 +2,6 @@
 
 namespace ProcessMaker\InboxRules;
 
-use Carbon\Carbon;
-use PhpOffice\PhpSpreadsheet\Calculation\Logical\Boolean;
 use ProcessMaker\Models\InboxRule;
 use ProcessMaker\Models\ProcessRequestToken;
 

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -77,7 +77,7 @@ class MatchingTasks
     }
 
     public function isEndDatePast($rule) {
-        if ($rule->end_date && Carbon::parse($rule->end_date)->isPast()) {
+        if ($rule->end_date && $rule->end_date->isPast()) {
             return true;
         }
         return false;

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\InboxRules;
 
 use Carbon\Carbon;
+use PhpOffice\PhpSpreadsheet\Calculation\Logical\Boolean;
 use ProcessMaker\Models\InboxRule;
 use ProcessMaker\Models\ProcessRequestToken;
 
@@ -20,7 +21,7 @@ class MatchingTasks
         if ($task && $task->user_id) {
             //The Foreach has only inbox rules ACTIVE=true and user_id = $task->user_id
             foreach ($this->queryInboxRules($task) as $rule) {
-                if ($rule->end_date && Carbon::parse($rule->end_date)->isPast()) {
+                if ($this->isEndDatePast($rule)) {
                     continue;
                 }
 
@@ -73,5 +74,12 @@ class MatchingTasks
         return InboxRule::where('active', true)
             ->where('user_id', $task->user_id)
             ->get();
+    }
+
+    public function isEndDatePast($rule) {
+        if ($rule->end_date && Carbon::parse($rule->end_date)->isPast()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -38,7 +38,6 @@ class MatchingTasks
                     $matchingInboxRules[] = $rule;
                 }
             }
-
             return $matchingInboxRules;
         } else {
             return [];

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -12,29 +12,28 @@ use ProcessMaker\Models\ProcessRequestToken;
  */
 class MatchingTasks
 {
-    public function matchingInboxRules(ProcessRequestToken $task) : array
+    public function matchingInboxRules(ProcessRequestToken $task): array
     {
         if (!$task || !$task->user_id) {
             return [];
         }
 
         $matchingInboxRules = [];
-
-            //The Foreach has only inbox rules ACTIVE=true and user_id = $task->user_id
-            foreach ($this->queryInboxRules($task) as $rule) {
-                if ($this->isEndDatePast($rule)) {
-                    continue;
-                }
-
-                if ($this->matchesSavedSearch($rule, $task)) {
-                    $matchingInboxRules[] = $rule;
-                }
-
-                if ($this->matchesProcessToken($rule, $task)) {
-                    $matchingInboxRules[] = $rule;
-                }
+        //The Foreach has only inbox rules ACTIVE=true and user_id = $task->user_id
+        foreach ($this->queryInboxRules($task) as $rule) {
+            if ($this->isEndDatePast($rule)) {
+                continue;
             }
-            return $matchingInboxRules;
+
+            if ($this->matchesSavedSearch($rule, $task)) {
+                $matchingInboxRules[] = $rule;
+            }
+
+            if ($this->matchesProcessToken($rule, $task)) {
+                $matchingInboxRules[] = $rule;
+            }
+        }
+        return $matchingInboxRules;
     }
 
     public function shouldSkipRule($rule): bool

--- a/ProcessMaker/Jobs/SmartInbox.php
+++ b/ProcessMaker/Jobs/SmartInbox.php
@@ -2,14 +2,14 @@
 
 namespace ProcessMaker\Jobs;
 
+use Facades\ProcessMaker\InboxRules\ApplyAction;
+use Facades\ProcessMaker\InboxRules\MatchingTasks;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Facades\ProcessMaker\InboxRules\ApplyAction;
-use Facades\ProcessMaker\InboxRules\MatchingTasks;
 use ProcessMaker\Models\ProcessRequestToken;
 
 class SmartInbox implements ShouldQueue
@@ -17,11 +17,12 @@ class SmartInbox implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public $incomingTaskId;
+
     /**
      * Create a new job instance.
      */
     public function __construct(int $incomingTaskId)
-    { 
+    {
         $this->incomingTaskId = $incomingTaskId;
     }
 
@@ -29,12 +30,12 @@ class SmartInbox implements ShouldQueue
      * Execute the job.
      */
     public function handle(): void
-    {   
+    {
         $incomingTask = ProcessRequestToken::findOrFail($this->incomingTaskId);
-        $matchResult = MatchingTasks::matchingInboxRules($incomingTask);
-        if($matchResult){
+        $matchingInboxRules = MatchingTasks::matchingInboxRules($incomingTask);
+        if (count($matchingInboxRules) > 0) {
             //Here calls ApplyAction Class
-            ApplyAction::applyActionOnTask($incomingTask);
+            ApplyAction::applyActionOnTask($incomingTask, $matchingInboxRules);
         }
     }
 }

--- a/ProcessMaker/Jobs/SmartInbox.php
+++ b/ProcessMaker/Jobs/SmartInbox.php
@@ -8,22 +8,21 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use ProcessMaker\InboxRules\ApplyAction;
-use ProcessMaker\InboxRules\MatchingTasks;
-use ProcessMaker\Models\InboxRule;
+use Facades\ProcessMaker\InboxRules\ApplyAction;
+use Facades\ProcessMaker\InboxRules\MatchingTasks;
 use ProcessMaker\Models\ProcessRequestToken;
 
 class SmartInbox implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public $task;
+    public $incomingTask;
     /**
      * Create a new job instance.
      */
-    public function __construct(ProcessRequestToken $task)
+    public function __construct(ProcessRequestToken $incomingTask)
     {
-        $this->task = $task;
+        $this->incomingTask = $incomingTask;
     }
 
     /**
@@ -31,11 +30,9 @@ class SmartInbox implements ShouldQueue
      */
     public function handle(): void
     {
-        $inboxRule = new InboxRule();
-        $matchingTasks = new MatchingTasks($inboxRule);
-        $matchResult = $matchingTasks->check($this->task);
-        if($matchResult){
-            //Here calls ApplyAction Class
+        $matchingInboxRules = MatchingTasks::matchingInboxRules($this->incomingTask);
+        if ($matchingInboxRules) {
+            ApplyAction::applyActionOnTask($matchingInboxRules);
         }
     }
 }

--- a/ProcessMaker/Jobs/SmartInbox.php
+++ b/ProcessMaker/Jobs/SmartInbox.php
@@ -9,7 +9,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Facades\ProcessMaker\InboxRules\ApplyAction;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use ProcessMaker\Models\ProcessRequestToken;
 
 class SmartInbox implements ShouldQueue
@@ -30,11 +29,7 @@ class SmartInbox implements ShouldQueue
      */
     public function handle(): void
     {   
-        try {
-            $incomingTask = ProcessRequestToken::findOrFail($this->incomingTaskId);
-            ApplyAction::applyActionOnTask($incomingTask);
-        } catch (ModelNotFoundException $e) {
-            \Log::error($e->getMessage());
-        }
+        $incomingTask = ProcessRequestToken::findOrFail($this->incomingTaskId);
+        ApplyAction::applyActionOnTask($incomingTask);
     }
 }

--- a/ProcessMaker/Jobs/SmartInbox.php
+++ b/ProcessMaker/Jobs/SmartInbox.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Facades\ProcessMaker\InboxRules\ApplyAction;
+use Facades\ProcessMaker\InboxRules\MatchingTasks;
 use ProcessMaker\Models\ProcessRequestToken;
 
 class SmartInbox implements ShouldQueue
@@ -20,7 +21,7 @@ class SmartInbox implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(int $incomingTaskId)
-    {
+    { 
         $this->incomingTaskId = $incomingTaskId;
     }
 
@@ -30,6 +31,10 @@ class SmartInbox implements ShouldQueue
     public function handle(): void
     {   
         $incomingTask = ProcessRequestToken::findOrFail($this->incomingTaskId);
-        ApplyAction::applyActionOnTask($incomingTask);
+        $matchResult = MatchingTasks::matchingInboxRules($incomingTask);
+        if($matchResult){
+            //Here calls ApplyAction Class
+            ApplyAction::applyActionOnTask($incomingTask);
+        }
     }
 }

--- a/ProcessMaker/Jobs/SmartInboxExistingTasks.php
+++ b/ProcessMaker/Jobs/SmartInboxExistingTasks.php
@@ -31,16 +31,11 @@ class SmartInboxExistingTasks implements ShouldQueue
      */
     public function handle(): void
     {
-        try {
-            //Load InboxRule by ID
-            $inboxRule = InboxRule::findOrFail($this->inboxRuleId);
+        //Load InboxRule by ID
+        $inboxRule = InboxRule::findOrFail($this->inboxRuleId);
 
-            $matchingTasks = MatchingTasks::get($inboxRule);
-            foreach ($matchingTasks as $task) {
-                ApplyAction::applyActionOnTask($task);
-            }
-        } catch (ModelNotFoundException $e) {
-            \Log::error($e->getMessage());
+        $matchingTasks = MatchingTasks::get($inboxRule);
+        foreach ($matchingTasks as $task) {
+            ApplyAction::applyActionOnTask($task);
         }
-    }
 }

--- a/ProcessMaker/Jobs/SmartInboxExistingTasks.php
+++ b/ProcessMaker/Jobs/SmartInboxExistingTasks.php
@@ -28,7 +28,7 @@ class SmartInboxExistingTasks implements ShouldQueue
      * Execute the job.
      */
     public function handle(): void
-    {   
+    {
         $matchingTasks = MatchingTasks::get($this->inboxRuleId);
         foreach ($matchingTasks as $task) {
             ApplyAction::applyActionOnTask($task);

--- a/ProcessMaker/Jobs/SmartInboxExistingTasks.php
+++ b/ProcessMaker/Jobs/SmartInboxExistingTasks.php
@@ -34,7 +34,7 @@ class SmartInboxExistingTasks implements ShouldQueue
         try {
             //Load InboxRule by ID
             $inboxRule = InboxRule::findOrFail($this->inboxRuleId);
-            
+
             $matchingTasks = MatchingTasks::get($inboxRule);
             foreach ($matchingTasks as $task) {
                 ApplyAction::applyActionOnTask($task);

--- a/ProcessMaker/Jobs/SmartInboxExistingTasks.php
+++ b/ProcessMaker/Jobs/SmartInboxExistingTasks.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Facades\ProcessMaker\InboxRules\MatchingTasks;
+use Facades\ProcessMaker\InboxRules\ApplyAction;
+
+class SmartInboxExistingTasks implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $inboxRuleId;
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(int $inboxRuleId)
+    {
+        $this->inboxRuleId = $inboxRuleId;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {   
+        $matchingTasks = MatchingTasks::get($this->inboxRuleId);
+        foreach ($matchingTasks as $task) {
+            ApplyAction::applyActionOnTask($task);
+        }
+    }
+}

--- a/ProcessMaker/Jobs/SmartInboxExistingTasks.php
+++ b/ProcessMaker/Jobs/SmartInboxExistingTasks.php
@@ -10,6 +10,8 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Facades\ProcessMaker\InboxRules\MatchingTasks;
 use Facades\ProcessMaker\InboxRules\ApplyAction;
+use Facades\ProcessMaker\Models\InboxRule;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class SmartInboxExistingTasks implements ShouldQueue
 {
@@ -29,9 +31,16 @@ class SmartInboxExistingTasks implements ShouldQueue
      */
     public function handle(): void
     {
-        $matchingTasks = MatchingTasks::get($this->inboxRuleId);
-        foreach ($matchingTasks as $task) {
-            ApplyAction::applyActionOnTask($task);
+        try {
+            //Load InboxRule by ID
+            $inboxRule = InboxRule::findOrFail($this->inboxRuleId);
+            
+            $matchingTasks = MatchingTasks::get($inboxRule);
+            foreach ($matchingTasks as $task) {
+                ApplyAction::applyActionOnTask($task);
+            }
+        } catch (ModelNotFoundException $e) {
+            \Log::error($e->getMessage());
         }
     }
 }

--- a/ProcessMaker/Models/InboxRule.php
+++ b/ProcessMaker/Models/InboxRule.php
@@ -18,6 +18,10 @@ class InboxRule extends ProcessMakerModel
 
     protected $table = 'inbox_rules';
 
+    protected $casts = [
+        'end_date' => 'datetime',
+    ];
+
     /**
      * Define the relationship with ProcessRequestToken model
      *

--- a/ProcessMaker/Models/InboxRule.php
+++ b/ProcessMaker/Models/InboxRule.php
@@ -12,12 +12,16 @@ class InboxRule extends ProcessMakerModel
 {
     use HasFactory;
 
+    protected $casts = [
+        'submit_data' => 'array',
+    ];
+
     protected $table = 'inbox_rules';
 
     /**
      * Define the relationship with ProcessRequestToken model
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function task(): BelongsTo
     {
@@ -27,7 +31,7 @@ class InboxRule extends ProcessMakerModel
     /**
      * Define the relationship with SavedSearch model
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function savedSearch(): BelongsTo
     {

--- a/ProcessMaker/Models/InboxRule.php
+++ b/ProcessMaker/Models/InboxRule.php
@@ -12,13 +12,10 @@ class InboxRule extends ProcessMakerModel
 {
     use HasFactory;
 
-    protected $casts = [
-        'submit_data' => 'array',
-    ];
-
     protected $table = 'inbox_rules';
 
     protected $casts = [
+        'submit_data' => 'array',
         'end_date' => 'datetime',
     ];
 

--- a/ProcessMaker/Models/InboxRule.php
+++ b/ProcessMaker/Models/InboxRule.php
@@ -15,7 +15,7 @@ class InboxRule extends ProcessMakerModel
     protected $table = 'inbox_rules';
 
     protected $casts = [
-        'submit_data' => 'array',
+        'data' => 'array',
         'end_date' => 'datetime',
     ];
 

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -146,7 +146,9 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         'riskchanges_at' => 'datetime',
         'data' => 'array',
         'self_service_groups' => 'array',
-        'token_properties' => 'array',    ];
+        'token_properties' => 'array',
+        'is_priority' => 'boolean',
+    ];
 
     /**
      * Get the indexable data array for the model.
@@ -1063,7 +1065,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
             return '';
         }
 
-        return $index !== null ?  $variable . '.' . $index : $variable;
+        return $index !== null ? $variable . '.' . $index : $variable;
     }
 
     /**

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -192,9 +192,9 @@ class ProcessMakerServiceProvider extends ServiceProvider
 
         //Fire job when task is assigned to a user
         Facades\Event::listen(ActivityAssigned::class, function ($event) {
-            $processRequestToken = $event->getProcessRequestToken();
+            $task_id = $event->getProcessRequestToken()->id;
             // Dispatch the SmartInbox job with the processRequestToken as parameter
-            SmartInbox::dispatch($processRequestToken);
+            SmartInbox::dispatch($task_id);
         });
     }
 

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -14,10 +14,12 @@ use Laravel\Dusk\DuskServiceProvider;
 use Laravel\Horizon\Horizon;
 use Laravel\Passport\Passport;
 use Lavary\Menu\Menu;
+use ProcessMaker\Events\ActivityAssigned;
 use ProcessMaker\Events\ScreenBuilderStarting;
 use ProcessMaker\Helpers\PmHash;
 use ProcessMaker\ImportExport\Extension;
 use ProcessMaker\ImportExport\SignalHelper;
+use ProcessMaker\Jobs\SmartInbox;
 use ProcessMaker\LicensedPackageManifest;
 use ProcessMaker\Managers;
 use ProcessMaker\Managers\MenuManager;
@@ -186,6 +188,13 @@ class ProcessMakerServiceProvider extends ServiceProvider
             $channels = implode(', ', $event->broadcastOn());
 
             Facades\Log::debug('Broadcasting Notification ' . $event->broadcastType() . 'on channel(s) ' . $channels);
+        });
+
+        //Fire job when task is assigned to a user
+        Facades\Event::listen(ActivityAssigned::class, function ($event) {
+            $processRequestToken = $event->getProcessRequestToken();
+            // Dispatch the SmartInbox job with the processRequestToken as parameter
+            SmartInbox::dispatch($processRequestToken);
         });
     }
 

--- a/database/factories/ProcessMaker/Models/InboxRuleFactory.php
+++ b/database/factories/ProcessMaker/Models/InboxRuleFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories\ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use ProcessMaker\Models\InboxRule;
+use ProcessMaker\Models\User;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\ProcessMaker\Models\InboxRule>
@@ -18,14 +19,18 @@ class InboxRuleFactory extends Factory
         //But never both null
         return [
             'name' => $this->faker->word,
+            'user_id' => function () {
+                return User::factory()->create()->id;
+            },
             'active' => true,
             'end_date' => null,
             'saved_search_id' => null,
             'process_request_token_id' => null,
             'mark_as_priority' => false,
             'reassign_to_user_id' => null,
-            'fill_data' => false,
-            'submit_data' => json_encode(['key1' => 'value1', 'key2' => 'value2']),
+            'make_draft' => false,
+            'submit_data' => false,
+            'data' => json_encode(['key1' => 'value1', 'key2' => 'value2']),
         ];
     }
 }

--- a/database/migrations/2024_02_14_195724_create_inbox_rules_table.php
+++ b/database/migrations/2024_02_14_195724_create_inbox_rules_table.php
@@ -21,7 +21,8 @@ return new class extends Migration {
             $table->boolean('mark_as_priority')->default(false);
             $table->integer('reassign_to_user_id')->nullable();
             $table->boolean('fill_data')->default(false);
-            $table->json('submit_data')->nullable();
+            $table->boolean('submit_data')->default(false);
+            $table->json('data')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_02_14_195724_create_inbox_rules_table.php
+++ b/database/migrations/2024_02_14_195724_create_inbox_rules_table.php
@@ -20,7 +20,7 @@ return new class extends Migration {
             $table->integer('process_request_token_id')->nullable();
             $table->boolean('mark_as_priority')->default(false);
             $table->integer('reassign_to_user_id')->nullable();
-            $table->boolean('fill_data')->default(false);
+            $table->boolean('make_draft')->default(false);
             $table->boolean('submit_data')->default(false);
             $table->json('data')->nullable();
             $table->timestamps();

--- a/tests/Jobs/SmartInboxTest.php
+++ b/tests/Jobs/SmartInboxTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Jobs;
+
+use Facades\ProcessMaker\InboxRules\ApplyAction;
+use Facades\ProcessMaker\InboxRules\MatchingTasks;
+use ProcessMaker\Jobs\SmartInbox;
+use ProcessMaker\Models\InboxRule;
+use ProcessMaker\Models\ProcessRequestToken;
+use Tests\TestCase;
+
+class SmartInboxTest extends TestCase
+{
+    public function testJobIsCalledWhenTaskIsAssigned()
+    {
+        $task = ProcessRequestToken::factory()->create();
+        $inboxRule = InboxRule::factory()->create();
+
+        MatchingTasks::shouldReceive('matchingInboxRules')
+            ->once()
+            ->with(\Mockery::on(fn ($arg) => $arg instanceof ProcessRequestToken && $arg->id === $task->id))
+            ->andReturn([$inboxRule]);
+
+        ApplyAction::shouldReceive('applyActionOnTask')
+            ->once()
+            ->with(\Mockery::on(fn ($arg) => $arg instanceof ProcessRequestToken && $arg->id === $task->id), [$inboxRule]);
+
+        SmartInbox::dispatch($task->id);
+    }
+}

--- a/tests/unit/ProcessMaker/InboxRules/ApplyActionTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/ApplyActionTest.php
@@ -30,7 +30,8 @@ class ApplyActionTest extends TestCase
         $inboxRule = InboxRule::factory()->create([
             'process_request_token_id' => $taskForInboxRule->id,
             'user_id' => $user->id,
-            'submit_data' => ['foo' => 'bar'],
+            'submit_data' => true,
+            'data' => ['foo' => 'bar'],
         ]);
 
         $activeTask = ProcessRequestToken::factory()->create([

--- a/tests/unit/ProcessMaker/InboxRules/ApplyActionTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/ApplyActionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests;
+
+use Facades\ProcessMaker\InboxRules\ApplyAction;
+use Facades\ProcessMaker\InboxRules\MatchingTasks;
+use ProcessMaker\Client\Model\ProcessCategory as ModelProcessCategory;
+use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Models\InboxRule;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessCategory;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use ProcessMaker\Package\SavedSearch\Models\SavedSearch;
+use Tests\TestCase;
+
+class ApplyActionTest extends TestCase
+{
+    public function testCompleteTaskWithData()
+    {
+        $user = User::factory()->create();
+
+        $taskForInboxRule = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'COMPLETED',
+        ]);
+
+        $inboxRule = InboxRule::factory()->create([
+            'process_request_token_id' => $taskForInboxRule->id,
+            'user_id' => $user->id,
+            'submit_data' => ['foo' => 'bar'],
+        ]);
+
+        $activeTask = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'ACTIVE',
+            'element_id' => 'UserTaskUID',
+        ]);
+
+        MatchingTasks::shouldReceive('matchingInboxRules')
+            ->once()
+            ->with($activeTask)
+            ->andReturn([$inboxRule]);
+
+        WorkflowManager::shouldReceive('completeTask')
+            ->once()
+            ->with(
+                $activeTask->process,
+                $activeTask->processRequest,
+                $activeTask,
+                ['foo' => 'bar']
+            );
+
+        ApplyAction::applyActionOnTask($activeTask);
+    }
+
+    public function testMarkAsPriority()
+    {
+        $user = User::factory()->create();
+
+        $taskForInboxRule = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'COMPLETED',
+        ]);
+
+        $inboxRule = InboxRule::factory()->create([
+            'process_request_token_id' => $taskForInboxRule->id,
+            'user_id' => $user->id,
+            'mark_as_priority' => true,
+            'submit_data' => null,
+        ]);
+
+        $activeTask = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'ACTIVE',
+            'element_id' => 'UserTaskUID',
+            'is_priority' => false,
+        ]);
+
+        MatchingTasks::shouldReceive('matchingInboxRules')
+            ->once()
+            ->with($activeTask)
+            ->andReturn([$inboxRule]);
+
+        ApplyAction::applyActionOnTask($activeTask);
+
+        $activeTask->refresh();
+
+        $this->assertTrue($activeTask->is_priority);
+    }
+}

--- a/tests/unit/ProcessMaker/InboxRules/ApplyActionTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/ApplyActionTest.php
@@ -145,15 +145,16 @@ class ApplyActionTest extends TestCase
             'process_request_token_id' => $taskForInboxRule->id,
             'user_id' => $user->id,
             'reassign_to_user_id' => null,
-            'submit_data' => null,
+            'submit_data' => false,
             'fill_data' => true,
+            'data' => ["input" => "some rule text"],
         ]);
 
         $activeTask = ProcessRequestToken::factory()->create([
             'user_id' => $user->id,
             'status' => 'ACTIVE',
             'element_id' => 'UserTaskUID',
-            'data' => ['input' => 'draft value'],
+            'data' => ['input' => 'active value'],
         ]);
 
         MatchingTasks::shouldReceive('matchingInboxRules')
@@ -166,6 +167,6 @@ class ApplyActionTest extends TestCase
         $taskDraftData = TaskDraft::where('task_id', $activeTask->id)->value('data');
 
         // Check if the expected data is contained in the recovered data
-        $this->assertArraySubset($activeTask->data, $taskDraftData);
+        $this->assertArraySubset($inboxRule->data, $taskDraftData);
     }
 }

--- a/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
@@ -79,11 +79,10 @@ class MatchingTasksTest extends TestCase
     
         $task = ProcessRequestToken::factory()->create([
             'user_id' => $user->id,
-            'status' => 'ACTIVE',
+            'status' => 'COMPLETED',
         ]);
 
-        $futureEndDate = now()->addDays(1);
-        
+        //Check with pastEndDate value
         $pastEndDate = now()->subDays(1);
         InboxRule::factory()->create([
             'process_request_token_id' => $task->id,
@@ -92,22 +91,18 @@ class MatchingTasksTest extends TestCase
         ]);
 
         $matchingRules = MatchingTasks::matchingInboxRules($task);
+        $this->assertEmpty($matchingRules);
 
-        $expectinginboxRule = InboxRule::factory()->create([
+        //Check with futureEndDate value
+        $futureEndDate = now()->addDays(1);
+        InboxRule::factory()->create([
             'process_request_token_id' => $task->id,
             'end_date' => $futureEndDate,
             'user_id' => $user->id,
         ]);
 
-        $notMatchingRules = MatchingTasks::matchingInboxRules($task);
+        $matchingRules = MatchingTasks::matchingInboxRules($task);
 
-        $this->assertEmpty($matchingRules);
-        $this->assertNotEmpty($notMatchingRules);
-        //when end date is not past and we have a task match
-        $this->assertEquals(
-            $expectinginboxRule->process_request_token_id,
-            $notMatchingRules[0]->process_request_token_id
-        );
-        
+        $this->assertNotEmpty($matchingRules);
     }
 }

--- a/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Facades\ProcessMaker\InboxRules\MatchingTasks;
 use ProcessMaker\Models\InboxRule;
 use ProcessMaker\Models\ProcessCategory;
+use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\User;
 use ProcessMaker\Package\SavedSearch\Models\SavedSearch;

--- a/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
@@ -82,7 +82,7 @@ class MatchingTasksTest extends TestCase
             'status' => 'ACTIVE',
         ]);
         
-        $futureEndDate = now()->addDays(1); 
+        $futureEndDate = now()->addDays(1);
         
         $pastEndDate = now()->subDays(1);
         InboxRule::factory()->create([
@@ -104,7 +104,10 @@ class MatchingTasksTest extends TestCase
         $this->assertEmpty($matchingRules);
         $this->assertNotEmpty($notMatchingRules);
         //when end date is not past and we have a task match
-        $this->assertEquals($expectinginboxRule->process_request_token_id, $notMatchingRules[0]->process_request_token_id);
+        $this->assertEquals(
+            $expectinginboxRule->process_request_token_id,
+            $notMatchingRules[0]->process_request_token_id
+        );
         
     }
 }

--- a/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
@@ -81,7 +81,7 @@ class MatchingTasksTest extends TestCase
             'user_id' => $user->id,
             'status' => 'ACTIVE',
         ]);
-        
+
         $futureEndDate = now()->addDays(1);
         
         $pastEndDate = now()->subDays(1);

--- a/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
@@ -93,15 +93,18 @@ class MatchingTasksTest extends TestCase
 
         $matchingRules = MatchingTasks::matchingInboxRules($task);
 
-        InboxRule::factory()->create([
+        $expectinginboxRule = InboxRule::factory()->create([
             'process_request_token_id' => $task->id,
             'end_date' => $futureEndDate,
             'user_id' => $user->id,
         ]);
 
         $notMatchingRules = MatchingTasks::matchingInboxRules($task);
+
         $this->assertEmpty($matchingRules);
         $this->assertNotEmpty($notMatchingRules);
+        //when end date is not past and we have a task match
+        $this->assertEquals($expectinginboxRule->process_request_token_id, $notMatchingRules[0]->process_request_token_id);
         
     }
 }


### PR DESCRIPTION
## Solution
- A Listener for the ActivityAssigned event in ProcessMaker/Providers/ProcessMakerServiceProvider.php was added in registerEvents method
- A Dispatch method for SmartInbox job was added.

## How to Test
- Create Inbox Rules
- Start a new request

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14120

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy