### PR TITLE
FOUR-14898 Can't hide the AI Global Search in the Platform using the visibility toggle

### DIFF
--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -9,7 +9,7 @@
     </div>
 
     <div class="d-flex d-lg-none w-100">
-        @if(hasPackage('package-ai'))
+        @if(hasPackage('package-ai') && shouldShow('globalSearchBar'))
         <global-search v-if="isMobile" class="w-100 small-screen"></global-search>
         @endif
     </div>
@@ -125,7 +125,7 @@
 
         <b-navbar-nav class="d-flex align-items-center ml-auto">
 
-            @if(hasPackage('package-ai'))
+            @if(hasPackage('package-ai') && shouldShow('globalSearchBar'))
             <global-search v-if="!isMobile" class="d-none d-lg-block"></global-search>
             @endif
 


### PR DESCRIPTION
## Issue & Reproduction Steps
A condition used by package dynamic-ui was removed in the feature https://processmaker.atlassian.net/browse/FOUR-11380

## Solution
Added the missing condition inthe template

## How to Test
1. Access ProcessMaker
2. Access the Admin Section
3. Access Groups → Group Details → Visibility Settings → Global Search Bar Toggle
4. Turn off the Global Search Bar Toggle
5. Log out
6. Log in
7. The Global Search Bar still shows

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14898

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
