### PR TITLE
[35205] Permissions not applying to groups assigned to group

### DIFF
--- a/ProcessMaker/Traits/HasAuthorization.php
+++ b/ProcessMaker/Traits/HasAuthorization.php
@@ -32,11 +32,23 @@ trait HasAuthorization
 
         foreach ($this->groupMembersFromMemberable as $gm) {
             $group = $gm->group;
+            $permissions = $this->loadPermissionOfGroups($group, $permissions);
             $names = $group->permissions->pluck('name')->toArray();
             $permissions = array_merge($permissions, $names);
         }
 
         return $this->addCategoryViewPermissions($permissions);
+    }
+
+    public function loadPermissionOfGroups(Group $group, array $permissions = [])
+    {
+        foreach ($group->groupMembersFromMemberable as $member) {
+            $group = $member->group;
+            $permissions = $this->loadPermissionOfGroups($group, $permissions);
+            $permissions = array_merge($permissions, $group->permissions->pluck('name')->toArray());
+        }
+
+        return $permissions;
     }
 
     public function hasPermission($permissionString)


### PR DESCRIPTION
## Issue & Reproduction Steps
when you have the following assignment
User1 => without permissions.
Group1 => User1 assigned to the group, and the group has permission to Create-update Users.
Group2 => Group1 assigned to the group, and the group has permission to Create-Update processes.
The user does not have all permissions assigned.

## Solution
-  review recursively assigned groups.

## How to Test
create
User1 => without permissions.
Group1 => User1 assigned to the group, and the group has permission to Create-update Users.
Group2 => Group1 assigned to the group, and the group has permission to Create-Update processes.

loggin with user and review permissions

## Related Tickets & Packages
- [FOUR-12843](https://processmaker.atlassian.net/browse/FOUR-12843)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12843]: https://processmaker.atlassian.net/browse/FOUR-12843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ