### PR TITLE
Standardize Template Imports and Fix Duplicate Error Issue

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ImportController.php
+++ b/ProcessMaker/Http/Controllers/Api/ImportController.php
@@ -89,45 +89,6 @@ class ImportController extends Controller
         return response()->json(['processId' => $newProcessId, 'message' => Importer::getMessages()], 200);
     }
 
-    // public function importTemplate(String $type, Request $request): JsonResponse
-    // {
-    //     $jsonData = $request->file('file')->get();
-    //     // $payload = json_decode($jsonData, true);
-    //     // $fileOptions = !is_null($request->file('options')) ? $request->file('options') : [];
-    //     // // dd($type, json_decode(file_get_contents(utf8_decode($request->file('options'))), true));
-    //     // $options = new Options($fileOptions);
-    //     // $importer = new Importer($payload, $options);
-    //     // $manifest = $importer->doImport();
-    //     // // dd($manifest);
-
-    //     // // Call Event to store Template Changes in Log
-    //     // TemplateCreated::dispatch($payload);
-
-    //     // return response()->json([], 200);
-    // }
-
-    // public function importScreenTemplate(Request $request)
-    // {
-    //     $request->validate(['file' => 'required|file|mimes:json|max:5000']);
-    //     $jsonData = $request->file('file')->get();
-    //     $payload = json_decode($jsonData, true);
-
-    //     $postOptions = [];
-    //     foreach ($payload['export'] as $key => $asset) {
-    //         $postOptions[$key] = [
-    //             'mode' => 'copy',
-    //         ];
-    //     }
-
-    //     $options = new Options($postOptions);
-    //     $importer = new Importer($payload, $options);
-    //     $manifest = $importer->doImport();
-    //     dd('here ');
-    //     TemplateCreated::dispatch($payload);
-
-    //     return $manifest;
-    // }
-
     private function handlePasswordDecrypt(Request $request, array $payload)
     {
         return Importer::handlePasswordDecrypt($payload, $request->input('password'));

--- a/ProcessMaker/Http/Controllers/Api/ImportController.php
+++ b/ProcessMaker/Http/Controllers/Api/ImportController.php
@@ -89,41 +89,44 @@ class ImportController extends Controller
         return response()->json(['processId' => $newProcessId, 'message' => Importer::getMessages()], 200);
     }
 
-    public function importTemplate(String $type, Request $request): JsonResponse
-    {
-        $jsonData = $request->file('file')->get();
-        $payload = json_decode($jsonData, true);
+    // public function importTemplate(String $type, Request $request): JsonResponse
+    // {
+    //     $jsonData = $request->file('file')->get();
+    //     // $payload = json_decode($jsonData, true);
+    //     // $fileOptions = !is_null($request->file('options')) ? $request->file('options') : [];
+    //     // // dd($type, json_decode(file_get_contents(utf8_decode($request->file('options'))), true));
+    //     // $options = new Options($fileOptions);
+    //     // $importer = new Importer($payload, $options);
+    //     // $manifest = $importer->doImport();
+    //     // // dd($manifest);
 
-        $options = new Options(json_decode(file_get_contents(utf8_decode($request->file('options'))), true));
-        $importer = new Importer($payload, $options);
-        $manifest = $importer->doImport();
+    //     // // Call Event to store Template Changes in Log
+    //     // TemplateCreated::dispatch($payload);
 
-        // Call Event to store Template Changes in Log
-        TemplateCreated::dispatch($payload);
+    //     // return response()->json([], 200);
+    // }
 
-        return response()->json([], 200);
-    }
+    // public function importScreenTemplate(Request $request)
+    // {
+    //     $request->validate(['file' => 'required|file|mimes:json|max:5000']);
+    //     $jsonData = $request->file('file')->get();
+    //     $payload = json_decode($jsonData, true);
 
-    public function importScreenTemplate(Request $request)
-    {
-        $request->validate(['file' => 'required|file|mimes:json|max:5000']);
-        $jsonData = $request->file('file')->get();
-        $payload = json_decode($jsonData, true);
+    //     $postOptions = [];
+    //     foreach ($payload['export'] as $key => $asset) {
+    //         $postOptions[$key] = [
+    //             'mode' => 'copy',
+    //         ];
+    //     }
 
-        $postOptions = [];
-        foreach ($payload['export'] as $key => $asset) {
-            $postOptions[$key] = [
-                'mode' => 'copy',
-            ];
-        }
+    //     $options = new Options($postOptions);
+    //     $importer = new Importer($payload, $options);
+    //     $manifest = $importer->doImport();
+    //     dd('here ');
+    //     TemplateCreated::dispatch($payload);
 
-        $options = new Options($postOptions);
-        $importer = new Importer($payload, $options);
-        $manifest = $importer->doImport();
-        TemplateCreated::dispatch($payload);
-
-        return $manifest;
-    }
+    //     return $manifest;
+    // }
 
     private function handlePasswordDecrypt(Request $request, array $payload)
     {

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -179,6 +179,23 @@ class TemplateController extends Controller
         return $this->template->deleteTemplate($type, $request);
     }
 
+    /**
+     * Import template
+     *
+     * @param  Template  $template
+     * @return \Illuminate\Http\Response
+     */
+    public function import(string $type, Request $request)
+    {
+        $result = $this->preimportValidation($type, $request);
+
+        if ($result->getStatusCode() === 422) {
+            return $result;
+        }
+
+        return $this->template->importTemplate($type, $request);
+    }
+
     public function preimportValidation(string $type, Request $request)
     {
         $content = $request->file('file')->get();
@@ -221,7 +238,8 @@ class TemplateController extends Controller
         $decoded = substr($content, 0, 1) === '{' ? json_decode($content) : (($content = base64_decode($content)) && substr($content, 0, 1) === '{' ? json_decode($content) : null);
         $isDecoded = $decoded && is_object($decoded);
         $hasType = $isDecoded && isset($decoded->type) && is_string($decoded->type);
-        $validType = $hasType && $decoded->type === 'process_templates_package';
+        // $validType = $hasType && $decoded->type === 'process_templates_package';
+        $validType = $hasType && ($decoded->type === 'process_templates_package' || $decoded->type === 'screen_templates_package');
 
         if ($validType) {
             return (new ImportController())->preview($request, $decoded->version);

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -30,6 +30,7 @@ class TemplateController extends Controller
             ProcessCategory::class,
             'process_category_id',
             'process_templates',
+            'process_templates_package',
         ],
         'screen' => [
             Screen::class,
@@ -37,6 +38,7 @@ class TemplateController extends Controller
             ScreenCategory::class,
             'screen_category_id',
             'screen_templates',
+            'screen_templates_package',
         ],
     ];
 
@@ -252,7 +254,7 @@ class TemplateController extends Controller
 
         // Validate the type
         $validTypes = ['process_templates_package', 'screen_templates_package'];
-        if (!in_array($decoded->type, $validTypes) || $decoded->type !== $type) {
+        if (!in_array($decoded->type, $validTypes) || $decoded->type !== $this->types[$type][5]) {
             return null; // Invalid package type
         }
 

--- a/ProcessMaker/Models/ScreenTemplates.php
+++ b/ProcessMaker/Models/ScreenTemplates.php
@@ -32,10 +32,6 @@ class ScreenTemplates extends Template implements HasMedia
 
     public $screen_category_id;
 
-    // public $handleDuplicatesByIncrementing = ['name'];
-
-    // public static $fallbackMatchColumn = 'name';
-
     /**
      * Category of the screen template
      *

--- a/ProcessMaker/Models/ScreenTemplates.php
+++ b/ProcessMaker/Models/ScreenTemplates.php
@@ -32,6 +32,10 @@ class ScreenTemplates extends Template implements HasMedia
 
     public $screen_category_id;
 
+    // public $handleDuplicatesByIncrementing = ['name'];
+
+    // public static $fallbackMatchColumn = 'name';
+
     /**
      * Category of the screen template
      *

--- a/ProcessMaker/Models/Template.php
+++ b/ProcessMaker/Models/Template.php
@@ -85,6 +85,11 @@ class Template extends ProcessMakerModel
         return (new $this->types[$type][1])->destroy($id);
     }
 
+    public function importTemplate(string $type, Request $request)
+    {
+        return (new $this->types[$type][1])->importTemplate($request);
+    }
+
     public function publishTemplate(string $type, Request $request)
     {
         return (new $this->types[$type][1])->publishTemplate($request);

--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -474,7 +474,7 @@ class ProcessTemplate implements TemplateInterface
 
             $this->preparePayloadForImport($payload);
 
-            $importOptions = $this->configureImportOptions($payload);
+            $importOptions = $this->configureImportOptions($request);
 
             $this->performImport($payload, $importOptions);
 
@@ -634,16 +634,9 @@ class ProcessTemplate implements TemplateInterface
      * @param  array  $payload
      * @return \Importer\Options
      */
-    private function configureImportOptions(array $payload): Options
+    private function configureImportOptions(Request $request): Options
     {
-        $postOptions = [];
-        foreach ($payload['export'] as $key => $asset) {
-            $postOptions[$key] = [
-                'mode' => 'copy',
-            ];
-        }
-
-        return new Options($postOptions);
+        return new Options(json_decode(file_get_contents(utf8_decode($request->file('options'))), true));
     }
 
     /**

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -388,7 +388,7 @@ class ScreenTemplate implements TemplateInterface
     }
 
     /**
-     *  Update process template configurations
+     *  Import screen template
      * @param Request
      * @return JsonResponse
      */
@@ -398,27 +398,19 @@ class ScreenTemplate implements TemplateInterface
             $jsonData = $request->file('file')->get();
 
             $payload = json_decode($jsonData, true);
-            $postOptions = [];
 
-            foreach ($payload['export'] as $key => $asset) {
-                $postOptions[$key] = [
-                    'mode' => 'copy',
-                ];
-                $payload['export'][$key]['attributes']['editing_screen_uuid'] = null;
-            }
+            $this->preparePayloadForImport($payload);
 
-            $options = new Options($postOptions);
-            $importer = new Importer($payload, $options);
-            $importer->doImport();
+            $importOptions = $this->configureImportOptions($payload);
 
-            // Call Event to store Template Changes in Log
+            $this->performImport($payload, $importOptions);
+
+            // Dispatch event for template creation
             TemplateCreated::dispatch($payload);
 
             return response()->json([], 200);
         } catch (\Exception $e) {
-            return response([
-                'message' => $e->getMessage(),
-            ], 422);
+            return response()->json(['message' => $e->getMessage()], 422);
         }
     }
 
@@ -717,5 +709,50 @@ class ScreenTemplate implements TemplateInterface
         foreach ($result as $media) {
             $template->addMediaFromBase64($media['url'])->toMediaCollection($template->media_collection);
         }
+    }
+
+    /**
+     * Prepare payload for import.
+     *
+     * @param  array  $payload
+     * @return void
+     */
+    private function preparePayloadForImport(array &$payload): void
+    {
+        foreach ($payload['export'] as &$asset) {
+            // Modify asset attributes as needed
+            $asset['attributes']['editing_screen_uuid'] = null;
+        }
+    }
+
+    /**
+     * Configure import options.
+     *
+     * @param  array  $payload
+     * @return \Importer\Options
+     */
+    private function configureImportOptions(array $payload): Options
+    {
+        $postOptions = [];
+
+        foreach ($payload['export'] as $key => $asset) {
+            // Set import mode for each asset
+            $postOptions[$key] = ['mode' => 'copy'];
+        }
+
+        return new Options($postOptions);
+    }
+
+    /**
+     * Perform the import operation.
+     *
+     * @param  array  $payload
+     * @param  \Importer\Options  $options
+     * @return void
+     */
+    private function performImport(array $payload, Options $options): void
+    {
+        $importer = new Importer($payload, $options);
+        $importer->doImport();
     }
 }

--- a/resources/views/templates/import-screen.blade.php
+++ b/resources/views/templates/import-screen.blade.php
@@ -120,7 +120,7 @@
               return
             }
             this.submitted = true;
-            ProcessMaker.apiClient.post('import/screen-template',
+            ProcessMaker.apiClient.post('import/screen/do-import',
               formData,
               {
                 headers: {

--- a/resources/views/templates/import-screen.blade.php
+++ b/resources/views/templates/import-screen.blade.php
@@ -120,7 +120,7 @@
               return
             }
             this.submitted = true;
-            ProcessMaker.apiClient.post('import/screen/do-import',
+            ProcessMaker.apiClient.post('template/screen/do-import',
               formData,
               {
                 headers: {

--- a/routes/api.php
+++ b/routes/api.php
@@ -311,7 +311,6 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('import/preview', [ImportController::class, 'preview'])->name('import.preview')->middleware('can:export-processes');
     Route::get('import/get-manifest', [ImportController::class, 'getImportManifest'])->name('import.get-import-manifest')->middleware('can:import-processes');
     Route::post('import/do-import', [ImportController::class, 'import'])->name('import.do_import')->middleware('can:import-processes');
-    // Route::post('import/screen-template', [ImportController::class, 'importScreenTemplate'])->name('import.import_screen')->middleware('can:import-screens');
 
     // Templates
     Route::get('templates/{type}', [TemplateController::class, 'index'])->name('template.index')->middleware('template-authorization');

--- a/routes/api.php
+++ b/routes/api.php
@@ -311,11 +311,11 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('import/preview', [ImportController::class, 'preview'])->name('import.preview')->middleware('can:export-processes');
     Route::get('import/get-manifest', [ImportController::class, 'getImportManifest'])->name('import.get-import-manifest')->middleware('can:import-processes');
     Route::post('import/do-import', [ImportController::class, 'import'])->name('import.do_import')->middleware('can:import-processes');
-    Route::post('import/screen-template', [ImportController::class, 'importScreenTemplate'])->name('import.import_screen')->middleware('can:import-screens');
+    // Route::post('import/screen-template', [ImportController::class, 'importScreenTemplate'])->name('import.import_screen')->middleware('can:import-screens');
 
     // Templates
     Route::get('templates/{type}', [TemplateController::class, 'index'])->name('template.index')->middleware('template-authorization');
-    Route::post('template/{type}/do-import', [ImportController::class, 'importTemplate'])->name('import.do_importTemplate')->middleware('template-authorization');
+    Route::post('template/{type}/do-import', [TemplateController::class, 'import'])->name('import.do_importTemplate')->middleware('template-authorization');
     Route::post('template/{type}/{id}', [TemplateController::class, 'store'])->name('template.store')->middleware('template-authorization');
     Route::post('template/create/{type}/{id}', [TemplateController::class, 'create'])->name('template.create')->middleware('template-authorization');
     Route::put('template/{type}/{processId}', [TemplateController::class, 'updateTemplateManifest'])->name('template.update')->middleware('template-authorization');

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -226,7 +226,7 @@ class ScreenTemplateTest extends TestCase
         $jsonFileName = 'screen_template_routes.json';
         $file = UploadedFile::fake()->createWithContent($jsonFileName, json_encode($payload));
         // API call to import screen template
-        $url = '/import/screen-template';
+        $url = '/template/screen/do-import';
         $params = ['file' => $file];
         $importResponse = $this->apiCall('POST', $url, $params);
         $importResponse->assertStatus(200);


### PR DESCRIPTION
## Issue & Reproduction Steps

This pull request addresses the issue of encountering a `500 duplicate error` when uploading the same template multiple times in the Public Template tab. This problem stemmed from the screen template's `editing_screen_uuid` column not being cleared upon screen template import. 

Additionally, this PR standardizes the import functionality for both Process Templates and Screen Templates by integrating them into the TemplateController. This consolidation enhances manageability and ensures uniformity across template imports.

## Solution

- Moved Process Template and Screen Template import functionality from `ImportController` to `TemplateController`.
- Implemented the `importTemplate` method for each asset within the Templates interface.
- Updated the payload for screen and process templates to clear specific columns like `editing_screen_uuid` upon import.

## How to Test

1. Ensure existing Templates for both Screens and Processes.
2. Export the assets.
3. Import the assets (Screens in both My Templates and Public Templates tab).
4. Verify the absence of errors during import.
5. Confirm successful import of assets.
6. Ensure subsequent imports correctly increment asset names.

## Related Tickets & Packages
- [FOUR-14859](https://processmaker.atlassian.net/browse/FOUR-14859)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14859]: https://processmaker.atlassian.net/browse/FOUR-14859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ