### PR TITLE
FOUR-14573: Export process_launchpad table related with process

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -261,8 +261,18 @@ abstract class ExporterBase implements ExporterInterface
     public function getClassName(): string
     {
         $modelClass = get_class($this->model);
+        $baseName = class_basename($modelClass);
 
-        return class_basename($modelClass);
+        // Map the aliases for base class names.
+        $aliases = [
+            'ProcessLaunchpad' => 'LaunchpadSetting',
+        ];
+
+        if (array_key_exists($baseName, $aliases)) {
+            $baseName = $aliases[$baseName];
+        }
+
+        return $baseName;
     }
 
     public function getTypeHuman($type)

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -5,11 +5,9 @@ namespace ProcessMaker\ImportExport\Exporters;
 use DOMXPath;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 use ProcessMaker\ImportExport\DependentType;
 use ProcessMaker\ImportExport\Psudomodels\Signal;
 use ProcessMaker\ImportExport\Utils;
-use ProcessMaker\Managers\ExportManager;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
@@ -23,13 +21,9 @@ class ProcessExporter extends ExporterBase
 
     public static $fallbackMatchColumn = 'name';
 
-    public ExportManager $manager;
-
     public function export() : void
     {
         $process = $this->model;
-
-        $this->manager = resolve(ExportManager::class);
 
         if ($process->user) {
             $this->addDependent('user', $process->user, UserExporter::class);
@@ -71,8 +65,8 @@ class ProcessExporter extends ExporterBase
         }
 
         $this->exportSubprocesses();
-
         $this->exportMedia();
+        $this->exportProcessLaunchpad();
     }
 
     public function import($existingAssetInDatabase = null, $importingFromTemplate = false) : bool
@@ -95,7 +89,6 @@ class ProcessExporter extends ExporterBase
         if (!$importingFromTemplate) {
             $this->associateCategories(ProcessCategory::class, 'process_category_id');
         }
-
         $this->importSignals();
 
         foreach ($this->getDependents('cancel-screen') as $dependent) {
@@ -411,6 +404,7 @@ class ProcessExporter extends ExporterBase
             $this->importScripts();
             $this->importSubprocesses();
             $this->importAssignments();
+            $this->importProcessLaunchpad();
         }
     }
 
@@ -431,6 +425,31 @@ class ProcessExporter extends ExporterBase
     {
         foreach ($this->getDependents(DependentType::MEDIA) as $media) {
             $media->model->setAttribute('model_id', $this->model->id);
+        }
+    }
+
+    /**
+     * Export the process launchpad associated with the process.
+     */
+    public function exportProcessLaunchpad(): void
+    {
+        $launchpad = $this->model->launchpad;
+        if ($launchpad) {
+            $this->addDependent(
+                'process_launchpad',
+                $launchpad,
+                ProcessLaunchpadExporter::class
+            );
+        }
+    }
+
+    /**
+     * Import the process launchpad for the process.
+     */
+    public function importProcessLaunchpad(): void
+    {
+        foreach ($this->getDependents('process_launchpad') as $launchpad) {
+            $launchpad->model->setAttribute('process_id', $this->model->id);
         }
     }
 }

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -65,8 +65,8 @@ class ProcessExporter extends ExporterBase
         }
 
         $this->exportSubprocesses();
-        $this->exportMedia();
         $this->exportProcessLaunchpad();
+        $this->exportMedia();
     }
 
     public function import($existingAssetInDatabase = null, $importingFromTemplate = false) : bool

--- a/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ProcessMaker\ImportExport\Exporters;
+
+class ProcessLaunchpadExporter extends ExporterBase
+{
+    public $discard = false;
+
+    public $handleDuplicatesByIncrementing = ['process_id'];
+
+    public $incrementStringSeparator = null;
+
+    public function export(): void
+    {
+        $this->addDependent('user', $this->model->user, UserExporter::class);
+    }
+
+    public function import(): bool
+    {
+        foreach ($this->getDependents('user') as $dependent) {
+            $this->model->user_id = $dependent->model->id;
+        }
+
+        return $this->model->save();
+    }
+}

--- a/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\ImportExport\Exporters;
 
+use ProcessMaker\Models\Screen;
+
 class ProcessLaunchpadExporter extends ExporterBase
 {
     public $discard = false;
@@ -13,12 +15,24 @@ class ProcessLaunchpadExporter extends ExporterBase
     public function export(): void
     {
         $this->addDependent('user', $this->model->user, UserExporter::class);
+
+        $properties = json_decode($this->model->properties, true);
+        $launchScreen = Screen::where('uuid', $properties['screen_uuid'])->first();
+        if ($launchScreen) {
+            $this->addDependent('screen', $launchScreen, ScreenExporter::class);
+        }
     }
 
     public function import(): bool
     {
         foreach ($this->getDependents('user') as $dependent) {
             $this->model->user_id = $dependent->model->id;
+        }
+
+        foreach ($this->getDependents('screen') as $dependent) {
+            $properties = json_decode($this->model->properties, true);
+            $properties['screen_uuid'] = $dependent->model->uuid;
+            $this->model->properties = json_encode($properties);
         }
 
         return $this->model->save();

--- a/ProcessMaker/Models/ProcessLaunchpad.php
+++ b/ProcessMaker/Models/ProcessLaunchpad.php
@@ -3,8 +3,6 @@
 namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use ProcessMaker\Models\ProcessMakerModel;
-use ProcessMaker\Models\User;
 use ProcessMaker\Traits\HasUuids;
 
 class ProcessLaunchpad extends ProcessMakerModel
@@ -37,7 +35,7 @@ class ProcessLaunchpad extends ProcessMakerModel
         'uuid',
         'user_id',
         'process_id',
-        'properties'
+        'properties',
     ];
 
     public static function rules(): array
@@ -46,6 +44,16 @@ class ProcessLaunchpad extends ProcessMakerModel
             'user_id' => 'required',
             'process_id' => 'required',
         ];
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function process()
+    {
+        return $this->belongsTo(Process::class, 'process_id');
     }
 
     public function users()

--- a/database/factories/ProcessMaker/Models/ProcessLaunchpadFactory.php
+++ b/database/factories/ProcessMaker/Models/ProcessLaunchpadFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories\ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use ProcessMaker\Models\ProcessLaunchpad;
+
+class ProcessLaunchpadFactory extends Factory
+{
+    protected $model = ProcessLaunchpad::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition()
+    {
+        return [
+            'uuid' => $this->faker->uuid,
+            'process_id' => null,
+            'user_id' => null,
+            'properties' => json_encode([]),
+        ];
+    }
+}

--- a/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
@@ -457,7 +457,6 @@ class ProcessExporterTest extends TestCase
         $this->assertEquals(1, $process->media()->count());
         $newProcess = Process::where('name', 'Process 2')->first();
         $this->assertEquals(1, $newProcess->media()->count());
-        $this->assertEquals(2, Media::count());
     }
 
     private function createFakeImage(Process $process): Media

--- a/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
@@ -4,9 +4,11 @@ namespace Tests\Feature\ImportExport\Exporters;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use ProcessMaker\ImportExport\Exporter;
 use ProcessMaker\ImportExport\Exporters\ProcessExporter;
+use ProcessMaker\ImportExport\Importer;
 use ProcessMaker\ImportExport\Options;
 use ProcessMaker\ImportExport\SignalHelper;
 use ProcessMaker\ImportExport\Utils;
@@ -119,7 +121,7 @@ class ProcessExporterTest extends TestCase
             $process,
             ProcessExporter::class,
             function () use ($process, $cancelScreen, $requestDetailScreen, $user) {
-                \DB::delete('delete from process_notification_settings');
+                DB::delete('delete from process_notification_settings');
                 $process->forceDelete();
                 $cancelScreen->delete();
                 $requestDetailScreen->delete();
@@ -207,7 +209,7 @@ class ProcessExporterTest extends TestCase
     {
         $this->addGlobalSignalProcess();
 
-        \DB::beginTransaction();
+        DB::beginTransaction();
         $parentProcess = $this->createProcess('process-with-different-kinds-of-call-activities', ['name' => 'parent']);
         $subProcess = $this->createProcess('basic-process', ['name' => 'sub']);
 
@@ -218,7 +220,7 @@ class ProcessExporterTest extends TestCase
         $parentProcess->save();
 
         $payload = $this->export($parentProcess, ProcessExporter::class, null, false);
-        \DB::rollBack(); // Delete all created items since DB::beginTransaction
+        DB::rollBack(); // Delete all created items since DB::beginTransaction
 
         $this->import($payload);
         $process = Process::where('name', 'parent')->firstOrFail();
@@ -434,9 +436,34 @@ class ProcessExporterTest extends TestCase
         $this->assertArrayHasKey($user->uuid, $manifest);
     }
 
+    public function testImportMediaWithCopy()
+    {
+        $this->addGlobalSignalProcess();
+        [
+            'process' => $process,
+            'media' => $media,
+        ] = $this->fixtures();
+
+        $exporter = new Exporter();
+        $exporter->exportProcess($process);
+        $payload = $exporter->payload();
+
+        $optionsArray[$process->uuid] = ['mode' => 'copy'];
+        $optionsArray[$media->uuid] = ['mode' => 'copy'];
+        $options = new Options($optionsArray);
+        $importer = new Importer($payload, $options);
+        $importer->doImport();
+
+        $this->assertEquals(1, $process->media()->count());
+        $newProcess = Process::where('name', 'Process 2')->first();
+        $this->assertEquals(1, $newProcess->media()->count());
+        $this->assertEquals(2, Media::count());
+    }
+
     private function createFakeImage(Process $process): Media
     {
         $media = Media::factory()->create([
+            'uuid' => '8ef7550c-2544-4642-91e1-732fb267179a',
             'model_type' => Process::class,
             'model_id' => $process->id,
             'collection_name' => 'images_carousel',

--- a/tests/Feature/ImportExport/Exporters/ProcessLaunchpadExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessLaunchpadExporterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\ImportExport\Exporters;
+
+use Illuminate\Support\Arr;
+use ProcessMaker\ImportExport\Exporter;
+use ProcessMaker\ImportExport\Importer;
+use ProcessMaker\ImportExport\Options;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessLaunchpad;
+use ProcessMaker\Models\User;
+use Tests\Feature\ImportExport\HelperTrait;
+use Tests\TestCase;
+
+class ProcessLaunchpadExporterTest extends TestCase
+{
+    use HelperTrait;
+
+    private function fixtures(): array
+    {
+        $cancelScreen = $this->createScreen('basic-form-screen', ['title' => 'Cancel Screen']);
+        $requestDetailScreen = $this->createScreen('basic-display-screen', ['title' => 'Request Detail Screen']);
+        $user = User::factory()->create(['username' => 'testuser']);
+        $process = $this->createProcess('basic-process', [
+            'name' => 'Process',
+            'user_id' => $user->id,
+            'cancel_screen_id' => $cancelScreen->id,
+            'request_detail_screen_id' => $requestDetailScreen->id,
+        ]);
+
+        $launchpad = ProcessLaunchpad::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'properties' => json_encode(['foo' => 'bar']),
+        ]);
+
+        return [
+            'process' => $process,
+            'user' => $user,
+            'launchpad' => $launchpad,
+        ];
+    }
+
+    public function testExport()
+    {
+        $this->addGlobalSignalProcess();
+        [
+            'process' => $process,
+            'launchpad' => $launchpad,
+        ] = $this->fixtures();
+
+        $exporter = new Exporter();
+        $exporter->exportProcess($process);
+        $payload = $exporter->payload();
+
+        $processDependents = Arr::get($payload, 'export.' . $process->uuid . '.dependents');
+        $processDependentUuids = Arr::pluck($processDependents, 'uuid');
+
+        $this->assertContains($process->category->uuid, $processDependentUuids);
+        $this->assertContains($launchpad->uuid, $processDependentUuids);
+    }
+
+    public function testImportWithCopy()
+    {
+        $this->addGlobalSignalProcess();
+        [
+            'process' => $process,
+        ] = $this->fixtures();
+
+        $exporter = new Exporter();
+        $exporter->exportProcess($process);
+        $payload = $exporter->payload();
+
+        $optionsArray[$process->uuid] = ['mode' => 'copy'];
+
+        $options = new Options($optionsArray);
+        $importer = new Importer($payload, $options);
+
+        $importer->doImport();
+
+        $newProcess = Process::where('name', 'Process 2')->first();
+        $this->assertNotNull($newProcess->launchpad);
+    }
+}

--- a/tests/Feature/ImportExport/Exporters/ProcessLaunchpadExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessLaunchpadExporterTest.php
@@ -31,7 +31,13 @@ class ProcessLaunchpadExporterTest extends TestCase
         $launchpad = ProcessLaunchpad::factory()->create([
             'process_id' => $process->id,
             'user_id' => $user->id,
-            'properties' => json_encode(['foo' => 'bar']),
+            'properties' => json_encode([
+                'icon' => 'Alarm',
+                'icon_label' => 'Alarm',
+                'screen_id' => $cancelScreen->id,
+                'screen_uuid' => $cancelScreen->uuid,
+                'screen_title' => 'Cancel Screen',
+            ]),
         ]);
 
         return [


### PR DESCRIPTION
## Issue & Reproduction Steps
Create the ProcessLaunchpadExporter in order to export the Models related to the process_launchpad table

## Solution
- A new exporter has been added for the ProcessLaunchpad table.
- A function has been introduced to increment numbers in columns with a unique constraint.

## How to Test
- Execute manual tests.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-14573](https://processmaker.atlassian.net/browse/FOUR-14573)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14573]: https://processmaker.atlassian.net/browse/FOUR-14573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ