### PR TITLE
feature/FOUR-14891: The input embed URL is not cleared after pressing cancel button in Launch pad

### DIFF
--- a/resources/js/components/shared/InputImageCarousel.vue
+++ b/resources/js/components/shared/InputImageCarousel.vue
@@ -279,7 +279,7 @@
           <button
             type="button"
             class="btn btn-cancel-delete btns-popover"
-            @click="showNewEmbed = false"
+            @click="cancelNewEmbed"
           >
             {{ $t('Cancel') }}
           </button>
@@ -637,6 +637,10 @@ export default {
         type: "delete",
       };
       ProcessMaker.EventBus.$emit("getLaunchpadImagesEvent", params);
+    },
+    cancelNewEmbed() {
+      this.newEmbed = "";
+      this.showNewEmbed = false;
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
The input embed URL is not cleared after pressing cancel button in Launch pad 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14891

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy