### PR TITLE
FOUR-14582: Updating a Screen Template

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -283,6 +283,7 @@ class ScreenController extends Controller
         //Creating temporary Key to store multiple id categories
         $changes['tmp_screen_category_id'] = $request->input('screen_category_id');
         ScreenUpdated::dispatch($screen, $changes, $original);
+        $this->updateScreenTemplate($screen);
 
         return response([], 204);
     }
@@ -588,5 +589,18 @@ class ScreenController extends Controller
             ->where('is_public', $isPublic)
             ->where('is_default_template', 1)
             ->update(['is_default_template' => 0]);
+    }
+
+    private function updateScreenTemplate($screen)
+    {
+        $screen = Screen::find($screen);
+        \Log::debug('===== MESSAGE =====', ['prop' => $screen->is_template]);
+        // \Log::debug("===== MESSAGE request =====", ["prop" => $request]);
+        if ($screen['is_template'] === 1) {
+            \Log::debug('===== MESSAGE =====', ['prop' => 'here']);
+            $screenTemplate = ScreenTemplates::where('editing_screen_uuid', $screen->uuid)->firstOrFail();
+            $payload = $this->export($screen, Screen::class);
+            $screenTemplate->update(['manifest', $payload]);
+        }
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
When updating a Screen Template, the changes are not being reflected

1. Create a Screen Template.
2. Navigate to the Template section.
3. Select the desired template and click on "Edit Template".
4. Apply the necessary modifications and click "Save" to update the template.
5. Create a new Screen using the recently updated template.

Please note: Despite following these steps, you may observe that the alterations to the template have not been applied to the new Screen. This indicates a potential issue with the template update process that needs to be addressed.

## Solution
Implemented a new function, `updateScreenTemplate`, within the screen's update method to facilitate template updates.

## How to Test
Please follow the reproduction steps and ensure that the Screen template updates are reflected when creating a new Screen utilizing the Updated Screen Template.

## Related Tickets & Packages
- Ticket: [FOUR-14582](https://processmaker.atlassian.net/browse/FOUR-14582)
ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14582]: https://processmaker.atlassian.net/browse/FOUR-14582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ