### PR TITLE
bugfix/FOUR-14580 Changed openTask call

### DIFF
--- a/resources/js/tasks/components/TasksHome.vue
+++ b/resources/js/tasks/components/TasksHome.vue
@@ -31,7 +31,7 @@
         <b-button
           class="btn-light text-secondary"
           :aria-label="$t('Open Task')"
-          :href="openTask()"
+          @click="openTask()"
         >
           <i class="fas fa-external-link-alt" />
         </b-button>


### PR DESCRIPTION
## Issue & Reproduction Steps
Open Preview Task (eye icon) is open the screen in the Task tab

## Solution
This action show an empty form then redirect to the Task tab

## How to Test
Login
Go to Home
My Task → Click in the eye icon

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14580

ci:deploy
ci:next