### PR TITLE
Resolve 500 Error During Guided Template Execution 

### DIFF
--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -4,6 +4,7 @@ export default {
       task: null,
       currentUserId: null,
       formData: {},
+      importingProcessTemplate: false,
     };
   },
   methods: {
@@ -86,9 +87,9 @@ export default {
       this.task = task;
     },
     completed() {
-      if (this.shouldImportProcessTemplate) {
+      if (!this.importingProcessTemplate && this.shouldImportProcessTemplate) {
         this.importProcessTemplate();
-      } else {
+      } else if (this.shouldImportProcessTemplate) {
         this.showHelperProcess = false;
         this.$bvModal.hide("processWizard");
       }
@@ -103,6 +104,7 @@ export default {
       });
     },
     importProcessTemplate() {
+      this.importingProcessTemplate = true;
       ProcessMaker.apiClient.post(`template/create/process/${this.template.process_template_id}`, {
         name: this.template.name,
         description: this.template.description,
@@ -112,6 +114,7 @@ export default {
         wizardTemplateUuid: this.template.uuid,
         helperProcessRequestId: this.task.process_request_id,
       }).then((response) => {
+        this.importingProcessTemplate = false;
         if (response.data?.existingAssets) {
           this.handleExistingAssets(response.data);
         } else {


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses a 500 error encountered when running a Guided Template for the first time. The error occurred due to attempting to import the process template twice while the import process was still ongoing.

## Solution
The solution introduces an `importingProcess` status to indicate when the process template is being imported. Before retrying the import, the system checks against this status to avoid duplicate imports.

## How to Test

Note: This issue only replicated during the first run of a guided template. 

1. Ensure you have a clean instance to sync the guided templates `php artisan processmaker:sync-guided-templates`
2. Navigate to Processes -> Guided Template
3. Initiate a Guided Template process.
4. Verify that the process runs without encountering a 500 error.
5. Repeat the process initiation step to ensure consistent behavior across multiple attempts.


## Related Tickets & Packages
- [FOUR-14269](https://processmaker.atlassian.net/browse/FOUR-14269)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14269]: https://processmaker.atlassian.net/browse/FOUR-14269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ