### PR TITLE
Fix Default Template Overwrite Issue in Shared Templates

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -272,6 +272,7 @@ class ScreenTemplate implements TemplateInterface
     {
         $id = (int) $request->id;
         $template = ScreenTemplates::where('id', $id)->firstOrFail();
+        $template->is_default_template = false;
         $template->is_public = true;
         $template->saveOrFail();
 
@@ -314,6 +315,11 @@ class ScreenTemplate implements TemplateInterface
             $id = (int) $request->id;
             $template = ScreenTemplates::where('id', $id)->firstOrFail();
             $this->syncTemplateMedia($template, $request->template_media);
+
+            if ($request->is_public !== $template->is_public) {
+                $template->is_default_template = false;
+            }
+
             $template->fill($request->except('id'));
             $template->user_id = Auth::user()->id;
 
@@ -321,7 +327,7 @@ class ScreenTemplate implements TemplateInterface
 
             return response()->json();
         } catch (\Exception $e) {
-            return response([
+            return response()->json([
                 'message' => $e->getMessage(),
             ], 422);
         }

--- a/resources/js/processes/screen-templates/mixins/navigationMixin.js
+++ b/resources/js/processes/screen-templates/mixins/navigationMixin.js
@@ -12,6 +12,7 @@ export default {
               description: data.description,
               version: data.version,
               is_public: true,
+              is_default_template: false,
             })
             .then(() => {
               ProcessMaker.alert(this.$t("The template is now public."), "success");

--- a/resources/js/templates/components/ScreenTemplateConfigurations.vue
+++ b/resources/js/templates/components/ScreenTemplateConfigurations.vue
@@ -71,8 +71,8 @@
                     id="make-screen-template-public"
                     v-model="template.is_public"
                     name="make-screen-template-public"
-                    value="true"
-                    unchecked-value="false"
+                    :value="true"
+                    :unchecked-value="false"
                 >
                 {{ $t('Make Public') }}
                 </b-form-checkbox>


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves an issue where setting a template as the default template in the "My Templates" tab would overwrite the default template in the "Shared Templates" tab when the template was shared. The issue occurred because the default template setting was not properly reset when a template was shared, leading to unintended changes in default templates.

## Solution

- Implemented logic to properly reset the default template for the template being shared.

## How to Test

### Test Case A

- Set a default template in the "My Templates" tab using the create screen modal.
- Take note of the default template in the "Shared Templates" tab.
- Navigate to Designer > Screens and select the default template in the "My Templates" tab.
- Select the "Make public" action in the option menu.
- Ensure that the default template in the "Shared Templates" tab remains unchanged.
- Verify that setting a template as the default in the "My Templates" tab does not affect the default template in the "Shared Templates" tab.

### Test Case B

- Set a default template in the "My Templates" tab using the create screen modal.
- Take note of the default template in the "Shared Templates" tab.
- Navigate to Designer > Screens and select the default template in the "My Templates" tab.
- Select the "Configure Template" action in the option menu.
- Select the "Make public" checkbox and save.
- Ensure that the default template in the "Shared Templates" tab remains unchanged.
- Verify that setting a template as the default in the "My Templates" tab does not affect the default template in the "Shared Templates" tab.

## Related Tickets & Packages
- [FOUR-14918](https://processmaker.atlassian.net/browse/FOUR-14918)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
