### PR TITLE
FOUR-12844: Add username to searched columns when searching for users to add to a group 

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/GroupMemberController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupMemberController.php
@@ -408,8 +408,9 @@ class GroupMemberController extends Controller
             //filter by name group
             $filter = '%' . $filter . '%';
             $query->where(function ($query) use ($filter) {
-                $query->Where('firstname', 'like', $filter)
-                    ->orWhere('lastname', 'like', $filter);
+                $query->where('firstname', 'like', $filter)
+                      ->orWhere('lastname', 'like', $filter)
+                      ->orWhere('username', 'like', $filter);
             });
         }
         $response =


### PR DESCRIPTION
## Issue
Previously, if you searched for users to add to a group which have very similar names, it would be difficult to find the specific user you were searching for. In this scenario, it would make sense to search by username since usernames must be unique, however the search did not consider the username column and the search result would be empty.

## Reproduction Steps
Please following the reproduction steps in the [related FOUR ticket](https://processmaker.atlassian.net/browse/FOUR-12844).

## Solution\
- Add the username column to be one of the searched columns when searching for a user to add to a group.

## How to Test
You should now be able to type in the username of a given user not in a group on the screen where you add users to a group (which aren't already in the group).

## Related Tickets & Packages
- [FOUR-12844](https://processmaker.atlassian.net/browse/FOUR-12844)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


####
ci:next

[FOUR-12844]: https://processmaker.atlassian.net/browse/FOUR-12844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ