### PR TITLE
FOUR-14302 Fix error when rendering lists

### DIFF
--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -84,11 +84,18 @@ export default {
       data.meta.to = data.meta.from + data.meta.count;
       data.data = this.jsonRows(data.data);
 
-      for (const record of data.data) {
-        // format owner avatar and category
-        record.owner = this.formatAvatar(record.user);
-        record.category_list = this.formatCategory(record.categories);
-      }
+      data.data.forEach((record) => {
+        // format owner avatar if exists
+        if (Object.hasOwn(record, "user")) {
+          // eslint-disable-next-line no-param-reassign
+          record.owner = this.formatAvatar(record.user);
+        }
+        // format category if exists
+        if (Object.hasOwn(record, "category")) {
+          // eslint-disable-next-line no-param-reassign
+          record.category_list = this.formatCategory(record.categories);
+        }
+      });
       return data;
     },
     // Some controllers return each row as a json object to preserve integer keys (ie saved search)


### PR DESCRIPTION
## Issue & Reproduction Steps
An error is displayed when entering to some lists like: script executor, Collections, users, ...

## Solution
- Fix `database.js` to validate if the record has owner or category to format them.

## How to Test
Open the lists:
- User
- Groups
- Executor Script
- Collections

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14302
- https://processmaker.atlassian.net/browse/FOUR-14301

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:deploy
