### PR TITLE
FOUR-13420 Alternative Testing

### DIFF
--- a/ProcessMaker/Filters/Filter.php
+++ b/ProcessMaker/Filters/Filter.php
@@ -46,6 +46,7 @@ class Filter
         'in',
         'contains',
         'regex',
+        'starts_with',
     ];
 
     public static function filter(Builder $query, string|array $filterDefinitions)
@@ -152,7 +153,7 @@ class Filter
     private function operator()
     {
         if (!in_array($this->operator, $this->operatorWhitelist)) {
-            abort("Invalid operator: {$this->operator}");
+            abort(422, "Invalid operator: {$this->operator}");
         }
 
         if ($this->operator === 'contains' || $this->operator === 'starts_with') {

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -49,12 +49,11 @@ class ModelerController extends Controller
         // Get plugin addons for the 'show' action
         $addons = $this->getPluginAddons('show', []);
 
-        // Retrieve custom blade view and alternatives from addons
+        // Retrieve custom blade from addons
         $customBlade = ($addons[0] ?? [])['new-blade'] ?? null;
-        $alternatives = ($addons[0] ?? [])['alternatives'] ?? null;
 
-        // If a custom blade view and alternatives are provided, render the custom view
-        if ($customBlade && $alternatives) {
+        // If a custom blade view is provided, render the custom view
+        if ($customBlade) {
             return view($customBlade, $this->prepareModelerData($manager, $process, $request, 'A'));
         }
 
@@ -79,6 +78,13 @@ class ModelerController extends Controller
      */
     public function prepareModelerData(ModelerManager $manager, Process $process, Request $request, string $alternative)
     {
+        // Initializing variables
+        $processA = $processB = null;
+        $startingPointsA = $startingPointsB = [];
+        $startingPoints = ['A' => [], 'B' => []];
+        $resumePointsA = $resumePointsB = [];
+        $resumePoints = ['A' => [], 'B' => []];
+
         // Retrieve PM block list and external integrations list
         $pmBlockList = $this->getPmBlockList();
         $externalIntegrationsList = $this->getExternalIntegrationsList();
@@ -112,9 +118,109 @@ class ModelerController extends Controller
 
         // Append notifications to the process
         $process->append('notifications', 'task_notifications');
+
         // Load the alternative if the package is installed
         if (class_exists('ProcessMaker\Package\PackageABTesting\Models\Alternative')) {
             $process->load('alternativeInfo');
+
+            // Load the another alternative
+            if ($process->alternative === 'A') {
+                $processAlternative = $process->getLatestVersion('B');
+                if (!is_null($processAlternative)) {
+                    $processB = Process::find($process->id);
+                    $processB->bpmn = $processAlternative->bpmn;
+                }
+                $processA = $process;
+            } else if ($process->alternative === 'B') {
+                $processAlternative = $process->getLatestVersion('A');
+                if (!is_null($processAlternative)) {
+                    $processA = Process::find($process->id);
+                    $processA->bpmn = $processAlternative->bpmn;
+                }
+                $processB = $process;
+            }
+
+            // Force to get updated start events
+            if (!is_null($processA)) {
+                $processA->start_events = $processA->getUpdatedStartEvents();
+            }
+            if (!is_null($processB)) {
+                $processB->start_events = $processB->getUpdatedStartEvents();
+            }
+
+            // Get all starting points
+            if (!empty($processA)) {
+                if (!empty($processA->start_events)) {
+                    foreach ($processA->start_events as $startEvent) {
+                        $startingPointsA[] = [
+                            'id' => $startEvent['id'],
+                            'name' => $startEvent['name'],
+                            'type' => 'startEvent',
+                        ];
+                    }
+                }
+                foreach ($processA->getTasks() as $task) {
+                    $startingPointsA[] = [
+                        'id' => $task['id'],
+                        'name' => $task['name'],
+                        'type' => 'task',
+                    ];
+                }
+            }
+
+            if (!empty($processB)) {
+                if (!empty($processB->start_events)) {
+                    foreach ($processB->start_events as $startEvent) {
+                        $startingPointsB[] = [
+                            'id' => $startEvent['id'],
+                            'name' => $startEvent['name'],
+                            'type' => 'startEvent',
+                        ];
+                    }
+                }
+                foreach ($processB->getTasks() as $task) {
+                    $startingPointsB[] = [
+                        'id' => $task['id'],
+                        'name' => $task['name'],
+                        'type' => 'task',
+                    ];
+                }
+            }
+
+            $startingPoints = [
+                'A' => $startingPointsA,
+                'B' => $startingPointsB,
+            ];
+
+            // Get all resume points
+            if (!empty($processA)) {
+                foreach ($processA->getTasks() as $task) {
+                    if ($task['type'] === 'task' || $task['type'] === 'userTask' || $task['type'] === 'manualTask') {
+                        $resumePointsA[] = [
+                            'id' => $task['id'],
+                            'name' => $task['name'],
+                            'type' => $task['type'],
+                        ];
+                    }
+                }
+            }
+
+            if (!empty($processB)) {
+                foreach ($processB->getTasks() as $task) {
+                    if ($task['type'] === 'task' || $task['type'] === 'userTask' || $task['type'] === 'manualTask') {
+                        $resumePointsB[] = [
+                            'id' => $task['id'],
+                            'name' => $task['name'],
+                            'type' => $task['type'],
+                        ];
+                    }
+                }
+            }
+
+            $resumePoints = [
+                'A' => $resumePointsA,
+                'B' => $resumePointsB,
+            ];
         }
 
         return [
@@ -137,6 +243,9 @@ class ModelerController extends Controller
             'isAiGenerated' => request()->query('ai'),
             'runAsUserDefault' => $runAsUserDefault,
             'alternative' => $alternative,
+            'abPublish' => PackageHelper::isPackageInstalled('ProcessMaker\Package\PackageABTesting\PackageServiceProvider'),
+            'startingPoints' => $startingPoints,
+            'resumePoints' => $resumePoints,
         ];
     }
 

--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -131,7 +131,7 @@ class ModelerController extends Controller
                     $processB->bpmn = $processAlternative->bpmn;
                 }
                 $processA = $process;
-            } else if ($process->alternative === 'B') {
+            } elseif ($process->alternative === 'B') {
                 $processAlternative = $process->getLatestVersion('A');
                 if (!is_null($processAlternative)) {
                     $processA = Process::find($process->id);
@@ -228,7 +228,8 @@ class ModelerController extends Controller
             'manager' => $manager,
             'signalPermissions' => SignalManager::permissions($request->user()),
             'autoSaveDelay' => config('versions.delay.process', 5000),
-            'isVersionsInstalled' => PackageHelper::isPackageInstalled('ProcessMaker\Package\Versions\PluginServiceProvider'),
+            'isVersionsInstalled' =>
+                PackageHelper::isPackageInstalled('ProcessMaker\Package\Versions\PluginServiceProvider'),
             'isDraft' => $draft !== null,
             'draftAlternative' => $draft !== null ? $draft->alternative : null,
             'pmBlockList' => $pmBlockList,
@@ -243,7 +244,8 @@ class ModelerController extends Controller
             'isAiGenerated' => request()->query('ai'),
             'runAsUserDefault' => $runAsUserDefault,
             'alternative' => $alternative,
-            'abPublish' => PackageHelper::isPackageInstalled('ProcessMaker\Package\PackageABTesting\PackageServiceProvider'),
+            'abPublish' =>
+                PackageHelper::isPackageInstalled('ProcessMaker\Package\PackageABTesting\PackageServiceProvider'),
             'startingPoints' => $startingPoints,
             'resumePoints' => $resumePoints,
         ];

--- a/resources/js/tasks/components/TasksHome.vue
+++ b/resources/js/tasks/components/TasksHome.vue
@@ -31,7 +31,7 @@
         <b-button
           class="btn-light text-secondary"
           :aria-label="$t('Open Task')"
-          :href="openTask()"
+          @click="openTask()"
         >
           <i class="fas fa-external-link-alt" />
         </b-button>

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -65,7 +65,6 @@ div.main {
   window.ProcessMaker.PMBlockList = @json($pmBlockList);
   window.ProcessMaker.ExternalIntegrationsList = @json($externalIntegrationsList);
   window.ProcessMaker.modeler = {
-    abPublish: false,
     process: @json($process),
     autoSaveDelay: @json($autoSaveDelay),
     xml: @json($process->bpmn),
@@ -93,6 +92,10 @@ div.main {
     isPackageAiInstalled: @json($isPackageAiInstalled),
     isAiGenerated: @json($isAiGenerated),
     runAsUserDefault: @json($runAsUserDefault),
+    abPublish: @json($abPublish),
+    alternative: @json($alternative),
+    startingPoints: @json($startingPoints),
+    resumePoints: @json($resumePoints),
   }
   const warnings = @json($process->warnings);
 

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -94,6 +94,7 @@ div.main {
     runAsUserDefault: @json($runAsUserDefault),
     abPublish: @json($abPublish),
     alternative: @json($alternative),
+    draftAlternative: @json($draftAlternative),
     startingPoints: @json($startingPoints),
     resumePoints: @json($resumePoints),
   }


### PR DESCRIPTION
https://processmaker.atlassian.net/browse/FOUR-13420

A process designer that is testing a process, I want to control which alternative is tested and perform a test that represents how my process alternative will conduct.

If I dont define anything explicit, the test should execute following the same AB distribution that would apply during runtime (be it A or B ) . As tester, I should be able to identify immediately which alternative is executing.

Conversely, as a tester I can define which alternative to test explicitly with any given scenario, overriding any AB distribution setting. That way I can force test both alternatives with any scenario.