### PR TITLE
Fix Default Template Persistence Issue

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -222,7 +222,7 @@ class ScreenController extends Controller
         $screen->fill($request->input());
         $newScreen = $screen->fill($request->input());
 
-        if ($request->has('defaultTemplateId') && $request->has('is_public')) {
+        if ($request->has('defaultTemplateId') && is_null($request->defaultTemplateId) && $request->has('is_public')) {
             $this->updateDefaultTemplate($request->type, $request->is_public);
         }
 

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -70,6 +70,7 @@ class ScreenTemplate implements TemplateInterface
                 'screen_templates.screen_category_id',
                 'screen_templates.screen_type',
                 'screen_templates.is_public',
+                'screen_templates.is_default_template',
                 'screen_templates.is_system',
                 'screen_templates.asset_type',
                 'screen_templates.media_collection',

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -273,15 +273,9 @@ export default {
         this.formData.asset_type = null;
       }
       this.disabled = true;
-      if (this.formData.templateId !== null && this.formData.templateId !== undefined && this.formData.defaultTemplateId !== null) {
+      if (this.formData.templateId !== null && this.formData.templateId !== undefined || this.formData.defaultTemplateId !== null) {
         this.handleCreateFromTemplate();
-      } else if (this.formData.defaultTemplateId !== null && this.formData.templateId === undefined) {
-        this.handleCreateFromBlank();
-      } else if (this.formData.templateId === undefined) {
-        this.handleCreateFromBlank();
-      } else if (this.formData.defaultTemplateId === null && this.formData.templateId !== null) {
-        this.handleCreateFromTemplate();
-      } else if (this.formData.defaultTemplateId === null && this.formData.templateId === null) {
+      } else {
         this.handleCreateFromBlank();
       }
     },

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -222,6 +222,9 @@ export default {
     },
     otherTemplateSelected() {
       return this.formData.selectedTemplate;
+    },
+    getTemplateId() {
+      return this.hasTemplateId ? this.formData.templateId : this.formData.defaultTemplateId;
     }
   },
   mounted() {
@@ -303,7 +306,7 @@ export default {
     },
     handleCreateFromTemplate() {
       ProcessMaker.apiClient.post(
-        `template/create/screen/${this.formData.templateId}`,
+        `template/create/screen/${this.getTemplateId}`,
         this.formData,
         {
           headers: {

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -214,6 +214,15 @@ export default {
     templateTypeLabel() {
       return this.$t("Styles for the Screen Type").toUpperCase();
     },
+    hasTemplateId() {
+      return this.formData.templateId !== null && this.formData.templateId !== undefined; 
+    },
+    hasDefaultTemplateId() {
+      return this.formData.defaultTemplateId !== null;
+    },
+    otherTemplateSelected() {
+      return this.formData.selectedTemplate;
+    }
   },
   mounted() {
     this.resetFormData();
@@ -273,7 +282,7 @@ export default {
         this.formData.asset_type = null;
       }
       this.disabled = true;
-      if (this.formData.templateId !== null && this.formData.templateId !== undefined || this.formData.defaultTemplateId !== null) {
+      if (this.otherTemplateSelected && this.hasTemplateId || this.hasDefaultTemplateId && !this.otherTemplateSelected || this.hasTemplateId) {
         this.handleCreateFromTemplate();
       } else {
         this.handleCreateFromBlank();
@@ -359,6 +368,7 @@ export default {
     },
     handleSelectedTemplate(templateId) {
       this.formData.templateId =  templateId;
+      this.formData.selectedTemplate = true;
       this.formData.templateOptions = JSON.stringify(['CSS', 'Layout', 'Fields']);
     },
     handleSelectedTemplateOptions(options) {


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves an issue where setting the Default Template does not persist in the database and the UI. The problem stemmed from the returned templates not including the `is_default_template column`, as well as an improper conditional preventing the setting of the default template from being stored in the request data for the POST method.

## Solution

- Updated the query in the index method to return the `is_default_template` column along with other template data.
- Refactored the conditional logic for creating screens based on selected or default templates or a blank screen.
- Improved the conditional logic to prevent the erasure of the default template when selecting a blank template.

## How to Test

1. Create a screen template.
2. Navigate to 'Screen -> Designer'.
3. Select '+ Screen'.
4. Ensure the Blank template is set as the default.
5. Create a screen.
6. Verify that the created screen is blank.
7. Select '+ Screen'.
8. Choose a new template and set it as the new default template.
9. Create a screen.
10. Confirm that the created screen matches the selected template.
11. Select '+ Screen'.
12. Verify that the previously set default template is still selected.
13. Create a screen without selecting any templates.
14. Ensure that the created screen matches the selected default template.
15. Select '+ Screen'.
16. Choose a template thumbnail or a blank template.
17. Create a screen.
18. Confirm that the created screen matches the selected template.
19. Select '+ Screen'.
20. Ensure that the default template is still the previously selected template.

## Related Tickets & Packages
- [FOUR-14587](https://processmaker.atlassian.net/browse/FOUR-14587)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14587]: https://processmaker.atlassian.net/browse/FOUR-14587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ