### PR TITLE
Filter tasks by user if they are not an admin

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -120,6 +120,8 @@ class TaskController extends Controller
 
         $this->applyAdvancedFilter($query, $request);
 
+        $this->applyForCurrentUser($query, $user);
+
         // If only the total is being requested (by a Saved Search), send it now
         if ($getTotal === true) {
             return $query->count();

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -210,4 +210,20 @@ trait TaskControllerIndexMethods
             return new Resource($processRequestToken);
         });
     }
+
+    private function applyForCurrentUser($query, $user)
+    {
+        if ($user->is_administrator) {
+            return $query;
+        }
+
+        if ($user->can('view-all_requests')) {
+            return $query;
+        }
+
+        $query->where(function ($query) use ($user) {
+            $query->where('user_id', $user->id)
+                ->orWhereIn('id', $user->availableSelfServiceTaskIds());
+        });
+    }
 }

--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -13,7 +13,6 @@ const PMColumnFilterCommonMixin = {
       userId: window.Processmaker.userId,
       viewAssignee: [],
       viewParticipants: [],
-      viewProcesses: []
     };
   },
   watch: {
@@ -238,16 +237,6 @@ const PMColumnFilterCommonMixin = {
         for (let i in response.data.data) {
           this.viewParticipants.push({
             text: response.data.data[i].username,
-            value: response.data.data[i].id
-          });
-        }
-      });
-    },
-    getProcess() {
-      ProcessMaker.apiClient.get('/processes?per_page=100').then(response => {
-        for (let i in response.data.data) {
-          this.viewProcesses.push({
-            text: response.data.data[i].name,
             value: response.data.data[i].id
           });
         }

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -386,7 +386,6 @@ export default {
   },
   mounted: function mounted() {
     this.getAssignee("");
-    this.getProcess();
     this.setupColumns();
     this.getFilterConfiguration();
 


### PR DESCRIPTION
See https://processmaker.atlassian.net/browse/FOUR-14709

- Filter tasks for non-admin users and users that don't have the view-all-requests permission
- Remove unused API call that was causing an error message for non-admin users

ci:next