### PR TITLE
Enhance Behavior of Creating Screens from Templates with Template Options

### DIFF
--- a/ProcessMaker/Helpers/ScreenTemplateHelper.php
+++ b/ProcessMaker/Helpers/ScreenTemplateHelper.php
@@ -97,11 +97,6 @@ class ScreenTemplateHelper
 
         foreach ($item['items'] as $index => $column) {
             $filteredColumnItems = self::filterColumnItems($column, $components, $removeMultiColumn);
-            if (isset($filteredColumnItems['items'])) {
-                $filteredMultiColumnItems['items'][$index] = $filteredColumnItems;
-            } else {
-                $filteredMultiColumnItems[] = $filteredColumnItems;
-            }
 
             if (isset($filteredMultiColumnItems['items'])) {
                 $filteredMultiColumnItems['items'][$index] = $filteredColumnItems;

--- a/ProcessMaker/Templates/ScreenComponents.php
+++ b/ProcessMaker/Templates/ScreenComponents.php
@@ -17,9 +17,11 @@ class ScreenComponents
                 ],
             ],
             'Fields' => [
+                'AiSection',
                 'FormInput',
                 'FormSelectList',
                 'FormTextArea',
+                'FormHtmlViewer',
                 'FormDatePicker',
                 'FormCheckbox',
                 'FormRichText',


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR improves the behavior of creating screens from templates by refining the functionality of template options such as 'CSS', 'Layout', and 'Fields'. It addresses issues related to exclusion and duplication of components when applying specific template options, ensuring a more accurate and streamlined screen creation process.

## Solution

- Added missing field components for AI-generated components and Rich Text to the Screen Components array.
- Removed duplicated code responsible for parsing and adding related screen fields, preventing the occurrence of duplicated field inputs.

## How to Test

1. Create a screen with AI-generated and Rich Text components.
2. Save the screen as a template.
3. Create a new screen.
4. Select the created template and access the 'Template Preview'.
5. Test each option for 'CSS', 'Layout', and 'Fields'.
6. Verify that all selected options are correctly applied to the new screen, ensuring proper inclusion or exclusion of components based on the chosen template options.

## Related Tickets & Packages
- [FOUR-14589](https://processmaker.atlassian.net/browse/FOUR-14589)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14589]: https://processmaker.atlassian.net/browse/FOUR-14589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ