### PR TITLE
Feature/FOUR-14120c: Backend - Fire job when task is assigned to a user

### DIFF
--- a/ProcessMaker/InboxRules/ApplyAction.php
+++ b/ProcessMaker/InboxRules/ApplyAction.php
@@ -12,10 +12,11 @@ use ProcessMaker\SanitizeHelper;
 
 class ApplyAction
 {
-    public function applyActionOnTask(ProcessRequestToken $task, array $inboxRules)
+    public function applyActionOnTask(ProcessRequestToken $task, $inboxRules)
     {
         foreach ($inboxRules as $inputRule) {
             //Mark as priority
+            //if (is_object($inputRule) && $inputRule->mark_as_priority === true) {
             if ($inputRule->mark_as_priority === true) {
                 $this->markAsPriority($task);
             }

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\InboxRules;
 
+use Illuminate\Support\Collection;
 use ProcessMaker\Models\InboxRule;
 use ProcessMaker\Models\ProcessRequestToken;
 
@@ -53,22 +54,19 @@ class MatchingTasks
             && $task->element_id == $rule->task->element_id;
     }
 
-    public function get(InboxRule $inboxRule) : array
+    public function get(InboxRule $inboxRule) : Collection
     {
         if ($savedSearch = $inboxRule->savedSearch) {
-            $savedSearches = $savedSearch->query->get();
-            return $savedSearches->toArray();
+            return $savedSearch->query->get();
         }
 
         if ($task = $inboxRule->task) {
-            $tasks = ProcessRequestToken::where([
+            return ProcessRequestToken::where([
                 'process_id' => $task->process_id,
                 'element_id' => $task->element_id,
                 'user_id' => $inboxRule->user_id,
                 'status' => 'ACTIVE',
             ])->get();
-
-            return $tasks->toArray();
         }
     }
 

--- a/ProcessMaker/InboxRules/MatchingTasks.php
+++ b/ProcessMaker/InboxRules/MatchingTasks.php
@@ -56,16 +56,19 @@ class MatchingTasks
     public function get(InboxRule $inboxRule) : array
     {
         if ($savedSearch = $inboxRule->savedSearch) {
-            return $savedSearch->query->get();
+            $savedSearches = $savedSearch->query->get();
+            return $savedSearches->toArray();
         }
 
         if ($task = $inboxRule->task) {
-            return ProcessRequestToken::where([
+            $tasks = ProcessRequestToken::where([
                 'process_id' => $task->process_id,
                 'element_id' => $task->element_id,
                 'user_id' => $inboxRule->user_id,
                 'status' => 'ACTIVE',
             ])->get();
+
+            return $tasks->toArray();
         }
     }
 

--- a/ProcessMaker/Jobs/SmartInboxExistingTasks.php
+++ b/ProcessMaker/Jobs/SmartInboxExistingTasks.php
@@ -36,7 +36,7 @@ class SmartInboxExistingTasks implements ShouldQueue
 
         $matchingTasks = MatchingTasks::get($inboxRule);
         foreach ($matchingTasks as $task) {
-            ApplyAction::applyActionOnTask($task, $inboxRule->toArray());
+            ApplyAction::applyActionOnTask($task, $inboxRule);
         }
     }
 }

--- a/ProcessMaker/Jobs/SmartInboxExistingTasks.php
+++ b/ProcessMaker/Jobs/SmartInboxExistingTasks.php
@@ -17,7 +17,7 @@ class SmartInboxExistingTasks implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public $inboxRuleId;
+    public int $inboxRuleId;
     /**
      * Create a new job instance.
      */
@@ -36,6 +36,7 @@ class SmartInboxExistingTasks implements ShouldQueue
 
         $matchingTasks = MatchingTasks::get($inboxRule);
         foreach ($matchingTasks as $task) {
-            ApplyAction::applyActionOnTask($task);
+            ApplyAction::applyActionOnTask($task, $inboxRule->toArray());
         }
+    }
 }

--- a/tests/Jobs/SmartInboxExistingTasksTest.php
+++ b/tests/Jobs/SmartInboxExistingTasksTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Jobs;
+
+use Facades\ProcessMaker\InboxRules\ApplyAction;
+use Facades\ProcessMaker\InboxRules\MatchingTasks;
+use ProcessMaker\Jobs\SmartInboxExistingTasks;
+use ProcessMaker\Models\InboxRule;
+use ProcessMaker\Models\ProcessRequestToken;
+use Tests\TestCase;
+
+class SmartInboxExistingTasksTest extends TestCase
+{
+    public function testJobIsCalledToExistingTasksFromInboxRule()
+    {
+        $task = ProcessRequestToken::factory()->create();
+        $inboxRule = InboxRule::factory()->create();
+
+        MatchingTasks::shouldReceive('get')
+        ->once()
+        ->with(\Mockery::on(fn ($arg) => $arg instanceof InboxRule && $arg === $inboxRule))
+        ->andReturn([$task]);
+
+        ApplyAction::shouldReceive('applyActionOnTask')
+            ->once()
+            ->with(\Mockery::on(fn ($arg) => $arg instanceof ProcessRequestToken && $arg->id === $task->id), [$inboxRule]);
+
+        SmartInboxExistingTasks::dispatch($inboxRule->id);
+    }
+}

--- a/tests/Jobs/SmartInboxExistingTasksTest.php
+++ b/tests/Jobs/SmartInboxExistingTasksTest.php
@@ -18,16 +18,18 @@ class SmartInboxExistingTasksTest extends TestCase
 
         MatchingTasks::shouldReceive('get')
         ->once()
-        ->with(\Mockery::on(fn ($arg) => $arg instanceof InboxRule && $arg === $inboxRule))
-        ->andReturn([$task]);
+        ->with(\Mockery::on(fn ($arg) => $arg instanceof InboxRule && optional($arg)->id === $inboxRule->id))
+        ->andReturn(collect([$task]));
 
         ApplyAction::shouldReceive('applyActionOnTask')
             ->once()
             ->with(
-                \Mockery::on(function ($arg) use ($task) {
-                    return $arg instanceof ProcessRequestToken && $arg->id === $task->id;
+                \Mockery::on(function ($arg1) use ($task) {
+                    return $arg1 instanceof ProcessRequestToken && $arg1->id === $task->id;
                 }),
-                [$inboxRule]
+                \Mockery::on(function ($arg2) use ($inboxRule) {
+                    return $arg2 instanceof InboxRule && $arg2->id === $inboxRule->id;
+                })
             );
 
         SmartInboxExistingTasks::dispatch($inboxRule->id);

--- a/tests/Jobs/SmartInboxExistingTasksTest.php
+++ b/tests/Jobs/SmartInboxExistingTasksTest.php
@@ -23,7 +23,12 @@ class SmartInboxExistingTasksTest extends TestCase
 
         ApplyAction::shouldReceive('applyActionOnTask')
             ->once()
-            ->with(\Mockery::on(fn ($arg) => $arg instanceof ProcessRequestToken && $arg->id === $task->id), [$inboxRule]);
+            ->with(
+                \Mockery::on(function ($arg) use ($task) {
+                    return $arg instanceof ProcessRequestToken && $arg->id === $task->id;
+                }),
+                [$inboxRule]
+            );
 
         SmartInboxExistingTasks::dispatch($inboxRule->id);
     }

--- a/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
@@ -20,12 +20,14 @@ class MatchingTasksTest extends TestCase
             'user_id' => $user->id,
             'status' => 'COMPLETED',
         ]);
+
         $activeTask = ProcessRequestToken::factory()->create([
             'user_id' => $user->id,
             'status' => 'ACTIVE',
             'element_id' => $completedTask->element_id,
             'process_id' => $completedTask->process_id,
         ]);
+
         $inboxRule = InboxRule::factory()->create([
             'process_request_token_id' => $completedTask->id,
             'user_id' => $user->id,
@@ -47,6 +49,7 @@ class MatchingTasksTest extends TestCase
             'status' => 'ACTIVE',
             'element_name' => 'My Test Task',
         ]);
+        
         $savedSearch = SavedSearch::factory()->create([
             'type' => 'task',
             'pmql' => 'task = "My Test Task"',
@@ -104,5 +107,31 @@ class MatchingTasksTest extends TestCase
         $matchingRules = MatchingTasks::matchingInboxRules($task);
 
         $this->assertNotEmpty($matchingRules);
+    }
+
+    public function testGet()
+    {
+        $user = User::factory()->create();
+    
+        $task = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'COMPLETED',
+        ]);
+
+        $activeTask = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'ACTIVE',
+            'process_id' => $task->process_id,
+            'element_id' => $task->element_id,
+        ]);
+
+        $inboxRule = InboxRule::factory()->create([
+            'process_request_token_id' => $task->id,
+            'user_id' => $user->id,
+        ]);
+
+        $matchingTasks = MatchingTasks::get($inboxRule);
+
+        $this->assertEquals($task->process_id, $matchingTasks[0]["process_id"]);
     }
 }

--- a/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
+++ b/tests/unit/ProcessMaker/InboxRules/MatchingTasksTest.php
@@ -118,7 +118,7 @@ class MatchingTasksTest extends TestCase
             'status' => 'COMPLETED',
         ]);
 
-        $activeTask = ProcessRequestToken::factory()->create([
+        ProcessRequestToken::factory()->create([
             'user_id' => $user->id,
             'status' => 'ACTIVE',
             'process_id' => $task->process_id,


### PR DESCRIPTION
## Solution
- New tests for MatchingTasks class and SmartInboxExistingTasks Job

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14120

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy