### PR TITLE
FOUR-14746: It is possible to publish the alternatives when the start…

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -118,34 +118,32 @@ export default {
         const svgString = new XMLSerializer().serializeToString(svg);
         const xml = await this.$refs.modeler.getXmlFromDiagram();
         this.setLoadingState(true);
-        ProcessMaker.apiClient.put(`/processes/${this.process.id}/draft`, {
-          name: this.process.name,
-          description: this.process.description,
-          task_notifications: this.getTaskNotifications(),
-          projects: this.process.projects,
-          bpmn: xml,
-          svg: svgString,
-          alternative: window.ProcessMaker.modeler.draftAlternative || "A",
-        })
-          .then((response) => {
-            this.process.updated_at = response.data.updated_at;
-            window.ProcessMaker.EventBus.$emit("save-changes", null, null, generatingAssets);
-            this.$set(this, "warnings", response.data.warnings || []);
-            if (response.data.warnings && response.data.warnings.length > 0) {
-              window.ProcessMaker.EventBus.$emit("save-changes-activate-autovalidate");
-            }
-            // Set draft status.
-            this.setVersionIndicator(true);
-          })
-          .catch((error) => {
-            if (error.response) {
-              const { message } = error.response.data;
-              ProcessMaker.alert(message, "danger");
-            }
-          })
-          .finally(() => {
-            this.setLoadingState(false);
+        try {
+          const response = await ProcessMaker.apiClient.put(`/processes/${this.process.id}/draft`, {
+            name: this.process.name,
+            description: this.process.description,
+            task_notifications: this.getTaskNotifications(),
+            projects: this.process.projects,
+            bpmn: xml,
+            svg: svgString,
+            alternative: window.ProcessMaker.modeler.draftAlternative || "A",
           });
+          this.process.updated_at = response.data.updated_at;
+          window.ProcessMaker.EventBus.$emit("save-changes", null, null, generatingAssets);
+          this.$set(this, "warnings", response.data.warnings || []);
+          if (response.data.warnings && response.data.warnings.length > 0) {
+            window.ProcessMaker.EventBus.$emit("save-changes-activate-autovalidate");
+          }
+          // Set draft status.
+          this.setVersionIndicator(true);
+        } catch (error) {
+          if (error.response) {
+            const { message } = error.response.data;
+            ProcessMaker.alert(message, "danger");
+          }
+        } finally {
+          this.setLoadingState(false);
+        }
       };
     },
     closeHref() {


### PR DESCRIPTION
## Issue & Reproduction Steps

It is possible to publish the alternatives when the start event is different in both alternatives

## Solution
- add message
- improve Validation
[validationABalternatives.webm](https://github.com/ProcessMaker/package-ab-testing/assets/1401911/db881586-d78a-4876-b5ce-fede5c71980a)


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14746

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
