### PR TITLE
Implement Services Configuration for Syncing Screen Templates from GitHub Repo

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -53,4 +53,10 @@ return [
         'template_categories' => env('GUIDED_TEMPLATE_CATEGORIES', 'all'),
     ],
 
+    'screen_templates_github' => [
+        'base_url' => 'https://raw.githubusercontent.com/processmaker/',
+        'template_repo' => env('SCREEN_TEMPLATE_REPO', 'screen-templates'),
+        'template_branch' => env('SCREEN_TEMPLATE_BRANCH', 'spring-2024'),
+        'template_categories' => env('SCREEN_TEMPLATE_CATEGORIES', 'all'),
+    ],
 ];


### PR DESCRIPTION
This PR introduces the necessary service configurations to facilitate the synchronization of Screen Templates from the screen-templates GitHub repository into a ProcessMaker instance.

## Changes Made
Added a new property named `screen_templates_github` to the `services.php` array, enabling the integration with the `screen-templates` GitHub repository.

## Related Tickets & Packages
- [FOUR-13617](https://processmaker.atlassian.net/browse/FOUR-13617)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13617]: https://processmaker.atlassian.net/browse/FOUR-13617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ