### PR TITLE
FOUR-11455 STORY Enable Alternatives

### DIFF
--- a/ProcessMaker/Facades/FormalExpression.php
+++ b/ProcessMaker/Facades/FormalExpression.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ProcessMaker\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * FormalExpression Facade
+ *
+ * @see \ProcessMaker\Models\FormalExpression
+ */
+class FormalExpression extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'workflow.FormalExpression';
+    }
+}

--- a/ProcessMaker/Facades/WorkflowManager.php
+++ b/ProcessMaker/Facades/WorkflowManager.php
@@ -28,6 +28,8 @@ use ProcessMaker\Bpmn\Process;
  */
 class WorkflowManager extends Facade
 {
+    const NAYRA_PUBLISHER = 'nayra.publisher:';
+
     /**
      * Get the registered name of the component.
      *

--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -93,7 +93,7 @@ abstract class BpmnAction implements ShouldQueue
             $instance = $engine->loadProcessRequest($instance);
         } else {
             $processModel = Definitions::find($this->definitionsId);
-            $definitions = $processModel->getDefinitions();
+            $definitions = $processModel->getPublishedVersion()->getDefinitions();
             $engine = app(BpmnEngine::class, ['definitions' => $definitions, 'globalEvents' => !$this->disableGlobalEvents]);
             $instance = null;
         }

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -68,7 +68,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
         $this->validateData($data, $definitions, $event);
 
         // Get complementary information
-        $version = $definitions->getLatestVersion();
+        $version = $definitions->getPublishedVersion();
         $userId = $this->getCurrentUserId();
 
         // Create immediately a new process request
@@ -499,7 +499,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
         }
         // Dispatch complete task action
         $this->dispatchAction([
-            'bpmn' => $process->getLatestVersion()->getKey(),
+            'bpmn' => $process->getPublishedVersion()->getKey(),
             'action' => self::ACTION_TRIGGER_SIGNAL_EVENT,
             'params' => [
                 'signal_ref' => $signalRef,

--- a/ProcessMaker/RollbackProcessRequest.php
+++ b/ProcessMaker/RollbackProcessRequest.php
@@ -129,6 +129,7 @@ class RollbackProcessRequest
 
         $processRequest = $this->newTask->processRequest;
         $processRequest->status = 'ACTIVE';
+        // @todo Review why process_version_id is updated here
         $processRequest->process_version_id = $processRequest->process->getLatestVersion()->id;
         $processRequest->saveOrFail();
 


### PR DESCRIPTION
## STORY Enable Alternatives
Implements the enable alternative feature

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11455

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:package-ab-testing:feature/FOUR-11455

