### PR TITLE
FOUR-14863: Incorrect Screen Template Referenced When Creating Screen from PreviewTemplate

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -216,7 +216,7 @@ class ScreenTemplate implements TemplateInterface
             $screen->description = $requestData['description'];
             $screen->save();
 
-            $this->syncProjectAssets($requestData);
+            $this->syncProjectAssets($requestData, $screen->id);
 
             return response()->json(['id' => $newScreenId, 'title' => $screen->title]);
         } catch (Exception $e) {
@@ -535,6 +535,12 @@ class ScreenTemplate implements TemplateInterface
         return ScreenTemplates::where('name', $screenTemplate)->firstOrFail();
     }
 
+    /**
+     * Imports a screen using the provided data and existing assets.
+     *
+     * @param array $data The data for the screen import.
+     * @param array $existingAssets The existing assets to be considered during the import.
+     */
     protected function importScreen($data, $existingAssets)
     {
         $templateId = (int) $data['templateId'];
@@ -631,7 +637,10 @@ class ScreenTemplate implements TemplateInterface
         $newScreen->save();
     }
 
-    public function syncProjectAssets($data)
+    /**
+     * Synchronizes project assets with the given data and new screen ID.
+     */
+    public function syncProjectAssets($data, int $newScreenId): void
     {
         if (class_exists(self::PROJECT_ASSET_MODEL_CLASS) && !empty($data['projects'])) {
             $manifest = $this->getManifest('screen', $newScreenId);

--- a/database/factories/ProcessMaker/Models/ScreenTemplatesFactory.php
+++ b/database/factories/ProcessMaker/Models/ScreenTemplatesFactory.php
@@ -29,7 +29,7 @@ class ScreenTemplatesFactory extends Factory
             'name' => $this->faker->unique()->name(),
             'description' => $this->faker->unique()->sentence(20),
             'user_id' => User::factory()->create()->getKey(),
-            'editing_screen_uuid' => $screen->uuid,
+            'editing_screen_uuid' => null,
             'screen_type' => 'FORM',
             'media_collection' => $this->faker->unique()->name(),
             'manifest' => $manifest,
@@ -47,14 +47,14 @@ class ScreenTemplatesFactory extends Factory
 
     public function withCustomCss()
     {
-        return $this->state(function (array $attributes) {
-            $screen = Screen::where('uuid', $attributes['editing_screen_uuid'])->first();
-            $screen->fill(['custom_css' => 'body { background-color: red; }'])->save();
+        return $this->state(function () {
+            $screen = Screen::factory()->create([
+                'custom_css' => 'body { background-color: red; }',
+            ]);
             $response = (new ExportController)->manifest('screen', $screen->id);
-            $manifest = $response->getContent();
 
             return [
-                'manifest' => $manifest,
+                'manifest' => $response->getContent(),
             ];
         });
     }

--- a/database/factories/ProcessMaker/Models/ScreenTemplatesFactory.php
+++ b/database/factories/ProcessMaker/Models/ScreenTemplatesFactory.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use ProcessMaker\Http\Controllers\Api\ExportController;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
-use ProcessMaker\Models\ScreenTemplates;
 use ProcessMaker\Models\User;
 
 /**
@@ -30,7 +29,7 @@ class ScreenTemplatesFactory extends Factory
             'name' => $this->faker->unique()->name(),
             'description' => $this->faker->unique()->sentence(20),
             'user_id' => User::factory()->create()->getKey(),
-            'editing_screen_uuid' => null,
+            'editing_screen_uuid' => $screen->uuid,
             'screen_type' => 'FORM',
             'media_collection' => $this->faker->unique()->name(),
             'manifest' => $manifest,
@@ -44,5 +43,19 @@ class ScreenTemplatesFactory extends Factory
                 return ScreenCategory::factory()->create()->getKey();
             },
         ];
+    }
+
+    public function withCustomCss()
+    {
+        return $this->state(function (array $attributes) {
+            $screen = Screen::where('uuid', $attributes['editing_screen_uuid'])->first();
+            $screen->fill(['custom_css' => 'body { background-color: red; }'])->save();
+            $response = (new ExportController)->manifest('screen', $screen->id);
+            $manifest = $response->getContent();
+
+            return [
+                'manifest' => $manifest,
+            ];
+        });
     }
 }

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -241,6 +241,8 @@ export default {
     if (this.callFromAiModeler === true) {
       this.screenTypes = this.types;
     }
+    this.formData.selectedTemplate = true;
+    this.formData.templateId = undefined;
   },
   methods: {
     show() {

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -193,6 +193,10 @@ class ScreenTemplateTest extends TestCase
 
     public function testCreateScreenFromTemplateWithProjects()
     {
+        if (!class_exists(Project::class)) {
+            $this->markTestSkipped('Package Projects is not installed.');
+        }
+
         $project = Project::factory()->create();
         $screenTemplateId = ScreenTemplates::factory()->create()->id;
         $screen_category_id = ScreenCategory::factory()->create()->id;

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -10,6 +10,7 @@ use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
 use ProcessMaker\Models\ScreenTemplates;
 use ProcessMaker\Models\User;
+use ProcessMaker\Package\Projects\Models\Project;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\Feature\Templates\HelperTrait;
 use Tests\TestCase;
@@ -188,6 +189,27 @@ class ScreenTemplateTest extends TestCase
             'is_public' => 0,
             'is_default_template' => 1,
         ]);
+    }
+
+    public function testCreateScreenFromTemplateWithProjects()
+    {
+        $project = Project::factory()->create();
+        $screenTemplateId = ScreenTemplates::factory()->create()->id;
+        $screen_category_id = ScreenCategory::factory()->create()->id;
+        $user = User::factory()->create();
+
+        $route = route('api.template.create', ['screen', $screenTemplateId]);
+        $data = [
+            'title' => 'Test Screen Creation',
+            'description' => 'Test Screen Creation from Template',
+            'screen_category_id' => $screen_category_id,
+            'type' => 'FORM',
+            'templateId' => $screenTemplateId,
+            'projects' => implode(',', [$project->id]),
+        ];
+
+        $response = $this->actingAs($user, 'api')->call('POST', $route, $data);
+        $response->assertStatus(200);
     }
 
     public function testMakePublicScreenTemplate()

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -122,20 +122,33 @@ class ScreenTemplateTest extends TestCase
 
     public function testCreateScreenFromTemplate()
     {
-        $screenTemplateId = ScreenTemplates::factory()->create()->id;
-        $screen_category_id = ScreenCategory::factory()->create()->id;
         $user = User::factory()->create();
+        $defaultScreenTemplate = ScreenTemplates::factory()->withCustomCss()->create([
+            'name' => 'Default Screen Template',
+            'is_default_template' => true,
+        ]);
+        $screenTemplate = ScreenTemplates::factory()->create([
+            'name' => 'Screen Template',
+            'is_default_template' => false,
+        ]);
+        $screenCategory = ScreenCategory::factory()->create();
 
-        $route = route('api.template.create', ['screen', $screenTemplateId]);
+        $route = route('api.template.create', ['screen', $screenTemplate->id]);
         $data = [
             'title' => 'Test Screen Creation',
             'description' => 'Test Screen Creation from Template',
-            'screen_category_id' => $screen_category_id,
+            'screen_category_id' => $screenCategory->id,
             'type' => 'FORM',
-            'templateId' => $screenTemplateId,
+            'templateId' => $screenTemplate->id,
+            'defaultTemplateId' => $defaultScreenTemplate->id,
+            'is_public' => true,
         ];
         $response = $this->actingAs($user, 'api')->call('POST', $route, $data);
         $response->assertStatus(200);
+
+        // The new screen should not have custom_css because the selected screenTemplate does not have custom_css.
+        $newScreen = Screen::where('title', 'Test Screen Creation')->first();
+        $this->assertNull($newScreen->custom_css);
     }
 
     public function testCreateScreenFromTemplateWithDefault()
@@ -155,12 +168,13 @@ class ScreenTemplateTest extends TestCase
 
         // Create a screen from a public template.
         $data = [
-            'title' => $this->faker->name(),
+            'title' => $this->faker->unique()->name(),
             'type' => 'FORM',
             'description' => $this->faker->sentence(),
             'is_public' => false,
             'screen_category_id' => $screenCategory->id,
             'defaultTemplateId' => $publicScreenTemplate->id,
+            'templateId' => $publicScreenTemplate->id,
         ];
         $route = route('api.template.create', ['screen', $publicScreenTemplate->id]);
         $response = $this->actingAs($user, 'api')->call('POST', $route, $data);
@@ -168,12 +182,13 @@ class ScreenTemplateTest extends TestCase
 
         // Create a screen from my template.
         $data = [
-            'title' => $this->faker->name(),
+            'title' => $this->faker->unique()->name(),
             'type' => 'FORM',
             'description' => $this->faker->sentence(),
             'is_public' => false,
             'screen_category_id' => $screenCategory->id,
             'defaultTemplateId' => $myScreenTemplate->id,
+            'templateId' => $publicScreenTemplate->id,
         ];
         $route = route('api.template.create', ['screen', $myScreenTemplate->id]);
         $response = $this->actingAs($user, 'api')->call('POST', $route, $data);
@@ -204,7 +219,7 @@ class ScreenTemplateTest extends TestCase
 
         $route = route('api.template.create', ['screen', $screenTemplateId]);
         $data = [
-            'title' => 'Test Screen Creation',
+            'title' => $this->faker->unique()->name(),
             'description' => 'Test Screen Creation from Template',
             'screen_category_id' => $screen_category_id,
             'type' => 'FORM',


### PR DESCRIPTION
## Issue & Reproduction Steps
When a default template is selected, but the user opts to use another template by selecting the thumbnail or configuring options in the PreviewTemplate, the template referenced to create the screen is the configured default template, rather than the template the user selected. This behavior results in screens being created based on the default template, regardless of the user's selection.

## Solution
- Following the expected behavior: `The created screen should be based on the selected screen template, regardless of the default template configuration.`. Removed the code that forced the use of the defaultTemplate for screen creation. 
- Added a unit test to cover these cases. 
- The default option in the mounted section of the CreateScreenModal.vue file has been set to a blank screen.

## How to Test
You can do manual testing in the deployed QA server.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-14863](https://processmaker.atlassian.net/browse/FOUR-14863)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14863]: https://processmaker.atlassian.net/browse/FOUR-14863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ