### PR TITLE
Bugfix/FOUR-14842: Error appear in Import process when the launch pad is deselected in the exportation

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/EmbedExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/EmbedExporter.php
@@ -7,8 +7,6 @@ use ProcessMaker\Models\Embed;
 
 class EmbedExporter extends ExporterBase
 {
-    public $discard = false;
-
     public $handleDuplicatesByIncrementing = ['uuid'];
 
     public $incrementStringSeparator = null;

--- a/ProcessMaker/ImportExport/Exporters/MediaExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/MediaExporter.php
@@ -8,8 +8,6 @@ use ProcessMaker\ImportExport\DependentType;
 
 class MediaExporter extends ExporterBase
 {
-    public $discard = false;
-
     public function export(): void
     {
         $media = $this->model;

--- a/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
@@ -6,8 +6,6 @@ use ProcessMaker\Models\Screen;
 
 class ProcessLaunchpadExporter extends ExporterBase
 {
-    public $discard = false;
-
     public $handleDuplicatesByIncrementing = ['process_id'];
 
     public $incrementStringSeparator = null;

--- a/ProcessMaker/Models/Embed.php
+++ b/ProcessMaker/Models/Embed.php
@@ -5,9 +5,11 @@ namespace ProcessMaker\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use ProcessMaker\Models\ProcessMakerModel;
 use ProcessMaker\Traits\HasUuids;
+use ProcessMaker\Traits\Exportable;
 
 class Embed extends ProcessMakerModel
 {
+    use Exportable;
     use HasFactory;
     use HasUuids;
 

--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Validation\ValidationException;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Traits\Exportable;
 use Spatie\MediaLibrary\MediaCollections\Models\Media as MediaLibraryModel;
 
 /**
@@ -56,6 +57,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media as MediaLibraryModel;
  */
 class Media extends MediaLibraryModel
 {
+    use Exportable;
     use HasFactory;
 
     protected $connection = 'processmaker';

--- a/ProcessMaker/Models/ProcessLaunchpad.php
+++ b/ProcessMaker/Models/ProcessLaunchpad.php
@@ -4,9 +4,11 @@ namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use ProcessMaker\Traits\HasUuids;
+use ProcessMaker\Traits\Exportable;
 
 class ProcessLaunchpad extends ProcessMakerModel
 {
+    use Exportable;
     use HasFactory;
     use HasUuids;
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Error appear in Import process when the launch pad is deselected in the exportation

## Solution
- List the changes you've introduced to solve the issue.

## How to Test

1. Create a process
2. Configure The launch pad setup with Icon 
3. Save the configuration 
4. Export the process with all configuration 
5. Import the process
6. Select custom importation 
7. Unchecked the Launchpad setup
8. Check the configurations launch pad

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14842

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy