### PR TITLE
FOUR-14625 Refactor column filter badges

### DIFF
--- a/resources/js/components/PMBadgesFilters.vue
+++ b/resources/js/components/PMBadgesFilters.vue
@@ -1,0 +1,144 @@
+<template>
+  <div style="display: flex;">
+    <div v-if="filterBadges.length > 0"
+         class="selected-filters-bar d-flex pt-2">
+
+      <span v-for="filter in filterBadges"
+            class="selected-filter-item d-flex align-items-center">
+
+        <span class="selected-filter-key mr-1">
+          {{ $t(capitalizeString(filter[0])) }}
+          <template v-if="!get(filter, '1.0.advanced_filter', false)">:</template>
+        </span>
+        {{ filter[1][0].operator ?? '' }}
+        <template v-if="filter[0] === 'Status'">
+          {{ $t(filter[1][0].name) }}
+        </template>
+        <template v-else>
+          {{ filter[1][0].name ? filter[1][0].name : filter[1][0].fullname }}
+        </template>
+
+        <span v-if="filter[1].length > 1"
+              class="badge badge-pill ml-2 filter-counter">
+          +{{ filter[1].length - 1 }}
+        </span>
+
+        <i v-if="!get(filter, '1.0.advanced_filter', false)"
+           role="button"
+           class="fa fa-times pl-2 pr-0">
+        </i>
+
+      </span>
+
+    </div>
+    <div style="margin-left: auto">
+      <slot name="right-of-badges" />
+    </div>
+  </div>
+</template>
+
+<script>
+  import { get } from 'lodash';
+  export default {
+    props: [
+      "value",
+      "advancedFilterProp",
+      "showPmqlBadge"
+    ],
+    data() {
+      return {
+        get: get,
+        pmql: "",
+        selectedFilters: [],
+        query: "",
+        advancedFilter: []
+      };
+    },
+    mounted() {
+      window.ProcessMaker.EventBus.$on('advanced-filter-updated', this.setAdvancedFilter);
+
+      this.setAdvancedFilter();
+    },
+    computed: {
+      filterBadges() {
+        let result = [
+          ...this.pmqlBadge,
+          ...this.selectedFilters,
+          ...this.formatAdvancedFilterForBadges
+        ];
+        return result;
+      },
+      pmqlBadge() {
+        let result = [];
+        if (this.value) {
+          result.push([
+            'pmql',
+            [
+              {
+                name: this.value,
+                operator: '',
+                advanced_filter: true
+              }
+            ]
+          ]);
+        }
+        return result;
+      },
+      formatAdvancedFilterForBadges() {
+        let result = [];
+        if (Array.isArray(this.advancedFilter)) {
+          this.formatForBadge(this.advancedFilter, result);
+        }
+        return result;
+      }
+    },
+    watch: {
+      advancedFilterProp: {
+        deep: true,
+        handler(a) {
+          this.setAdvancedFilter();
+        }
+      }
+    },
+    methods: {
+      setAdvancedFilter() {
+        this.advancedFilter = get(this.advancedFilterProp, 'filters') ||
+                get(window, 'ProcessMaker.advanced_filter.filters', []);
+      },
+      capitalizeString(string) {
+        if (string === "") {
+          return "";
+        }
+        let str = string.toLowerCase();
+        return str.charAt(0).toUpperCase() + str.slice(1);
+      },
+      formatForBadge(filters, result) {
+        for (let filter of filters) {
+          if (filter._hide_badge) {
+            continue;
+          }
+          result.push([
+            this.formatBadgeSubject(filter),
+            [
+              {
+                name: filter.value,
+                operator: filter.operator,
+                advanced_filter: true
+              }
+            ]
+          ]);
+
+          if (filter.or && filter.or.length > 0) {
+            this.formatForBadge(filter.or, result);
+          }
+        }
+      },
+      formatBadgeSubject(filter) {
+        return get(filter, '_column_label', get(filter, 'subject.value', ''));
+      }
+    }
+  }
+</script>
+
+<style lang="scss">
+</style>

--- a/resources/js/components/PMBadgesFilters.vue
+++ b/resources/js/components/PMBadgesFilters.vue
@@ -139,6 +139,3 @@
     }
   }
 </script>
-
-<style lang="scss">
-</style>

--- a/resources/js/inbox-rules/components/InboxRuleFilters.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFilters.vue
@@ -16,22 +16,14 @@
         {{ taskTitle }}
       </div>
       <div class="mb-3">
-        <pmql-input ref="pmql_input"
-                    :value="pmql"
-                    search-type="tasks"
-                    :ai-enabled="false"
-                    :show-filters="true"
-                    :aria-label="$t('Advanced Search (PMQL)')"
-                    :advanced-filter-prop="savedSearchAdvancedFilter"
-                    :show-search-bar="false"
-                    :show-pmql-badge="!!savedSearchId"
-                    >
+        <PMBadgesFilters :value="pmql"
+                         :advancedFilterProp="savedSearchAdvancedFilter">
           <template v-slot:right-of-badges v-if="showColumnSelectorButton">
             <b-button class="ml-md-2" v-b-modal.columns>
               <i class="fas fw fa-cog"></i>
             </b-button>
           </template>
-        </pmql-input>
+        </PMBadgesFilters>
       </div>
 
       <tasks-list
@@ -82,6 +74,7 @@
   import TasksList from "../../tasks/components/TasksList.vue";
   import ColumnChooserAdapter from "./ColumnChooserAdapter.vue";
   import PMMessageScreen from "../../components/PMMessageScreen.vue";
+  import PMBadgesFilters from "../../components/PMBadgesFilters.vue";
   export default {
     props: {
       savedSearchId: {
@@ -111,7 +104,8 @@
     components: {
       TasksList,
       ColumnChooserAdapter,
-      PMMessageScreen
+      PMMessageScreen,
+      PMBadgesFilters
     },
     methods: {
       emitSavedSearchData() {
@@ -248,6 +242,7 @@
       savedSearchAdvancedFilter: {
         deep: true,
         handler() {
+          //to do: reviewing this assignment may result in a loop.
           this.savedSearchAdvancedFilter = this.addRequiredSavedSearchFilters(this.savedSearchAdvancedFilter);
           this.emitSavedSearchData();
         }


### PR DESCRIPTION
We are hacking resources/js/components/shared/PmqlInput.vue with the resources/js/common/advancedFilterStatusMixin.js

I want to make this an entirely separate component that correctly displays the badges for the advanced filters. Should show all filters and all sub-filters under or in the advanced filter json

Any PMQL should just be it’s own, single badge like [PMQL = ….]