### PR TITLE
FOUR-14517: 400 Error in Search engine with "Failed" as parameter

### DIFF
--- a/resources/js/components/shared/PmqlInput.vue
+++ b/resources/js/components/shared/PmqlInput.vue
@@ -383,7 +383,7 @@ export default {
       } else if (this.aiEnabledLocal) {
         this.runNLQToPMQL();
       } else if (!this.query.isPMQL() && !this.aiEnabledLocal) {
-        const fullTextSearch = `(fulltext LIKE "%${this.query}%")`;
+        const fullTextSearch = encodeURIComponent(`(fulltext LIKE "%${this.query}%")`);
         this.pmql = fullTextSearch;
         this.$emit("submit", fullTextSearch);
         this.$emit("input", fullTextSearch);


### PR DESCRIPTION
## Issue & Reproduction Steps
- Log in to Processmaker
- Go to Admin Setting
- In the search engine type “Failed“
- Press enter

## Solution
- Url encoding of PMQL query



## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14517

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next