### PR TITLE
FOUR-14892 Publish Version Modal combined with LaunchPad

### DIFF
--- a/resources/js/components/shared/ModalSaveVersion.vue
+++ b/resources/js/components/shared/ModalSaveVersion.vue
@@ -235,7 +235,7 @@ export default {
               versionable_type: this.options.type,
             })
             .then((response) => {
-              ProcessMaker.alert(this.$t("The version was saved."), "success");
+              ProcessMaker.alert(this.$t("The process version was saved."), "success");
               this.saving = false;
               this.verifyLaunchPad();
               this.hideModal();

--- a/resources/js/components/shared/ModalSaveVersion.vue
+++ b/resources/js/components/shared/ModalSaveVersion.vue
@@ -149,7 +149,7 @@ export default {
       this.showModal();
 
       // AB Testing installed
-      this.isABTestingInstalled = ProcessMaker.modeler.abPublish;
+      this.isABTestingInstalled = !!window.ProcessMaker.AbTesting;
       // AB Testing component
       if (this.isABTestingInstalled && ProcessMaker?.AbTesting?.PublishVersion) {
         this.alternative = ProcessMaker?.modeler?.process?.alternative_info;
@@ -270,7 +270,8 @@ export default {
           const alternative = window.ProcessMaker.AbTesting?.alternative;
           const iFrame = window.parent[`alternative${alternative}`];
           const isActive = iFrame ? iFrame.classList.contains("active") : false;
-          if (!response.data?.[0].launchpad && (!this.isABTestingInstalled || isActive)) {
+          const isABTestingInstalled = !!window.ProcessMaker.AbTesting;
+          if (!response.data?.[0].launchpad && (!isABTestingInstalled || isActive)) {
             this.$refs["launchpad-modal"].showModal();
           }
         });

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -1375,6 +1375,7 @@
   "Signal": "Signal",
   "Signals": "Signale",
   "Subscriber": "Abonnent/in",
+  "The process version was saved.": "The process version was saved.",
   "The version was saved.": "Die Version wurde gespeichert.",
   "The Process field is required.": "Das Feld Prozess ist ein Pflichtfeld.",
   "The start event of the call activity is not a start event": "Das Startereignis der Aufrufaktivität ist kein Startereignis.",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -1375,6 +1375,7 @@
   "Signal": "Señal",
   "Signals": "Señales",
   "Subscriber": "Suscriptor",
+  "The process version was saved.": "La versión del proceso se ha guardado.",
   "The version was saved.": "Se ha guardado la versión.",
   "The Process field is required.": "El campo Proceso es obligatorio.",
   "The start event of the call activity is not a start event": "El evento de inicio de la actividad de llamada no es un evento de inicio",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -1375,6 +1375,7 @@
   "Signal": "Signal",
   "Signals": "Signaux",
   "Subscriber": "Abonné(e)",
+  "The process version was saved.": "The process version was saved.",
   "The version was saved.": "La version a été enregistrée.",
   "The Process field is required.": "Le champ Processus est obligatoire.",
   "The start event of the call activity is not a start event": "L'événement de début de l'activité d'appel n'est pas un événement de début",


### PR DESCRIPTION
## Issue & Reproduction Steps

- publish modal is not disappear after saved
- sometime the LaunchPad does not appears

## Solution
- Fix the logic to show LaunchPad and Alternative Publish.

## How to Test
- Publish a New Process without Alternative A or B
- Publish a New Process with Alternative A
- Publish a New Process with Alternative B
- Publish a New Process with Alternative AB
- After each case the LaunchPad should be displayed only the first time the process is published.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14892
- https://processmaker.atlassian.net/browse/FOUR-14833

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:package-ab-testing:bugfix/FOUR-14892

