### PR TITLE
FOUR-14833 Save message appears before clicking launchpad modal when publishing an alternative

### DIFF
--- a/resources/js/components/shared/ModalSaveVersion.vue
+++ b/resources/js/components/shared/ModalSaveVersion.vue
@@ -235,7 +235,6 @@ export default {
               versionable_type: this.options.type,
             })
             .then((response) => {
-              ProcessMaker.alert(this.$t("The version was saved."), "success");
               this.saving = false;
               this.verifyLaunchPad();
               this.hideModal();
@@ -272,6 +271,8 @@ export default {
           const isActive = iFrame ? iFrame.classList.contains("active") : false;
           if (!response.data?.[0].launchpad && (!this.isABTestingInstalled || isActive)) {
             this.$refs["launchpad-modal"].showModal();
+          } else {
+            ProcessMaker.alert(this.$t("The version was saved."), "success");
           }
         });
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
Save message appears before clicking the launchpad modal when publishing an alternative.

## Solution
- Show the version saved message if launchpad is configured or AB testing is not installed

## How to Test
1. Create a process
2. Enable alternative B
3. First scenario: Publish alternative A
   1. Go to alternative A
   2. Click on publish button
   3. Select alternative A
   4. Click on Save and publish
4. Second scenario: Publish alternative B
   1. Go to alternative B
   2. Click on publish button
   3. Select alternative B
   4. Click on Save and publish
5. Third scenario: Publish alternative A+B
   1. Go to alternative A or B
   2. Click on publish button
   3. Select alternative A+B
   4. Click on Save and publish

## Related Tickets & Packages
[FOUR-14833](https://processmaker.atlassian.net/browse/FOUR-14833)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
