### PR TITLE
QA Observation Bugfix/FOUR-15011: Different user cannot create an Inbox Rule with the same name

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/InboxRulesController.php
+++ b/ProcessMaker/Http/Controllers/Api/InboxRulesController.php
@@ -64,10 +64,12 @@ class InboxRulesController extends Controller
         $request->validate([
             'name' => [
                 'required',
-                Rule::unique('inbox_rules')->ignore(null),
+                Rule::unique('inbox_rules')->where(function ($query) use ($request) {
+                    return $query->where('user_id', $request->user()->id);
+                }),
                 'alpha_spaces'
             ]
-        ]);
+        ]);        
 
         // We always create a new saved search when we create a new inbox rule
         $savedSearch = InboxRule::createSavedSearch([


### PR DESCRIPTION
## How to Test
- Go to PM4 environment 
- Create a userA
- Login with userA
- Go to tasks/rules
- Create a inboxRule named test1_A
- Create a userB
- Login with userB
- Go to tasks/rules
- Create a inboxRule named test1_A

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15011

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next