### PR TITLE
SCO-22193 Remove force AB Testing deploy and enabled

### DIFF
--- a/ProcessMaker/LicensedPackageManifest.php
+++ b/ProcessMaker/LicensedPackageManifest.php
@@ -59,7 +59,7 @@ class LicensedPackageManifest extends PackageManifest
 
     private function licensedPackages()
     {
-        $default = collect(['packages', 'package-ab-testing']); // always allow the packages package
+        $default = collect(['packages']);
         $data = $this->parseLicense();
         $expires = Carbon::parse($data['expires_at']);
         if ($expires->isPast()) {

--- a/composer.json
+++ b/composer.json
@@ -172,7 +172,6 @@
                 "packages": "^0"
             },
             "docker-executors": {
-                "package-ab-testing": "1.0.0",
                 "docker-executor-java": "1.0.4",
                 "docker-executor-python": "1.0.1",
                 "docker-executor-csharp": "1.0.2"


### PR DESCRIPTION
## Remove force AB Testing deploy and enabled

## Solution
- CloudOps added the ab-testing to the license for PM^4.10
- Remove the forced deploy of ab-testing for testing purposes

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/SCO-22193

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
