### PR TITLE
Refine Query to Retrieve User-Specific Non-Public Screen Templates

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -57,6 +57,11 @@ class ScreenTemplate implements TemplateInterface
             }
         }
 
+        if (!$isPublic) {
+            $authUserId = Auth::user()->id;
+            $templates->where('user_id', $authUserId);
+        }
+
         return $templates
             ->select(
                 'screen_templates.id',


### PR DESCRIPTION
This PR refines the query to retrieve non-public screen templates created by the logged-in user. Previously, there was a loophole where non-public templates created by one user were visible to other users, including the admin. This PR ensures that only the creator of a non-public template can view and access it.

## Solution
- Improved the query to specifically fetch templates created by the authenticated user.


## How to Test

1. Create two users and enable all user permissions for both.
2. Log in as User A.
3. Create a non-public screen template.
4. Log in as User B.
5. Navigate to the "My Templates" tab.
6. Ensure that the screen template created by User A is not visible to User B.
7. Log in as an admin.
8. Ensure that the screen template created by User A is not visible to the admin.

## Related Tickets & Packages
- [FOUR-14696](https://processmaker.atlassian.net/browse/FOUR-14696)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14696]: https://processmaker.atlassian.net/browse/FOUR-14696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ