### PR TITLE
FOUR-14864: 500 Error When Adding Screen from Template to Project

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -216,7 +216,7 @@ class ScreenTemplate implements TemplateInterface
             $screen->description = $requestData['description'];
             $screen->save();
 
-            $this->syncProjectAssets($requestData);
+            $this->syncProjectAssets($requestData, $screen->id);
 
             return response()->json(['id' => $newScreenId, 'title' => $screen->title]);
         } catch (Exception $e) {
@@ -535,6 +535,12 @@ class ScreenTemplate implements TemplateInterface
         return ScreenTemplates::where('name', $screenTemplate)->firstOrFail();
     }
 
+    /**
+     * Imports a screen using the provided data and existing assets.
+     *
+     * @param array $data The data for the screen import.
+     * @param array $existingAssets The existing assets to be considered during the import.
+     */
     protected function importScreen($data, $existingAssets)
     {
         $templateId = (int) $data['templateId'];
@@ -631,7 +637,10 @@ class ScreenTemplate implements TemplateInterface
         $newScreen->save();
     }
 
-    public function syncProjectAssets($data)
+    /**
+     * Synchronizes project assets with the given data and new screen ID.
+     */
+    public function syncProjectAssets($data, int $newScreenId): void
     {
         if (class_exists(self::PROJECT_ASSET_MODEL_CLASS) && !empty($data['projects'])) {
             $manifest = $this->getManifest('screen', $newScreenId);

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -193,6 +193,10 @@ class ScreenTemplateTest extends TestCase
 
     public function testCreateScreenFromTemplateWithProjects()
     {
+        if (!class_exists(Project::class)) {
+            $this->markTestSkipped('Package Projects is not installed.');
+        }
+
         $project = Project::factory()->create();
         $screenTemplateId = ScreenTemplates::factory()->create()->id;
         $screen_category_id = ScreenCategory::factory()->create()->id;

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -10,6 +10,7 @@ use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
 use ProcessMaker\Models\ScreenTemplates;
 use ProcessMaker\Models\User;
+use ProcessMaker\Package\Projects\Models\Project;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\Feature\Templates\HelperTrait;
 use Tests\TestCase;
@@ -188,6 +189,27 @@ class ScreenTemplateTest extends TestCase
             'is_public' => 0,
             'is_default_template' => 1,
         ]);
+    }
+
+    public function testCreateScreenFromTemplateWithProjects()
+    {
+        $project = Project::factory()->create();
+        $screenTemplateId = ScreenTemplates::factory()->create()->id;
+        $screen_category_id = ScreenCategory::factory()->create()->id;
+        $user = User::factory()->create();
+
+        $route = route('api.template.create', ['screen', $screenTemplateId]);
+        $data = [
+            'title' => 'Test Screen Creation',
+            'description' => 'Test Screen Creation from Template',
+            'screen_category_id' => $screen_category_id,
+            'type' => 'FORM',
+            'templateId' => $screenTemplateId,
+            'projects' => implode(',', [$project->id]),
+        ];
+
+        $response = $this->actingAs($user, 'api')->call('POST', $route, $data);
+        $response->assertStatus(200);
     }
 
     public function testMakePublicScreenTemplate()


### PR DESCRIPTION
## Issue & Reproduction Steps
When attempting to add a new screen created from a template (other than the Blank Template) to a project, 500 errors occur. This issue disrupts the screen creation process and prevents users from successfully adding screens to projects.

## Solution
- Added unit test to cover this specific case.
- Fixed  method related to projects as it was missing a parameter.

## How to Test
Perform manual tests on deployed QA server.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-14864](https://processmaker.atlassian.net/browse/FOUR-14864)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
