### PR TITLE
observation/FOUR-14549 The screens pager is not the same as the other process pagers

### DIFF
--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -14,7 +14,6 @@
         :sortOrder="sortOrder"
         :css="css"
         :api-mode="false"
-        @vuetable:pagination-data="onPaginationData"
         :fields="fields"
         :data="data"
         data-path="data"

--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -40,16 +40,12 @@
       </vuetable>
 
       <add-to-project-modal id="add-to-project-modal" ref="add-to-project-modal"  assetType="screen" :assetId="screenId" :assetName="assetName" :assignedProjects="assignedProjects"/>
-
-      <pagination
-        single="Screen"
-        plural="Screens"
-        :perPageSelectEnabled="true"
-        @changePerPage="changePerPage"
-        @vuetable-pagination:change-page="onPageChange"
-        ref="pagination"
-      ></pagination>
     </div>
+    <pagination-table
+      :meta="data.meta"
+      @page-change="changePage"
+      @per-page-change="changePerPage"
+    />
     <b-modal ref="myModalRef" :title="$t('Copy Screen')" centered header-close-content="&times;">
       <form>
         <div class="form-group">
@@ -112,13 +108,14 @@ import ellipsisMenuMixin from "../../../components/shared/ellipsisMenuActions";
 import screenNavigationMixin from "../../../components/shared/screenNavigation";
 import CreateTemplateModal from "../../../components/templates/CreateTemplateModal.vue";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
+import PaginationTable from "../../../components/shared/PaginationTable.vue";
 
 import { createUniqIdsMixin } from "vue-uniq-ids";
 import AddToProjectModal from "../../../components/shared/AddToProjectModal.vue";
 const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
-  components: { EllipsisMenu, AddToProjectModal, CreateTemplateModal },
+  components: { EllipsisMenu, AddToProjectModal, CreateTemplateModal, PaginationTable },
   mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin, ellipsisMenuMixin, screenNavigationMixin],
   props: ["filter", "id", "permission", "currentUserId", 'types'],
   data() {
@@ -244,6 +241,10 @@ export default {
       this.screenTemplateName = name;
       this.screenType = type;
       this.$refs["create-template-modal"].show();
+    },
+    changePage(page) {
+      this.page = page;
+      this.fetch();
     },
   },
 


### PR DESCRIPTION
## Issue & Reproduction Steps
We see that the pager in screens does not have the same UI as other pagers.

## Solution
Changed the pagination component

## How to Test

1. Log in 
2. Click on Desginer
3. Click on Screens 
4. See the pager
5. Click on the other screens tabs My template, category, or public template
6. Click on Process 
7. see the pager of the process tabs

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14549

ci:deploy
ci:next