### PR TITLE
Exclude Existing Process Categories from Process Template Export Manifest

### DIFF
--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -229,6 +229,15 @@ class ProcessTemplate implements TemplateInterface
                 continue;
             }
 
+            // Exclude the import of process categories if the category already exists in the database
+            if ($asset['model'] === 'ProcessMaker\Models\ProcessCategory') {
+                $processCategory = ProcessCategory::where('uuid', $key)->first();
+                if ($processCategory !== null) {
+                    unset($payload['export'][$key]);
+                    continue;
+                }
+            }
+
             $postOptions[$key] = [
                 'mode' => 'copy',
                 'isTemplate' => false,


### PR DESCRIPTION
This PR enhances the export process to prevent redundant entries for process categories in the export process template manifest. By checking if a category already exists in the database before importing, duplicate entries are avoided, resulting in a cleaner import process.


## Solution
The solution involves modifying the export process template manifest to unset the ProcessCategory dependency in the exported manifest if the category already exists in the database.

## How to Test

1. Ensure that guided templates are available in your environment by running `php artisan processmaker:sync-guided-templates`.
2. Navigate to the Processes section and verify the presence of at least one existing 'Finance' category or keep track of the count of 'Finance' categories.
3. Initiate a guided template under Processes > Guided Templates.
4. Upon completion and redirection to the LaunchPad page of the newly created process, verify that no new 'Finance' category is created.
5. Select the main 'Finance' category and confirm that the newly created process is listed under it.

ci:deploy

## Related Tickets & Packages
- [FOUR-14262](https://processmaker.atlassian.net/browse/FOUR-14262)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14262]: https://processmaker.atlassian.net/browse/FOUR-14262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ