### PR TITLE
FOUR-14754:Redirecting the page for a + MAIL Driver does not redirect to the last one in Admin Settings

### DIFF
--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -30,7 +30,7 @@
               :key="`btn-${index}`"
               :ref="formatGroupName(btn.group)"
               :data-cy="btn.key"
-              :disabled="false"
+              :disabled="disableButton"
               class="ml-2 nowrap"
               @click="handler(btn)"
             >
@@ -258,6 +258,7 @@ export default {
       shouldDisplayNoDataMessage: false,
       noDataMessageConfig: null,
       loading: true,
+      disableButton: false,
     };
   },
   computed: {
@@ -526,6 +527,7 @@ export default {
       if (btn.ui && btn.ui.handler && window[btn.ui.handler]) {
         window[btn.ui.handler](this);
         if (btn.ui.handler === "addMailServer") {
+          this.disableButton = true;
           this.$parent.$refs["menu-collapse"].changeEmailServers = true;
         }
       }


### PR DESCRIPTION
## Issue & Reproduction Steps
Redirecting the page for a + MAIL Driver does not redirect to the last one in Admin Settings

## Solution
- The page should be redirected to last MAIL DRIVER that was created, like the previous version 

## How to Test

1. Log in to PM4
2. Go to Admin Settings
3. Click on Email Default Settings 
4. Click on +MAIL DRIVER more that one time(Exe: 3 times)
5. Check where the page was redirected

## Related Tickets & Packages
- [FOUR-14754](https://processmaker.atlassian.net/browse/FOUR-14754)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:next

[FOUR-14754]: https://processmaker.atlassian.net/browse/FOUR-14754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ