### PR TITLE
FOUR-14492: Not able to delete a template

### DIFF
--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -143,6 +143,10 @@ export default {
   methods: {
     onMyTemplateNavigate(actionType, data) {
       switch (actionType?.value) {
+        case "placeholder-action":
+          break;
+        case "placeholder-action-2":
+          break;
         case "delete-template":
           ProcessMaker.confirmModal(
             this.$t("Caution!"),

--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -96,7 +96,7 @@
                     :data="row"
                     :divider="true"
                     :screen-template="true"
-                    @navigate="onMyTemplateNavigate"
+                    @navigate="onTemplateNavigate"
                   />
                 </template>
                 <template v-if="header.field !== 'name'">
@@ -132,11 +132,11 @@ import { createUniqIdsMixin } from "vue-uniq-ids";
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import ellipsisMenuMixin from "../../../components/shared/ellipsisMenuActions";
-import screenNavigationMixin from "../../../components/shared/screenNavigation";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
 import FilterTableBodyMixin from "../../../components/shared/FilterTableBodyMixin";
 import paginationTable from "../../../components/shared/PaginationTable.vue";
 import fieldsMixin from "../mixins/fieldsMixin";
+import navigationMixin from "../mixins/navigationMixin";
 
 const uniqIdsMixin = createUniqIdsMixin();
 
@@ -147,9 +147,9 @@ export default {
     dataLoadingMixin,
     uniqIdsMixin,
     ellipsisMenuMixin,
-    screenNavigationMixin,
     FilterTableBodyMixin,
     fieldsMixin,
+    navigationMixin,
   ],
   props: {
     permission: {
@@ -194,34 +194,6 @@ export default {
     });
   },
   methods: {
-    onMyTemplateNavigate(actionType, data) {
-      switch (actionType?.value) {
-        case "placeholder-action":
-          break;
-        case "placeholder-action-2":
-          break;
-        case "delete-template":
-          ProcessMaker.confirmModal(
-            this.$t("Caution!"),
-            this.$t(
-              "Are you sure you want to delete the screen template {{item}}?",
-              {
-                item: data.title,
-              },
-            ),
-            "",
-            () => {
-              ProcessMaker.apiClient.delete(`template/screen/${data.id}`).then(() => {
-                ProcessMaker.alert(this.$t("The template was deleted."), "success");
-                this.fetch();
-              });
-            },
-          );
-          break;
-        default:
-          break;
-      }
-    },
     fetch() {
       this.loading = true;
       // change method sort by slot name

--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -136,6 +136,7 @@ import screenNavigationMixin from "../../../components/shared/screenNavigation";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
 import FilterTableBodyMixin from "../../../components/shared/FilterTableBodyMixin";
 import paginationTable from "../../../components/shared/PaginationTable.vue";
+import fieldsMixin from "../mixins/fieldsMixin";
 
 const uniqIdsMixin = createUniqIdsMixin();
 
@@ -148,10 +149,11 @@ export default {
     ellipsisMenuMixin,
     screenNavigationMixin,
     FilterTableBodyMixin,
+    fieldsMixin,
   ],
   props: {
     permission: {
-      type: [String, Object],
+      type: [String, Object, Array],
       default: "",
     },
     filter: {
@@ -180,49 +182,11 @@ export default {
           direction: "asc",
         },
       ],
-
-      fields: [
-        {
-          label: this.$t("Name"),
-          field: "name",
-          width: 200,
-          sortable: true,
-          truncate: true,
-          direction: "none",
-        },
-        {
-          label: this.$t("Description"),
-          field: "description",
-          width: 200,
-          sortable: true,
-          direction: "none",
-          sortField: "description",
-        },
-        {
-          label: this.$t("Type of Screen"),
-          field: "screen_type",
-          width: 160,
-          sortable: true,
-          direction: "none",
-          sortField: "screen_type",
-        },
-        {
-          label: this.$t("Modified"),
-          field: "updated_at",
-          format: "datetime",
-          width: 160,
-          sortable: true,
-          direction: "none",
-        },
-        {
-          name: "__slot:actions",
-          field: "actions",
-          width: 60,
-        },
-      ],
+      fields: [],
     };
   },
   created() {
+    this.fields = this.commonFields;
     ProcessMaker.EventBus.$on("api-data-my-screen-templates", () => {
       this.fetch();
       this.apiDataLoading = false;

--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -141,8 +141,29 @@ export default {
     });
   },
   methods: {
-    onMyTemplateNavigate() {
-      console.log('ellipsis menu action');
+    onMyTemplateNavigate(actionType, data) {
+      switch (actionType?.value) {
+        case "delete-template":
+          ProcessMaker.confirmModal(
+            this.$t("Caution!"),
+            this.$t(
+              "Are you sure you want to delete the screen {{item}}? Deleting this asset will break any active tasks that are assigned.",
+              {
+                item: data.title,
+              },
+            ),
+            "",
+            () => {
+              ProcessMaker.apiClient.delete(`template/screen/${data.id}`).then(() => {
+                ProcessMaker.alert(this.$t("The template was deleted."), "success");
+                this.fetch();
+              });
+            },
+          );
+          break;
+        default:
+          break;
+      }
     },
     fetch() {
       this.loading = true;

--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -240,7 +240,7 @@ export default {
           ProcessMaker.confirmModal(
             this.$t("Caution!"),
             this.$t(
-              "Are you sure you want to delete the screen {{item}}? Deleting this asset will break any active tasks that are assigned.",
+              "Are you sure you want to delete the screen template {{item}}?",
               {
                 item: data.title,
               },

--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -1,31 +1,75 @@
+<!-- eslint-disable vue/no-v-html -->
 <template>
   <div class="data-table">
-    <data-loading :for="/screens/" v-show="shouldShowLoader" :empty="$t('No Data Available')" :empty-desc="$t('')"
-      empty-icon="noData" />
-    <div v-show="!shouldShowLoader" class="card card-body my-templates-table-card" data-cy="my-templates-table">
-      <filter-table :headers="fields" :data="data" table-name="my-screen-templates" style="height: calc(100vh - 355px);">
+    <data-loading
+      v-show="shouldShowLoader"
+      :for="/screens/"
+      :empty="$t('No Data Available')"
+      :empty-desc="$t('')"
+      empty-icon="noData"
+    />
+    <div
+      v-show="!shouldShowLoader"
+      class="card card-body my-templates-table-card"
+      data-cy="my-templates-table"
+    >
+      <filter-table
+        :headers="fields"
+        :data="data"
+        table-name="my-screen-templates"
+        style="height: calc(100vh - 355px)"
+      >
         <!-- Slot Table Header filter Button -->
-        <template v-for="(column, index) in fields" #[`filter-${column.field}`]>
-          <div v-if="column.sortable" :key="index" @click="handleEllipsisClick(column)">
-            <i :class="['fas', {
-              'fa-sort': column.direction === 'none',
-              'fa-sort-up': column.direction === 'asc',
-              'fa-sort-down': column.direction === 'desc',
-            }]" />
+        <template
+          v-for="(column, index) in fields"
+          #[`filter-${column.field}`]
+        >
+          <div
+            v-if="column.sortable"
+            :key="index"
+            @click="handleEllipsisClick(column)"
+          >
+            <i
+              :class="[
+                'fas',
+                {
+                  'fa-sort': column.direction === 'none',
+                  'fa-sort-up': column.direction === 'asc',
+                  'fa-sort-down': column.direction === 'desc',
+                },
+              ]"
+            />
           </div>
         </template>
         <!-- Slot Table Body -->
-        <template v-for="(row, rowIndex) in data.data" #[`row-${rowIndex}`]>
-          <td v-for="(header, colIndex) in fields" :key="`${rowIndex}_${colIndex}`"
-            :data-cy="`my-templates-table-td-${rowIndex}-${colIndex}`">
-            <div v-if="containsHTML(row[header.field])" :data-cy="`my-templates-table-html-${rowIndex}-${colIndex}`"
-              v-html="sanitize(row[header.field])" />
+        <template
+          v-for="(row, rowIndex) in data.data"
+          #[`row-${rowIndex}`]
+        >
+          <td
+            v-for="(header, colIndex) in fields"
+            :key="`${rowIndex}_${colIndex}`"
+            :data-cy="`my-templates-table-td-${rowIndex}-${colIndex}`"
+          >
+            <div
+              v-if="containsHTML(row[header.field])"
+              :data-cy="`my-templates-table-html-${rowIndex}-${colIndex}`"
+              v-html="sanitize(row[header.field])"
+            />
             <template v-else>
-              <template v-if="isComponent(row[header.field])"
-                :data-cy="`my-templates-table-component-${rowIndex}-${colIndex}`">
-                <component :is="row[header.field].component" v-bind="row[header.field].props" />
+              <template
+                v-if="isComponent(row[header.field])"
+                :data-cy="`my-templates-table-component-${rowIndex}-${colIndex}`"
+              >
+                <component
+                  :is="row[header.field].component"
+                  v-bind="row[header.field].props"
+                />
               </template>
-              <template v-else :data-cy="`my-templates-table-field-${rowIndex}-${colIndex}`">
+              <template
+                v-else
+                :data-cy="`my-templates-table-field-${rowIndex}-${colIndex}`"
+              >
                 <template v-if="header.field === 'name'">
                   <div
                     :id="`my-templates-${row.id}`"
@@ -36,13 +80,24 @@
                       {{ row[header.field] }}
                     </span>
                   </div>
-                  <b-tooltip v-if="header.truncate" :target="`element-${row.id}`" custom-class="pm-table-tooltip">
+                  <b-tooltip
+                    v-if="header.truncate"
+                    :target="`element-${row.id}`"
+                    custom-class="pm-table-tooltip"
+                  >
                     {{ row[header.field] }}
                   </b-tooltip>
                 </template>
                 <template v-if="header.field === 'actions'">
-                  <ellipsis-menu class="my-template-table" :actions="myTemplateActions" :permission="permission"
-                    :data="row" :divider="true" :screen-template="true" @navigate="onMyTemplateNavigate" />
+                  <ellipsis-menu
+                    class="my-template-table"
+                    :actions="myTemplateActions"
+                    :permission="permission"
+                    :data="row"
+                    :divider="true"
+                    :screen-template="true"
+                    @navigate="onMyTemplateNavigate"
+                  />
                 </template>
                 <template v-if="header.field !== 'name'">
                   <div :style="{ maxWidth: header.width + 'px' }">
@@ -55,14 +110,25 @@
         </template>
       </filter-table>
 
-      <pagination-table :meta="data.meta" data-cy="my-templates-pagination" @page-change="changePage" />
-      <pagination ref="pagination" :single="$t('My Template')" :plural="$t('My Templates')"
-        :per-page-select-enabled="true" @changePerPage="changePerPage" @vuetable-pagination:change-page="onPageChange" />
+      <pagination-table
+        :meta="data.meta"
+        data-cy="my-templates-pagination"
+        @page-change="changePage"
+      />
+      <pagination
+        ref="pagination"
+        :single="$t('My Template')"
+        :plural="$t('My Templates')"
+        :per-page-select-enabled="true"
+        @changePerPage="changePerPage"
+        @vuetable-pagination:change-page="onPageChange"
+      />
     </div>
   </div>
 </template>
-  
+
 <script>
+import { createUniqIdsMixin } from "vue-uniq-ids";
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import ellipsisMenuMixin from "../../../components/shared/ellipsisMenuActions";
@@ -71,13 +137,36 @@ import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
 import FilterTableBodyMixin from "../../../components/shared/FilterTableBodyMixin";
 import paginationTable from "../../../components/shared/PaginationTable.vue";
 
-import { createUniqIdsMixin } from "vue-uniq-ids";
 const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
   components: { EllipsisMenu, paginationTable },
-  mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin, screenNavigationMixin, FilterTableBodyMixin],
-  props: ["filter", "id", "pmql", "permission"],
+  mixins: [
+    datatableMixin,
+    dataLoadingMixin,
+    uniqIdsMixin,
+    ellipsisMenuMixin,
+    screenNavigationMixin,
+    FilterTableBodyMixin,
+  ],
+  props: {
+    permission: {
+      type: [String, Object],
+      default: "",
+    },
+    filter: {
+      type: String,
+      default: "",
+    },
+    pmql: {
+      type: String,
+      default: "",
+    },
+    id: {
+      type: String,
+      default: "",
+    },
+  },
   data() {
     return {
       orderBy: "name",
@@ -88,8 +177,8 @@ export default {
         {
           field: "name",
           sortField: "name",
-          direction: "asc"
-        }
+          direction: "asc",
+        },
       ],
 
       fields: [
@@ -129,12 +218,12 @@ export default {
           name: "__slot:actions",
           field: "actions",
           width: 60,
-        }
-      ]
+        },
+      ],
     };
   },
   created() {
-    ProcessMaker.EventBus.$on("api-data-my-screen-templates", (val) => {
+    ProcessMaker.EventBus.$on("api-data-my-screen-templates", () => {
       this.fetch();
       this.apiDataLoading = false;
       this.apiNoResults = false;
@@ -171,28 +260,18 @@ export default {
     },
     fetch() {
       this.loading = true;
-      //change method sort by slot name
+      // change method sort by slot name
       this.orderBy = this.orderBy === "__slot:name" ? "name" : this.orderBy;
       // Load from our api client
       ProcessMaker.apiClient
         .get(
-          "templates/screen" +
-          "?page=" +
-          this.page +
-          "&per_page=" +
-          this.perPage +
-          "&is_public=0" +
-          "&filter=" +
-          this.filter +
-          "&pmql=" + 
-          encodeURIComponent(this.pmql) +
-          "&order_by=" +
-          this.orderBy +
-          "&order_direction=" +
-          this.orderDirection +
-          "&include=categories,category,user"
+          "templates/screen"
+            + `?page=${this.page}&per_page=${this.perPage}&is_public=0`
+            + `&filter=${this.filter}&pmql=${encodeURIComponent(this.pmql)}&order_by=${
+              this.orderBy
+            }&order_direction=${this.orderDirection}&include=categories,category,user`,
         )
-        .then(response => {
+        .then((response) => {
           this.data = this.transform(response.data);
           this.loading = false;
         });
@@ -200,7 +279,7 @@ export default {
   },
 };
 </script>
-  
+
 <style lang="scss" scoped>
 :deep(th#_description) {
   width: 250px;

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-v-html -->
 <template>
   <div class="data-table">
     <data-loading
@@ -147,7 +148,24 @@ export default {
     FilterTableBodyMixin,
     uniqIdsMixin,
   ],
-  props: ["permission", "filter", "pmql", "id"],
+  props: {
+    permission: {
+      type: [String, Object],
+      default: "",
+    },
+    filter: {
+      type: String,
+      default: "",
+    },
+    pmql: {
+      type: String,
+      default: "",
+    },
+    id: {
+      type: String,
+      default: "",
+    },
+  },
   data() {
     return {
       orderBy: "name",
@@ -158,7 +176,6 @@ export default {
           direction: "asc",
         },
       ],
-
       fields: [
         {
           label: this.$t("Name"),

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -135,6 +135,7 @@ import screenNavigationMixin from "../../../components/shared/screenNavigation";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
 import FilterTableBodyMixin from "../../../components/shared/FilterTableBodyMixin";
 import paginationTable from "../../../components/shared/PaginationTable.vue";
+import fieldsMixin from "../mixins/fieldsMixin";
 
 const uniqIdsMixin = createUniqIdsMixin();
 
@@ -147,10 +148,11 @@ export default {
     screenNavigationMixin,
     FilterTableBodyMixin,
     uniqIdsMixin,
+    fieldsMixin,
   ],
   props: {
     permission: {
-      type: [String, Object],
+      type: [String, Object, Array],
       default: "",
     },
     filter: {
@@ -176,56 +178,19 @@ export default {
           direction: "asc",
         },
       ],
-      fields: [
-        {
-          label: this.$t("Name"),
-          field: "name",
-          width: 200,
-          sortable: true,
-          truncate: true,
-          direction: "none",
-        },
-        {
-          label: this.$t("Description"),
-          field: "description",
-          width: 200,
-          sortable: true,
-          direction: "none",
-          sortField: "description",
-        },
-        {
-          label: this.$t("Type of Screen"),
-          field: "screen_type",
-          width: 160,
-          sortable: true,
-          direction: "none",
-          sortField: "screen_type",
-        },
-        {
-          label: this.$t("Owner"),
-          field: "owner",
-          width: 160,
-          sortable: true,
-          direction: "none",
-          sortField: "user.username",
-        },
-        {
-          label: this.$t("Modified"),
-          field: "updated_at",
-          format: "datetime",
-          width: 160,
-          sortable: true,
-          direction: "none",
-        },
-        {
-          name: "__slot:actions",
-          field: "actions",
-          width: 60,
-        },
-      ],
+      fields: [],
     };
   },
   created() {
+    this.insertFieldAfter("screen_type", {
+      label: this.$t("Owner"),
+      field: "owner",
+      width: 160,
+      sortable: true,
+      direction: "none",
+      sortField: "user.username",
+    });
+    this.fields = this.commonFields;
     ProcessMaker.EventBus.$on("api-data-public-screen-templates", () => {
       this.fetch();
       this.apiDataLoading = false;

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -236,6 +236,10 @@ export default {
     },
     onPublicTemplateNavigate(actionType, data) {
       switch (actionType?.value) {
+        case "placeholder-action":
+          break;
+        case "placeholder-action-2":
+          break;
         case "delete-template":
           ProcessMaker.confirmModal(
             this.$t("Caution!"),

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -96,7 +96,7 @@
                     :data="row"
                     :divider="true"
                     :screen-template="true"
-                    @navigate="onPublicTemplateNavigate"
+                    @navigate="onTemplateNavigate"
                   />
                 </template>
                 <template v-if="header.field !== 'name'">
@@ -131,11 +131,11 @@ import { createUniqIdsMixin } from "vue-uniq-ids";
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import ellipsisMenuMixin from "../../../components/shared/ellipsisMenuActions";
-import screenNavigationMixin from "../../../components/shared/screenNavigation";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
 import FilterTableBodyMixin from "../../../components/shared/FilterTableBodyMixin";
 import paginationTable from "../../../components/shared/PaginationTable.vue";
 import fieldsMixin from "../mixins/fieldsMixin";
+import navigationMixin from "../mixins/navigationMixin";
 
 const uniqIdsMixin = createUniqIdsMixin();
 
@@ -145,10 +145,10 @@ export default {
     datatableMixin,
     dataLoadingMixin,
     ellipsisMenuMixin,
-    screenNavigationMixin,
     FilterTableBodyMixin,
     uniqIdsMixin,
     fieldsMixin,
+    navigationMixin,
   ],
   props: {
     permission: {
@@ -215,34 +215,6 @@ export default {
           this.data = this.transform(response.data);
           this.loading = false;
         });
-    },
-    onPublicTemplateNavigate(actionType, data) {
-      switch (actionType?.value) {
-        case "placeholder-action":
-          break;
-        case "placeholder-action-2":
-          break;
-        case "delete-template":
-          ProcessMaker.confirmModal(
-            this.$t("Caution!"),
-            this.$t(
-              "Are you sure you want to delete the screen template {{item}}?",
-              {
-                item: data.title,
-              },
-            ),
-            "",
-            () => {
-              ProcessMaker.apiClient.delete(`template/screen/${data.id}`).then(() => {
-                ProcessMaker.alert(this.$t("The template was deleted."), "success");
-                this.fetch();
-              });
-            },
-          );
-          break;
-        default:
-          break;
-      }
     },
   },
 };

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -261,7 +261,7 @@ export default {
           ProcessMaker.confirmModal(
             this.$t("Caution!"),
             this.$t(
-              "Are you sure you want to delete the screen {{item}}? Deleting this asset will break any active tasks that are assigned.",
+              "Are you sure you want to delete the screen template {{item}}?",
               {
                 item: data.title,
               },

--- a/resources/js/processes/screen-templates/mixins/fieldsMixin.js
+++ b/resources/js/processes/screen-templates/mixins/fieldsMixin.js
@@ -1,0 +1,53 @@
+export default {
+  data() {
+    return {
+      commonFields: [
+        {
+          label: this.$t("Name"),
+          field: "name",
+          width: 200,
+          sortable: true,
+          truncate: true,
+          direction: "none",
+        },
+        {
+          label: this.$t("Description"),
+          field: "description",
+          width: 200,
+          sortable: true,
+          direction: "none",
+          sortField: "description",
+        },
+        {
+          label: this.$t("Type of Screen"),
+          field: "screen_type",
+          width: 160,
+          sortable: true,
+          direction: "none",
+          sortField: "screen_type",
+        },
+        {
+          label: this.$t("Modified"),
+          field: "updated_at",
+          format: "datetime",
+          width: 160,
+          sortable: true,
+          direction: "none",
+        },
+        {
+          name: "__slot:actions",
+          field: "actions",
+          width: 60,
+        },
+      ],
+    };
+  },
+  methods: {
+    insertFieldAfter(fieldName, newField) {
+      const index = this.commonFields.findIndex((field) => field.field === fieldName);
+      if (index !== -1) {
+        this.commonFields.splice(index + 1, 0, newField);
+      }
+    },
+  },
+};

--- a/resources/js/processes/screen-templates/mixins/navigationMixin.js
+++ b/resources/js/processes/screen-templates/mixins/navigationMixin.js
@@ -1,0 +1,30 @@
+export default {
+  methods: {
+    onTemplateNavigate(actionType, data) {
+      switch (actionType?.value) {
+        case "placeholder-action":
+          break;
+
+        case "placeholder-action-2":
+          break;
+
+        case "delete-template":
+          ProcessMaker.confirmModal(
+            this.$t("Caution!"),
+            this.$t("Are you sure you want to delete the screen template {{item}}?", { item: data.title }),
+            "",
+            () => {
+              ProcessMaker.apiClient.delete(`template/screen/${data.id}`).then(() => {
+                ProcessMaker.alert(this.$t("The template was deleted."), "success");
+                this.fetch();
+              });
+            },
+          );
+          break;
+
+        default:
+          break;
+      }
+    },
+  },
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
Screen templates cannot be deleted.

1. Go to the designer - screens - my templates or public templates tab.
2. Click on the ellipsis menu.
3. Select 'Delete'.

## Solution
- Missing code has been added to enable the deletion of screen templates.

https://github.com/ProcessMaker/processmaker/assets/90741874/20312f94-408e-4a59-9ec7-70a5ae45f80a

## How to Test
- Follow the mentioned steps to test on a CI server.
- There is currently a PHP unit test that supports this functionality `php artisan test --filter ScreenTemplateTest::testDeleteScreenTemplate`.

## Related Tickets & Packages
- [FOUR-14492](https://processmaker.atlassian.net/browse/FOUR-14492)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14492]: https://processmaker.atlassian.net/browse/FOUR-14492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ