### PR TITLE
FOUR-14916 | Screen Templates Tooltip Overflows Table Rows

### DIFF
--- a/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/MyTemplatesListing.vue
@@ -293,5 +293,6 @@ export default {
   color: #888;
   width: 32px;
   height: 32px;
+  margin-top: 4px;
 }
 </style>

--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -300,5 +300,6 @@ export default {
   color: #888;
   width: 32px;
   height: 32px;
+  margin-top: 4px;
 }
 </style>

--- a/resources/js/processes/screen-templates/components/ScreenTemplatesTooltip.vue
+++ b/resources/js/processes/screen-templates/components/ScreenTemplatesTooltip.vue
@@ -4,7 +4,6 @@
     class="screen-templates-tooltip"
   >
     <slot
-      class="screen-templates-tooltip-body"
       name="screen-templates-tooltip-body"
     />
   </div>
@@ -24,7 +23,6 @@ export default {
 <style scoped>
 .screen-templates-tooltip {
   position: absolute;
-  padding: 8px;
   border-radius: 4px;
   height: 45px;
   background-color: #FFFFFF;

--- a/resources/js/processes/screen-templates/components/ScreenTemplatesTooltip.vue
+++ b/resources/js/processes/screen-templates/components/ScreenTemplatesTooltip.vue
@@ -3,7 +3,10 @@
     :style="{ top: (position.y) + 'px', right: '50px' }"
     class="screen-templates-tooltip"
   >
-    <slot name="screen-templates-tooltip-body" />
+    <slot
+      class="screen-templates-tooltip-body"
+      name="screen-templates-tooltip-body"
+    />
   </div>
 </template>
 
@@ -23,8 +26,10 @@ export default {
   position: absolute;
   padding: 8px;
   border-radius: 4px;
+  height: 45px;
   background-color: #FFFFFF;
   color: #566877;
+  padding: 2px 8px 0 8px;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
 }
 </style>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-14916](https://processmaker.atlassian.net/browse/FOUR-14916)

The tooltip menu for My Templates and Public Templates is larger than the table rows.

# Solution
- Adjust tooltip height
- Center elements inside of tooltip

# Previous UI
![Screen Shot 2024-04-10 at 12 13 27 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/4504724a-505e-40ac-8e7a-ee39825e3cb2)


# Updated UI
![Screen Shot 2024-04-10 at 13 04 24 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/eed1749a-57d1-4d06-a0c2-29cc4d32c79f)


# How to Test
1. Go to branch `observation/FOUR-14916` in `processmaker`.
2. Go to Designer → Screens → My Templates or Public Templates.
3. Hover over a Template.
4. The tooltip menus should not be larger than their rows.

ci:next
ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-14916]: https://processmaker.atlassian.net/browse/FOUR-14916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ