### PR TITLE
FOUR-14342 Update process quietly in WebEntryUrlFixer upgrade

### DIFF
--- a/upgrades/2024_02_07_113706_web_entry_url_fixer.php
+++ b/upgrades/2024_02_07_113706_web_entry_url_fixer.php
@@ -70,6 +70,8 @@ class WebEntryUrlFixer extends Upgrade
         }
 
         $process->bpmn = $definitions->saveXml();
-        $process->save();
+        // Save process without firing events, as the webentryRouteConfig.entryUrl
+        // does not needed any additional update.
+        $process->saveQuietly();
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The upgrade never finishes because it gets stuck in the web entry URL fixer migration.
This is caused because all the processes are being refreshed unnecessarily

## Solution
There are 3 process observers in all ProcessMaker:
- In core to: update events, self service, conditionals and bpmn validation
- In data-sources: to disable non used Webhooks
- In Ellucian: to updateEthosEvents

Non of them changes when the `webentryRouteConfig.entryUrl` is updated.

Based on that analysis the solution is:

- Save process without firing events, as the `webentryRouteConfig.entryUrl` does not needed any additional update.

## How to Test
- Run the WebEntryUrlFixer upgrade `php artisan upgrade`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14342

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
