### PR TITLE
FOUR-14554: The make public option from my template does not work

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -4,19 +4,13 @@ namespace ProcessMaker\Templates;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\View\View;
 use ProcessMaker\Http\Controllers\Api\ExportController;
-use ProcessMaker\ImportExport\Exporter;
-use ProcessMaker\ImportExport\Exporters\ScreenExporter;
 use ProcessMaker\ImportExport\Importer;
 use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
 use ProcessMaker\Models\ScreenTemplates;
-use ProcessMaker\Models\Template;
 use ProcessMaker\Traits\HasControllerAddons;
 use ProcessMaker\Traits\HideSystemResources;
 use SebastianBergmann\CodeUnit\Exception;
@@ -169,6 +163,31 @@ class ScreenTemplate implements TemplateInterface
         $template->saveOrFail();
 
         return response()->json();
+    }
+
+    /**
+     * Update the template.
+     */
+    public function updateTemplate(Request $request): JsonResponse
+    {
+        $request->validate([
+            'is_public' => 'sometimes|boolean',
+        ]);
+
+        $template = ScreenTemplates::findOrFail($request->id);
+
+        try {
+            $template->update($request->all());
+
+            $response = response()->json();
+        } catch (Exception $e) {
+            $response = response([
+                'message' => $e->getMessage(),
+                'errors' => $e->getMessage(),
+            ], 422);
+        }
+
+        return $response;
     }
 
     /**

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -1,4 +1,4 @@
-import DataLoading from "../common/DataLoading";
+import DataLoading from "../common/DataLoading.vue";
 
 export default {
   components: {
@@ -28,7 +28,7 @@ export default {
           href: "/process-browser/{{id}}",
           permission: ["edit-processes", "create-projects", "view-projects"],
           icon: "fas fa-file-export",
-          conditional: "if(status == 'ACTIVE', true, false)"
+          conditional: "if(status == 'ACTIVE', true, false)",
         },
         {
           value: "open-in-modeler",
@@ -37,14 +37,14 @@ export default {
           href: "/modeler/{{id}}",
           permission: ["edit-processes", "view-additional-asset-actions"],
           icon: "fas fa-edit",
-          conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)"
+          conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)",
         },
         {
           value: "edit-launchpad",
           content: "Edit in Launchpad",
           permission: ["edit-processes", "view-additional-asset-actions"],
           icon: "fas fa-edit",
-          conditional: "if(status == 'ACTIVE', true, false)"
+          conditional: "if(status == 'ACTIVE', true, false)",
         },
         {
           value: "create-template",
@@ -62,7 +62,7 @@ export default {
           value: "add-to-project",
           content: "Add to Project",
           icon: "fas fa-folder-plus",
-          permission: 'create-projects',
+          permission: "create-projects",
         },
         {
           value: "edit-item",
@@ -71,7 +71,8 @@ export default {
           href: "/processes/{{id}}/edit",
           permission: ["edit-processes", "view-additional-asset-actions"],
           icon: "fas fa-cog",
-          conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)"},
+          conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)",
+        },
         {
           value: "view-documentation",
           content: "View Documentation",
@@ -86,7 +87,7 @@ export default {
           content: "Archive",
           permission: ["archive-processes", "view-additional-asset-actions"],
           icon: "fas fa-archive",
-          conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)"
+          conditional: "if(status == 'ACTIVE' or status == 'INACTIVE', true, false)",
         },
         { value: "divider" },
         {
@@ -204,7 +205,7 @@ export default {
           permission: [
             "edit-data-sources",
             "view-data-sources",
-            "view-additional-asset-actions"
+            "view-additional-asset-actions",
           ],
         },
         {
@@ -217,7 +218,7 @@ export default {
           value: "remove-item",
           content: "Delete",
           icon: "fas fa-trash",
-          permission: ["delete-data-sources", "view-additional-asset-actions"]
+          permission: ["delete-data-sources", "view-additional-asset-actions"],
         },
       ],
       decisionTableActions: [
@@ -227,8 +228,8 @@ export default {
           icon: "fas fa-pen-square",
           permission: [
             "edit-decision_tables",
-            "view-additional-asset-actions"
-          ]
+            "view-additional-asset-actions",
+          ],
         },
         {
           value: "configure-item",
@@ -236,8 +237,8 @@ export default {
           icon: "fas fa-cog",
           permission: [
             "edit-decision_tables",
-            "view-additional-asset-actions"
-          ]
+            "view-additional-asset-actions",
+          ],
         },
         {
           value: "add-to-project",
@@ -249,17 +250,16 @@ export default {
           value: "export-item",
           content: "Export",
           icon: "fas fa-file-export",
-          permission: ["export-decision_tables", "view-additional-asset-actions"]
+          permission: ["export-decision_tables", "view-additional-asset-actions"],
         },
         {
           value: "remove-item",
           content: "Delete",
           icon: "fas fa-trash",
-          permission: ["delete-decision_tables", "view-additional-asset-actions"]
+          permission: ["delete-decision_tables", "view-additional-asset-actions"],
         },
       ],
       myTemplateActions: [
-        //TODO: Update My Template Ellipsis Menu Actions
         {
           value: "edit-template",
           content: "Edit Template",
@@ -271,8 +271,6 @@ export default {
         {
           value: "make-public",
           content: "Make Public",
-          link: true,
-          href: "/designer/screens/{{id}}/edit",
           permission: "publish-screen-templates",
           icon: "fas fa-globe",
         },
@@ -292,7 +290,6 @@ export default {
         },
       ],
       publicTemplateActions: [
-        //TODO: Update Public Template Ellipsis Menu Actions
         {
           value: "export-item",
           content: "Export Template",

--- a/resources/js/components/templates/CreateTemplateModal.vue
+++ b/resources/js/components/templates/CreateTemplateModal.vue
@@ -125,7 +125,7 @@ export default {
         });
       },  
       updateTemplate() {   
-        ProcessMaker.apiClient.put("template/" + this.assetType + "/" + this.existingAssetId, this.templateData)
+        ProcessMaker.apiClient.put("template/" + this.assetType + "/" + this.existingAssetId + "/update", this.templateData)
         .then(response => {
           ProcessMaker.alert( this.$t("Template successfully updated"),"success");
           this.close();

--- a/resources/js/processes/screen-templates/mixins/navigationMixin.js
+++ b/resources/js/processes/screen-templates/mixins/navigationMixin.js
@@ -5,7 +5,18 @@ export default {
         case "placeholder-action":
           break;
 
-        case "placeholder-action-2":
+        case "make-public":
+          ProcessMaker.apiClient
+            .put(`template/screen/${data.id}/update`, {
+              name: data.name,
+              description: data.description,
+              version: data.version,
+              is_public: true,
+            })
+            .then(() => {
+              ProcessMaker.alert(this.$t("The template is now public."), "success");
+              this.fetch();
+            });
           break;
 
         case "delete-template":

--- a/routes/api.php
+++ b/routes/api.php
@@ -295,7 +295,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('template/{type}/{id}', [TemplateController::class, 'store'])->name('template.store')->middleware('template-authorization');
     Route::post('template/create/{type}/{id}', [TemplateController::class, 'create'])->name('template.create')->middleware('template-authorization');
     Route::put('template/{type}/{processId}', [TemplateController::class, 'updateTemplateManifest'])->name('template.update')->middleware('template-authorization');
-    Route::put('template/{type}/{id}', [TemplateController::class, 'updateTemplate'])->name('template.update.template')->middleware('template-authorization');
+    Route::put('template/{type}/{id}/update', [TemplateController::class, 'updateTemplate'])->name('template.update.template')->middleware('template-authorization');
     Route::put('template/settings/{type}/{id}', [TemplateController::class, 'updateTemplateConfigs'])->name('template.settings.update')->middleware('template-authorization');
     Route::delete('template/{type}/{id}', [TemplateController::class, 'delete'])->name('template.delete')->middleware('template-authorization');
     Route::get('modeler/templates/{type}/{id}', [TemplateController::class, 'show'])->name('modeler.template.show')->middleware('template-authorization');

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -2,9 +2,7 @@
 
 namespace Tests\Feature\Templates\Api;
 
-use Exception;
 use Illuminate\Foundation\Testing\WithFaker;
-use ProcessMaker\Http\Controllers\Api\ExportController;
 use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
@@ -132,5 +130,46 @@ class ScreenTemplateTest extends TestCase
         ];
         $response = $this->actingAs($user, 'api')->call('POST', $route, $data);
         $response->assertStatus(200);
+    }
+
+    public function testMakePublicScreenTemplate()
+    {
+        $screenTemplate = ScreenTemplates::factory()->create(['is_public' => false]);
+
+        $route = route('api.template.update.template', [
+            'type' => 'screen',
+            'id' => $screenTemplate->id,
+        ]);
+        $params = [
+            'name' => $screenTemplate->name,
+            'description' => $screenTemplate->description,
+            'version' => $screenTemplate->version,
+            'is_public' => true,
+        ];
+        $response = $this->apiCall('PUT', $route, $params);
+
+        // Check that the screen template is now public.
+        $response->assertStatus(200);
+        $screenTemplate->refresh();
+        $this->assertEquals(1, $screenTemplate->is_public);
+    }
+
+    public function testMakePrivateScreenTemplate()
+    {
+        $screenTemplate = ScreenTemplates::factory()->create(['is_public' => true]);
+
+        $url = "/template/screen/{$screenTemplate->id}/update";
+        $params = [
+            'name' => $screenTemplate->name,
+            'description' => $screenTemplate->description,
+            'version' => $screenTemplate->version,
+            'is_public' => false,
+        ];
+        $response = $this->apiCall('PUT', $url, $params);
+
+        // Check that the screen template is now private.
+        $response->assertStatus(200);
+        $screenTemplate->refresh();
+        $this->assertEquals(0, $screenTemplate->is_public);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The "Make Public" menu option doesn't work.

1. have a screen 
2. create a screen template 
3. click on menu options
4. click on "make public"

## Solution
1. Fixed conflict in the route `'template/{type}/{id}'`, which was conflicting with `'template/{type}/{processId}'`. To differentiate them, the route was updated to: `'template/{type}/{id}/update'` and corresponding references were updated. 
2. Added unit test for functionality of making a template public. Added tweaks in the frontend to make this API call.

https://github.com/ProcessMaker/processmaker/assets/90741874/2fdcffe8-b6e6-4bc1-a33f-f9cd23b8bce1

## How to Test
- Test on the deployed server / all tests should pass.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-14554](https://processmaker.atlassian.net/browse/FOUR-14554)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-14554]: https://processmaker.atlassian.net/browse/FOUR-14554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ