### PR TITLE
Assignment option "self service" is not shown for the option "Process Variable" in simple tasks.

### DIFF
--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -334,7 +334,7 @@
       },
       assignmentSupportsSelfService (assignmentType) {
         let options = ['process_variable', 'user_group', 'rule_expression'];
-        if (_.get(this.node, "loopCharacteristics") !== 'undefined') {
+        if (assignmentType === "process_variable" && _.get(this.node, "loopCharacteristics") !== undefined) {
           options = ['user_group', 'rule_expression'];
         }
         return options.includes(assignmentType);


### PR DESCRIPTION
## Issue & Reproduction Steps
The SelfService option is not shown when configuring an assignment of type ProcessVariable without any type of loop.

## Solution
- validate assignment is process variable
## How to Test
steps in ticket

## Related Tickets & Packages
- [FOUR-14760](https://processmaker.atlassian.net/browse/FOUR-14760)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
