### PR TITLE
FOUR-14957 Server error replacing alternative A with B

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -126,7 +126,7 @@ export default {
             projects: this.process.projects,
             bpmn: xml,
             svg: svgString,
-            alternative: window.ProcessMaker.modeler.draftAlternative || "A",
+            alternative: window.ProcessMaker.AbTesting.alternative || window.ProcessMaker.modeler.draftAlternative || "A",
           });
           this.process.updated_at = response.data.updated_at;
           window.ProcessMaker.EventBus.$emit("save-changes", null, null, generatingAssets);


### PR DESCRIPTION
## Issue & Reproduction Steps
Error message displayed when try to copy alternative diagram

## Solution
Only if exist a defined "from" version tries to copy the diagram.

## How to Test

1. Enable alternative B
2. Go to menu option
3. Click on Discard draft
4. Add task to alternative A
5. Go to alternative 
6. Click on replace button

## Related Tickets & Packages
- [FOUR-14957](https://processmaker.atlassian.net/browse/FOUR-14957)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:package-ab-testing:FOUR-14957


[FOUR-14957]: https://processmaker.atlassian.net/browse/FOUR-14957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ