### PR TITLE
Update Screen Sync Command to Support Refined File Structure

### DIFF
--- a/ProcessMaker/Models/ScreenTemplates.php
+++ b/ProcessMaker/Models/ScreenTemplates.php
@@ -202,14 +202,13 @@ class ScreenTemplates extends Template implements HasMedia
 
         // Get preview thumbs
         $previewThumbs = $this->getMedia($mediaCollectionName, ['media_type' => 'preview-thumbs']);
-        $previewThumbsUrls = $previewThumbs->pluck('url')->all();
 
         // Get thumbnail media
         $thumbnailMedia = $this->getMedia($mediaCollectionName, ['media_type' => 'thumbnail'])->first();
 
         // If thumbnail media is not found and no preview thumbs are available,
         // get any media associated with the template
-        if (is_null($thumbnailMedia) && empty($previewThumbsUrls)) {
+        if (is_null($thumbnailMedia) && $previewThumbs->isEmpty()) {
             $allMedia = $this->getMedia($mediaCollectionName);
 
             return $allMedia->map(function ($media) {
@@ -218,10 +217,19 @@ class ScreenTemplates extends Template implements HasMedia
                 return $media;
             })->all();
         } else {
-            // Return thumbnail and preview thumbs URLs
+            // Prepare URLs for thumbnail and preview thumbs
+            if ($thumbnailMedia) {
+                $thumbnailMedia->url = $thumbnailMedia->getFullUrl();
+            }
+            $previewThumbs = $previewThumbs->map(function ($thumb) {
+                $thumb->url = $thumb->getFullUrl();
+
+                return $thumb;
+            })->all();
+
             return [
-                'thumbnail' => $thumbnailMedia ? $thumbnailMedia->getFullUrl() : '',
-                'previewThumbs' => $previewThumbsUrls,
+                'thumbnail' => $thumbnailMedia ? $thumbnailMedia : '',
+                'previewThumbs' => $previewThumbs,
             ];
         }
     }

--- a/resources/js/components/templates/PreviewTemplate.vue
+++ b/resources/js/components/templates/PreviewTemplate.vue
@@ -108,15 +108,7 @@
                 return _.isArray(this.allThumbnails) && this.allThumbnails.length > 0 || !_.isEmpty(this.allThumbnails);
             },
             allThumbnails() {
-                if (this.templateData && this.templateData.template_media) {
-                    if (this.templateData.template_media.previewThumbs) {
-                        return this.templateData.template_media.previewThumbs;
-                    } else {
-                        return this.templateData.template_media;
-                    }
-                } else {
-                    return [];
-                }
+                return this.templateData?.template_media?.previewThumbs ?? (this.templateData?.template_media ? [this.templateData.template_media] : []);
             },
         },
         watch: {

--- a/resources/js/components/templates/PreviewTemplate.vue
+++ b/resources/js/components/templates/PreviewTemplate.vue
@@ -108,7 +108,15 @@
                 return _.isArray(this.allThumbnails) && this.allThumbnails.length > 0 || !_.isEmpty(this.allThumbnails);
             },
             allThumbnails() {
-                return this.templateData?.template_media?.previewThumbs ?? (this.templateData?.template_media ? [this.templateData.template_media] : []);
+               if (this.templateData?.template_media) {
+                    if (this.templateData.template_media?.previewThumbs) {
+                        return this.templateData.template_media?.previewThumbs;
+                    } else {
+                        return this.templateData.template_media;
+                    }
+               } else {
+                return [];
+               }
             },
         },
         watch: {

--- a/resources/js/components/templates/PreviewTemplate.vue
+++ b/resources/js/components/templates/PreviewTemplate.vue
@@ -17,7 +17,7 @@
                 <div class="thumbnail-preview">
                     <div v-if="templateHasThumbnails" class="text-center">
                         <img 
-                            v-for="thumbnail in templateData?.template_media"
+                            v-for="thumbnail in allThumbnails"
                             class="thumb mb-2"
                             :src="thumbnail?.url"
                             fluid
@@ -105,8 +105,19 @@
                 return this.templateData.screen_custom_css !== null;
             },
             templateHasThumbnails() {
-                return this.templateData?.template_media.length > 0;
-            }
+                return _.isArray(this.allThumbnails) && this.allThumbnails.length > 0 || !_.isEmpty(this.allThumbnails);
+            },
+            allThumbnails() {
+                if (this.templateData && this.templateData.template_media) {
+                    if (this.templateData.template_media.previewThumbs) {
+                        return this.templateData.template_media.previewThumbs;
+                    } else {
+                        return this.templateData.template_media;
+                    }
+                } else {
+                    return [];
+                }
+            },
         },
         watch: {
             selectedTemplateOptions() {

--- a/resources/js/components/templates/ScreenTemplateCard.vue
+++ b/resources/js/components/templates/ScreenTemplateCard.vue
@@ -58,7 +58,12 @@ export default {
   },
   computed: {
     thumbnail() {
-      return this.template?.template_media && this.template.template_media.length > 0 ? this.template.template_media[0].url : null;
+      if (this.template?.template_media && this.template.template_media.length > 0) {
+        return this.template.template_media[0].url;
+      } else if (this.template?.template_media?.thumbnail?.url) {
+        return this.template?.template_media.thumbnail.url
+      }
+      return null;
     },
     isBlankTemplate() {
       return !this.template.hasOwnProperty('uuid') ? true : false;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR updates the screen sync command `php artisan processmaker:sync-guided-templates` to support the refined file structure of the `screen-template` GitHub repository. Additionally, it adds support for displaying the template thumbnail and preview thumbnail.

.

## Solution

- Dynamically set specific template details from the exported screen template payload, such as `screen_type` and `screen_custom_css`.
- Properly handle the displaying of the `thumbnail` and `previewThumbs` media in the Create Screen Modal.

## How to Test

1. Run the command php artisan processmaker:sync-guided-templates.
2. Verify that the command synchronizes the screen templates correctly, including their updated file structure.
3. Open the Create Screen Modal and confirm that the template thumbnail and preview thumbnails are displayed properly.


## Related Tickets & Packages
- [FOUR-14508](https://processmaker.atlassian.net/browse/FOUR-14508)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14508]: https://processmaker.atlassian.net/browse/FOUR-14508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ