### PR TITLE
Fix Security log download fail feedback

### DIFF
--- a/ProcessMaker/Events/SecurityLogDownloadFailed.php
+++ b/ProcessMaker/Events/SecurityLogDownloadFailed.php
@@ -56,7 +56,7 @@ class SecurityLogDownloadFailed implements ShouldBroadcastNow
      */
     public function broadcastAs()
     {
-        return 'SecurityLogDownloadFailed';
+        return 'SecurityLogDownloadJobDone';
     }
 
     /**

--- a/ProcessMaker/Events/SecurityLogDownloadJobCompleted.php
+++ b/ProcessMaker/Events/SecurityLogDownloadJobCompleted.php
@@ -56,7 +56,7 @@ class SecurityLogDownloadJobCompleted implements ShouldBroadcastNow
      */
     public function broadcastAs()
     {
-        return 'SecurityLogDownloadJobCompleted';
+        return 'SecurityLogDownloadJobDone';
     }
 
     /**

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -368,7 +368,7 @@ if (userID) {
         }, 100);
       }
     })
-    .listen(".SecurityLogDownloadJobCompleted", (e) => {
+    .listen(".SecurityLogDownloadJobDone", (e) => {
       if (e.success) {
         const { link } = e;
         const { message } = e;


### PR DESCRIPTION
## Issue & Reproduction Steps
We are not providing any feedback to user on Security log failed .
This PR will fix it .

## Solution
Unify the event name for both Failed/Completed states of the SecurityLogDownload jobs .

## How to Test
All tests remain passing with these chanes .

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
