### PR TITLE
FOUR:15000: Version Name is Not Saved

### DIFF
--- a/resources/js/components/shared/ModalSaveVersion.vue
+++ b/resources/js/components/shared/ModalSaveVersion.vue
@@ -97,10 +97,10 @@ export default {
   props: {
     options: {
       type: Object,
-      default: {
+      default: () => ({
         id: "",
         type: "",
-      },
+      }),
     },
     filter: {
       type: String,
@@ -161,11 +161,17 @@ export default {
   },
   methods: {
     abPublishVersion(alternativeData) {
-      this.subject = alternativeData.subject;
-      this.description = alternativeData.description;
+      const {
+        subject = this.subject,
+        description = this.description,
+      } = alternativeData || {};
 
-      this.saveModal(alternativeData);
+      this.subject = subject;
+      this.description = description;
+
+      this.saveModal();
     },
+
     /**
      * Method to store initial data from process description field
      */
@@ -226,7 +232,7 @@ export default {
       });
 
       promise
-        .then((response) => {
+        .then(() => {
           ProcessMaker.apiClient
             .post("/version_histories", {
               subject: this.subject,
@@ -234,7 +240,7 @@ export default {
               versionable_id: this.options.id,
               versionable_type: this.options.type,
             })
-            .then((response) => {
+            .then(() => {
               ProcessMaker.alert(this.$t("The process version was saved."), "success");
               this.saving = false;
               this.verifyLaunchPad();
@@ -244,15 +250,9 @@ export default {
               if (error.response.status && error.response.status === 422) {
                 this.errors = error.response.data.errors;
               }
-              if (error.response.status === 404) {
-                // version_histories route not found because package-versions is not installed
-                console.error(err);
-              }
             });
         })
-        .catch((err) => {
-          console.error(err);
-        });
+        .catch(() => {});
     },
     showModal() {
       this.subject = "";


### PR DESCRIPTION
## Issue & Reproduction Steps
Version name is not saved.

1. Have any process
2. Publish the process
3. Name the version
4. Check it in version history in Configuration

## Solution
- Added a check for when the `alternativeData` object is undefined, allowing the subject and description from the input to be used. This ensures the name and description of the version are stored correctly.

![Screenshot_2024-04-15_at_10-39-06_Configure_Process_-_ProcessMaker](https://github.com/ProcessMaker/processmaker/assets/90741874/89b8db8d-c3f9-4927-bf13-14d2d77f0bc5)

## How to Test
Test in the deployed QA server.

ci:deploy
ci:next

## Related Tickets & Packages
- [FOUR-15000](https://processmaker.atlassian.net/browse/FOUR-15000)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15000]: https://processmaker.atlassian.net/browse/FOUR-15000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ