### PR TITLE
FOUR-14890: The elements are cloned in both alternatives

### DIFF
--- a/resources/js/processes/modeler/index.js
+++ b/resources/js/processes/modeler/index.js
@@ -1,12 +1,14 @@
 import Vue from "vue";
 import ModelerApp from "./components/ModelerApp";
 
-window.ProcessMaker.i18nPromise.then(() => {
-  new Vue({
-    render: (h) => h(ModelerApp, {
-      props: {
-        showToolbar: window.document.getElementById("modeler-app").getAttribute("show-toolbar") !== "false",
-      },
-    }),
-  }).$mount("#modeler-app");
+document.addEventListener("DOMContentLoaded", () => {
+  window.ProcessMaker.i18nPromise.then(() => {
+    new Vue({
+      render: (h) => h(ModelerApp, {
+        props: {
+          showToolbar: window.document.getElementById("modeler-app").getAttribute("show-toolbar") !== "false",
+        },
+      }),
+    }).$mount("#modeler-app");
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
The elements are cloned in both alternatives
"Another user is working on this object, please wait until you finish making changes" message appears when clicking an item

## Solution
- add DOMContentLoaded event because packages require DOM initialization 
[clone.webm](https://github.com/ProcessMaker/processmaker/assets/1401911/508b687c-8832-4570-bf43-637f73ead165)



## How to Test

1. Create a process
2. Add control to modeler
3. Click on Publish button
4. Click on Publish
5. Close Launchpad modal
6. Enable alternative B
7. Add some controls to modeler
8. Review antother alternative


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14890

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next