### PR TITLE
FOUR-14339 Fix An empty tab appears in the table of a request

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -90,14 +90,14 @@
                 </a>
               </li>
               @isset($addons)
-                @foreach ($addons as $addon)
+                @foreach ($addons as $addon) @if (!empty($addon['title']))
                   <li class="nav-item">
                     <a class="nav-link" id="{{ $addon['id'] . '-tab' }}" data-toggle="tab" href="{{ '#' . $addon['id'] }}"
                       role="tab" aria-controls="{{ $addon['id'] }}" aria-selected="false">
                       {{ __($addon['title']) }}
                     </a>
                   </li>
-                @endforeach
+                @endif @endforeach
               @endisset
             </template>
           </ul>


### PR DESCRIPTION
## Issue & Reproduction Steps
An empty tab appears in the table of a request
![image](https://github.com/ProcessMaker/processmaker/assets/8028650/266a2cb9-d915-4592-90ff-36992c6d06d7)

## Solution
- Not all the Request addons includes a tab, then a validation was added to check if the addon has a tab title

![image](https://github.com/ProcessMaker/processmaker/assets/8028650/4a807080-710e-4e9d-8937-59a2647ececd)

## How to Test
- Open any request in progress
- Check there is no an empty tab at the end

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14339

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
