### PR TITLE
FOUR-14478: Option to render the Launchpad images of carousel in Launchap

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCarousel.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCarousel.vue
@@ -3,6 +3,7 @@
     <b-carousel
       id="processes-carousel"
       v-model="slide"
+      no-animation
       :interval="interval"
       indicators
       img-height="400px"

--- a/resources/js/processes-catalogue/components/ProcessesCarousel.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCarousel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-block">
+  <div class="carousel-container">
     <b-carousel
       id="processes-carousel"
       v-model="slide"
@@ -18,7 +18,7 @@
           <img
             :src="image.url"
             :alt="process.name"
-            class="d-block w-100 img-carousel"
+            class="d-block img-carousel"
           >
         </template>
       </b-carousel-slide>
@@ -112,7 +112,12 @@ export default {
   height: 400px;
 }
 .img-carousel {
-  max-width: 100%;
-  height: inherit;
+  max-width: 800px;
+  height: 400px;
+}
+.carousel-container {
+  display: flex;
+  justify-content: center;
+  background-color: #edf1f6;
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
Option to render the Launchpad images of carousel in Launchap

## Solution
- Height: 400 pixels
- Width: 800 pixels
- Aligned Centered
- Background color: #edf1f6

## How to Test
Go to Processes
Open a process and review the carousel

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14478

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy