### PR TITLE
Fix Console Error in Guided Template Listing Page

### DIFF
--- a/resources/js/components/templates/TemplateSelectCard.vue
+++ b/resources/js/components/templates/TemplateSelectCard.vue
@@ -7,7 +7,7 @@
         @show-details="showDetails()"
       />
       <screen-template-card
-        v-if="type === 'screen'"
+        v-else-if="type === 'screen'"
         :template="template"
         :is-active="isActive"
         :default-template-id="defaultTemplateId"


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses a console error occurring when navigating to the Guided Template listing page. The error stemmed from a failing `v-else` conditional, causing a component that should be hidden to render during the loading of Guided Templates.

## Solution
- Resolved the failing `v-if` conditional on the `screen-templates-card` component by replacing it with `v-else-if`.


## How to Test

1. Open your browser console.
2. Navigate to the Processes section.
3. Select 'Guided Templates'.
4. Verify that no console errors are displayed upon loading the Guided Template listing page.

## Related Tickets & Packages
- [FOUR-14594](https://processmaker.atlassian.net/browse/FOUR-14594)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14594]: https://processmaker.atlassian.net/browse/FOUR-14594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ