### PR TITLE
[36258 ]Interstitial pages load twice

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -872,11 +872,10 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     public function notifyProcessUpdated($eventName)
     {
         $event = new ProcessUpdated($this, $eventName);
-        event($event);
         if ($this->parentRequest) {
             $this->parentRequest->notifyProcessUpdated($eventName);
-            event($event);
         }
+        event($event);
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
When you have a process with multiple thread levels and interstitial enabled, the interstitial is loaded twice.

## Solution
- remove event 

## How to Test
In order to reproduce the problem you need to add a 2 second sleep to the file
ProcessMaker/Models/ProcessRequest.php
in the notifyProcessUpdated function before sending the event.
In this way a delay is created in the sending of the events.

create a case and then derive it to check that the interstitial is not loaded twice.

note:
1. interstitial in a single process (enable interstitial in multiple assigned tasks)
2. interstitial in a SubProcess (multiple levels in SubProcesses and enable interstitial in multiple assigned tasks)
3. interstitial with WebEntry (enable interstitial on multiple assigned tasks)
4. verification in the display of tasks (activate/deactivate the interstitial in several assigned tasks)

## Related Tickets & Packages
- [FOUR-14542](https://processmaker.atlassian.net/browse/FOUR-14542)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:screen-builder:bugfix/FOUR-14542
ci:deploy

[FOUR-14542]: https://processmaker.atlassian.net/browse/FOUR-14542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ