### PR TITLE
feature/FOUR-14732

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
@@ -68,7 +68,7 @@ class ProcessLaunchpadController extends Controller
         $contentCarousel = $request->input('imagesCarousel');
         if (!empty($contentCarousel)) {
             foreach ($contentCarousel as $row) {
-                $content = !empty($row['url']) ? $row['url'] : '';
+                $content = !empty($row['type']) ? $row['type'] : '';
                 switch ($content) {
                     case 'image':
                         // Store the images related into the Media table

--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -187,11 +187,11 @@ export default {
      */
     getLaunchpadSettings() {
       ProcessMaker.apiClient
-        .get(`processes/${this.processId}/media`)
+        .get(`process_launchpad/${this.processId}`)
         .then((response) => {
-          const firstResponse = response.data.data.shift();
+          const firstResponse = response.data.shift();
           const launchpadProperties = JSON.parse(
-            firstResponse?.launchpad_properties,
+            firstResponse?.launchpad.launchpad_properties,
           );
           if (launchpadProperties && Object.keys(launchpadProperties).length > 0) {
             this.selectedSavedChart = launchpadProperties.saved_chart_title ?? this.defaultChart.title;
@@ -272,7 +272,7 @@ export default {
       });
 
       ProcessMaker.apiClient
-        .put(`processes/${this.options.id}`, {
+        .put(`process_launchpad/${this.options.id}`, {
           imagesCarousel: this.dataProcess.imagesCarousel,
           description: this.dataProcess.description,
           launchpad_properties: this.dataProcess.launchpad_properties,

--- a/resources/js/processes-catalogue/components/ProcessesCarousel.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCarousel.vue
@@ -74,9 +74,9 @@ export default {
      */
     getLaunchpadImages() {
       ProcessMaker.apiClient
-        .get(`processes/${this.process.id}/media`)
+        .get(`process_launchpad/${this.process.id}`)
         .then((response) => {
-          const firstResponse = response.data.data.shift();
+          const firstResponse = response.data.shift();
           const mediaArray = firstResponse.media;
           const embedArray = firstResponse.embed;
           mediaArray.forEach((media) => {

--- a/routes/api.php
+++ b/routes/api.php
@@ -164,7 +164,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     // Process Launchpad
     Route::get('process_launchpad/{process}', [ProcessLaunchpadController::class, 'index'])
         ->name('launchpad.index')->middleware($middlewareCatalog);
-    Route::post('process_launchpad/{process}', [ProcessLaunchpadController::class, 'store'])
+    Route::put('process_launchpad/{process}', [ProcessLaunchpadController::class, 'store'])
         ->name('launchpad.store')->middleware($middlewareCatalog);
     Route::delete('process_launchpad/{process}', [ProcessLaunchpadController::class, 'destroy'])
         ->name('launchpad.destroy')->middleware($middlewareCatalog);


### PR DESCRIPTION
## Issue & Reproduction Steps
Use this new API GET `process_launchpad/process_id` this new API will return all the information related to launchpad and the media and embed

This API will return the same information like the current consider for access the `launchpad.launchpad_properties`

instead of GET `processes/process_id`

Use this new API PUT `process_launchpad/process_id ` this new API will save all the information related to launchpad and the media and embed

instead of PUT `processes/process_id`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14732

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy