### PR TITLE
FOUR-14964: Modal content is different when AB testing is not enabled

### DIFF
--- a/resources/js/components/shared/ModalSaveVersion.vue
+++ b/resources/js/components/shared/ModalSaveVersion.vue
@@ -25,7 +25,7 @@
         v-else
         class="form-group"
       >
-        <p>{{ $t("Once published, all new requests will use the new process model.") }}</p>
+        <p>{{ $t("New requests will use the published process") }}</p>
         <div>
           <label for="name">{{ $t("Version Name") }} </label>
           <input


### PR DESCRIPTION
## Issue & Reproduction Steps
Modal content is different when AB testing is not enabled

## Solution
- the label was updated so the button is working as design


[label publish.webm](https://github.com/ProcessMaker/processmaker/assets/1401911/dd2846a0-0a38-4e21-97d5-206359c2639f)

## How to Test

1. Create a process
2. Click on Publish button

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14964

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
