### PR TITLE
FOUR-14352: Translation in Radio Options field are not working

### DIFF
--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -319,7 +319,7 @@ class ProcessTranslation
                 // Specific for Select list
                 if ($item['component'] === 'FormSelectList') {
                     if (isset($item['config']) && isset($item['config']['options']) && isset($item['config']['options']['optionsList'])) {
-                        foreach ($item['config']['options']['optionsList'] as $option) {
+                        foreach ($item['config']['options']['optionsList'] as &$option) {
                             if ($option['content'] === $key) {
                                 $option['content'] = $translatedString;
                             }

--- a/ProcessMaker/ProcessTranslations/ScreenTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ScreenTranslation.php
@@ -186,7 +186,7 @@ class ScreenTranslation
                 // Specific for Select list
                 if ($item['component'] === 'FormSelectList') {
                     if (isset($item['config']) && isset($item['config']['options']) && isset($item['config']['options']['optionsList'])) {
-                        foreach ($item['config']['options']['optionsList'] as $option) {
+                        foreach ($item['config']['options']['optionsList'] as &$option) {
                             if ($option['content'] === $key) {
                                 $option['content'] = $translatedString;
                             }


### PR DESCRIPTION
## Issue & Reproduction Steps
- Login into ProcessMaker
- Go to Designer tab
- Select a process to translate
- Add New translation
- Select a screen and click on translate
- In the section of translation it has the translated text (See the image attached)
- Create a case with the translation mode the Radio Fields option is with the default label
- In the same screen some fields are required and has validation those are not having the translation (See the image attached

## Solution
- Added an object reference when parsing select list options


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14352


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
