### PR TITLE
feature/FOUR-14541: When a new +MAIL DRIVER is deleted, this is not redirected to Email default Settigns tab

### DIFF
--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -531,13 +531,13 @@ export default {
       }
     },
     removeElement() {
-      this.$parent.$refs["menu-collapse"].firstTime = true;
-      this.$parent.$refs["menu-collapse"].getMenuGrups();
+      this.$parent.$refs["menu-collapse"].changeEmailServers = true;
+      this.$parent.$refs["menu-collapse"].refresh();
     },
     refresh() {
       this.$refs.table.refresh();
       this.$parent.$refs["menu-collapse"].firstTime = false;
-      this.$parent.$refs["menu-collapse"].getMenuGrups();
+      this.$parent.$refs["menu-collapse"].refresh();
     },
     formatGroupName(name) {
       return name.toLowerCase().replaceAll(" ", "-");

--- a/resources/js/admin/settings/components/SettingsMenuCollapse.vue
+++ b/resources/js/admin/settings/components/SettingsMenuCollapse.vue
@@ -82,8 +82,7 @@ export default {
           this.checkCollapedMenus();
           if (this.changeEmailServers) {
             this.checkChangeEmailServer();
-          }
-          if (this.firstTime) {
+          } else if (this.firstTime) {
             this.selectFirstItem();
           }
         });

--- a/resources/js/admin/settings/components/SettingsMenuCollapse.vue
+++ b/resources/js/admin/settings/components/SettingsMenuCollapse.vue
@@ -64,13 +64,14 @@ export default {
       groups: [],
       menuGroups: [],
       selectedItem: "",
-      firstTime: true,
+      firstTime: false,
       collapsedMenus: {},
       oldMenuGroups: [],
       changeEmailServers: false,
     };
   },
   mounted() {
+    this.firstTime = true;
     this.getMenuGrups();
   },
   methods: {
@@ -79,11 +80,10 @@ export default {
         .then((response) => {
           this.transformResponse(response.data.data);
           this.checkCollapedMenus();
-          if (this.firstTime) {
-            this.selectFirstItem();
-          }
           if (this.changeEmailServers) {
             this.checkChangeEmailServer();
+          } else if (this.firstTime) {
+            this.selectFirstItem();
           }
         });
     },
@@ -96,9 +96,9 @@ export default {
       });
     },
     checkChangeEmailServer() {
-      const oldEmailMenu = this.oldMenuGroups.filter((menu) => menu.menu_group === "Email")[0].groups;
-      const newEmailMenu = this.menuGroups.filter((menu) => menu.menu_group === "Email")[0].groups;
-      // Check if a Email Server was addded
+      const oldEmailMenu = this.oldMenuGroups.find((menu) => menu.menu_group === "Email").groups;
+      const newEmailMenu = this.menuGroups.find((menu) => menu.menu_group === "Email").groups;
+      // Check if a Email Server was added
       if (oldEmailMenu.length < newEmailMenu.length) {
         const newGroup = newEmailMenu.filter((group) => !oldEmailMenu.some((oldGroup) => group.id === oldGroup.id));
         if (newGroup[0].id.includes("Email Server")) {
@@ -107,7 +107,10 @@ export default {
       }
       // Check if a Email Server was deleted
       if (oldEmailMenu.length > newEmailMenu.length) {
-        this.selectFirstItem();
+        const emailDefaultItem = this.menuGroups[0].groups.find((group) => {
+          return group.name === "Email Default Settings"
+        })
+        this.selectItem(emailDefaultItem);
       }
       this.changeEmailServers = false;
       this.refreshing = false;

--- a/resources/js/admin/settings/components/SettingsMenuCollapse.vue
+++ b/resources/js/admin/settings/components/SettingsMenuCollapse.vue
@@ -82,7 +82,8 @@ export default {
           this.checkCollapedMenus();
           if (this.changeEmailServers) {
             this.checkChangeEmailServer();
-          } else if (this.firstTime) {
+          }
+          if (this.firstTime) {
             this.selectFirstItem();
           }
         });
@@ -112,6 +113,7 @@ export default {
         })
         this.selectItem(emailDefaultItem);
       }
+      this.firstTime = false;
       this.changeEmailServers = false;
       this.refreshing = false;
     },

--- a/resources/js/admin/settings/components/SettingsMenuCollapse.vue
+++ b/resources/js/admin/settings/components/SettingsMenuCollapse.vue
@@ -82,7 +82,8 @@ export default {
           this.checkCollapedMenus();
           if (this.changeEmailServers) {
             this.checkChangeEmailServer();
-          } else if (this.firstTime) {
+          }
+          if (this.firstTime) {
             this.selectFirstItem();
           }
         });


### PR DESCRIPTION
## Issue & Reproduction Steps
After delete the MAIL DRIVER the page is not redirect to Email default Settings 

## How Test
Go to Settings
Create a new Email 
Delete the new email

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14541

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:connector-send-email:feature/FOUR-14541
ci:next