### PR TITLE
Implement Unit Tests for Publish Screen Templates Permission

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -185,6 +185,17 @@ class TemplateController extends Controller
         return $result;
     }
 
+    /**
+     * Set a template as a Public Template
+     *
+     * @param  \ProcessMaker\Models\Template  $template
+     * @return \Illuminate\Http\Response
+     */
+    public function publishTemplate(string $type, Request $request)
+    {
+        return $this->template->publishTemplate($type, $request);
+    }
+
     private function validateImportedFile($content, $request)
     {
         $decoded = substr($content, 0, 1) === '{' ? json_decode($content) : (($content = base64_decode($content)) && substr($content, 0, 1) === '{' ? json_decode($content) : null);

--- a/ProcessMaker/Models/Template.php
+++ b/ProcessMaker/Models/Template.php
@@ -85,6 +85,11 @@ class Template extends ProcessMakerModel
         return (new $this->types[$type][1])->destroy($id);
     }
 
+    public function publishTemplate(string $type, Request $request)
+    {
+        return (new $this->types[$type][1])->publishTemplate($request);
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -120,37 +120,19 @@ class ScreenTemplate implements TemplateInterface
     // }
 
     /**
-     *  Update process template bpmn.
+     *  Publish a Screen Template to display in the Public Templates tab
      * @param mixed $request
      * @return JsonResponse
      */
-    //  // TODO: May not need this function for with screen templates
-    // public function updateTemplate($request) : JsonResponse
-    // {
-    //     $id = (int) $request->id;
-    //     $template = ProcessTemplates::where('id', $id)->firstOrFail();
+    public function publishTemplate($request) : JsonResponse
+    {
+        $id = (int) $request->id;
+        $template = ScreenTemplates::where('id', $id)->firstOrFail();
+        $template->is_public = true;
+        $template->saveOrFail();
 
-    //     $manifest = $this->getManifest('process', $request->process_id);
-    //     $rootUuid = Arr::get($manifest, 'root');
-    //     $export = Arr::get($manifest, 'export');
-    //     $svg = Arr::get($export, $rootUuid . '.attributes.svg', null);
-
-    //     $template->fill($request->all());
-    //     $template->svg = $svg;
-    //     $template->manifest = json_encode($manifest);
-
-    //     try {
-    //         $template->saveOrFail();
-
-    //         return response()->json();
-    //     } catch (Exception $e) {
-    //         return response(
-    //             ['message' => $e->getMessage(),
-    //                 'errors' => ['bpmn' => $e->getMessage()], ],
-    //             422
-    //         );
-    //     }
-    // }
+        return response()->json();
+    }
 
     /**
      *  Update process template configurations

--- a/database/factories/ProcessMaker/Models/ScreenTemplatesFactory.php
+++ b/database/factories/ProcessMaker/Models/ScreenTemplatesFactory.php
@@ -35,6 +35,7 @@ class ScreenTemplatesFactory extends Factory
             'screen_type' => 'FORM',
             // 'manifest' => json_encode($manifest),
             'manifest' => '{}',
+            'is_public' => false,
             'is_system' => false,
             'asset_type' => null,
             'version' => '1.0.0',

--- a/database/migrations/2024_02_28_212635_add_is_public_to_screen_templates_table.php
+++ b/database/migrations/2024_02_28_212635_add_is_public_to_screen_templates_table.php
@@ -11,7 +11,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('screen_templates', function (Blueprint $table) {
-            $table->boolean('is_public', false)->after('manifest');
+            $table->boolean('is_public')->default('false')->after('manifest');
         });
     }
 

--- a/database/migrations/2024_02_28_212635_add_is_public_to_screen_templates_table.php
+++ b/database/migrations/2024_02_28_212635_add_is_public_to_screen_templates_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('screen_templates', function (Blueprint $table) {
+            $table->boolean('is_public', false)->after('manifest');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('screen_templates', function (Blueprint $table) {
+            $table->dropColumn('is_public');
+        });
+    }
+};

--- a/database/migrations/2024_02_28_212635_add_is_public_to_screen_templates_table.php
+++ b/database/migrations/2024_02_28_212635_add_is_public_to_screen_templates_table.php
@@ -11,7 +11,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('screen_templates', function (Blueprint $table) {
-            $table->boolean('is_public')->default('false')->after('manifest');
+            $table->boolean('is_public')->default(false)->after('manifest');
         });
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -282,6 +282,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::delete('template/{type}/{id}', [TemplateController::class, 'delete'])->name('template.delete')->middleware('template-authorization');
     Route::get('modeler/templates/{type}/{id}', [TemplateController::class, 'show'])->name('modeler.template.show')->middleware('template-authorization');
     Route::post('templates/{type}/import/validation', [TemplateController::class, 'preImportValidation'])->name('template.preImportValidation')->middleware('template-authorization');
+    Route::post('template/{type}/{id}/publish', [TemplateController::class, 'publishTemplate'])->name('template.publishTemplate')->middleware('can:publish-screen-templates');
 
     // Wizard Templates
     Route::get('wizard-templates', [WizardTemplateController::class, 'index'])->name('wizard-templates.index');


### PR DESCRIPTION
This PR introduces unit tests to verify the functionality of the "Publish Screen Templates" permission. Additionally, it implements the ability to publish a screen template when the user has the necessary permissions.

## Changes Made
- Implement migration to add the `is_public` column to the `screen_templates` table
- Created unit tests in `ScreenTemplateTest.php` to validate the behavior of the "Publish Screen Templates" permission.
- Implemented the logic to allow users with the appropriate permissions to publish a screen template.

## How to Test

1. Run `php artisan migrate` to run the new migration
2. Run `phpunit tests/Feature/Templates/Api/ScreenTemplateTest.php`
3. Verify that all tests pass without any failures or errors.

## Related Tickets & Packages
- [FOUR-13551](https://processmaker.atlassian.net/browse/FOUR-13551)

ci:next
.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13551]: https://processmaker.atlassian.net/browse/FOUR-13551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ