### PR TITLE
FOUR-14329:Message Anon Web Entry-Authenticated is visible in a we assigned to a user

### DIFF
--- a/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
@@ -7,7 +7,10 @@
       :disabled="processEvents.length === 0"
       @click="goToNewRequest(startEvent)"
     >
-      <i class="fa fa-play-circle" style="font-size: 16px;" />
+      <i
+        class="fa fa-play-circle"
+        style="font-size: 16px;"
+      />
       <span class="pl-2"> {{ $t('Start this process') }} </span>
     </button>
     <button
@@ -20,10 +23,16 @@
       @click="getStartEvents()"
     >
       <span>
-        <i class="fa fa-play-circle" style="font-size: 16px;"></i>
+        <i
+          class="fa fa-play-circle"
+          style="font-size: 16px;"
+        />
         <span class="pl-2"> {{ $t('Start this process') }} </span>
       </span>
-      <i class="fas fa-caret-down" style="font-size: 16px;"></i>
+      <i
+        class="fas fa-caret-down"
+        style="font-size: 16px;"
+      />
     </button>
     <div class="dropdown-menu dropdown-menu-right scrollable-menu p-3 pb-0 mt-2">
       <div
@@ -69,6 +78,7 @@ export default {
       processEvents: [],
       havelessOneStartEvent: false,
       startEvent: "",
+      anonUserId: "2",
     };
   },
   mounted() {
@@ -92,12 +102,12 @@ export default {
             }
           }
         })
-        .catch(err => {
+        .catch((err) => {
           this.disableButton();
           ProcessMaker.alert(err, "danger");
         });
     },
-    /** 
+    /**
      * Disable Start Button
      */
     disableButton() {
@@ -129,11 +139,11 @@ export default {
     copyLink(event) {
       const link = event.webEntry.webentryRouteConfig.entryUrl;
       navigator.clipboard.writeText(link);
-      if (event.assignment && ["user_group", "user"].includes(event.assignment)) {
+      if (event.assignedUsers && event.assignedUsers === this.anonUserId) {
         const msg = this.$t("Please use this link when you are not logged into ProcessMaker");
         ProcessMaker.alert(msg, "success", 5, false, false, "", "Anonymous Web Link Copied");
       } else {
-        this.$t("Link copied", "success");
+        ProcessMaker.alert(this.$t("Link copied"), "success");
       }
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
Message Anon Web Entry-Authenticated is visible in a we assigned to a user

1. Login with super admin user
2. Create a userA
3. Create a process with WE Authenticated
4. Assign the WE to userA
5. Go to Process-catalogue
6. Search the process
7. Copy the link of WE assigned to userA

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Create a web entry authenticated and copy the link from processes

## Related Tickets & Packages
- [FOUR-14329](https://processmaker.atlassian.net/browse/FOUR-14329)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:next

[FOUR-14329]: https://processmaker.atlassian.net/browse/FOUR-14329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ