### PR TITLE
[34697] Ellucian - _user magic variable generates for Self Service Tasks

### DIFF
--- a/ProcessMaker/Managers/DataManager.php
+++ b/ProcessMaker/Managers/DataManager.php
@@ -91,6 +91,10 @@ class DataManager
             unset($userData['remember_token']);
             $data['_user'] = $userData;
         }
+        // Magic variable: _user is removed when the task is SelfService.
+        if ($token->is_self_service === 1) {
+            unset($data['_user']);
+        }
 
         return $data;
     }
@@ -123,12 +127,7 @@ class DataManager
         }
 
         // Magic Variable: _user
-        $user = $token->user ?: Auth::user();
-        if ($user) {
-            $userData = $user->attributesToArray();
-            unset($userData['remember_token']);
-            $data['_user'] = $userData;
-        }
+        $data = $this->loadUserData($data, $token);
 
         // Magic Variable: _request
         $request = $token->getInstance() ?: $token->processRequest;

--- a/ProcessMaker/Managers/DataManager.php
+++ b/ProcessMaker/Managers/DataManager.php
@@ -92,7 +92,7 @@ class DataManager
             $data['_user'] = $userData;
         }
         // Magic variable: _user is removed when the task is SelfService.
-        if ($token->is_self_service === 1) {
+        if ($token && $token->is_self_service === 1) {
             unset($data['_user']);
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The information of magic variable _user is present when task is SelfService

## Solution
- Remove _user when the task is SelfService

## How to Test

1. Create process
2. Assign to administrator group or current user to SelfService
3. Create a new Request
4. Proceed to the next task, which is Self service
5. Open the request created
6. Go to the "Data" tab
7. review variable _user

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-13045](FOUR-13045)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy