### PR TITLE
FOUR-14286: Add a variable to hide AI for Fall and Winter

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -52,6 +52,7 @@ class ModelerController extends Controller
         asort($screenTypes);
         $countScreenCategories = ScreenCategory::where(['status' => 'ACTIVE', 'is_system' => false])->count();
         $isProjectsInstalled = PackageHelper::isPackageInstalled(PackageHelper::PM_PACKAGE_PROJECTS);
+        $isPackageAiInstalled = hasPackage('package-ai');
 
         // For create script modal in modeler
         $scriptExecutors = ScriptExecutor::list();
@@ -77,6 +78,7 @@ class ModelerController extends Controller
             'countScreenCategories' => $countScreenCategories,
             'countScriptCategories' => $countScriptCategories,
             'isProjectsInstalled' => $isProjectsInstalled,
+            'isPackageAiInstalled' => $isPackageAiInstalled,
         ]);
     }
 

--- a/config/app.php
+++ b/config/app.php
@@ -47,10 +47,10 @@ return [
 
     // Option Fractal, Serializer
     // TODO Does the ProcessMakerSerializer class exist, if so, we need to fix its namespace :)
-    'serialize_fractal' => env('SERIALIZE_FRACTAL', \ProcessMaker\Transformers\ProcessMakerSerializer::class),
+    'serialize_fractal' => env('SERIALIZE_FRACTAL', ProcessMaker\Transformers\ProcessMakerSerializer::class),
 
     //Option Fractal, paginator
-    'paginate_fractal' => env('PAGINATE_FRACTAL', \League\Fractal\Pagination\IlluminatePaginatorAdapter::class),
+    'paginate_fractal' => env('PAGINATE_FRACTAL', League\Fractal\Pagination\IlluminatePaginatorAdapter::class),
 
     // The processmaker identifier of the web client application
     'web_client_application_id' => env('PM_CLIENT_ID', 'x-pm-local-client'),
@@ -108,6 +108,10 @@ return [
 
     // Allows to detect if OpenAI is enabled or not
     'open_ai_nlq_to_pmql' => env('OPEN_AI_NLQ_TO_PMQL_ENABLED', false) && env('OPEN_AI_SECRET', false),
+
+    // Allows to detect if OpenAI is enabled or not
+    'open_ai_process_translations' => env('OPEN_AI_PROCESS_TRANSLATIONS_ENABLED', false) &&
+        env('OPEN_AI_SECRET', false),
 
     // Microservice AI Host
     'ai_microservice_host' => env('AI_MICROSERVICE_HOST'),

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -105,6 +105,7 @@
               <b-card-body class="overflow-hidden p-0">
                 <b-list-group class="w-100 h-100 overflow-auto">
                   <ai-tab
+                    v-if="packageAi"
                     ref="aiTab"
                     :user="user"
                     :source-code="code"
@@ -240,6 +241,7 @@
               <b-card-body class="overflow-hidden p-0">
                 <b-list-group class="w-100 h-100 overflow-auto">
                   <ai-tab
+                    v-if="packageAi"
                     ref="aiTab2"
                     :default-prompt="prompt"
                     :user="user"

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -25,12 +25,14 @@
                         <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-config"
                            role="tab"
                            aria-controls="nav-config" aria-selected="true" @click="activateTab">{{__('Configuration')}}</a>
-                        @can('view-process-translations')
-                            <a class="nav-item nav-link" id="nav-groups-tab" data-toggle="tab" href="#nav-translations"
-                                role="tab"
-                                data-test="translation-tab"
-                                aria-controls="nav-translations" aria-selected="true" @click="activateTab">{{__('Translations')}}</a>
-                        @endcan
+                        @if (config('app.open_ai_process_translations'))
+                            @can('view-process-translations')
+                                <a class="nav-item nav-link" id="nav-groups-tab" data-toggle="tab" href="#nav-translations"
+                                    role="tab"
+                                    data-test="translation-tab"
+                                    aria-controls="nav-translations" aria-selected="true" @click="activateTab">{{__('Translations')}}</a>
+                            @endcan
+                        @endif
                         <a class="nav-item nav-link" id="nav-groups-tab" data-toggle="tab" href="#nav-notifications"
                            role="tab"
                            aria-controls="nav-notifications" aria-selected="true" @click="activateTab">{{__('Notifications')}}</a>
@@ -182,79 +184,81 @@
                         </div>
 
                         {{-- Translations --}}
-                        @can('view-process-translations')
-                            <div class="tab-pane fade show" :class="{'active': activeTab === 'nav-translations'}" id="nav-translations" ref="nav-translations" role="tabpanel"
-                                aria-labelledby="nav-translations-tab">
-                                
-                                <div class="page-content mb-0" id="processTranslationIndex">
-                                    <div id="search-bar" class="search mb-3" vcloak>
-                                        <div class="d-flex flex-column flex-md-row">
-                                            <div class="flex-grow-1">
-                                                <div id="search" class="mb-3 mb-md-0">
-                                                    <div class="input-group w-100">
-                                                        <input id="search-box" v-model="filterTranslations" class="form-control" placeholder="{{__('Search')}}"  aria-label="{{__('Search')}}">
-                                                        <div class="input-group-append">
-                                                            <button type="button" class="btn btn-primary" aria-label="{{__('Search')}}">
-                                                                <i class="fas fa-search"></i>
-                                                            </button>
+                        @if (config('app.open_ai_process_translations'))
+                            @can('view-process-translations')
+                                <div class="tab-pane fade show" :class="{'active': activeTab === 'nav-translations'}" id="nav-translations" ref="nav-translations" role="tabpanel"
+                                    aria-labelledby="nav-translations-tab">
+                                    
+                                    <div class="page-content mb-0" id="processTranslationIndex">
+                                        <div id="search-bar" class="search mb-3" vcloak>
+                                            <div class="d-flex flex-column flex-md-row">
+                                                <div class="flex-grow-1">
+                                                    <div id="search" class="mb-3 mb-md-0">
+                                                        <div class="input-group w-100">
+                                                            <input id="search-box" v-model="filterTranslations" class="form-control" placeholder="{{__('Search')}}"  aria-label="{{__('Search')}}">
+                                                            <div class="input-group-append">
+                                                                <button type="button" class="btn btn-primary" aria-label="{{__('Search')}}">
+                                                                    <i class="fas fa-search"></i>
+                                                                </button>
+                                                            </div>
                                                         </div>
                                                     </div>
                                                 </div>
+                                                @canany(['import-process-translations', 'create-process-translations'])
+                                                    <div class="d-flex ml-md-0 flex-column flex-md-row">
+                                                        @can('import-process-translations')
+                                                            <div class="mb-3 mb-md-0 ml-md-2">
+                                                                <a href="#" aria-label="{{ __('Import Translation') }}" id="import_translation" class="btn btn-outline-secondary w-100" @click="importTranslation" data-test="translation-import">
+                                                                    <i class="fas fa-file-import"></i> {{__('Import')}}
+                                                                </a>
+                                                            </div>
+                                                        @endcan
+                                                        @can('create-process-translations')
+                                                            <div class="mb-3 mb-md-0 ml-md-2">
+                                                                <a href="#" 
+                                                                    aria-label="{{ __('New Translation') }}" 
+                                                                    id="new_translation" 
+                                                                    class="btn btn-primary w-100" 
+                                                                    @click="newTranslation"
+                                                                    data-test="translation-create-button">
+                                                                    {{__('+ Translation')}}
+                                                                </a>
+                                                            </div>
+                                                        @endcan
+                                                    </div>
+                                                @endcan
                                             </div>
-                                            @canany(['import-process-translations', 'create-process-translations'])
-                                                <div class="d-flex ml-md-0 flex-column flex-md-row">
-                                                    @can('import-process-translations')
-                                                        <div class="mb-3 mb-md-0 ml-md-2">
-                                                            <a href="#" aria-label="{{ __('Import Translation') }}" id="import_translation" class="btn btn-outline-secondary w-100" @click="importTranslation" data-test="translation-import">
-                                                                <i class="fas fa-file-import"></i> {{__('Import')}}
-                                                            </a>
-                                                        </div>
-                                                    @endcan
-                                                    @can('create-process-translations')
-                                                        <div class="mb-3 mb-md-0 ml-md-2">
-                                                            <a href="#" 
-                                                                aria-label="{{ __('New Translation') }}" 
-                                                                id="new_translation" 
-                                                                class="btn btn-primary w-100" 
-                                                                @click="newTranslation"
-                                                                data-test="translation-create-button">
-                                                                {{__('+ Translation')}}
-                                                            </a>
-                                                        </div>
-                                                    @endcan
-                                                </div>
-                                            @endcan
+                                        </div>
+                                    
+                                        <div class="container-fluid">
+                                            <process-translation-listing
+                                                ref="translationsListing"
+                                                :filter="filterTranslations"
+                                                :permission="{{ \Auth::user()->hasPermissionsFor('process-translations') }}"
+                                                @translated-languages-changed="onTranslatedLanguagesChanged"
+                                                @edit-translation="onEditTranslation"
+                                                :process-id="{{ $process->id }}"
+                                            ></process-translation-listing>
                                         </div>
                                     </div>
-                                
-                                    <div class="container-fluid">
-                                        <process-translation-listing
-                                            ref="translationsListing"
-                                            :filter="filterTranslations"
-                                            :permission="{{ \Auth::user()->hasPermissionsFor('process-translations') }}"
-                                            @translated-languages-changed="onTranslatedLanguagesChanged"
-                                            @edit-translation="onEditTranslation"
-                                            :process-id="{{ $process->id }}"
-                                        ></process-translation-listing>
+
+                                    <div class="d-flex justify-content-end mt-2">
+                                        {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
+                                        {!! Form::button(__('Save'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
                                     </div>
-                                </div>
 
-                                <div class="d-flex justify-content-end mt-2">
-                                    {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
-                                    {!! Form::button(__('Save'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
+                                    <create-process-translation-modal 
+                                        ref="createProcessTranslationModal" 
+                                        :process-id="{{ $process->id }}"
+                                        :permission="{{ \Auth::user()->hasPermissionsFor('process-translations') }}"
+                                        process-name="{{ $process->name }}"
+                                        :edit-translation="editTranslation"
+                                        @create-process-translation-closed="onCreateProcessTranslationClosed"
+                                        @translating-language="onTranslatingLanguage"
+                                        @language-saved="onLanguageSaved"/>
                                 </div>
-
-                                <create-process-translation-modal 
-                                    ref="createProcessTranslationModal" 
-                                    :process-id="{{ $process->id }}"
-                                    :permission="{{ \Auth::user()->hasPermissionsFor('process-translations') }}"
-                                    process-name="{{ $process->name }}"
-                                    :edit-translation="editTranslation"
-                                    @create-process-translation-closed="onCreateProcessTranslationClosed"
-                                    @translating-language="onTranslatingLanguage"
-                                    @language-saved="onLanguageSaved"/>
-                            </div>
-                        @endcan
+                            @endcan
+                        @endif
 
                         {{-- Notifications --}}
                         <div class="tab-pane fade show p-3" id="nav-notifications" role="tabpanel"

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -88,6 +88,7 @@ div.main {
     screenTypes: @json($screenTypes),
     scriptExecutors: @json($scriptExecutors),
     isProjectsInstalled: @json($isProjectsInstalled),
+    isPackageAiInstalled: @json($isPackageAiInstalled),
   }
   const warnings = @json($process->warnings);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Hide all AI features when the package-ai is uninstalled
Add an extra env variable `OPEN_AI_PROCESS_TRANSLATIONS_ENABLED=false` to hide process translations

## Related PRs and Tickets
- [Modeler PR](https://github.com/ProcessMaker/modeler/pull/1801)
- https://processmaker.atlassian.net/browse/FOUR-14286

ci:4.8.3
ci:modeler:FOUR-14286
ci:deploy
ci:next