### PR TITLE
FOUR-14694:External Integration are not update when a new one is added

### DIFF
--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -535,7 +535,9 @@ export default {
       this.$parent.$refs["menu-collapse"].getMenuGrups();
     },
     refresh() {
-      this.$refs.table.refresh();
+      if (this.$refs.table) {
+        this.$refs.table.refresh();
+      }
       this.$parent.$refs["menu-collapse"].firstTime = false;
       this.$parent.$refs["menu-collapse"].getMenuGrups();
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
External Integration are not update when a new one is added

## Solution
- The new Integrations added should be sync, these should be listed on the Integrations list without the need to refresh the screen 

## How to Test

1. Log in to PM4
2. Go to Admin Settings 
3. Click on Integrations category
4. Click on External Integration menu
5. Add a new integration 
6. Verify if the new external integrations was added in the table

## Related Tickets & Packages
- [FOUR-14694](https://processmaker.atlassian.net/browse/FOUR-14694)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-14694]: https://processmaker.atlassian.net/browse/FOUR-14694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ