### PR TITLE
Implement onLoad Functionality to Ensure Proper Tab Loading

### DIFF
--- a/resources/views/components/categorized_resource.blade.php
+++ b/resources/views/components/categorized_resource.blade.php
@@ -1,4 +1,4 @@
-<div class="px-3 page-content" id="categorizedList">
+<div class="px-3 page-content" id="categorizedList" style="display:none">
     @php
         $firstTab = $secondTab = 'nav-item nav-link';
         $firstContent = $secondContent = 'tab-pane fade show';
@@ -191,6 +191,13 @@
 
 @section('js')
     <script>
+      window.addEventListener('load', function() {
+        let categorizedListElement = document.getElementById('categorizedList');
+        if (categorizedListElement) {
+            categorizedListElement.style.display = 'block';
+        }
+      });
+
       loadCategory = function () {
         ProcessMaker.EventBus.$emit("api-data-category", true);
       };


### PR DESCRIPTION
This PR introduces an `onLoad` functionality to enhance the loading behavior of tabs within the Designer > Processes & Designer > Screens. Previously, tabs might display prematurely, leading to potential rendering issues and console errors when selected before the content was fully loaded. By incorporating an event listener for the window load event, the script now ensures that the categorized list element is displayed only after the page has fully loaded. This prevents potential issues and enhances the user experience by ensuring that tabs are fully loaded before they are interacted with.

## Solution

- Added an event listener for the window load event to ensure proper tab loading.
- Implemented logic to display the categorized list element only after the page has fully loaded.

## How to Test

1. Set the Network to 3G Slow if necessary.
2. Open the browser console.
3. Navigate to both Designer > Processes and Designer > Screens.
4. Upon page load, select a tab other than the main asset tab.
5. Verify that no errors occur when selecting a tab before the content is fully loaded.
6. Ensure that tabs are fully loaded and functional after the page has loaded completely.

## Related Tickets & Packages
- [FOUR-14721](https://processmaker.atlassian.net/browse/FOUR-14721)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14721]: https://processmaker.atlassian.net/browse/FOUR-14721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ