### PR TITLE
FOUR-14583: Deleting any associate Screen when deleting a Screen Template

### DIFF
--- a/ProcessMaker/Models/ScreenTemplates.php
+++ b/ProcessMaker/Models/ScreenTemplates.php
@@ -233,4 +233,16 @@ class ScreenTemplates extends Template implements HasMedia
             $this->addMedia($file->getPathname())->toMediaCollection($collectionName);
         }
     }
+
+    /**
+     * Listen for the deleting event on a ScreenTemplate
+     * instance and delete any associated Screen if exists
+     */
+    protected static function boot()
+    {
+        parent::boot();
+        static::deleting(function ($screenTemplate) {
+            Screen::where('uuid', $screenTemplate->editing_screen_uuid)->delete();
+        });
+    }
 }

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -349,7 +349,7 @@ class ScreenTemplate implements TemplateInterface
      */
     public function destroy(int $id) : bool
     {
-        return ScreenTemplates::where('id', $id)->delete();
+        return ScreenTemplates::find($id)->delete();
     }
 
     /**


### PR DESCRIPTION
## Issue Overview
When a Screen Template is deleted, it is crucial to ensure the associated editing screen is also removed to maintain data integrity and system cleanliness.

### Steps to Reproduce and Verify the Issue

1. Create a Screen Template
2. Navigate to the Template
3. Click on Edit Template
4. In the `screen_templates table`, you’ll notice that we now include the editing_screen_uuid of the Editing Screen
5. In the `screens` table, you’ll notice the new screen with a uuid === to the editing_screen_uuid and is_template as 1


## Solution
- Added a boot() function to the ScreenTemplates Model to Listen for the deleting event on a ScreenTemplate instance and delete any associated Screen if exists.

## How to Test
Please follow the listed reproduction steps carefully and ensure that the screen associated with the Editing Screen Template is also deleted.

## Related Tickets & Packages
- Ticket: [FOUR-14583](https://processmaker.atlassian.net/browse/FOUR-14583)
- ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14583]: https://processmaker.atlassian.net/browse/FOUR-14583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ