### PR TITLE
observation/FOUR-14555 Different labels to do the same action between Clear Task and Erase draft

### DIFF
--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -97,7 +97,7 @@
                     class="icon-button"
                     :aria-label="$t('Erase')"
                     variant="light"
-                    v-b-tooltip.hover title="Erase Draft"
+                    v-b-tooltip.hover title="Clear Draft"
                     @click="eraseDraft()"
                   >
                     <img src="/img/smartinbox-images/eraser.svg" :alt="$t('No Image')">

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -97,7 +97,7 @@
                 >
                   <b-button
                     class="icon-button"
-                    :aria-label="$t('Erase')"
+                    :aria-label="$t('Clear Draft')"
                     variant="light"
                     v-b-tooltip.hover title="Clear Draft"
                     @click="eraseDraft()"

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2191,6 +2191,7 @@
   "Select a saved search.": "Select a saved search.",
   "The Name has already been taken.": "The Name has already been taken.",
   "Clear Task": "Clear Task",
+  "Clear Draft": "Clear Draft",
   "The task is loading": "The task is loading",
   "Some assets can take some time to load": "Some assets can take some time to load",
   "Task Filled succesfully": "Task Filled succesfully",

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -211,11 +211,10 @@
                               <button
                                 type="button"
                                 class="btn btn-block button-actions"
-                                v-b-tooltip.hover title="Erase Draft"
                                 @click="eraseDraft()"
                               >
                                 <img src="/img/smartinbox-images/eraser.svg" :alt="$t('No Image')">
-                                {{ __('Clear Task') }}
+                                {{ __('Clear Draft') }}
                               </button>
                             </li>
                             <div :class="statusCard">


### PR DESCRIPTION
## Issue & Reproduction Steps
In Task Preview, The eraser button should have the tooltip "Clear Draft". This deletes the draft and reverts to the saved request data.

In the full Task Edit Page, the button should say "Clear Draft". No tooltip is necessary. This deletes the draft and reverts to the saved request data.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14555

ci:deploy
ci:next