### PR TITLE
observation/FOUR-14515 The task tab does not show the last created tasks

### DIFF
--- a/resources/js/tasks/index.js
+++ b/resources/js/tasks/index.js
@@ -49,6 +49,7 @@ new Vue({
     ProcessMaker.EventBus.$on('advanced-search-addition', (component) => {
       this.additions.push(component);
     });
+  this.onInbox();
   },
   created() {
     const params = new URL(document.location).searchParams;


### PR DESCRIPTION
## Issue & Reproduction Steps
The task tab does not show the last created tasks.

## Solution
Added a validation to clear tab filters when task list is loaded

## How to Test
1.Create a request without completing the first task
2.Go to tasks
3.Reload

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14515

ci:deploy
ci:next