### PR TITLE
FOUR-14788:Saved Search Chart is not visible in Screen Launcher Launchpad

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
+++ b/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
@@ -4,9 +4,12 @@ namespace ProcessMaker\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Events\ScreenBuilderStarting;
 use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Managers\ScreenBuilderManager;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
+use ProcessMaker\Traits\HasControllerAddons;
 
 /**
  * @param Request $request
@@ -16,9 +19,13 @@ use ProcessMaker\Models\ProcessCategory;
  */
 class ProcessesCatalogueController extends Controller
 {
+    use HasControllerAddons;
+    
     public function index(Request $request, Process $process = null)
     {
+        $manager = app(ScreenBuilderManager::class);
+        event(new ScreenBuilderStarting($manager, 'DISPLAY'));
         $currentUser = Auth::user()->only(['id', 'username', 'fullname', 'firstname', 'lastname', 'avatar']);
-        return view('processes-catalogue.index', compact('process' , 'currentUser'));
+        return view('processes-catalogue.index', compact('process', 'currentUser', 'manager'));
     }
 }

--- a/resources/views/processes-catalogue/index.blade.php
+++ b/resources/views/processes-catalogue/index.blade.php
@@ -17,11 +17,14 @@
       :current-user="{{ \Auth::user() }}"
       is-documenter-installed="{{\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled()}}"
     >
-  </processes-catalogue>
+    </processes-catalogue>
   </div>
 @endsection
 
 @section('js')
+  @foreach($manager->getScripts() as $script)  
+    <script src="{{$script}}"></script>
+  @endforeach
   <script src="{{mix('js/processes-catalogue/index.js')}}"></script>
   <script>
     window.Processmaker.user = @json($currentUser);

--- a/resources/views/processes-catalogue/index.blade.php
+++ b/resources/views/processes-catalogue/index.blade.php
@@ -22,7 +22,7 @@
 @endsection
 
 @section('js')
-  @foreach($manager->getScripts() as $script)  
+  @foreach($manager->getScripts() as $script)
     <script src="{{$script}}"></script>
   @endforeach
   <script src="{{mix('js/processes-catalogue/index.js')}}"></script>


### PR DESCRIPTION
## Issue & Reproduction Steps
Saved Search Chart is not visible in Screen Launcher Launchpad

## Solution
- Adding variables required for the show a save search

## How to Test

1. Create a Screen display type
2. Add Saved search chart
3. Save the changes
4. Go to process-browser
5. Select a process
6. Config the Process Launch pad
7. Select the screen created in Screen Launcher
8. Refresh the page

## Related Tickets & Packages
- [FOUR-14788](https://processmaker.atlassian.net/browse/FOUR-14788)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next


[FOUR-14788]: https://processmaker.atlassian.net/browse/FOUR-14788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ