### PR TITLE
FOUR-14807: Chart in launchpad confuses request In progress by completed

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -205,8 +205,8 @@ class ProcessRequestController extends Controller
 
     public function getDefaultChart(Request $request, $process)
     {
-        $countCompleted = ProcessRequest::where('process_id', $process)->inProgress()->count();
-        $countInProgress = ProcessRequest::where('process_id', $process)->completed()->count();
+        $countInProgress = ProcessRequest::where('process_id', $process)->inProgress()->count();
+        $countCompleted = ProcessRequest::where('process_id', $process)->completed()->count();
 
         return [
             'data' => [


### PR DESCRIPTION
## Issue & Reproduction Steps
Chart in launchpad confuses request In progress by completed

## Solution
- Change the variables

## How to Test

- Create process
- Start some requests in order to the process have in progress requests
- Go to process-browser
- Open the process 
- Check the Chart colors  

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14807

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy