### PR TITLE
FOUR-14817 The Launchpad Setting in the modal is not showing when the AB testing is not installed

### DIFF
--- a/resources/js/components/shared/ModalSaveVersion.vue
+++ b/resources/js/components/shared/ModalSaveVersion.vue
@@ -269,8 +269,8 @@ export default {
         .then((response) => {
           const alternative = window.ProcessMaker.AbTesting?.alternative;
           const iFrame = window.parent[`alternative${alternative}`];
-          const isActive = this.isABTestingInstalled && iFrame ? iFrame.classList.contains("active") : false;
-          if (!response.data?.[0].launchpad && isActive) {
+          const isActive = iFrame ? iFrame.classList.contains("active") : false;
+          if (!response.data?.[0].launchpad && (!this.isABTestingInstalled || isActive)) {
             this.$refs["launchpad-modal"].showModal();
           }
         });


### PR DESCRIPTION
## Issue & Reproduction Steps
Launchpad modal is not displayey when AB tetsing is not installed.

## Solution
- Validation changed, is not required to have AB testing installed to display Launchpad.

## How to Test
In an environment without AB testing create a new process and publish the same.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14817

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy