### PR TITLE
FOUR-11456: STORY Alternative Tabs in Modeler

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -32,7 +32,7 @@ class ModelerController extends Controller
      */
     public function show(ModelerManager $manager, Process $process, Request $request)
     {
-        return view('processes.modeler.index', $this->prepareShowData($manager, $process, $request));
+        return view('processes.modeler.index', $this->prepareModelerData($manager, $process, $request));
     }
     /**
      * Prepare data for displaying a process in the modeler.

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -28,11 +28,38 @@ class ModelerController extends Controller
     use ProcessMapTrait;
 
     /**
-     * Invokes the Process Modeler for rendering.
+     * Display the modeler interface for a specific process.
+     *
+     * This method renders the modeler interface for a specific process,
+     * allowing users to view and edit the process in the modeler.
+     * It checks for any plugin addons to customize the display,
+     * and if found, renders the custom blade view with the provided alternatives.
+     * Otherwise, it renders the default modeler interface view with prepared data.
+     *
+     * @param ModelerManager $manager The ModelerManager instance.
+     * @param Process $process The Process instance to be displayed.
+     * @param Request $request The current HTTP request.
+     * @return \Illuminate\View\View The view for the modeler interface.
      */
     public function show(ModelerManager $manager, Process $process, Request $request)
     {
-        return view('processes.modeler.index', $this->prepareModelerData($manager, $process, $request));
+        // Default view for the modeler interface
+        $defaultView = 'processes.modeler.index';
+
+        // Get plugin addons for the 'show' action
+        $addons = $this->getPluginAddons('show', []);
+
+        // Retrieve custom blade view and alternatives from addons
+        $customBlade = ($addons[0] ?? [])['new-blade'];
+        $alternatives = ($addons[0] ?? [])['alternatives'];
+
+        // If a custom blade view and alternatives are provided, render the custom view
+        if ($customBlade && $alternatives) {
+            return view($customBlade, compact('alternatives'));
+        }
+        
+        // Otherwise, render the default modeler interface view with prepared data
+        return view($defaultView, $this->prepareModelerData($manager, $process, $request));
     }
     /**
      * Prepare data for displaying a process in the modeler.


### PR DESCRIPTION
## Issue & Reproduction Steps
STORY Alternative Tabs in Modeler

## Solution
- Decouple the modeler show controller to reuse in the packages

## How to Test
Describe how to test that this solution works.
- Open the modeler

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11456

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
