### PR TITLE
Resolve Sorting Issue in My Template and Public Template Tabs

### DIFF
--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -32,6 +32,7 @@
             v-if="column.sortable"
             :key="index"
             style="display: inline-block"
+            @click="handleEllipsisClick(column)"
           >
             <i
               :class="[

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -33,6 +33,7 @@
             v-if="column.sortable"
             :key="index"
             style="display: inline-block"
+            @click="handleEllipsisClick(column)"
           >
             <i
               :class="[


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses an issue where the sorting functionality in the My Template and Public Template tabs was not working. The problem arose due to the inadvertent removal of the `@click` handler method for the sorting carets.

## Solution
- Added back the `@click` handler method for sorting carets to ensure proper sorting functionality.

## How to Test

1. Navigate to the My Templates or Public Templates tab.
2. Attempt to sort the tables by different columns.
3. Verify that the data is sorted correctly.
4. Confirm that no errors occur during the sorting process.

## Related Tickets & Packages
- [FOUR-14831](https://processmaker.atlassian.net/browse/FOUR-14831)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14831]: https://processmaker.atlassian.net/browse/FOUR-14831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ