### PR TITLE
FOUR-14231: Launch Card, overflow popover styles is not like figma

### DIFF
--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -35,6 +35,7 @@
           triggers="hover focus"
           :content="process.name"
           variant="custom"
+          class="popover-custom-text"
         />
       </div>
     </b-card-text>
@@ -186,5 +187,14 @@ export default {
   letter-spacing: -0.02em;
   text-align: left;
   padding: 20px;
+}
+.popover-custom-text {
+  color: var(--text-only, #556271);
+  font-family: 'Open Sans', sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  letter-spacing: -0.32px;
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
Launch Card, overflow popover styles is not like figma

## Solution
- Apply styles according figma.

## How to Test

1. Create a process with long text description
2. Go to Processes 
3. Mouse over in the card related to the process created

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14231

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy