### PR TITLE
36561 RIght-click to open in new tab in saved searches no longer available

### DIFF
--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -360,6 +360,13 @@ export default {
       }).join('<br/>');
       return htmlString;
     },
+    formatId(value) {
+      return `
+      <a href="${this.openRequest(value, 1)}"
+         class="text-nowrap">
+         # ${value.id}
+      </a>`;
+    },
     formatCaseNumber(value) {
       return `
       <a href="${this.openRequest(value, 1)}"
@@ -405,6 +412,7 @@ export default {
         record["status"] = this.formatStatus(record["status"]);
         record["participants"] = this.formatParticipants(record["participants"]);
         record["process_version_alternative"] = this.formatProcessVersionAlternative(record["process_version_alternative"]);
+        record["id"] = this.formatId(record);
       }
       return data;
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
The field ID no longer has the URL to open the request.

## Solution
-  Add URL to field ID

## How to Test
crear una búsqueda guardada y verificar que el campo del ID tiene la URL.

## Related Tickets & Packages
- [FOUR-14368](https://processmaker.atlassian.net/browse/FOUR-14368)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy


[FOUR-14368]: https://processmaker.atlassian.net/browse/FOUR-14368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ