### PR TITLE
FOUR-14395: Database Error: Table not found: 'project_assets' doesn't exist

### DIFF
--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -63,6 +63,9 @@ class AuthServiceProvider extends ServiceProvider
             if ($user->is_administrator) {
                 return true;
             }
+
+            // Let other policies handle the request.
+            return null;
         });
 
         try {
@@ -70,14 +73,15 @@ class AuthServiceProvider extends ServiceProvider
             // Define the Gate permissions
             $permissions->each(function ($permission) {
                 Gate::define($permission->name, function (User $user, ...$params) use ($permission) {
+                    $authorized = false;
+
                     // Check if the user has the permission
                     if ($user->hasPermission($permission->name)) {
                         return true;
                     }
 
-                    $projects = $this->getProjectsForUser($user->id);
-
                     // If the user has no projects, return false.
+                    $projects = $this->getProjectsForUser($user->id);
                     if (empty($projects)) {
                         return false;
                     }
@@ -85,12 +89,11 @@ class AuthServiceProvider extends ServiceProvider
                     // Check if the user has 'create-projects' permission and the request is from specific endpoints
                     // Users that ONLY have 'create-projects' permission are allowed to access specific endpoints
                     $isAllowedEndpoint = $this->checkAllowedEndpoints($projects, request()->path());
-
                     if ($user->hasPermission('create-projects') && $isAllowedEndpoint) {
-                        return $this->isProjectAsset($permission, $params);
+                        $authorized = $this->isProjectAsset($permission, $params);
                     }
 
-                    return false;
+                    return $authorized;
                 });
             });
         } catch (\Exception $e) {

--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -77,6 +77,11 @@ class AuthServiceProvider extends ServiceProvider
 
                     $projects = $this->getProjectsForUser($user->id);
 
+                    // If the user has no projects, return false.
+                    if (empty($projects)) {
+                        return false;
+                    }
+
                     // Check if the user has 'create-projects' permission and the request is from specific endpoints
                     // Users that ONLY have 'create-projects' permission are allowed to access specific endpoints
                     $isAllowedEndpoint = $this->checkAllowedEndpoints($projects, request()->path());


### PR DESCRIPTION
## Issue & Reproduction Steps
This error occurs when the `package-projects` is not installed and a non-administrator user account is used.

## Solution
Currently, there is a check to determine if the projects table exists in the database schema. The proposed solution is:
- If the projects table does not exist, then the Gate will return false by default.

The other changes are related to SonarQube. 
- The function inside the Gate had more than 4 returns
- The before() function had the error: "Vote methods should return at least once a negative response".

## How to Test
Since deploying a CI Server without the projects package is not possible, the best option for a functional test is to do it manually.

## Related Tickets & Packages
- [FOUR-14395](https://processmaker.atlassian.net/browse/FOUR-14395)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14395]: https://processmaker.atlassian.net/browse/FOUR-14395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ