### PR TITLE
[35775] SMTP configuration without TLS and authentication showing the error: Unable to connect with STARTTLS

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -49,7 +49,9 @@ return [
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
-            'local_domain' => env('MAIL_EHLO_DOMAIN'),
+            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url(env('APP_URL'))['host']),
+            'auth_mode'     => null,
+            'verify_peer' => env('VERIFY_PEER', false),
         ],
 
         'ses' => [


### PR DESCRIPTION
## Issue & Reproduction Steps
When using an SMTP configuration, it gives a certificate problem.
New parameters were added to the default mailer, to allow sending emails.

## Solution
- New parameters were added to the default mailer, to allow sending emails.

## How to Test
To test, you need an SMTP with a white list of servers since it gives an error 5.7.1 which does not allow sending email.
![image](https://github.com/ProcessMaker/processmaker/assets/1747025/bd336384-c45b-40a2-8f81-22fe2a6c5700)

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-14203](FOUR-14203)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:develop
ci:connector-send-email:bugfix/FOUR-14203
ci:deploy
