### PR TITLE
FOUR-14399: Fix problem with vite configuration in ab-testing project

### DIFF
--- a/ProcessMaker/Managers/ModelerManager.php
+++ b/ProcessMaker/Managers/ModelerManager.php
@@ -24,7 +24,7 @@ class ModelerManager
      * This method adds a script to the JavaScript registry along with optional parameters.
      * The script URL is added to the registry, and if additional parameters are provided,
      * they are merged with the default parameters.
-     * 
+     *
      * @param string $script The URL of the script to add to the registry.
      * @param array $params Additional parameters for configuring the script (optional).
      * @return void
@@ -33,7 +33,7 @@ class ModelerManager
     {
         // Add the script URL to the JavaScript registry
         $this->javascriptRegistry[] = $script;
-        
+
         // Merge additional parameters with the default parameters and add to the parameters registry
         $this->javascriptParamsRegistry[] = array_merge(['src' => $script], $params);
     }
@@ -53,7 +53,7 @@ class ModelerManager
      *
      * This method returns the JavaScript parameters registry, which contains
      * parameters used to configure scripts in the application.
-     * 
+     *
      * @return array The JavaScript parameters registry.
      */
     public function getScriptWithParams()

--- a/ProcessMaker/Managers/ModelerManager.php
+++ b/ProcessMaker/Managers/ModelerManager.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Managers;
 class ModelerManager
 {
     private $javascriptRegistry;
+    private $javascriptParamsRegistry;
 
     /**
      * Start our modeler manager, registering our initial javascript
@@ -18,15 +19,23 @@ class ModelerManager
     }
 
     /**
-     * Add a new script to the modeler load.  These scripts can then interact with the modeler
-     * during it's startup lifecycle to do this such as register new node types.
+     * Add a script to the JavaScript registry with optional parameters.
      *
-     * @param string $script Path to the javascript to load
+     * This method adds a script to the JavaScript registry along with optional parameters.
+     * The script URL is added to the registry, and if additional parameters are provided,
+     * they are merged with the default parameters.
+     * 
+     * @param string $script The URL of the script to add to the registry.
+     * @param array $params Additional parameters for configuring the script (optional).
      * @return void
      */
-    public function addScript($script)
+    public function addScript($script, array $params = [])
     {
+        // Add the script URL to the JavaScript registry
         $this->javascriptRegistry[] = $script;
+        
+        // Merge additional parameters with the default parameters and add to the parameters registry
+        $this->javascriptParamsRegistry[] = array_merge(['src' => $script], $params);
     }
 
     /**
@@ -38,5 +47,17 @@ class ModelerManager
     public function getScripts()
     {
         return $this->javascriptRegistry;
+    }
+    /**
+     * Retrieve the JavaScript parameters registry.
+     *
+     * This method returns the JavaScript parameters registry, which contains
+     * parameters used to configure scripts in the application.
+     * 
+     * @return array The JavaScript parameters registry.
+     */
+    public function getScriptWithParams()
+    {
+        return $this->javascriptParamsRegistry;
     }
 }

--- a/ProcessMaker/Traits/PluginServiceProviderTrait.php
+++ b/ProcessMaker/Traits/PluginServiceProviderTrait.php
@@ -43,22 +43,32 @@ trait PluginServiceProviderTrait
      */
     public function modelerStarting(ModelerStarting $event)
     {
-        foreach ($this->modelerScripts as $path => $public) {
-            if (File::exists(public_path() . '/' . $public)) {
-                $event->manager->addScript(mix($path, $public));
+        foreach ($this->modelerScripts as $path => $config) {
+            if (File::exists(public_path() . '/' . $config['script_src'])) {
+                $event->manager->addScript(mix($path, $config['script_src']), $config['script_params']);
             }
         }
     }
 
     /**
-     * Register a custom javascript for the modeler
+     * Register a custom script for the modeler with optional parameters.
      *
-     * @param string $path
-     * @param string $public
+     * This method registers a script for the modeler along with optional parameters.
+     * The script path and its corresponding public URL are added to the modeler scripts registry,
+     * and if additional parameters are provided, they are included in the registration.
+     * 
+     * @param string $path The path to the script file.
+     * @param string $public The public URL of the script.
+     * @param array $params Additional parameters for configuring the script (optional).
+     * @return void
      */
-    protected function registerModelerScript($path, $public)
+    protected function registerModelerScript($path, $public, array $params = [])
     {
-        $this->modelerScripts[$path] = $public;
+        // Register the script path and public URL along with optional parameters
+        $this->modelerScripts[$path] = [
+            'script_src' => $public,
+            'script_params' => $params,
+        ];
     }
 
     /**

--- a/ProcessMaker/Traits/PluginServiceProviderTrait.php
+++ b/ProcessMaker/Traits/PluginServiceProviderTrait.php
@@ -56,7 +56,7 @@ trait PluginServiceProviderTrait
      * This method registers a script for the modeler along with optional parameters.
      * The script path and its corresponding public URL are added to the modeler scripts registry,
      * and if additional parameters are provided, they are included in the registration.
-     * 
+     *
      * @param string $path The path to the script file.
      * @param string $public The public URL of the script.
      * @param array $params Additional parameters for configuring the script (optional).

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -100,8 +100,16 @@ div.main {
     addBreadcrumbs(breadcrumbData || []);
   });
   </script>
-    @foreach($manager->getScripts() as $script)
-      <script src="{{$script}}"></script>
+    @foreach($manager->getScriptWithParams() as $params)
+      <script
+      @foreach ($params as $key => $value)
+        @if (is_bool($value))
+          {{ $key }}
+        @else
+          {{ $key }}="{{ $value }}"
+        @endif
+      @endforeach
+      ></script>
     @endforeach
   <script src="{{ mix('js/processes/modeler/index.js') }}"></script>
 @endsection


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- Add params support for scripts tags 

## How to Test
- install the ab testing package branch feature/FOUR-14399 
- open the modeler 
- the variable window.HolaMundo must be present in the modeler

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14399

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
