### PR TITLE
FOUR-14579: The content to Config options in Admin Settings is not the same like figma

### DIFF
--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -386,12 +386,16 @@ class Setting extends ProcessMakerModel implements HasMedia
             ->select('group')
             ->groupBy('group')
             ->where('group_id', $menuId)
+            ->orderBy('group', 'ASC')
             ->notHidden()
             ->pluck('group');
         $response = $query->toArray();
         $result = [];
         foreach ($response as &$value) {
             // Technical debts: we need to add int key to identify a group, currently this is a label
+            if (strpos($value, "SSO -") === 0) {
+                $value = "- " . $value;
+            }
             $result[] = [
                 'id' => $value,
                 'name' => $value,

--- a/resources/js/admin/settings/components/SettingsMain.vue
+++ b/resources/js/admin/settings/components/SettingsMain.vue
@@ -95,5 +95,9 @@ export default {
   margin-right: 16px;
   height: calc(100vh - 150px);
   overflow-y: auto;
+  background-color: #fff;
+  padding: 16px 16px 106px 16px;
+  border-radius: 4px;
+  border: 1px solid var(--borders, #CDDDEE);
 }
 </style>

--- a/resources/js/admin/settings/components/SettingsMenuCollapse.vue
+++ b/resources/js/admin/settings/components/SettingsMenuCollapse.vue
@@ -91,8 +91,15 @@ export default {
       });
     },
     orderGroupAlphabetic(groups) {
-      const newGroups = groups.sort((a, b) => {
-        // Ignore upper and lowercase
+      const newGroups = groups.map(group => {
+        // Check if starts with "-"
+        if (group.name.startsWith('-')) {
+          // Remplace with the vignette
+          group.name = '•' + group.name.substring(1);
+        }
+        return group;
+      }).sort((a, b) => {
+        // Ordenar los grupos alfabéticamente por el nombre
         const nameA = a.name.toUpperCase();
         const nameB = b.name.toUpperCase();
         if (nameA < nameB) {


### PR DESCRIPTION
## Issue & Reproduction Steps
The content to Config options in Admin Settings is not the same like figma

## Solution
- Apply the styles defined in the figma

## How to Test

1. Log in to PM4
2. Go to Admin Settings 
3. Select any option on the Left Menu
4. Check the container to configuration
![image](https://github.com/ProcessMaker/processmaker/assets/42388723/8cbf6e49-89c7-44e8-88e2-c7655be05d4b)


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14579

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next