### PR TITLE
FOUR-14381: Translation not working in dropdown fields options, interstitials and summaries

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -24,6 +24,7 @@ use ProcessMaker\Models\UserResourceView;
 use ProcessMaker\Package\PackageComments\PackageServiceProvider;
 use ProcessMaker\Package\SavedSearch\Http\Controllers\SavedSearchController;
 use ProcessMaker\Package\SavedSearch\Models\SavedSearch;
+use ProcessMaker\ProcessTranslations\ProcessTranslation;
 use ProcessMaker\RetryProcessRequest;
 use ProcessMaker\Traits\HasControllerAddons;
 use ProcessMaker\Traits\SearchAutocompleteTrait;
@@ -186,6 +187,7 @@ class RequestController extends Controller
         if ($errorTask) {
             $eligibleRollbackTask = RollbackProcessRequest::eligibleRollbackTask($errorTask);
         }
+        $this->summaryScreenTranslation($request);
 
         if (isset($_SERVER['HTTP_USER_AGENT']) && MobileHelper::isMobile($_SERVER['HTTP_USER_AGENT'])) {
             return view('requests.showMobile', compact(
@@ -280,5 +282,19 @@ class RequestController extends Controller
         }
 
         return abort(response(__('File ID does not exist'), 404));
+    }
+
+    /**
+     * Translates the summary screen strings
+     * @param ProcessRequest $request
+     * @return void
+     */
+    public function summaryScreenTranslation(ProcessRequest $request): void
+    {
+        if ($request->summary_screen) {
+            $processTranslation = new ProcessTranslation($request->process);
+            $translatedConf = $processTranslation->applyTranslations($request->summary_screen);
+            $request->summary_screen['config'] = $translatedConf;
+        }
     }
 }

--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -53,6 +53,7 @@ class Task extends ApiResource
 
         $parentProcessRequest = $this->processRequest->parentRequest;
         $array['can_view_parent_request'] = $parentProcessRequest && $request->user()->can('view', $parentProcessRequest);
+        $process = Process::findOrFail($this->processRequest->process_id);
 
         if (in_array('component', $include)) {
             $array['component'] = $this->getScreenVersion() ? $this->getScreenVersion()->parent->renderComponent() : null;
@@ -72,7 +73,6 @@ class Task extends ApiResource
 
             if ($array['screen']) {
                 // Apply translations to screen
-                $process = Process::findOrFail($this->processRequest->process_id);
                 $processTranslation = new ProcessTranslation($process);
                 $array['screen']['config'] = $processTranslation->applyTranslations($array['screen']);
 
@@ -105,6 +105,12 @@ class Task extends ApiResource
         if (in_array('interstitial', $include)) {
             $interstitial = $this->getInterstitial();
             $array['allow_interstitial'] = $interstitial['allow_interstitial'];
+
+            // Translate interstitials
+            $processTranslation = new ProcessTranslation($process);
+            $translatedConf = $processTranslation->applyTranslations($interstitial['interstitial_screen']);
+            $interstitial['interstitial_screen']['config'] = $translatedConf;
+
             $array['interstitial_screen'] = $interstitial['interstitial_screen'];
         }
         if (in_array('userRequestPermission', $include)) {


### PR DESCRIPTION
## Issue & Reproduction Steps
- Log in to ProcessMaker.
- Navigate to the Designer tab.
- Create a form screen and a display screen.
- Develop a process, assigning the form screen to a task and the display screen as an interstitial for the initial event and also to an end event as a summary screen.
- Choose the created process for translation.
- Add a New translation.
- Select a screen and proceed to translate.
- Review Screen translated

## Solution
Added code to translate interstitials and summary screens.


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14381

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next