### PR TITLE
FOUR-14519: Memory allocation error in a big Screen Template

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -5,12 +5,8 @@ namespace ProcessMaker\Templates;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\View\View;
 use ProcessMaker\Http\Controllers\Api\ExportController;
-use ProcessMaker\ImportExport\Exporter;
-use ProcessMaker\ImportExport\Exporters\ScreenExporter;
 use ProcessMaker\ImportExport\Importer;
 use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Models\Screen;
@@ -61,7 +57,24 @@ class ScreenTemplate implements TemplateInterface
             }
         }
 
-        $templates = $templates->select('screen_templates.*')
+        return $templates
+            ->select(
+                'screen_templates.id',
+                'screen_templates.uuid',
+                'screen_templates.unique_template_id',
+                'screen_templates.name',
+                'screen_templates.description',
+                'screen_templates.version',
+                'screen_templates.user_id',
+                'screen_templates.editing_screen_uuid',
+                'screen_templates.screen_category_id',
+                'screen_templates.screen_type',
+                'screen_templates.is_public',
+                'screen_templates.is_system',
+                'screen_templates.asset_type',
+                'screen_templates.media_collection',
+                'screen_templates.screen_custom_css',
+            )
             ->leftJoin('screen_categories as category', 'screen_templates.screen_category_id', '=', 'category.id')
             ->leftJoin('users as user', 'screen_templates.user_id', '=', 'user.id')
             ->orderBy(...$orderBy)
@@ -80,9 +93,8 @@ class ScreenTemplate implements TemplateInterface
                             })
                             ->where('screen_categories.name', 'like', '%' . $filter . '%');
                     });
-            })->paginate($request->input('per_page', 10));
-
-        return $templates;
+            })
+            ->paginate($request->input('per_page', 10));
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
When creating a Template from a screen that contains several elements, an error will occur that would not allow me to continue.

1. Create a screen with several elements or import the Screen attached.
2. Save the Screen as a Template 
3. Click on My Templates and this error will appear.

## Solution
- Instead of selecting all columns from the "screen_templates" table, all are chosen except the `manifest` column, as it is not relevant in the 3 endpoints where it's used. This modification optimizes the query and prevents the 500 error.

## How to Test
Import the Screen with many fields and test in the deployed server.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-14519](https://processmaker.atlassian.net/browse/FOUR-14519)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14519]: https://processmaker.atlassian.net/browse/FOUR-14519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ