### PR TITLE
Add a force flag to remove license for CICD

### DIFF
--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -27,7 +27,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
   BUILD_BASE: ${{ (contains(github.event.pull_request.body, 'ci:build-base') || github.event_name == 'schedule') && '1' || '0' }}
   BASE_IMAGE: ${{ secrets.REGISTRY_HOST }}/processmaker/processmaker:base
-  K8S_BRANCH: develop
+  K8S_BRANCH: remove-license-cicd
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -27,7 +27,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
   BUILD_BASE: ${{ (contains(github.event.pull_request.body, 'ci:build-base') || github.event_name == 'schedule') && '1' || '0' }}
   BASE_IMAGE: ${{ secrets.REGISTRY_HOST }}/processmaker/processmaker:base
-  K8S_BRANCH: remove-license-cicd
+  K8S_BRANCH: develop
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/ProcessMaker/Console/Commands/ProcessMakerLicenseRemove.php
+++ b/ProcessMaker/Console/Commands/ProcessMakerLicenseRemove.php
@@ -13,7 +13,7 @@ class ProcessMakerLicenseRemove extends Command
      *
      * @var string
      */
-    protected $signature = 'processmaker:license-remove';
+    protected $signature = 'processmaker:license-remove {--force}';
 
     /**
      * The console command description.
@@ -35,7 +35,7 @@ class ProcessMakerLicenseRemove extends Command
     public function handle()
     {
         if (Storage::disk('local')->exists('license.json')) {
-            if ($this->confirm('Are you sure you want to remove the license.json file?')) {
+            if ($this->option('force') || $this->confirm('Are you sure you want to remove the license.json file?')) {
                 Storage::disk('local')->delete('license.json');
                 $this->info('license.json removed successfully!');
 


### PR DESCRIPTION
Requires https://github.com/ProcessMaker/pm4-k8s-distribution/pull/107

We need to remove the license in CICD so the test environment and unit tests have access to all installed packages
ci:next