### PR TITLE
FOUR-14380: Translate all strings in modal not working

### DIFF
--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -438,10 +438,6 @@ class ProcessTranslation
         if ($processTranslationToken) {
             $token = $processTranslationToken->token;
             $processTranslationToken->delete();
-
-            // Cancel pending batch jobs
-            $batch = Bus::findBatch($token);
-            $batch->cancel();
         }
 
         return true;

--- a/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
+++ b/resources/js/processes/translations/components/CreateProcessTranslationModal.vue
@@ -375,9 +375,14 @@ export default {
       const params = {
         language: this.selectedLanguage,
         processId: this.processId,
-        screenId: this.selectedScreen.id,
+        manualTranslation: this.manualTranslation,
+        promptSessionId: this.getPromptSessionForUser(),
+        nonce: localStorage.getItem("currentNonce"),
+        includeImages: true,
+        justStored: false,
         option,
-      };
+      }
+
       ProcessMaker.apiClient.post("/package-ai/language-translation", params)
         .then((response) => {
           this.screensTranslations = response.data.screensTranslations;

--- a/resources/js/processes/translations/components/ProcessTranslationListing.vue
+++ b/resources/js/processes/translations/components/ProcessTranslationListing.vue
@@ -189,8 +189,19 @@ export default {
       window.Echo.private(channel).listen(
         translationEvent,
         (response) => {
-          this.fetchPending();
-          this.fetch();
+          const language = response.data.language;
+          this.translatingLanguages.forEach(lang => {
+            if (lang.language === language) {
+              lang.stream = {
+                data: response.data.progress.progress + '%'
+              };
+              lang.humanLanguage += 'a';
+            }
+          });
+          if (response.data.progress.status === 'completed') {
+            this.fetchPending();
+            this.fetch();
+          }
         },
       );
     },
@@ -357,6 +368,13 @@ export default {
         )
         .then((response) => {
           this.translatingLanguages = response.data.translatingLanguages;
+
+          this.translatingLanguages.forEach(lang => {
+            lang.stream = {
+              data: "5 %",
+            };
+          });
+
           this.removeSocketListeners();
           this.subscribeToEvent();
         });

--- a/resources/js/processes/translations/components/ProcessTranslationListing.vue
+++ b/resources/js/processes/translations/components/ProcessTranslationListing.vue
@@ -29,16 +29,18 @@
           <td class="action">{{ formatDate(item.created_at) }}</td>
           <td class="action">{{ formatDate(item.updated_at) }}</td>
           <td class="action">
-            <ellipsis-menu
-              :actions="actionsInProgress"
-              :permission="permission"
-              :data="item"
-              :divider="true"
-              :customButton="inProgressButton"
-              :showProgress="true"
-              @navigate="onNavigate"
-            />
-            <p v-if="item.stream && item.stream.data">{{ item.stream.data }}</p>
+            <div class="translation-in-progress">
+              <ellipsis-menu
+                  :actions="actionsInProgress"
+                  :permission="permission"
+                  :data="item"
+                  :divider="true"
+                  :customButton="inProgressButton"
+                  :showProgress="true"
+                  @navigate="onNavigate"
+              />
+              <p class="right-aligned-percent" v-if="item.stream && item.stream.data">{{ item.stream.data }}</p>
+            </div>
           </td>
         </tr>
         <tr v-for="(item, index) in translatedLanguages" :key="index">
@@ -371,7 +373,7 @@ export default {
 
           this.translatingLanguages.forEach(lang => {
             lang.stream = {
-              data: "5 %",
+              data: "5%",
             };
           });
 
@@ -535,5 +537,19 @@ export default {
     left: 0;
     right: 0;
     top: 0;
+  }
+
+  .translation-in-progress {
+    display: flex;
+    flex-grow:1;
+    justify-content: flex-end;
+    align-items: center;
+  }
+
+  .right-aligned-percent {
+    float: right;
+    margin-left: 5px;
+    margin-top: 10px;
+    font-weight: bold;
   }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves the following observations:
- Translate all strings in modal not working
- Translate empty strings in modal not working
- Percentage number in translations not showing

## Solution
- Added code to support translations of just empty strings.

## How to Test
- Install package-ai
- Create a process with some tasks and screens
- Go to the process configurations and select the "Translations" tab.
- Add an automatic translation
- Edit the generated translation and press over the "Translating Options" button
- Test using Translate All and Translate just Empty translations.


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14380
- https://processmaker.atlassian.net/browse/FOUR-14379
- https://processmaker.atlassian.net/browse/FOUR-14378


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next