### PR TITLE
feature/FOUR-14874: Description fields is not saved from launch pad

### DIFF
--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -92,18 +92,15 @@
       <label>
         {{ $t("Description") }}
       </label>
-      <input
+      <textarea
         id="additional-details"
         v-model="processDescription"
         class="form-control input-custom mb-0"
         type="text"
         rows="5"
         :aria-label="$t('Description')"
+        disabled
       />
-      <span v-if="!processDescription" class="error-message">
-        {{ $t("The description field is required.") }}
-        <br>
-      </span>
     </div>
   </modal>
 </template>
@@ -270,7 +267,6 @@ export default {
      * Save description field in Process
      */
     saveProcessDescription() {
-      if (!this.processDescription) return;
       if (!this.$refs["image-carousel"].checkImages()) return;
       this.dataProcess.imagesCarousel = this.$refs["image-carousel"].getImages();
       this.dataProcess.properties = JSON.stringify({
@@ -312,7 +308,6 @@ export default {
       if (this.origin !== "core") {
         this.dataProcess = ProcessMaker.modeler.process;
       }
-      this.dataProcess.description = this.processDescription;
       this.saveProcessDescription();
     },
     /**
@@ -487,11 +482,16 @@ label {
 }
 .input-custom {
   height: 40px;
-  margin-bottom: 16px;
-  padding: 0px, 12px, 0px, 12px;
+  color: #556271;
+  background: white;
   border-radius: 4px;
-  gap: 6px;
   border: 1px solid #cdddee;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 21.79px;
+  letter-spacing: -0.02em;
+  gap: 6px;
 }
 .modal-dialog, .modal-content {
   min-width: 800px;


### PR DESCRIPTION
## Issue & Reproduction Steps
The description should be saved in export a process, if it was modified from launch pad and also it should be matched in process config 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14874

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy