### PR TITLE
QA Observation Bugfix/FOUR-14948: Clear Task Button in Inbox Rules page does not clear Date and Datetime fields

### DIFF
--- a/resources/js/inbox-rules/components/InboxRuleFillData.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFillData.vue
@@ -61,7 +61,7 @@
     },
     methods: {
       eraseData() {
-        this.sendEvent("eraseData", true);
+        this.sendEvent("eraseData", {});
       },
       reload() {
         this.formData = {};

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -98,6 +98,7 @@
                           :initial-task-id="{{ $task->id }}"
                           :initial-request-id="{{ $task->process_request_id }}"
                           :user-id="{{ Auth::user()->id }}"
+                          :clear-task="clearTask"
                           csrf-token="{{ csrf_token() }}"
                           initial-loop-context="{{ $task->getLoopContext() }}"
                           @task-updated="taskUpdated"
@@ -161,6 +162,7 @@
         store: store,
         el: "#task",
         data: {
+          clearTask: false,
           //Edit data
           fieldsToUpdate: [],
           jsonData: "",
@@ -441,6 +443,7 @@
 
           window.addEventListener('eraseData', event => {
             this.formData = {};
+            this.clearTask = true;
           });
 
           // listen for keydown on element with id interactionListener


### PR DESCRIPTION
## How to Test
- Select a Task
- Go to Inbox Rules
- Select "Save and reuse fill data"
- Press NEXT button
- Click on Quick Fill button
- Select a previous task (with Date or Datetime fields) and press Use This Task Data
- Click on "Clear Task" button.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14948

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next