### PR TITLE
FOUR-14704 AB Testing Integration - Run Test in Modeler based on the Alternative FE helpers (required by FOUR-13423)

### DIFF
--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -95,8 +95,6 @@ div.main {
     abPublish: @json($abPublish),
     alternative: @json($alternative),
     draftAlternative: @json($draftAlternative),
-    startingPoints: @json($startingPoints),
-    resumePoints: @json($resumePoints),
   }
   const warnings = @json($process->warnings);
 


### PR DESCRIPTION
## AB Testing Integration - Run Test in Modeler based on the Alternative FE helpers (required by FOUR-13423)

## Solution
- Add required helpers to complete the functionality
- Add the missing functionality related to alternatives

## How to Test
- Open modeler and try to run test
- Select the alternative before test

## Related tickets
- https://processmaker.atlassian.net/browse/FOUR-14704

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:deploy
ci:package-testing:FOUR-14704
ci:package-ab-testing:FOUR-14704
