### PR TITLE
bugfix/FOUR-15025: Adding the category Integrations in Plaid

### DIFF
--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -461,8 +461,8 @@ class Setting extends ProcessMakerModel implements HasMedia
                     case 'External Integrations': // Enterprise Integrations
                         $id = SettingsMenus::getId(SettingsMenus::INTEGRATIONS_MENU_GROUP);
                         break;
-                    default:
-                        $id = null;
+                    default: // The default configuration will Integration
+                        $id = SettingsMenus::getId(SettingsMenus::INTEGRATIONS_MENU_GROUP);
                         break;
                 }
                 if ($id !== null) {

--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -429,7 +429,7 @@ class Setting extends ProcessMakerModel implements HasMedia
      */
     public static function updateAllSettingsGroupId()
     {
-        Setting::chunk(100, function ($settings) {
+        Setting::whereNull('group_id')->chunk(100, function ($settings) {
             foreach ($settings as $setting) {
                 // Define the value of 'menu_group' based on 'group'
                 switch ($setting->group) {
@@ -458,11 +458,15 @@ class Setting extends ProcessMakerModel implements HasMedia
                         break;
                     case 'IDP': // Intelligent Document Processing
                     case 'DocuSign':
+                    case 'Plaid':
                     case 'External Integrations': // Enterprise Integrations
                         $id = SettingsMenus::getId(SettingsMenus::INTEGRATIONS_MENU_GROUP);
                         break;
-                    default: // The default configuration will Integration
-                        $id = SettingsMenus::getId(SettingsMenus::INTEGRATIONS_MENU_GROUP);
+                    case 'System': // System not related with settings menu
+                        $id = null;
+                        break;
+                    default: // The default value
+                        $id = SettingsMenus::getId(SettingsMenus::EMAIL_MENU_GROUP);
                         break;
                 }
                 if ($id !== null) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Refactor the table in order to detect the menu y submenus

## Solution
- Populate new column **settings.group_id**

## How to Test

- Go to Settings
- Integrations -> Plaid

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15025

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:package-plaid:bugfix/FOUR-15025