### PR TITLE
FOUR-14782: Validation issue when creating any of the Guided Templates

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -24,8 +24,8 @@ class TemplateController extends Controller
     use ProjectAssetTrait;
 
     protected array $types = [
-        'process' => [Process::class, ProcessTemplate::class, ProcessCategory::class, 'process_category_id', 'process_templates'],
-        'screen' => [Screen::class, ScreenTemplate::class, ScreenCategory::class, 'screen_category_id', 'screen_templates'],
+        'process' => [Process::class, ProcessTemplates::class, ProcessCategory::class, 'process_category_id', 'process_templates'],
+        'screen' => [Screen::class, ScreenTemplates::class, ScreenCategory::class, 'screen_category_id', 'screen_templates'],
     ];
 
     private $template;
@@ -254,7 +254,6 @@ class TemplateController extends Controller
 
     protected function createProcess(Request $request)
     {
-        $request->validate(Process::rules($request->id));
         $postOptions = $this->checkIfAssetsExist($request);
 
         if (!empty($postOptions)) {


### PR DESCRIPTION
## Issue & Reproduction Steps
When creating a Process utilizing one of the Guided Templates, a validation failure occurs if the same Guided Template is repeatedly used.

How to reproduce:

1. Navigate to Guided Templates 
2. Use any of the Guided templates until finishing the Process
3. Repeat step # 2 

You will encounter a validation error that prevents the Guided Template from completing.

## Solution
- Remove validation on the CreateProcess()

## How to Test
Please follow the reproduction steps and confirm that the Guided Template successfully completes during multiple executions.

## Related Tickets & Packages
- Ticket: [FOUR-14782](https://processmaker.atlassian.net/browse/FOUR-14782)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
