### PR TITLE
Update Terminology: Public Templates to Shared Templates

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -252,7 +252,7 @@ class ScreenTemplate implements TemplateInterface
     }
 
     /**
-     *  Publish a Screen Template to display in the Public Templates tab
+     *  Publish a Screen Template to display in the Shared Templates tab
      * @param mixed $request
      * @return JsonResponse
      */

--- a/database/migrations/2024_04_10_174318_update_publish_templates_permission_name.php
+++ b/database/migrations/2024_04_10_174318_update_publish_templates_permission_name.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use ProcessMaker\Models\Permission;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->updatePermissionTitle('publish-screen-templates', 'Share Screen Templates');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $this->updatePermissionTitle('publish-screen-templates', 'Publish Screen Templates');
+    }
+
+    /**
+     * Update permission title.
+     *
+     * @param string $permissionName
+     * @param string $newTitle
+     * @return void
+     */
+    private function updatePermissionTitle(string $permissionName, string $newTitle): void
+    {
+        $permission = Permission::where('name', $permissionName)->first();
+
+        if (!$permission) {
+            return; // Permission not found, nothing to update
+        }
+
+        $permission->update(['title' => $newTitle]);
+    }
+};

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -276,7 +276,7 @@ export default {
         },
         {
           value: "make-public",
-          content: "Make Public",
+          content: "Share Template",
           permission: "publish-screen-templates",
           icon: "fas fa-globe",
         },

--- a/resources/js/processes/screen-templates/components/CreateScreenTemplateForm.vue
+++ b/resources/js/processes/screen-templates/components/CreateScreenTemplateForm.vue
@@ -92,7 +92,7 @@
                                 value="true"
                                 unchecked-value="false"
                             >
-                            {{ $t('Make Public') }}
+                            {{ $t('Share Template') }}
                             </b-form-checkbox>
                         </b-form-group>
                     </b-col>

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -152,8 +152,8 @@
       />
       <pagination
         ref="pagination"
-        :single="$t('Public Template')"
-        :plural="$t('Public Templates')"
+        :single="$t('Shared Template')"
+        :plural="$t('Shared Templates')"
         :per-page-select-enabled="true"
         @changePerPage="changePerPage"
         @vuetable-pagination:change-page="onPageChange"

--- a/resources/js/processes/screen-templates/mixins/navigationMixin.js
+++ b/resources/js/processes/screen-templates/mixins/navigationMixin.js
@@ -14,7 +14,7 @@ export default {
               is_public: true,
             })
             .then(() => {
-              ProcessMaker.alert(this.$t("The template is now public."), "success");
+              ProcessMaker.alert(this.$t("The template has been successfully shared!"), "success");
               this.fetch();
             });
           break;

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -381,7 +381,7 @@ export default {
       this.formData.defaultTemplateId = templateId;
     },
     handleDefaultTemplateType(type) {
-      const isPublic = type === "Public Templates" ? 1 : 0;
+      const isPublic = type === "Shared Templates" ? 1 : 0;
       this.formData.is_public = isPublic;
     },
 

--- a/resources/js/processes/screens/components/ScreenTemplateOptions.vue
+++ b/resources/js/processes/screens/components/ScreenTemplateOptions.vue
@@ -75,7 +75,7 @@ export default {
   },
   computed: {
     isDefaultTemplatePublic() {
-      return this.templateType === 'Public Templates' ? 1 : 0;
+      return this.templateType === 'Shared Templates' ? 1 : 0;
     }
   },
   watch: {
@@ -106,14 +106,14 @@ export default {
       let url;
 
       if (this.templateType === "") {
-        this.templateType = "Public Templates";
+        this.templateType = "Shared Templates";
       }
 
       this.loading = true;
       this.apiDataLoading = true;
       this.orderBy = this.orderBy === "__slot:name" ? "name" : this.orderBy;
 
-      if (this.templateType === "Public Templates") {
+      if (this.templateType === "Shared Templates") {
         url = `templates/screen?screen_type=${this.selectedScreenType}&is_public=1`;
       } else if (this.templateType === "My Templates") {
         url = `templates/screen?screen_type=${this.selectedScreenType}&is_public=0`;

--- a/resources/js/processes/screens/components/TemplateTypeDropdown.vue
+++ b/resources/js/processes/screens/components/TemplateTypeDropdown.vue
@@ -42,12 +42,12 @@ export default {
     return {
       selectedTemplateType: [
         {
-          type: "Public Templates",
+          type: "Shared Templates",
         },
       ],
       templateTypes: [
         {
-          type: "Public Templates",
+          type: "Shared Templates",
         },
         {
           type: "My Templates",
@@ -56,7 +56,7 @@ export default {
     };
   },
   mounted() {
-    this.selectedTemplateType.type = "Public Templates";
+    this.selectedTemplateType.type = "Shared Templates";
     this.$emit("selected-template", this.selectedTemplateType.type);
   },
   methods: {

--- a/resources/js/templates/components/ScreenTemplateConfigurations.vue
+++ b/resources/js/templates/components/ScreenTemplateConfigurations.vue
@@ -73,7 +73,7 @@
                     value="true"
                     unchecked-value="false"
                 >
-                {{ $t('Make Public') }}
+                {{ $t('Share Template') }}
                 </b-form-checkbox>
             </b-form-group>
 

--- a/resources/views/components/categorized_resource.blade.php
+++ b/resources/views/components/categorized_resource.blade.php
@@ -71,7 +71,7 @@
                     onclick="loadPublicScreenTemplates()"
                     aria-controls="nav-publicTemplates"
                     aria-selected="true">
-                        {{ $tabs[3] ?? __('Public Templates') }}
+                        {{ $tabs[3] ?? __('Shared Templates') }}
                 </a>
             </li>
         @else

--- a/resources/views/processes/screens/index.blade.php
+++ b/resources/views/processes/screens/index.blade.php
@@ -21,7 +21,7 @@
             __('Screens'),
             __('Categories'),
             __('My Templates'),
-            __('Public Templates'),
+            __('Shared Templates'),
         ],
         'listConfig' => $listConfig,
         'catConfig' => $catConfig,

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -154,7 +154,7 @@ class ScreenTemplateTest extends TestCase
         ];
         $response = $this->apiCall('PUT', $route, $params);
 
-        // Check that the screen template is now public.
+        // Check that the screen template is now shared.
         $response->assertStatus(200);
         $screenTemplate->refresh();
         $this->assertEquals(1, $screenTemplate->is_public);


### PR DESCRIPTION
This PR updates all references of "Public Templates" to "Shared Templates" and "Make Public" to "Share Template" to better reflect the intended meaning and improve clarity within the application.

## Changes

- Replaced occurrences of "Public Templates" with "Shared Templates" throughout the codebase.
- Replaced occurrences of "Make Public" with "Shared Template" throughout the codebase.

## How to Test

1. Navigate to the screen where "Public Templates" were referenced.
2. Verify that all instances now display "Shared Templates".
3. Check for consistency in terminology across different sections of the application.
4. Ensure that functionality related to shared templates remains unaffected.

## Related Tickets & Packages
- [FOUR-14872](https://processmaker.atlassian.net/browse/FOUR-14872)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14872]: https://processmaker.atlassian.net/browse/FOUR-14872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ