### PR TITLE
Enable by default ab testing

### DIFF
--- a/ProcessMaker/LicensedPackageManifest.php
+++ b/ProcessMaker/LicensedPackageManifest.php
@@ -59,7 +59,7 @@ class LicensedPackageManifest extends PackageManifest
 
     private function licensedPackages()
     {
-        $default = collect(['packages']); // always allow the packages package
+        $default = collect(['packages', 'package-ab-testing']); // always allow the packages package
         $data = $this->parseLicense();
         $expires = Carbon::parse($data['expires_at']);
         if ($expires->isPast()) {


### PR DESCRIPTION
## Issue & Reproduction Steps
The package-ab-testing is enable is not present in the default licence.

## Solution
- Enable by default package-ab-testing for testing purposes

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:package-ab-testing:feature/FOUR-11361
