### PR TITLE
FOUR-14875 add data-test attribute in modeler for AB testing

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -118,6 +118,8 @@ window.ProcessMaker.navbar = new Vue({
       confirmVariant: "",
       confirmCallback: "",
       confirmSize: "md",
+      confirmDataTestClose: "confirm-btn-close",
+      confirmDataTestOk: "confirm-btn-ok",
       messageTitle: "",
       messageMessage: "",
       messageVariant: "",
@@ -277,13 +279,15 @@ window.ProcessMaker.closeSessionModal = function () {
 };
 
 // Set out own specific confirm modal.
-window.ProcessMaker.confirmModal = function (title, message, variant, callback, size = "md") {
+window.ProcessMaker.confirmModal = function (title, message, variant, callback, size = "md", dataTestClose = "confirm-btn-close", dataTestOk = "confirm-btn-ok") {
   ProcessMaker.navbar.confirmTitle = title || __("Confirm");
   ProcessMaker.navbar.confirmMessage = message || __("Are you sure you want to delete?");
   ProcessMaker.navbar.confirmVariant = variant;
   ProcessMaker.navbar.confirmCallback = callback;
   ProcessMaker.navbar.confirmShow = true;
   ProcessMaker.navbar.confirmSize = size;
+  ProcessMaker.navbar.confirmDataTestClose = dataTestClose;
+  ProcessMaker.navbar.confirmDataTestOk = dataTestOk;
 };
 
 // Set out own specific message modal.

--- a/resources/js/components/Confirm.vue
+++ b/resources/js/components/Confirm.vue
@@ -2,8 +2,8 @@
     <b-modal dialog-class="top-20" v-model="showModal" @hide="onClose" :title="title" :size="size ? size : 'md'">
         <div class="my-3" :class="classMessage" v-html="message"></div>
         <template #modal-footer>
-            <b-button class="m-0" variant="outline-secondary" @click="onDeny">Cancel</b-button>
-            <b-button class="m-0" @click="onConfirm">Confirm</b-button>
+            <b-button class="m-0" variant="outline-secondary" :data-test="dataTestClose" @click="onDeny">Cancel</b-button>
+            <b-button class="m-0" @click="onConfirm" :data-test="dataTestOk">Confirm</b-button>
         </template>
     </b-modal>
 </template>
@@ -11,7 +11,7 @@
 
 <script>
     export default {
-        props: ["title", "message", "variant", "callback", "show", "size"],
+        props: ["title", "message", "variant", "callback", "show", "size", "dataTestClose", "dataTestOk"],
         data() {
             return {
                 'classMessage': '',

--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -88,6 +88,7 @@
             :href="action.link ? itemLink(action, data) : null"
             class="ellipsis-dropdown-item mx-auto"
             @click="!action.link ? onClick(action, data) : null"
+            :data-test="action.dataTest"
           >
             <div class="ellipsis-dropdown-content">
               <i
@@ -125,7 +126,7 @@ export default {
     filterActions() {
       let btns = this.filterActionsByPermissions();
       btns = this.filterActionsByConditionals(btns);
-      
+
       return btns;
     },
     filterAboveDivider() {

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -17,6 +17,7 @@
     <b-collapse is-nav id="nav-collapse">
         <confirmation-modal class="d-none d-lg-block" id="confirmModal" :show="confirmShow" :title="confirmTitle" :message="confirmMessage"
                             :variant="confirmVariant" :callback="confirmCallback" :size="confirmSize"
+                            :data-test-close="confirmDataTestClose" :data-test-ok="confirmDataTestOk"
                             @close="confirmShow=false">
         </confirmation-modal>
         <message-modal class="d-none d-lg-block" id="messageModal" :show="messageShow" :title="messageTitle" :message="messageMessage"
@@ -111,7 +112,7 @@
                     left
                 >
                     <b-dropdown-item v-for="subItem in item.childItems"
-                        :key="subItem.url"                    
+                        :key="subItem.url"
                         :href="subItem.url"
                         :target="subItem.attributes.target"
                     >


### PR DESCRIPTION
## Issue & Reproduction Steps
Some elements don't have the `data-test` attribute in the modeler when AB Testing is enabled

## Solution
- Add missing `data-test` attribute

## Related Tickets & Packages
[FOUR-14875](https://processmaker.atlassian.net/browse/FOUR-14875)
https://github.com/ProcessMaker/package-ab-testing/pull/33
https://github.com/ProcessMaker/package-testing/pull/62

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:package-ab-testing:FOUR-14875
ci:package-testing:FOUR-14875


[FOUR-14875]: https://processmaker.atlassian.net/browse/FOUR-14875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ