### PR TITLE
FOUR-14234: Fix permissions issue preventing user from seeing "Start Timer Event" menu item

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -250,39 +250,24 @@ class User extends Authenticatable implements HasMedia
         ]);
     }
 
-    /**
-     * Returns a collection of the permission names for permission groups
-     *
-     * @param ...$permissionGroups
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function hasPermissionsFor(...$permissionGroups)
+    public function hasPermissionsFor(...$resources)
     {
-        // Setup our query for permissions
-        $permissionsQuery = Permission::query();
-
-        // If the user isn't a super administrator, then we'll
-        // check their session-set permissions
-        if (!$this->is_administrator) {
-            $permissionsQuery->whereIn('name', session('permissions') ?? []);
+        if ($this->is_administrator) {
+            $perms = Permission::all(['name'])->pluck('name');
+        } else {
+            $perms = collect(session('permissions'));
         }
 
-        // Query the permissions and include the
-        // group name for filtering later
-        $permissions = $permissionsQuery->get(['name', 'group']);
+        $filtered = $perms->filter(function ($value) use ($resources) {
+            foreach ($resources as $resource) {
+                $match = preg_match("/(.+)-{$resource}/", $value);
+                if ($match === 1) {
+                    return true;
+                }
+            }
+        });
 
-        // Convert the resource name to headline casing to match
-        // with how we save permission group names
-        $permissionGroups = array_map(static function ($permissionGroup) {
-            return Str::headline($permissionGroup);
-        }, $permissionGroups);
-
-        // Filter down to only the groups of permissions requested
-        $permissions = $permissions->whereIn('group', $permissionGroups);
-
-        // Send back only the names of the permissions themselves.
-        return $permissions->pluck('name')->values();
+        return $filtered->values();
     }
 
     public function groupMembersFromMemberable()

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -3,7 +3,6 @@
 namespace ProcessMaker\Models;
 
 use Exception;
-use Illuminate\Support\Str;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -36,7 +36,15 @@
             @endcan
         </div>
     </div>
-
+    @php
+    $permissions = \Auth::user()->hasPermissionsFor(
+        'processes',
+        'process-templates',
+        'pm-blocks',
+        'projects',
+        'additional-asset-actions'
+    );
+    @endphp
     <div class="container-fluid">
         <processes-listing
             ref="processListing"
@@ -45,7 +53,7 @@
             status="{{ $config->status }}"
             v-on:edit="edit"
             v-on:reload="reload"
-            :permission="{{ \Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects', 'additional-asset-actions') }}"
+            :permission="{{ $permissions }}"
             :current-user-id="{{ \Auth::user()->id }}"
             is-documenter-installed="{{\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()}}"
         ></processes-listing>

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -24,9 +24,9 @@
                         </div>
                     @endcan
                     @can('create-processes')
-                        <select-template-modal 
-                            :type="__('Process')" 
-                            :count-categories="@json($config->countCategories)" 
+                        <select-template-modal
+                            :type="__('Process')"
+                            :count-categories="@json($config->countCategories)"
                             :package-ai="{{ hasPackage('package-ai') ? '1' : '0' }}"
                             is-projects-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(\ProcessMaker\PackageHelper::PM_PACKAGE_PROJECTS)}}"
                             >
@@ -45,7 +45,7 @@
             status="{{ $config->status }}"
             v-on:edit="edit"
             v-on:reload="reload"
-            :permission="{{ \Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects') }}"
+            :permission="{{ \Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects', 'additional-asset-actions') }}"
             :current-user-id="{{ \Auth::user()->id }}"
             is-documenter-installed="{{\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()}}"
         ></processes-listing>


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process that contains a start timer event
2. Publish the process
3. Go to the process list
4. Find the process
5. Click on the process' ellipsis
6. Notice the "Pause Start Timer" menu option is missing

## Solution
- Add the missing permission name to the view

## Related Tickets & Packages
- [FOUR-14234](https://processmaker.atlassian.net/browse/FOUR-14234)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-14234]: https://processmaker.atlassian.net/browse/FOUR-14234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ