### PR TITLE
FOUR-13419 STORY Tag each request with the alternative identifier

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -166,7 +166,9 @@ class ProcessRequestController extends Controller
                 $response = $query->orderBy(
                     str_ireplace('.', '->', $request->input('order_by', 'name')),
                     $request->input('order_direction', 'ASC')
-                )->select('process_requests.*')
+                )
+                ->select('process_requests.*')
+                ->withAggregate('processVersion', 'alternative')
                 ->paginate($request->input('per_page', 10));
                 $total = $response->total();
             }

--- a/ProcessMaker/Managers/DataManager.php
+++ b/ProcessMaker/Managers/DataManager.php
@@ -188,6 +188,11 @@ class DataManager
         $data['_request']['startEventId'] = $startEventToken?->element_id;
         $data['_request']['startEventName'] = $startEventToken?->element_name;
 
+        // Magic Variable: _request.alternative
+        if ($request->processVersionAlternative) {
+            $data['_request']['alternative'] = $request->processVersionAlternative;
+        }
+
         return $data;
     }
 }

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -1050,10 +1050,10 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
             ->exists();
     }
 
-    public function getProcessVersionAlternativeAttribute(): string
+    public function getProcessVersionAlternativeAttribute(): string | null
     {
         if (class_exists('ProcessMaker\Package\PackageABTesting\Models\Alternative')) {
-            return $this->processVersion->alternative;
+            return $this->processVersion?->alternative;
         }
 
         return null;

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -19,6 +19,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\SignalEventDefinitionInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 use ProcessMaker\Nayra\Engine\ExecutionInstanceTrait;
+use ProcessMaker\Query\Expression;
 use ProcessMaker\Repositories\BpmnDocument;
 use ProcessMaker\Traits\ExtendedPMQL;
 use ProcessMaker\Traits\ForUserScope;
@@ -747,6 +748,23 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     }
 
     /**
+     * PMQL value alias for the alternative field in the process version
+     *
+     * @param string value
+     * @param ProcessMaker\Query\Expression expression
+     *
+     * @return callable
+     */
+    public function valueAliasAlternative(string $value, Expression $expression): callable
+    {
+        return function ($query) use ($expression, $value) {
+            $query->whereHas('processVersion', function ($query) use ($expression, $value) {
+                $query->where('alternative', $expression->operator, $value);
+            });
+        };
+    }
+
+    /**
      * Get the process version used by this request
      *
      * @return ProcessVersion
@@ -1030,5 +1048,14 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
             ->where('category_type', ProcessCategory::class)
             ->whereIn('category_id', $systemCategories)
             ->exists();
+    }
+
+    public function getProcessVersionAlternativeAttribute(): string
+    {
+        if (class_exists('ProcessMaker\Package\PackageABTesting\Models\Alternative')) {
+            return $this->processVersion->alternative;
+        }
+
+        return null;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,7 @@
                 "connector-slack": "1.8.0",
                 "docker-executor-cdata": "1.3.0",
                 "docker-executor-node-ssr": "1.5.0",
+                "package-ab-testing": "1.0.0",
                 "package-actions-by-email": "1.16.0",
                 "package-advanced-user-manager": "1.10.0",
                 "package-ai": "1.7.0",

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -18,9 +18,9 @@
         </template>
         <!-- Slot Table Header filter Button -->
         <template v-for="(column, index) in tableHeaders" v-slot:[`filter-${column.field}`]>
-            <PMColumnFilterPopover v-if="column.sortable" 
-                                   :key="index" 
-                                   :id="'pm-table-column-'+index" 
+            <PMColumnFilterPopover v-if="column.sortable"
+                                   :key="index"
+                                   :id="'pm-table-column-'+index"
                                    :type="getTypeColumnFilter(column.field)"
                                    :value="column.field"
                                    :format="getFormat(column)"
@@ -93,7 +93,7 @@
       v-show="shouldShowLoader"
       :for="/requests\?page|results\?page/"
       :empty="$t('No results have been found')"
-      :empty-desc="$t(`We apologize, but we were unable to find any results that match your search. 
+      :empty-desc="$t(`We apologize, but we were unable to find any results that match your search.
 Please consider trying a different search. Thank you`)"
       empty-icon="noData"
     />
@@ -256,6 +256,18 @@ export default {
           truncate: true,
         },
         {
+          label: "Alternative",
+          field: "process_version_alternative",
+          sortable: true,
+          default: true,
+          width: 150,
+          truncate: true,
+          filter_subject: {
+            type: "Relationship",
+            value: "processVersion.alternative",
+          },
+        },
+        {
           label: "Task",
           field: "active_tasks",
           sortable: false,
@@ -372,6 +384,9 @@ export default {
         },
       };
     },
+    formatProcessVersionAlternative(value) {
+      return `Alternative ${value}`;
+    },
     transform(dataInput) {
       const data = _.cloneDeep(dataInput);
       // Clean up fields for meta pagination so vue table pagination can understand
@@ -388,6 +403,7 @@ export default {
         }
         record["status"] = this.formatStatus(record["status"]);
         record["participants"] = this.formatParticipants(record["participants"]);
+        record["process_version_alternative"] = this.formatProcessVersionAlternative(record["process_version_alternative"]);
       }
       return data;
     },
@@ -418,7 +434,7 @@ export default {
             (this.orderBy === "__slot:ids" ? "id" : this.orderBy) +
             "&order_direction=" +
             this.orderDirection +
-            this.additionalParams + 
+            this.additionalParams +
             advancedFilter,
             {
               cancelToken: new CancelToken((c) => {


### PR DESCRIPTION
## Issue & Reproduction Steps
ProcessMaker platform will automatically set the version (A or B ) in the metadata of the request

## Solution
- Add alternative info to DataManager
- Add an alternative column to Request list
- Add support to alternative filtering, sorting, and PMQL 

## Related Tickets & Packages
[FOUR-13419](https://processmaker.atlassian.net/browse/FOUR-13419)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:package-ab-testing:feature/FOUR-11361


[FOUR-13419]: https://processmaker.atlassian.net/browse/FOUR-13419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ