### PR TITLE
FOUR-14228 fIX Error on artisan processmaker:upgrade - web entry url fixer

### DIFF
--- a/ProcessMaker/ImportExport/Utils.php
+++ b/ProcessMaker/ImportExport/Utils.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use ProcessMaker\Exception\ExportEmptyProcessException;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Nayra\Storage\BpmnElement;
+use ProcessMaker\Repositories\BpmnDocument;
 
 class Utils
 {
@@ -69,9 +70,10 @@ class Utils
         }
 
         $xpath = new DOMXPath($document);
-        $elements = $xpath->query(rtrim($path, '|'));
+        // add bpmn namespace
+        $xpath->registerNamespace('bpmn', BpmnDocument::BPMN_MODEL);
 
-        return $elements;
+        return $xpath->query(rtrim($path, '|'));
     }
 
     public static function setPmConfigValue(BpmnElement &$element, string $path, $value) : void


### PR DESCRIPTION
## Issue & Reproduction Steps
Error on artisan processmaker:upgrade - web entry url fixer.
This happens when the environment has a process that has a namespace prefix for `http://www.omg.org/spec/BPMN/20100524/MODEL` different to "**bpmn**"


## Solution
- Register at Utils.php the prefix `bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"`

## How to Test

1. Import the attached process.
[test.json](https://github.com/ProcessMaker/processmaker/files/14386276/test.json)
2. Make sure the `2024_02_07_113706_web_entry_url_fixer` was not previously executed (remove it from DB if necessary)
3. Run the upgrade command `php artisan upgrade`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14228

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
