### PR TITLE
Fix Guided Template Helper Process Reinitialization Issue

### DIFF
--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -89,7 +89,7 @@ export default {
     completed() {
       if (!this.importingProcessTemplate && this.shouldImportProcessTemplate) {
         this.importProcessTemplate();
-      } else if (this.shouldImportProcessTemplate) {
+      } else if (!this.importingProcessTemplate && !this.shouldImportProcessTemplate) {
         this.showHelperProcess = false;
         this.$bvModal.hide("processWizard");
       }


### PR DESCRIPTION
This PR addresses the problem of the guided template helper process reinitializing when completing a guided template, leading to unexpected behavior in the process launchpad redirection. The issue stemmed from an improper conditional statement prematurely closing the "active" helper process.

## Solution

- Updated the conditional statement to properly handle the closure of the "active" helper process.

The conditional now checks if the completed process is not currently being imported and is not supposed to be imported before closing the helper process. This ensures that the process helper is only hidden when relaunching the wizard template from the process launchpad.

## How to Test

1. Perform guided template processes and ensure completion.
2. Verify that the guided template helper process does not reinitialize unexpectedly.
3. Check the redirection behavior in the process launchpad after completing guided templates to ensure correctness.

## Related Tickets & Packages
- [FOUR-14322](https://processmaker.atlassian.net/browse/FOUR-14322)

ci:deploy
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14322]: https://processmaker.atlassian.net/browse/FOUR-14322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ