### PR TITLE
FOUR-14331: The API settings/menu-groups needs to return the groups related

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SettingController.php
+++ b/ProcessMaker/Http/Controllers/Api/SettingController.php
@@ -25,6 +25,7 @@ class SettingController extends Controller
         'name',
         'helper',
         'group',
+        'group_id',
         'format',
         'created_at',
         'updated_at',
@@ -81,7 +82,7 @@ class SettingController extends Controller
     {
         $query = SettingsMenus::query();
 
-        $query->select('menu_group', 'ui');
+        $query->select('id', 'menu_group', 'ui');
 
         $orderBy = 'menu_group';
         $orderDirection = 'ASC';
@@ -96,6 +97,12 @@ class SettingController extends Controller
 
         $response = $query->orderBy($orderBy, $orderDirection)
             ->paginate($request->input('per_page', 10));
+
+        $response->map(function ($item) {
+            $item->groups = Setting::groupsByMenu($item->id);
+
+            return $item;
+        });
 
         return new ApiCollection($response);
     }

--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -93,6 +93,7 @@ class Setting extends ProcessMakerModel implements HasMedia
         'name',
         'helper',
         'group',
+        'group_id',
         'hidden',
         'ui',
     ];
@@ -369,5 +370,29 @@ class Setting extends ProcessMakerModel implements HasMedia
         }
 
         return $url . '?id=' . bin2hex(random_bytes(16));
+    }
+
+    /**
+     * Get the groups related to the specific group_id
+     *
+     * @param int menuId
+     *
+     * @return array
+     */
+    public static function groupsByMenu($menuId)
+    {
+        $query = Setting::query()->select('group')->groupBy('group')
+            ->where('group_id', $menuId)->pluck('group');
+        $response = $query->toArray();
+        $result = [];
+        foreach ($response as &$value) {
+            // Technical debts: we need to add int key to identify a group, currently this is a label
+            $result[] = [
+                'id' => $value,
+                'name' => $value,
+            ];
+        }
+
+        return $result;
     }
 }

--- a/ProcessMaker/Models/SettingsMenus.php
+++ b/ProcessMaker/Models/SettingsMenus.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use ProcessMaker\Models\ProcessMakerModel;
+use ProcessMaker\Models\Setting;
 
 class SettingsMenus extends ProcessMakerModel
 {
@@ -73,5 +74,10 @@ class SettingsMenus extends ProcessMakerModel
             'menu_group' => 'required',
             'menu_group_icon' => 'required',
         ];
+    }
+
+    public function groups()
+    {
+        return $this->hasMany(Setting::class, 'group_id');
     }
 }

--- a/upgrades/2024_02_29_131833_populate_update_settings_menu.php
+++ b/upgrades/2024_02_29_131833_populate_update_settings_menu.php
@@ -94,6 +94,7 @@ class PopulateUpdateSettingsMenu extends Upgrade
                         $id = $this->getId(SettingsMenus::INTEGRATIONS_MENU_GROUP);
                         break;
                     default:
+                        $id = null;
                         break;
                 }
                 if ($id !== null) {


### PR DESCRIPTION
## Issue & Reproduction Steps
The API settings/menu-groups needs to return the groups related

## Solution
- Return information about the groups related to the menu_groups

## How to Test
`API GET https://SERVER/api/1.0/settings/menu-groups`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14331

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:develop