### PR TITLE
FOUR-14972: The list of users/groups does not match the pagination selection option.

### DIFF
--- a/resources/js/components/common/Pagination.vue
+++ b/resources/js/components/common/Pagination.vue
@@ -62,8 +62,8 @@
           class="pagination-nav-item pagination-nav-drop"
           :aria-label="$t('Per page')"
         >
-          <option value="10">10</option>
-          <option value="25">25</option>
+          <option value="15">15</option>
+          <option value="30">30</option>
           <option value="50">50</option>
         </select>
       </div>
@@ -78,7 +78,7 @@ export default {
   props: ["perPageSelectEnabled", "single", "plural"],
   data() {
     return {
-      perPage: 10
+      perPage: 15
     };
   },
   computed: {


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to admin
- Click on users
- Scroll to pagination
- Click on groups
- Scroll to pagination

**Current Behavior:**

The list of users/groups does not match the pagination selection option, more than 10 user/groups are shown.

**Expected Behavior:**

As in previous versions, the list should be shown with the correct pagination

## Solution
- The pagination has been configured to use by default groups of 15, 30 and 50 items

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
[- Link to any related FOUR tickets, PRDs, or packages](https://processmaker.atlassian.net/browse/FOUR-14972)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next