### PR TITLE
 FOUR-14137 - Enable External Integration with BambooHR (develop)

### DIFF
--- a/resources/js/admin/settings/components/AdditionalDriverConnectionProperties.vue
+++ b/resources/js/admin/settings/components/AdditionalDriverConnectionProperties.vue
@@ -40,7 +40,7 @@ export default {
         "cdata.github": "github-connection-properties",
         "cdata.docusign": "docusign-connection-properties",
         "cdata.gmail": "gmail-connection-properties",
-        "cdata.bamboohr": "bamboohr-connection-properties",
+        "cdata.BambooHR": "bamboohr-connection-properties",
       },
     };
   },

--- a/resources/js/admin/settings/components/AdditionalDriverConnectionProperties.vue
+++ b/resources/js/admin/settings/components/AdditionalDriverConnectionProperties.vue
@@ -14,6 +14,7 @@ import GithubConnectionProperties from "./cdata/GithubConnectionProperties.vue";
 import DocusignConnectionProperties from "./cdata/DocusignConnectionProperties.vue";
 import GmailConnectionProperties from "./cdata/GmailConnectionProperties.vue";
 import BamboohrConnectionProperties from "./cdata/BamboohrConnectionProperties.vue";
+import SapHanaConnectionProperties from "./cdata/SapHanaConnectionProperties.vue";
 
 export default {
   components: {
@@ -22,6 +23,7 @@ export default {
     DocusignConnectionProperties,
     GmailConnectionProperties,
     BamboohrConnectionProperties,
+    SapHanaConnectionProperties,
   },
   props: {
     formData: {
@@ -41,6 +43,7 @@ export default {
         "cdata.docusign": "docusign-connection-properties",
         "cdata.gmail": "gmail-connection-properties",
         "cdata.BambooHR": "bamboohr-connection-properties",
+        "cdata.saphana": "sap-hana-connection-properties",
       },
     };
   },

--- a/resources/js/admin/settings/components/AdditionalDriverConnectionProperties.vue
+++ b/resources/js/admin/settings/components/AdditionalDriverConnectionProperties.vue
@@ -13,6 +13,7 @@ import ExcelConnectionProperties from "./cdata/ExcelConnectionProperties.vue";
 import GithubConnectionProperties from "./cdata/GithubConnectionProperties.vue";
 import DocusignConnectionProperties from "./cdata/DocusignConnectionProperties.vue";
 import GmailConnectionProperties from "./cdata/GmailConnectionProperties.vue";
+import BamboohrConnectionProperties from "./cdata/BamboohrConnectionProperties.vue";
 
 export default {
   components: {
@@ -20,6 +21,7 @@ export default {
     GithubConnectionProperties,
     DocusignConnectionProperties,
     GmailConnectionProperties,
+    BamboohrConnectionProperties,
   },
   props: {
     formData: {
@@ -38,6 +40,7 @@ export default {
         "cdata.github": "github-connection-properties",
         "cdata.docusign": "docusign-connection-properties",
         "cdata.gmail": "gmail-connection-properties",
+        "cdata.bamboohr": "bamboohr-connection-properties",
       },
     };
   },

--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -46,9 +46,9 @@
       </template>
       <div>
         <component
-          :is="authSchemeToComponent(setting.config.AuthScheme)"
+          :is="authSchemeToComponent(setting.config?.AuthScheme)"
           :form-data="formData"
-          :auth-scheme="setting.config.AuthScheme"
+          :auth-scheme="setting.config?.AuthScheme"
           @updateFormData="updateFormData"
         />
 
@@ -118,7 +118,7 @@ export default {
   props: {
     setting: {
       type: [Object, null],
-      default: null,
+      default: () => ({}),
     },
     value: {
       type: Object,

--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -220,8 +220,19 @@ export default {
         });
     },
     authorizeNoneConnection() {
-      const { driver } = this.setting.config;
-      window.location.href = `${window.location.origin}/external-integrations/${driver}`;
+      ProcessMaker.apiClient
+        .post(`settings/${this.setting.id}/authorize-driver`, this.formData)
+        .then((response) => {
+          window.location = response.data.url;
+          this.showModal = false;
+          this.showAuthorizingModal = true;
+        })
+        .catch((error) => {
+          const errorMessage = error.response?.data?.message || error.message;
+          ProcessMaker.alert(errorMessage, "danger");
+          this.showModal = true;
+          this.showAuthorizingModal = false;
+        });
     },
     onSave() {
       this.formData.name = this.setting.config?.name;

--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -100,13 +100,13 @@
 import { FormErrorsMixin, Required } from "SharedComponents";
 import settingMixin from "../mixins/setting";
 import AdditionalDriverConnectionProperties from "./AdditionalDriverConnectionProperties.vue";
-import OAuthConnectionProperties from "./cdata/OauthConnectionProperties.vue";
+import OauthConnectionProperties from "./cdata/OauthConnectionProperties.vue";
 import NoneConnectionProperties from "./cdata/NoneConnectionProperties.vue";
 
 export default {
   components: {
     AdditionalDriverConnectionProperties,
-    OAuthConnectionProperties,
+    OauthConnectionProperties,
     NoneConnectionProperties,
   },
   mixins: [settingMixin, FormErrorsMixin, Required],
@@ -130,7 +130,6 @@ export default {
       transformed: null,
       errors: {},
       isInvalid: true,
-      type: "password",
       resetData: true,
       componentsMap: {
         OAuth: "oauth-connection-properties",
@@ -154,12 +153,6 @@ export default {
     },
     changed() {
       return JSON.stringify(this.formData) !== JSON.stringify(this.transformed);
-    },
-    icon() {
-      if (this.type === "password") {
-        return "fa-eye";
-      }
-      return "fa-eye-slash";
     },
     isButtonDisabled() {
       return this.isInvalid || (this.isAuthorized && !this.changed);
@@ -185,13 +178,6 @@ export default {
   methods: {
     authSchemeToComponent(scheme) {
       return this.componentsMap[scheme] || null;
-    },
-    togglePassword() {
-      if (this.type === "text") {
-        this.type = "password";
-      } else {
-        this.type = "text";
-      }
     },
     validateData() {
       // Check if client_id and client_secret are empty

--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -46,8 +46,9 @@
       </template>
       <div>
         <component
-          :is="authSchemeToComponent(setting.config?.AuthScheme)"
+          :is="authSchemeToComponent(setting.config.AuthScheme)"
           :form-data="formData"
+          :auth-scheme="setting.config.AuthScheme"
           @updateFormData="updateFormData"
         />
 
@@ -104,12 +105,14 @@ import settingMixin from "../mixins/setting";
 import AdditionalDriverConnectionProperties from "./AdditionalDriverConnectionProperties.vue";
 import OauthConnectionProperties from "./cdata/OauthConnectionProperties.vue";
 import NoneConnectionProperties from "./cdata/NoneConnectionProperties.vue";
+import PasswordConnectionProperties from "./cdata/PasswordConnectionProperties.vue";
 
 export default {
   components: {
     AdditionalDriverConnectionProperties,
     OauthConnectionProperties,
     NoneConnectionProperties,
+    PasswordConnectionProperties,
   },
   mixins: [settingMixin, FormErrorsMixin, Required],
   props: {
@@ -135,6 +138,8 @@ export default {
       componentsMap: {
         OAuth: "oauth-connection-properties",
         None: "none-connection-properties",
+        Password: "password-connection-properties",
+        Basic: "password-connection-properties",
       },
     };
   },

--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -192,6 +192,14 @@ export default {
       this.showAuthorizingModal = true;
       this.showModal = false;
       this.resetData = false;
+
+      if (this.setting.config.AuthScheme === "OAuth") {
+        this.authorizeOAuthConnection();
+      } else {
+        this.authorizeNoneConnection();
+      }
+    },
+    authorizeOAuthConnection() {
       ProcessMaker.apiClient
         .post(`settings/${this.setting.id}/get-oauth-url`, this.formData)
         .then((response) => {
@@ -206,11 +214,13 @@ export default {
           this.showAuthorizingModal = false;
         });
     },
+    authorizeNoneConnection() {
+      const { driver } = this.setting.config;
+      window.location.href = `${window.location.origin}/external-integrations/${driver}`;
+    },
     onSave() {
-      const name = this.setting.key.split("cdata.")[1];
-      this.formData.name = name;
-      const driver = this.setting.config?.driver;
-      this.formData.driver = driver;
+      this.formData.name = this.setting.config?.name;
+      this.formData.driver = this.setting.config?.driver;
       this.transformed = { ...this.formData };
       this.authorizeConnection();
     },

--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -5,8 +5,8 @@
         pill
         :variant="isAuthorized ? 'success' : 'warning'"
       >
-        <span v-if="isAuthorized">{{ $t('Authorized') }}</span>
-        <span v-else>{{ $t('Not Authorized') }}</span>
+        <span v-if="isAuthorized">{{ $t("Authorized") }}</span>
+        <span v-else>{{ $t("Not Authorized") }}</span>
       </b-badge>
     </div>
     <div v-else>
@@ -24,34 +24,34 @@
         class="d-block"
       >
         <div>
-          <h5
-            v-if="setting.name"
-            class="mb-0"
-          >
-            {{ $t(setting.name) }}
+          <h5 class="mb-0">
+            <span v-if="setting.name">{{ $t(setting.name) }}</span>
+            <span v-else>{{ $t(setting.key) }}</span>
           </h5>
-          <h5
-            v-else
-            class="mb-0"
-          >
-            {{ setting.key }}
-          </h5>
-          <small class="form-text text-muted">{{ $t('Configure the driver connection properties.') }}</small>
+          <small class="form-text text-muted">{{
+            $t("Configure the driver connection properties.")
+          }}</small>
         </div>
         <button
           type="button"
-          :aria-label="$t('Close')"
           class="close"
+          :aria-label="$t('Close')"
           @click="onCancel"
         >
-          ×
+          &times;
         </button>
       </template>
       <div>
         <b-form-group
           required
           :label="$t('Client ID')"
-          :description="formDescription('The client ID assigned when you register your application.', 'client_id', errors)"
+          :description="
+            formDescription(
+              'The client ID assigned when you register your application.',
+              'client_id',
+              errors
+            )
+          "
           :invalid-feedback="errorMessage('client_id', errors)"
           :state="errorState('client_id', errors)"
         >
@@ -69,7 +69,13 @@
         <b-form-group
           required
           :label="$t('Client Secret')"
-          :description="formDescription('The client secret assigned when you register your application.', 'client_secret', errors)"
+          :description="
+            formDescription(
+              'The client secret assigned when you register your application.',
+              'client_secret',
+              errors
+            )
+          "
           :invalid-feedback="errorMessage('client_secret', errors)"
           :state="errorState('client_secret', errors)"
         >
@@ -103,7 +109,13 @@
         <b-form-group
           required
           :label="$t('Redirect URL')"
-          :description="formDescription('This value must match the callback URL you specify in your app settings.', 'callback_url', errors)"
+          :description="
+            formDescription(
+              'This value must match the callback URL you specify in your app settings.',
+              'callback_url',
+              errors
+            )
+          "
           :invalid-feedback="errorMessage('callback_url', errors)"
           :state="errorState('callback_url', errors)"
         >
@@ -145,7 +157,7 @@
           data-cy="cancel-button"
           @click="onCancel"
         >
-          {{ $t('Cancel') }}
+          {{ $t("Cancel") }}
         </button>
         <button
           type="button"
@@ -154,7 +166,7 @@
           :disabled="isButtonDisabled"
           @click="onSave"
         >
-          {{ $t('Authorize') }}
+          {{ $t("Authorize") }}
         </button>
       </div>
     </b-modal>
@@ -169,7 +181,7 @@
       no-fade
     >
       <div class="text-center">
-        <h3>{{ $t('Connecting Driver') }}</h3>
+        <h3>{{ $t("Connecting Driver") }}</h3>
         <i class="fas fa-circle-notch fa-spin fa-3x p-0 text-primary" />
       </div>
     </b-modal>
@@ -259,11 +271,20 @@ export default {
   },
   methods: {
     onCopy() {
-      navigator.clipboard.writeText(this.formData.callback_url).then(() => {
-        ProcessMaker.alert(this.$t("The setting was copied to your clipboard."), "success");
-      }, () => {
-        ProcessMaker.alert(this.$t("The setting was not copied to your clipboard."), "danger");
-      });
+      navigator.clipboard.writeText(this.formData.callback_url).then(
+        () => {
+          ProcessMaker.alert(
+            this.$t("The setting was copied to your clipboard."),
+            "success",
+          );
+        },
+        () => {
+          ProcessMaker.alert(
+            this.$t("The setting was not copied to your clipboard."),
+            "danger",
+          );
+        },
+      );
     },
     togglePassword() {
       if (this.type === "text") {
@@ -298,7 +319,8 @@ export default {
       this.showAuthorizingModal = true;
       this.showModal = false;
       this.resetData = false;
-      ProcessMaker.apiClient.post(`settings/${this.setting.id}/get-oauth-url`, this.formData)
+      ProcessMaker.apiClient
+        .post(`settings/${this.setting.id}/get-oauth-url`, this.formData)
         .then((response) => {
           window.location = response.data?.url;
         })

--- a/resources/js/admin/settings/components/cdata/BamboohrConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/BamboohrConnectionProperties.vue
@@ -1,0 +1,105 @@
+<template>
+  <div>
+    <!-- API key input field -->
+    <b-form-group
+      required
+      :label="$t('API Key')"
+      :description="formDescription('Your BambooHR API Key.', 'APIKey', errors)"
+      :invalid-feedback="errorMessage('APIKey', errors)"
+      :state="errorState('APIKey', errors)"
+    >
+      <b-input-group>
+        <b-form-input
+          v-model="config.APIKey"
+          required
+          autofocus
+          autocomplete="off"
+          trim
+          :type="inputType"
+          :state="errorState('APIKey', errors)"
+          name="APIKey"
+          data-cy="api-key"
+        />
+        <b-input-group-append>
+          <b-button
+            :aria-label="$t('Toggle Show Password')"
+            variant="secondary"
+            @click="togglePassword"
+          >
+            <i
+              class="fas"
+              :class="icon"
+            />
+          </b-button>
+        </b-input-group-append>
+      </b-input-group>
+    </b-form-group>
+
+    <!-- Domain input field -->
+    <b-form-group
+      required
+      :label="$t('Domain')"
+      :description="
+        formDescription('The Domain for the BambooHR account.', 'Domain', errors)
+      "
+      :invalid-feedback="errorMessage('Domain', errors)"
+      :state="errorState('Domain', errors)"
+    >
+      <b-form-input
+        v-model="config.Domain"
+        required
+        autofocus
+        autocomplete="off"
+        :state="errorState('Domain', errors)"
+        name="Domain"
+        data-cy="domain"
+      />
+    </b-form-group>
+  </div>
+</template>
+<script>
+// eslint-disable-next-line import/no-unresolved
+import { FormErrorsMixin } from "SharedComponents";
+
+export default {
+  mixins: [FormErrorsMixin],
+  props: {
+    formData: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      errors: {},
+      config: {
+        AuthScheme: "None",
+        APIKey: "",
+        Domain: "",
+      },
+      inputType: "password",
+    };
+  },
+  computed: {
+    icon() {
+      return this.inputType === "password" ? "fa-eye-slash" : "fa-eye";
+    },
+  },
+  watch: {
+    config: {
+      deep: true,
+      handler() {
+        this.$emit("updateFormData", this.config);
+      },
+    },
+  },
+  mounted() {
+    this.$emit("updateFormData", this.config);
+  },
+  methods: {
+    togglePassword() {
+      this.inputType = this.inputType === "password" ? "text" : "password";
+    },
+  },
+};
+</script>

--- a/resources/js/admin/settings/components/cdata/BamboohrConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/BamboohrConnectionProperties.vue
@@ -73,7 +73,6 @@ export default {
     return {
       errors: {},
       config: {
-        AuthScheme: "None",
         APIKey: "",
         Domain: "",
       },

--- a/resources/js/admin/settings/components/cdata/DocusignConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/DocusignConnectionProperties.vue
@@ -51,7 +51,10 @@ export default {
     },
   },
   mounted() {
-    this.config.use_sandbox = this.formData?.use_sandbox ?? true;
+    this.config = {
+      ...this.config,
+      ...this.formData,
+    };
 
     // Emit the updateFormData event after assigning values.
     this.$emit("updateFormData", this.config);

--- a/resources/js/admin/settings/components/cdata/ExcelConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/ExcelConnectionProperties.vue
@@ -61,7 +61,6 @@ export default {
       config: {
         connection_type: "",
         uri: "",
-        AuthScheme: "OAuth",
       },
       connectionOptions: {
         oauth: [

--- a/resources/js/admin/settings/components/cdata/GmailConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/GmailConnectionProperties.vue
@@ -18,7 +18,6 @@ export default {
     return {
       errors: {},
       config: {
-        AuthScheme: "OAuth",
         Schema: "REST",
         Scope: "https://mail.google.com/",
       },

--- a/resources/js/admin/settings/components/cdata/NoneConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/NoneConnectionProperties.vue
@@ -1,0 +1,21 @@
+<template>
+  <div />
+</template>
+<script>
+export default {
+  props: {
+    formData: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      config: {},
+    };
+  },
+  mounted() {
+    this.config = this.formData;
+  },
+};
+</script>

--- a/resources/js/admin/settings/components/cdata/NoneConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/NoneConnectionProperties.vue
@@ -11,7 +11,9 @@ export default {
   },
   data() {
     return {
-      config: {},
+      config: {
+        AuthScheme: "None",
+      },
     };
   },
   mounted() {

--- a/resources/js/admin/settings/components/cdata/NoneConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/NoneConnectionProperties.vue
@@ -17,7 +17,10 @@ export default {
     };
   },
   mounted() {
-    this.config = this.formData;
+    this.config = {
+      ...this.config,
+      ...this.formData,
+    };
   },
 };
 </script>

--- a/resources/js/admin/settings/components/cdata/OauthConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/OauthConnectionProperties.vue
@@ -1,0 +1,149 @@
+<template>
+  <div>
+    <b-form-group
+      required
+      :label="$t('Client ID')"
+      :description="
+        formDescription(
+          'The client ID assigned when you register your application.',
+          'client_id',
+          errors
+        )
+      "
+      :invalid-feedback="errorMessage('client_id', errors)"
+      :state="errorState('client_id', errors)"
+    >
+      <b-form-input
+        v-model="config.client_id"
+        required
+        autofocus
+        autocomplete="off"
+        :state="errorState('client_id', errors)"
+        name="client_id"
+        data-cy="client_id"
+      />
+    </b-form-group>
+
+    <b-form-group
+      required
+      :label="$t('Client Secret')"
+      :description="
+        formDescription(
+          'The client secret assigned when you register your application.',
+          'client_secret',
+          errors
+        )
+      "
+      :invalid-feedback="errorMessage('client_secret', errors)"
+      :state="errorState('client_secret', errors)"
+    >
+      <b-input-group>
+        <b-form-input
+          v-model="config.client_secret"
+          required
+          autofocus
+          autocomplete="off"
+          trim
+          :type="type"
+          :state="errorState('client_secret', errors)"
+          name="client_secret"
+          data-cy="client_secret"
+        />
+        <b-input-group-append>
+          <b-button
+            :aria-label="$t('Toggle Show Password')"
+            variant="secondary"
+            @click="togglePassword"
+          >
+            <i
+              class="fas"
+              :class="icon"
+            />
+          </b-button>
+        </b-input-group-append>
+      </b-input-group>
+    </b-form-group>
+
+    <b-form-group
+      required
+      :label="$t('Redirect URL')"
+      :description="
+        formDescription(
+          'This value must match the callback URL you specify in your app settings.',
+          'callback_url',
+          errors
+        )
+      "
+      :invalid-feedback="errorMessage('callback_url', errors)"
+      :state="errorState('callback_url', errors)"
+    >
+      <b-input-group>
+        <b-form-input
+          v-model="config.callback_url"
+          autofocus
+          readonly
+          autocomplete="off"
+          :state="errorState('callback_url', errors)"
+          name="callback_url"
+          data-cy="callback_url"
+        />
+        <b-input-group-append>
+          <b-button
+            :aria-label="$t('Copy')"
+            variant="secondary"
+            @click="onCopy"
+          >
+            <i class="fas fa-copy" />
+          </b-button>
+        </b-input-group-append>
+      </b-input-group>
+    </b-form-group>
+  </div>
+</template>
+<script>
+// eslint-disable-next-line import/no-unresolved
+import { FormErrorsMixin } from "SharedComponents";
+
+export default {
+  mixins: [FormErrorsMixin],
+  props: {
+    formData: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      config: {
+        client_id: "",
+        client_secret: "",
+        callback_url: "",
+      },
+      errors: {},
+    };
+  },
+  watch: {
+    config: {
+      deep: true,
+      handler() {
+        this.$emit("updateFormData", this.config);
+      },
+    },
+  },
+  mounted() {
+    this.config = this.formData;
+    this.$emit("updateFormData", this.config);
+  },
+  methods: {
+    onCopy() {
+      this.$copyText(this.config.callback_url).then(() => {
+        this.$bvToast.toast(this.$t("Copied"), {
+          title: this.$t("Success"),
+          variant: "success",
+          solid: true,
+        });
+      });
+    },
+  },
+};
+</script>

--- a/resources/js/admin/settings/components/cdata/OauthConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/OauthConnectionProperties.vue
@@ -115,6 +115,7 @@ export default {
   data() {
     return {
       config: {
+        AuthScheme: "OAuth",
         client_id: "",
         client_secret: "",
         callback_url: "",

--- a/resources/js/admin/settings/components/cdata/OauthConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/OauthConnectionProperties.vue
@@ -140,7 +140,10 @@ export default {
     },
   },
   mounted() {
-    this.config = this.formData;
+    this.config = {
+      ...this.config,
+      ...this.formData,
+    };
     this.$emit("updateFormData", this.config);
   },
   methods: {

--- a/resources/js/admin/settings/components/cdata/OauthConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/OauthConnectionProperties.vue
@@ -44,7 +44,7 @@
           autofocus
           autocomplete="off"
           trim
-          :type="type"
+          :type="inputType"
           :state="errorState('client_secret', errors)"
           name="client_secret"
           data-cy="client_secret"
@@ -120,7 +120,15 @@ export default {
         callback_url: "",
       },
       errors: {},
+      inputType: "password",
     };
+  },
+  computed: {
+    icon() {
+      return this.inputType === "password"
+        ? "fa-eye-slash"
+        : "fa-eye";
+    },
   },
   watch: {
     config: {
@@ -143,6 +151,9 @@ export default {
           solid: true,
         });
       });
+    },
+    togglePassword() {
+      this.inputType = this.inputType === "password" ? "text" : "password";
     },
   },
 };

--- a/resources/js/admin/settings/components/cdata/PasswordConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/PasswordConnectionProperties.vue
@@ -1,24 +1,45 @@
 <template>
   <div>
-    <!-- API key input field -->
     <b-form-group
       required
-      :label="$t('API Key')"
-      :description="formDescription('Your BambooHR API Key.', 'APIKey', errors)"
-      :invalid-feedback="errorMessage('APIKey', errors)"
-      :state="errorState('APIKey', errors)"
+      :label="$t('User')"
+      :description="
+        formDescription('The user account used to authenticate.', 'user', errors)
+      "
+      :invalid-feedback="errorMessage('user', errors)"
+      :state="errorState('user', errors)"
+    >
+      <b-form-input
+        v-model="config.user"
+        required
+        autofocus
+        autocomplete="off"
+        :state="errorState('user', errors)"
+        name="user"
+        data-cy="user"
+      />
+    </b-form-group>
+
+    <b-form-group
+      required
+      :label="$t('Password')"
+      :description="
+        formDescription('The password used to authenticate the user.', 'password', errors)
+      "
+      :invalid-feedback="errorMessage('password', errors)"
+      :state="errorState('password', errors)"
     >
       <b-input-group>
         <b-form-input
-          v-model="config.APIKey"
+          v-model="config.password"
           required
           autofocus
           autocomplete="off"
           trim
           :type="inputType"
-          :state="errorState('APIKey', errors)"
-          name="APIKey"
-          data-cy="api-key"
+          :state="errorState('password', errors)"
+          name="password"
+          data-cy="password"
         />
         <b-input-group-append>
           <b-button
@@ -34,27 +55,6 @@
         </b-input-group-append>
       </b-input-group>
     </b-form-group>
-
-    <!-- Domain input field -->
-    <b-form-group
-      required
-      :label="$t('Domain')"
-      :description="
-        formDescription('The Domain for the BambooHR account.', 'Domain', errors)
-      "
-      :invalid-feedback="errorMessage('Domain', errors)"
-      :state="errorState('Domain', errors)"
-    >
-      <b-form-input
-        v-model="config.Domain"
-        required
-        autofocus
-        autocomplete="off"
-        :state="errorState('Domain', errors)"
-        name="Domain"
-        data-cy="domain"
-      />
-    </b-form-group>
   </div>
 </template>
 <script>
@@ -68,14 +68,19 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    authScheme: {
+      type: String,
+      default: "Password",
+    },
   },
   data() {
     return {
-      errors: {},
       config: {
-        APIKey: "",
-        Domain: "",
+        AuthScheme: this.authScheme,
+        user: "",
+        password: "",
       },
+      errors: {},
       inputType: "password",
     };
   },

--- a/resources/js/admin/settings/components/cdata/SapHanaConnectionProperties.vue
+++ b/resources/js/admin/settings/components/cdata/SapHanaConnectionProperties.vue
@@ -1,0 +1,125 @@
+<template>
+  <div>
+    <!-- Server input field -->
+    <b-form-group
+      required
+      :label="$t('Server')"
+      :description="
+        formDescription(
+          'The name of the server running SAP HANA database.',
+          'server',
+          errors
+        )
+      "
+      :invalid-feedback="errorMessage('server', errors)"
+      :state="errorState('server', errors)"
+    >
+      <b-form-input
+        v-model="config.server"
+        type="text"
+        required
+        trim
+        name="server"
+        data-cy="server"
+        :state="errorState('server', errors)"
+      />
+    </b-form-group>
+
+    <!-- Port input field -->
+    <b-form-group
+      required
+      :label="$t('Port')"
+      :description="formDescription('The port of the SAP HANA database.', 'port', errors)"
+      :invalid-feedback="errorMessage('port', errors)"
+      :state="errorState('port', errors)"
+    >
+      <b-form-input
+        v-model="config.port"
+        required
+        name="port"
+        data-cy="port"
+        :state="errorState('port', errors)"
+      />
+    </b-form-group>
+
+    <!-- Database input field -->
+    <b-form-group
+      required
+      :label="$t('Database')"
+      :description="
+        formDescription('The name of the SAP HANA database.', 'database', errors)
+      "
+      :invalid-feedback="errorMessage('database', errors)"
+      :state="errorState('database', errors)"
+    >
+      <b-form-input
+        v-model="config.database"
+        required
+        name="database"
+        data-cy="database"
+        :state="errorState('database', errors)"
+      />
+    </b-form-group>
+
+    <!-- UseSSL switch field -->
+    <b-form-group
+      :label="$t('Use SSL')"
+      :description="
+        formDescription('This field sets whether SSL is enabled.', 'UseSSL', errors)
+      "
+      :invalid-feedback="errorMessage('UseSSL', errors)"
+      :state="errorState('UseSSL', errors)"
+    >
+      <b-form-checkbox
+        v-model="config.UseSSL"
+        name="use_ssl"
+        data-cy="use_ssl"
+        switch
+        :state="errorState('UseSSL', errors)"
+      />
+    </b-form-group>
+  </div>
+</template>
+<script>
+// eslint-disable-next-line import/no-unresolved
+import { FormErrorsMixin } from "SharedComponents";
+
+export default {
+  mixins: [FormErrorsMixin],
+  props: {
+    formData: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      errors: {},
+      config: {
+        server: "",
+        port: "",
+        database: "",
+        UseSSL: true,
+      },
+    };
+  },
+  computed: {},
+  watch: {
+    config: {
+      deep: true,
+      handler() {
+        this.$emit("updateFormData", this.config);
+      },
+    },
+  },
+  mounted() {
+    this.config = {
+      ...this.config,
+      ...this.formData,
+    };
+
+    this.$emit("updateFormData", this.config);
+  },
+  methods: {},
+};
+</script>


### PR DESCRIPTION
## Issue & Reproduction Steps
The CDATA package currently focuses on drivers with OAuth authentication. The goal is to expand the supported drivers to include new drivers using alternative authentication methods.

## Solution
- Now, when editing a driver, fields are loaded based on its AuthScheme and if necessary, other unique fields for that specific driver will be loaded.

## How to Test
Conduct manual testing of the drivers' authorization:
- BambooHR

## Related Tickets & Packages
- [FOUR-14137](https://processmaker.atlassian.net/browse/FOUR-14137)
- [Package CData](https://github.com/ProcessMaker/package-cdata/pull/29)
- [Package CData Docker Executor](https://github.com/ProcessMaker/docker-executor-cdata/pull/11)

ci:package-cdata:task/FOUR-12942
ci:docker-executor-cdata:task/FOUR-12942

[FOUR-14137]: https://processmaker.atlassian.net/browse/FOUR-14137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ