### PR TITLE
FOUR-14443: API return the information for show the status

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -167,9 +167,9 @@ class ProcessRequestController extends Controller
                     str_ireplace('.', '->', $request->input('order_by', 'name')),
                     $request->input('order_direction', 'ASC')
                 )
-                ->select('process_requests.*')
-                ->withAggregate('processVersion', 'alternative')
-                ->paginate($request->input('per_page', 10));
+                    ->select('process_requests.*')
+                    ->withAggregate('processVersion', 'alternative')
+                    ->paginate($request->input('per_page', 10));
                 $total = $response->total();
             }
         } catch (QueryException $e) {
@@ -198,10 +198,29 @@ class ProcessRequestController extends Controller
 
     public function getCount(Request $request, $process)
     {
-        $query = ProcessRequest::select();
-        $query->where('process_id', $process);
+        $query = ProcessRequest::where('process_id', $process);
 
         return ['meta' => ['total' => $query->count()]];
+    }
+
+    public function getDefaultChart(Request $request, $process)
+    {
+        $countCompleted = ProcessRequest::where('process_id', $process)->inProgress()->count();
+        $countInProgress = ProcessRequest::where('process_id', $process)->completed()->count();
+
+        return [
+            'data' => [
+                'labels' => [__('Completed'), __('In Progress')],
+                'datasets' => [
+                    'label' => __('Default chart'),
+                    'data' => [$countCompleted, $countInProgress],
+                    'backgroundColor' => [
+                        'CLOSED' => '#62B2FD', // Color for 'Completed'
+                        'ACTIVE' => '#9BDFC4', // Color for 'In Progress'
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -711,7 +730,7 @@ class ProcessRequestController extends Controller
         $tokensCount = $request->tokens()
             ->where([
                 'element_id' => $httpRequest->element_id,
-                'process_request_id'=> $request->id,
+                'process_request_id' => $request->id,
             ])->count();
         $token->count = $countFlag ? $tokensCount - 1 : $tokensCount;
         if ($token->count === 0) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -203,6 +203,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     // Requests
     Route::get('requests', [ProcessRequestController::class, 'index'])->name('requests.index'); // Already filtered in controller
     Route::get('requests/{process}/count', [ProcessRequestController::class, 'getCount'])->name('requests.count');
+    Route::get('requests/{process}/default-chart', [ProcessRequestController::class, 'getDefaultChart'])->name('requests.default.chart');
     Route::get('requests/{request}', [ProcessRequestController::class, 'show'])->name('requests.show')->middleware('can:view,request');
     Route::put('requests/{request}', [ProcessRequestController::class, 'update'])->name('requests.update')->middleware('can:update,request');
     Route::put('requests/{request}/retry', [ProcessRequestController::class, 'retry'])->name('requests.retry')->middleware('can:update,request');


### PR DESCRIPTION
## Issue & Reproduction Steps
API return the information for show the status

## Solution
- Create a new API `requests/24/default-chart` in order to return the information for show the chart

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14443

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy