### PR TITLE
FOUR-14903: When the pager has a second digit, the entire last digit is not displayed

### DIFF
--- a/resources/js/components/shared/PaginationTable.vue
+++ b/resources/js/components/shared/PaginationTable.vue
@@ -9,9 +9,10 @@
     </button>
 
     <input
+      ref="pageInput"
       v-model="pageInput"
       type="text"
-      :placeholder="`${currentPage}-${totalPageCount}`"
+      :placeholder="pageInputPlaceholder"
       class="pagination-button pagination-input"
       @keyup.enter="redirectPage(pageInput)"
     >
@@ -110,6 +111,19 @@ export default {
     perPageButton() {
       return `${this.meta.per_page} per Page`;
     },
+    pageInputPlaceholder() {
+      return `${this.currentPage}-${this.totalPageCount}`;
+    },
+  },
+  watch: {
+    pageInputPlaceholder() {
+      this.adjustInputWidth();
+    },
+  },
+  mounted() {
+    this.$nextTick(() => {
+      this.adjustInputWidth();
+    });
   },
   methods: {
     previousPage() {
@@ -131,6 +145,23 @@ export default {
     redirectPage(value) {
       this.$emit("page-change", value);
       this.pageInput = "";
+    },
+    adjustInputWidth() {
+      const input = this.$refs.pageInput;
+      const span = document.createElement("span");
+      document.body.appendChild(span);
+
+      span.style.font = window.getComputedStyle(input).font;
+      span.style.position = "absolute";
+      span.style.visibility = "hidden";
+      span.style.whiteSpace = "nowrap";
+
+      span.textContent = input.value || input.placeholder;
+
+      const width = span.offsetWidth;
+      document.body.removeChild(span);
+
+      input.style.width = `${width + 30}px`;
     },
   },
 };
@@ -179,9 +210,6 @@ export default {
   font-weight: 400;
   font-size: 14.5px;
   color: #5C5C63;
-}
-.pagination-input {
-  width: 50px;
 }
 .pagination-input::placeholder {
   text-align: center;

--- a/resources/js/components/shared/PaginationTable.vue
+++ b/resources/js/components/shared/PaginationTable.vue
@@ -22,7 +22,7 @@
       class="pagination-button"
       @click="nextPage"
     >
-      <span>&gt;</span>
+      <strong>&gt;</strong>
     </button>
     <span class="pagination-total">
       {{ totalItems }}

--- a/resources/js/components/shared/PaginationTable.vue
+++ b/resources/js/components/shared/PaginationTable.vue
@@ -5,12 +5,12 @@
       class="pagination-button"
       @click="previousPage"
     >
-      <strong><</strong>
+      <strong>&lt;</strong>
     </button>
 
     <input
-      type="text"
       v-model="pageInput"
+      type="text"
       :placeholder="`${currentPage}-${totalPageCount}`"
       class="pagination-button pagination-input"
       @keyup.enter="redirectPage(pageInput)"
@@ -21,19 +21,26 @@
       class="pagination-button"
       @click="nextPage"
     >
-      <strong>></strong>
+      <span>&gt;</span>
     </button>
     <span class="pagination-total">
       {{ totalItems }}
     </span>
     <div class="btn-group dropup pagination-dropdown-group">
-      <button type="button" class="btn dropdown-toggle pagination-dropup" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button
+        type="button"
+        class="btn dropdown-toggle pagination-dropup"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false"
+      >
         {{ perPageButton }}
       </button>
       <div class="dropdown-menu">
         <a
           v-for="(item, index) in itemsPerPage"
-          :key="index" class="dropdown-item pagination-dropdown-items"
+          :key="index"
+          class="dropdown-item pagination-dropdown-items"
           href="#"
           @click="changePerPage(item.value)"
         >
@@ -96,12 +103,12 @@ export default {
     },
     totalItems() {
       if (this.meta.total === 1) {
-        return this.meta.total + " item";
+        return `${this.meta.total} item`;
       }
-      return this.meta.total + " items";
+      return `${this.meta.total} items`;
     },
     perPageButton() {
-      return this.meta.per_page + " per Page"
+      return `${this.meta.per_page} per Page`;
     },
   },
   methods: {
@@ -116,13 +123,13 @@ export default {
       }
     },
     goToPage(page) {
-      this.$emit('page-change', page);
+      this.$emit("page-change", page);
     },
     changePerPage(value) {
-      this.$emit('per-page-change', value);
+      this.$emit("per-page-change", value);
     },
     redirectPage(value) {
-      this.$emit('page-change', value);
+      this.$emit("page-change", value);
       this.pageInput = "";
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps

The size of the pagination input is small and when the page reaches two digits, the second digit is not shown.

1. Have more than 10 pages in My template or Public template.
2. Go to the following pages until you reach 10.

## Solution
- Since adjusting the width of the input field based on the content of the placeholder is not natively possible, used JS to measure the width of the placeholder text and then apply that same width to the input field.

## How to Test
- Test in the QA server.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-14903](https://processmaker.atlassian.net/browse/FOUR-14903)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14903]: https://processmaker.atlassian.net/browse/FOUR-14903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ