### PR TITLE
observation/FOUR-14768-A Drafts don't save when switching tasks in task preview

### DIFF
--- a/resources/js/tasks/components/PreviewMixin.js
+++ b/resources/js/tasks/components/PreviewMixin.js
@@ -23,7 +23,7 @@ const PreviewMixin = {
       options: {
         is_loading: false,
       },
-      autoSaveDelay: 2000,
+      autoSaveDelay: 500,
       savedIcon: null,
       lastAutosave: "",
       errorAutosave: false,
@@ -44,6 +44,7 @@ const PreviewMixin = {
       showReassignment: false,
       taskDefinition: {},
       user: {},
+      disbaleNavigation: false,
       actions: [
         {
           value: "clear-draft",

--- a/resources/js/tasks/components/PreviewMixin.js
+++ b/resources/js/tasks/components/PreviewMixin.js
@@ -44,7 +44,7 @@ const PreviewMixin = {
       showReassignment: false,
       taskDefinition: {},
       user: {},
-      disbaleNavigation: false,
+      disableNavigation: false,
       actions: [
         {
           value: "clear-draft",

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -60,7 +60,7 @@
                 <b-button
                   class="arrow-button"
                   variant="outline-secondary"
-                  :disabled="!existPrev"
+                  :disabled="!existPrev || disableNavigation"
                   @click="goPrevNext('Prev')"
                 >
                   <i class="fas fa-chevron-left" />
@@ -68,7 +68,7 @@
                 <b-button
                   class="arrow-button"
                   variant="outline-secondary"
-                  :disabled="!existNext"
+                  :disabled="!existNext || disableNavigation"
                   @click="goPrevNext('Next')"
                 >
                   <i class="fas fa-chevron-right" />
@@ -308,6 +308,7 @@ export default {
       this.formData = data;
       if (this.userHasInteracted) {
         this.handleAutosave();
+        this.disableNavigation = true;
       }
     });
 
@@ -346,6 +347,7 @@ export default {
       this.showUseThisTask = false;
       ProcessMaker.alert(message, 'success');
       this.handleAutosave();
+      this.disableNavigation = false;
     },
     sendEvent(name, data)
     {
@@ -385,6 +387,7 @@ export default {
         .finally(() => {
           this.options.is_loading = false;
           this.errorAutosave = false;
+          this.disableNavigation = false;
         });
     },
     eraseDraft() {
@@ -397,6 +400,7 @@ export default {
           }, 4900);
           this.showSideBar(this.task, this.data);
           this.task.draft = null;
+          this.userHasInteracted = false;
         });
     },
     reassignUser() {


### PR DESCRIPTION
## Issue & Reproduction Steps
When actions are performed quickly, the data is not saved

## Solution
Added a delay and disable the task navigation buttons and and change the user Interact flag after a Clear Draft

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14768

ci:deploy
ci:next