### PR TITLE
Fix PHP Syntax Error in Instance Upgrade Process

### DIFF
--- a/ProcessMaker/Jobs/SyncGuidedTemplates.php
+++ b/ProcessMaker/Jobs/SyncGuidedTemplates.php
@@ -190,7 +190,7 @@ class SyncGuidedTemplates implements ShouldQueue
 
             return $rootLog['newId'];
         } catch (Exception $e) {
-            throw new Exception('Error:' . $e->getMessage());
+            throw new Exception('Error: ' . $e->getMessage());
         }
     }
 


### PR DESCRIPTION
This PR addresses a PHP syntax error occurring during the instance upgrade process. The error was caused by improper concatenation, resulting in a syntax error. By ensuring proper syntax in concatenation, the error is resolved, allowing the code to execute without issues.

## Solution
- Corrected the syntax error in the affected line of code, ensuring proper concatenation.

## Related Tickets & Packages
- [FOUR-14374](https://processmaker.atlassian.net/browse/FOUR-14374)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14374]: https://processmaker.atlassian.net/browse/FOUR-14374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ