### PR TITLE
FOUR-14497: BambooHR Driver Authorization Error

### DIFF
--- a/resources/js/admin/settings/components/SettingDriverAuthorization.vue
+++ b/resources/js/admin/settings/components/SettingDriverAuthorization.vue
@@ -236,7 +236,7 @@ export default {
     },
     onSave() {
       this.formData.name = this.setting.config?.name;
-      this.formData.driver = this.setting.config?.driver;
+      this.formData.driver = this.setting.config?.name;
       this.transformed = { ...this.formData };
       this.authorizeConnection();
     },


### PR DESCRIPTION
## Issue & Reproduction Steps

There is a validation error when trying to authorize the BambooHR driver.

1. Go to admin - settings.
2. Add the Bamboo driver.
3. Click on the edit and authorize buttons.

Solution

- This error occurs in drivers using the CData API driver.
- Since the API driver operates in the background, only the driver's name or API profile should be sent from the UI. In this case, `api` should not be sent, but rather `BambooHR`. Therefore, the change from driver to name was made.

## How to Test

- Follow the steps described above; you should not encounter any problems when authorizing the BambooHR driver.
It can be tested on the CI Server.

## Related Tickets & Packages
- [FOUR-14497](https://processmaker.atlassian.net/browse/FOUR-14497)

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14497]: https://processmaker.atlassian.net/browse/FOUR-14497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ