### PR TITLE
Remove 'Preview Template' action for Blank Templates

### DIFF
--- a/resources/js/components/templates/ScreenTemplateCard.vue
+++ b/resources/js/components/templates/ScreenTemplateCard.vue
@@ -34,7 +34,7 @@
             <span class="checkbox-label">{{ $t('Set as Default Template') }}</span>
           </b-form-checkbox>
         </div>
-        <div class="preview-template pt-1">
+        <div v-if="!isBlankTemplate" class="preview-template pt-1">
           <b-link @click="showTemplatePreview">
             <i class="fas fa-eye fa-fw mr-0 pr-3 preview-icon" />
             {{ $t('Preview Template') }}
@@ -60,6 +60,9 @@ export default {
     thumbnail() {
       return this.template?.thumbnails && this.template.thumbnails.length > 0 ? this.template.thumbnails[0] : null;
     },
+    isBlankTemplate() {
+      return !this.template.hasOwnProperty('uuid') ? true : false;
+    }
   },
   watch: {
     template: {


### PR DESCRIPTION
This PR removes the "Preview Template" option for blank templates in the New Screen Modal interface. Previously, even for blank templates, users could access the "Preview Template" feature, which was unnecessary as blank templates don't have any content to preview.

## Solution

- Implemented a computed property to determine if the template is blank.
- Conditionally render the "Preview Template" option based on whether the template is blank.

## How to Test

1. Navigate to the Screen Designer interface.
2. Click on the "+ Screen" button to create a new screen.
3. Ensure that for all screen types and template types (My Templates, Public Templates),  the  blank template "Preview Template" option is not available.

## Related Tickets & Packages
- [FOUR-14697](https://processmaker.atlassian.net/browse/FOUR-14697)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14697]: https://processmaker.atlassian.net/browse/FOUR-14697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ