### PR TITLE
FOUR-14893:After reload process by launchpad the Uncategorized is selected in categories

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
+++ b/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
@@ -31,12 +31,9 @@ class ProcessesCatalogueController extends Controller
         $bookmarkId = 0;
         $currentUser = Auth::user()->only(['id', 'username', 'fullname', 'firstname', 'lastname', 'avatar']);
         if (!is_null($process)) {
-            $launchpad = ProcessLaunchpad::getLaunchpad(true, $process->id);
-            $bookmarkId = Bookmark::getBookmarked(true, $process->id, $currentUser['id']);
+            $process->launchpad = ProcessLaunchpad::getLaunchpad(true, $process->id);
+            $process->bookmarkId = Bookmark::getBookmarked(true, $process->id, $currentUser['id']);
         }
-        return view(
-            'processes-catalogue.index',
-            compact('process', 'launchpad', 'currentUser', 'manager', 'bookmarkId')
-        );
+        return view('processes-catalogue.index', compact('process', 'currentUser', 'manager'));
     }
 }

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -130,7 +130,9 @@ export default {
      * Go to process info
      */
     openProcessInfo(process) {
-      window.history.replaceState(null, null, `/process-browser/${process.id}`);
+      debugger;
+      const categoryId = this.category ? this.category.id : -1;
+      window.history.replaceState(null, null, `/process-browser/${process.id}?categorySelected=${categoryId}`);
       this.$emit("openProcess", process);
     },
     /**

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -130,7 +130,6 @@ export default {
      * Go to process info
      */
     openProcessInfo(process) {
-      debugger;
       const categoryId = this.category ? this.category.id : -1;
       window.history.replaceState(null, null, `/process-browser/${process.id}?categorySelected=${categoryId}`);
       this.$emit("openProcess", process);

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -190,7 +190,7 @@ export default {
         this.openProcess(this.process);
         this.fromProcessList = true;
         const { searchParams } = new URL(window.location);
-        let categoryId = "default";
+        let categoryId;
         if (searchParams.get("categorySelected") !== null) {
           categoryId = searchParams.get("categorySelected");
         } else {

--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -172,11 +172,13 @@ export default {
     loadMore() {
       this.$emit("addCategories");
     },
-    markCategory(item) {
+    markCategory(item, filter = true) {
       this.comeFromProcess = true;
       this.selectedProcessItem = item;
       this.selectedTemplateItem = null;
-      this.$refs.searchCategory.fillFilter(item.name);
+      if (filter) {
+        this.$refs.searchCategory.fillFilter(item.name);
+      }
     },
     selectProcessItem(item) {
       this.comeFromProcess = false;

--- a/resources/views/processes-catalogue/index.blade.php
+++ b/resources/views/processes-catalogue/index.blade.php
@@ -12,8 +12,6 @@
   <div class="px-3 page-content mb-0" id="processes-catalogue">
     <processes-catalogue
       :process="{{$process ?? 0}}"
-      :launchpad="{{$launchpad ?? 0}}"
-      :bookmark-id="{{$bookmarkId ?? 0}}"
       :current-user-id="{{ \Auth::user()->id }}"
       :permission="{{ \Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects') }}"
       :current-user="{{ \Auth::user() }}"


### PR DESCRIPTION
## Issue & Reproduction Steps
After reload process by launchpad the Uncategorized is selected in categories


## How to Test

1. Create process categories
2. Create a process
3. Go to Processes
4. Open a process with a category
5. Open a process without category

## Related Tickets & Packages
- [FOUR-14893](https://processmaker.atlassian.net/browse/FOUR-14893)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:next

[FOUR-14893]: https://processmaker.atlassian.net/browse/FOUR-14893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ