### PR TITLE
FOUR-14545: Save as template is not present inside the screen

### DIFF
--- a/resources/js/components/Menu.vue
+++ b/resources/js/components/Menu.vue
@@ -89,7 +89,7 @@
             }"
             :key="index"
             :options="item.options"
-            @navigate="(action, data) => handleNavigate(action, data)"
+            @navigate="handleNavigate"
           />
         </template>
       </b-col>
@@ -160,9 +160,12 @@ export default {
   },
   methods: {
     handleNavigate(action) {
-      switch (action.value) {
+      switch (action?.value) {
         case "discard-draft":
           window.ProcessMaker.EventBus.$emit("open-versions-discard-modal");
+          break;
+        case "create-template":
+          window.ProcessMaker.EventBus.$emit("show-create-template-modal");
           break;
         default:
           if (action.action) {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -291,7 +291,7 @@
           <tree-view
             v-model="previewDataStringify"
             :iframe-height="iframeHeight"
-            style="border:1px; solid gray;"
+            style="border: 1px solid gray;"
           />
         </b-col>
       </b-row>
@@ -311,6 +311,20 @@
       ref="watchersPopup"
       v-model="watchers"
       @input="onInput()"
+    />
+    <create-template-modal
+      id="create-template-modal"
+      ref="create-template-modal"
+      asset-type="screen"
+      :current-user-id="user.id"
+      :asset-name="screen.title"
+      :asset-id="screen.id"
+      :screen-type="screen.type"
+      :permission="permission"
+      :types="{ [screen.type]: screen.type }"
+      header-class="border-0"
+      footer-class="border-0"
+      modal-size="lg"
     />
   </div>
 </template>
@@ -334,6 +348,7 @@ import formTypes from "./formTypes";
 import DataLoadingBasic from "../../components/shared/DataLoadingBasic.vue";
 import AssetRedirectMixin from "../../components/shared/AssetRedirectMixin";
 import autosaveMixins from "../../modules/autosave/mixins";
+import CreateTemplateModal from "../../components/templates/CreateTemplateModal.vue";
 
 export default {
   components: {
@@ -345,6 +360,7 @@ export default {
     MonacoEditor,
     TopMenu,
     DataLoadingBasic,
+    CreateTemplateModal,
   },
   mixins: [...autosaveMixins, AssetRedirectMixin],
   props: {
@@ -373,6 +389,7 @@ export default {
       default: false,
     },
     processId: {
+      type: Number,
       default: 0,
     },
   },
@@ -502,6 +519,7 @@ export default {
     ];
 
     return {
+      user: {},
       previewDataStringify: "",
       numberOfElements: 0,
       preview: {
@@ -567,6 +585,11 @@ export default {
             content: this.$t("Discard Draft"),
             icon: "fas fa-angle-double-down",
             hide: this.isVersionsInstalled,
+          },
+          {
+            value: "create-template",
+            content: this.$t("Save as Template"),
+            icon: "fas fa-file-image",
           },
         ],
       },
@@ -673,7 +696,8 @@ export default {
   },
   mounted() {
     // To include another language in the Validator with variable processmaker
-    if (window.ProcessMaker?.user?.lang) {
+    this.user = window.ProcessMaker?.user;
+    if (this.user?.lang) {
       Validator.useLang(window.ProcessMaker.user.lang);
     }
 
@@ -689,6 +713,9 @@ export default {
     this.setVersionIndicator();
     // Display ellipsis menu.
     this.setEllipsisMenu();
+    ProcessMaker.EventBus.$on("show-create-template-modal", () => {
+      this.$refs["create-template-modal"].show();
+    });
   },
   methods: {
     ...mapMutations("globalErrorsModule", { setStoreMode: "setMode" }),
@@ -757,9 +784,9 @@ export default {
           return;
         }
         warnings.push(
-          // eslint-disable-next-line max-len
           this.$t(
-            "{{name}} on page {{pageName}} is not accessible to screen readers. Please add a Label in the Variable section or an Aria Label in the Advanced section.",
+            "{{name}} on page {{pageName}} is not accessible to screen readers. "
+            + "Please add a Label in the Variable section or an Aria Label in the Advanced section.",
             {
               name: item.config.name,
               pageName,
@@ -1246,7 +1273,7 @@ body {
 .page-dropdown-menu {
   min-width: 333px;
   .dropdown-item {
-   font-size: 14px !important; 
+   font-size: 14px !important;
   };
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
Save as template is not in the option menu of screen builder.

1. Create a new  screen 
2. Inside the screen click on the op menu

## Solution
- Added new "Save as Template" menu item in `screen-builder` section.

## How to Test
- Please test following the reproduction steps on the deployed CI Server.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-14545](https://processmaker.atlassian.net/browse/FOUR-14545)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14545]: https://processmaker.atlassian.net/browse/FOUR-14545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ