### PR TITLE
FOUR-14815 | Screen Type Dropdown is Distorted in Screen Template Configurations

### DIFF
--- a/resources/js/processes/screen-templates/components/CreateScreenTemplateForm.vue
+++ b/resources/js/processes/screen-templates/components/CreateScreenTemplateForm.vue
@@ -44,6 +44,7 @@
                             :invalid-feedback="errorMessage('type', errors)"
                         >
                             <screen-type-dropdown
+                                id="createTemplateScreenType"
                                 :value="screenType"
                                 :screen-types="types"
                                 copy-asset-mode="true"

--- a/resources/js/processes/screens/components/ScreenTypeDropdown.vue
+++ b/resources/js/processes/screens/components/ScreenTypeDropdown.vue
@@ -1,5 +1,6 @@
 <template>
   <multiselect
+    id="screenTypeDropdown"
     v-model="selectedType"
     :options="screenTypeOptions"
     track-by="type"

--- a/resources/js/templates/components/ScreenTemplateConfigurations.vue
+++ b/resources/js/templates/components/ScreenTemplateConfigurations.vue
@@ -31,6 +31,7 @@
                 :invalid-feedback="errorMessage('type', errors)"
             >
                 <screen-type-dropdown
+                    id="screenConfigsScreenType"
                     :value="template.screen_type"
                     :screen-types="screenTypes"
                     copy-asset-mode="true"

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1064,3 +1064,18 @@ nav {
 .type-style-col .multiselect--disabled .multiselect__select {
   background-color: transparent;
 }
+
+// Create Screen Template modal styling
+#createTemplateScreenType .multiselect__select {
+  height: 48px;
+}
+
+// Configure Screen Template, Screen Type Dropdown styling
+#screenConfigsScreenType .multiselect__single .type-icon-placeholder {
+  padding-right: 10px !important;
+  font-size: 26px;
+}
+
+#screenConfigsScreenType .multiselect__tags {
+  padding: 6px 40px 0 6px;
+}


### PR DESCRIPTION
# Issue
Ticket: [FOUR-14815](https://processmaker.atlassian.net/browse/FOUR-14815)

- In the Screen Template Configurations, the content of the Screen Type Dropdown does not fit inside of the multiselect container.
- In the Create Screen Template modal, the multiselect arrow on the Screen Type Dropdown does not fit the height of the multiselect container.

# Solution
- Update the Screen Type Dropdown styles in the Screen Template Configurations page and the Create Screen Template modal

# Previous UI
![Screen Shot 2024-04-09 at 10 54 33 AM](https://github.com/ProcessMaker/processmaker/assets/73713665/a1c02495-fa4e-4d15-9382-c68d5b2895af)
![Screen Shot 2024-04-09 at 12 14 48 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/b4754886-124c-49c4-babe-b139350b120d)


# Updated UI
![Screen Shot 2024-04-09 at 11 29 32 AM](https://github.com/ProcessMaker/processmaker/assets/73713665/88512ffc-cb8b-4786-92a2-46ded15b18af)

![Screen Shot 2024-04-09 at 12 14 03 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/beddc1dd-01fb-4578-a94c-8ee865fb2ede)

# How to Test
1. Go to branch `observation/FOUR-14815` in `processmaker`.
2. Go to Designer → Screens.
3. Hover over a Screen and select 'Save as Template' from the tooltip menu.
4. In the Create Screen Template modal, the Screen Type Dropdown arrow should fit the height of its container.
5. Go to the 'My Templates' tab.
6. Hover over a Screen Template and select 'Configure Template' from the tooltip menu.
7. On the Screen Template Configuration page, the content of the Screen Type Dropdown should fit inside of its container.

ci:next
ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-14815]: https://processmaker.atlassian.net/browse/FOUR-14815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ