### PR TITLE
FOUR-14799: Improve error messaging for AI 

### DIFF
--- a/resources/js/processes/scripts/components/AiTab.vue
+++ b/resources/js/processes/scripts/components/AiTab.vue
@@ -232,7 +232,7 @@ export default {
             this.promptSessionId = "";
             this.getPromptSession();
           } else {
-            window.ProcessMaker.alert(errorMsg, "danger");
+            console.error(errorMsg);
           }
         });
     },
@@ -314,8 +314,8 @@ export default {
             this.$emit("request-started", this.progress, this.$t("Generating"));
           }
         })
-        .catch((error) => {
-          const errorMsg = error.response?.data?.message || error.message;
+        .catch(() => {
+          const errorMsg = this.$t("Replace error message");
           window.ProcessMaker.alert(errorMsg, "danger");
         });
     },
@@ -354,7 +354,7 @@ export default {
           }
         })
         .catch((error) => {
-          const errorMsg = error.response?.data?.message || error.message;
+          const errorMsg = this.$t("Replace error message");
           window.ProcessMaker.alert(errorMsg, "danger");
         });
     },
@@ -392,12 +392,12 @@ export default {
             this.$emit(
               "request-started",
               this.progress,
-              this.$t("Documenting")
+              this.$t("Documenting"),
             );
           }
         })
-        .catch((error) => {
-          const errorMsg = error.response?.data?.message || error.message;
+        .catch(() => {
+          const errorMsg = this.$t("Replace error message");
           window.ProcessMaker.alert(errorMsg, "danger");
         });
     },
@@ -438,8 +438,8 @@ export default {
             );
           }
         })
-        .catch((error) => {
-          const errorMsg = error.response?.data?.message || error.message;
+        .catch(() => {
+          const errorMsg = this.$t("Replace error message");
           window.ProcessMaker.alert(errorMsg, "danger");
         });
     },

--- a/resources/js/processes/scripts/components/AiTab.vue
+++ b/resources/js/processes/scripts/components/AiTab.vue
@@ -315,7 +315,7 @@ export default {
           }
         })
         .catch(() => {
-          const errorMsg = this.$t("Replace error message");
+          const errorMsg = this.$t("ProcessMaker AI is currently offline. Please try again later.");
           window.ProcessMaker.alert(errorMsg, "danger");
         });
     },
@@ -353,8 +353,8 @@ export default {
             this.$emit("request-started", this.progress, this.$t("Cleaning"));
           }
         })
-        .catch((error) => {
-          const errorMsg = this.$t("Replace error message");
+        .catch(() => {
+          const errorMsg = this.$t("ProcessMaker AI is currently offline. Please try again later.");
           window.ProcessMaker.alert(errorMsg, "danger");
         });
     },
@@ -397,7 +397,7 @@ export default {
           }
         })
         .catch(() => {
-          const errorMsg = this.$t("Replace error message");
+          const errorMsg = this.$t("ProcessMaker AI is currently offline. Please try again later.");
           window.ProcessMaker.alert(errorMsg, "danger");
         });
     },
@@ -439,7 +439,7 @@ export default {
           }
         })
         .catch(() => {
-          const errorMsg = this.$t("Replace error message");
+          const errorMsg = this.$t("ProcessMaker AI is currently offline. Please try again later.");
           window.ProcessMaker.alert(errorMsg, "danger");
         });
     },

--- a/resources/js/processes/scripts/components/GenerateScriptTextPrompt.vue
+++ b/resources/js/processes/scripts/components/GenerateScriptTextPrompt.vue
@@ -108,7 +108,7 @@ export default {
           this.tokens = response.data.tokens;
         }).catch((error) => {
           const errorMsg = error.response?.data?.message || error.message;
-          window.ProcessMaker.alert(errorMsg, "danger");
+          console.error(errorMsg);
         });
     }, 500),
     onSuggestionApplied(suggestion) {

--- a/resources/js/processes/scripts/components/GenerateScriptTextPrompt.vue
+++ b/resources/js/processes/scripts/components/GenerateScriptTextPrompt.vue
@@ -140,7 +140,7 @@ export default {
         }).catch((error) => {
           if (error.response.status !== 404) {
             const errorMsg = error.response?.data?.message || error.message;
-            console.log(errorMsg);
+            console.error(errorMsg);
           }
           this.loadingSuggestions = false;
         });

--- a/resources/js/processes/scripts/components/GenerateScriptTextPrompt.vue
+++ b/resources/js/processes/scripts/components/GenerateScriptTextPrompt.vue
@@ -140,7 +140,7 @@ export default {
         }).catch((error) => {
           if (error.response.status !== 404) {
             const errorMsg = error.response?.data?.message || error.message;
-            window.ProcessMaker.alert(errorMsg, "danger");
+            console.log(errorMsg);
           }
           this.loadingSuggestions = false;
         });

--- a/resources/js/processes/translations/components/ProcessTranslationListing.vue
+++ b/resources/js/processes/translations/components/ProcessTranslationListing.vue
@@ -292,7 +292,7 @@ export default {
             this.promptSessionId = '';
             this.fetchHistory();
           } else {
-            window.ProcessMaker.alert(errorMsg, 'danger');
+            console.error(errorMsg);
           }
         });
     },

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2191,5 +2191,5 @@
   "Select a saved search.": "Select a saved search.",
   "The Name has already been taken.": "The Name has already been taken.",
   "This is an AI feature and can provide inaccurate or biased responses.": "This is an AI feature and can provide inaccurate or biased responses.",
-  "ProcessMaker AI is currently offline. Please try again later.": "ProcessMaker AI is currently offline. Please try again later.",
+  "ProcessMaker AI is currently offline. Please try again later.": "ProcessMaker AI is currently offline. Please try again later."
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2189,5 +2189,7 @@
   "The inbox rule '{{name}}' was created.": "The inbox rule '{{name}}' was created.",
   "The inbox rule '{{name}}' was updated.": "The inbox rule '{{name}}' was updated.",
   "Select a saved search.": "Select a saved search.",
-  "The Name has already been taken.": "The Name has already been taken."
+  "The Name has already been taken.": "The Name has already been taken.",
+  "This is an AI feature and can provide inaccurate or biased responses.": "This is an AI feature and can provide inaccurate or biased responses.",
+  "ProcessMaker AI is currently offline. Please try again later.": "ProcessMaker AI is currently offline. Please try again later.",
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Descripción

In sync with @Claudia Iriarte some modifications in the error messages are required:

Instead of showing the Server error alert message in all the pages all time when AI micro service is down, show the message in the console as error.

We need to show a more user friendly alert message ProcessMaker AI is currently offline. Please try again later. just when the user performs an specific AI action like:

- Clicks on generate process from text button
- Clicks on generate process from image button
- Clicks on generate script from text button
- Clicks on document script button
- Clicks on clean script button
- Clicks on explain script button
- Clicks on generate process assets button in modeler
- Clicks on generate form button in screen builder


By the other hand we need an informational tooltip message in the AI modeler component, similar to the following screen (This is an AI feature and can provide …):

![image (1)](https://github.com/ProcessMaker/modeler/assets/90727999/1f127e8e-3aa2-498c-b0e0-74bcab387200)


## Related Tickets and PRS
[FOUR-14799](https://processmaker.atlassian.net/browse/FOUR-14799)
- [core PR](https://github.com/ProcessMaker/processmaker/pull/6579)
- [package-ai PR](https://github.com/ProcessMaker/package-ai/pull/139)
- [modeler PR](https://github.com/ProcessMaker/modeler/pull/1807)



[FOUR-14799]: https://processmaker.atlassian.net/browse/FOUR-14799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:next