### PR TITLE
FOUR-14553: The pagination controls of my templates is on the edge of the frame

### DIFF
--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -10,7 +10,7 @@
     />
     <div
       v-show="!shouldShowLoader"
-      class="card card-body my-templates-table-card"
+      class="my-templates-table-card"
       data-cy="my-templates-table"
     >
       <filter-table

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -10,7 +10,7 @@
     />
     <div
       v-show="!shouldShowLoader"
-      class="card card-body public-templates-table-card"
+      class="public-templates-table-card"
       data-cy="public-templates-table"
     >
       <filter-table


### PR DESCRIPTION
## Issue & Reproduction Steps

The pagination controls of my template and public template is very close to the edge of the frame.

1. Click on Designer
2. Click on Screens
3. Click on My Template and Public Template

## Solution
- Removed non necessary classes from the div.

![Screenshot 2024-03-22 at 10-02-42 Screens - ProcessMaker](https://github.com/ProcessMaker/processmaker/assets/90741874/d113a38a-46e2-448e-8469-ec06bc71397b)

## How to Test
- Manual testing or deployed server.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-14553](https://processmaker.atlassian.net/browse/FOUR-14553)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14553]: https://processmaker.atlassian.net/browse/FOUR-14553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ