### PR TITLE
FOUR-15036:The default list in Processes is all Processes but this is not selected

### DIFF
--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -164,7 +164,7 @@ export default {
     this.checkPackageAiInstalled();
   },
   updated() {
-    if (!this.selectedProcessItem) {
+    if (!this.selectedProcessItem && !this.selectedTemplateItem) {
       this.selectDefault();
     }
   },

--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -241,7 +241,6 @@ export default {
     selectDefault() {
       if (window.location.pathname === "/process-browser") {
         this.selectProcessItem(this.data[0]);
-        // this.selectedProcessItem = this.data[0];
       }
     },
   },

--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -95,8 +95,7 @@
       :count-categories="categoryCount"
       :package-ai="hasPackageAI"
       hide-add-btn="true"
-    >
-    </select-template-modal>
+    />
   </div>
 </template>
 
@@ -151,7 +150,7 @@ export default {
      * Filters options regarding user permissions
      */
     filteredTemplateOptions() {
-      return this.templateOptions.filter(item => this.shouldShowTemplateItem(item));
+      return this.templateOptions.filter((item) => this.shouldShowTemplateItem(item));
     },
   },
   mounted() {
@@ -161,9 +160,13 @@ export default {
         this.loadMore();
       }
     });
-    this.selectDefault();
     this.comeFromProcess = this.fromProcessList;
     this.checkPackageAiInstalled();
+  },
+  updated() {
+    if (!this.selectedProcessItem) {
+      this.selectDefault();
+    }
   },
   methods: {
     /**
@@ -192,20 +195,20 @@ export default {
     },
     selectTemplateItem(item) {
       if (item.id === "all_templates") {
-          this.addNewProcess();
-          return;
+        this.addNewProcess();
+        return;
       }
-        this.selectedTemplateItem = item;
-        this.selectedProcessItem = null;
-        this.select(item);
-        this.$emit("wizardLinkSelect");
+      this.selectedTemplateItem = item;
+      this.selectedProcessItem = null;
+      this.select(item);
+      this.$emit("wizardLinkSelect");
     },
     /**
      * This method opens New Process modal window
      */
     addNewProcess() {
       this.$nextTick(() => {
-        this.$refs["addProcessModal"].show();
+        this.$refs.addProcessModal.show();
       });
     },
     isSelectedProcess(item) {
@@ -227,7 +230,7 @@ export default {
       this.filterCategories(value);
     },
     hasPermission() {
-      return this.permission.includes("create-processes")
+      return this.permission.includes("create-processes");
     },
     checkPackageAiInstalled() {
       this.hasPackageAI = ProcessMaker.packages.includes("package-ai") ? 1 : 0;
@@ -238,6 +241,7 @@ export default {
     selectDefault() {
       if (window.location.pathname === "/process-browser") {
         this.selectProcessItem(this.data[0]);
+        // this.selectedProcessItem = this.data[0];
       }
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
The default list in Processes is all Processes but this is not selected

## Solution
- Add the selected in the default list

## How to Test

1. Go to Processes
2. Per default we can see the All Processes
3. 

## Related Tickets & Packages
- [FOUR-15036](https://processmaker.atlassian.net/browse/FOUR-15036)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:next

[FOUR-15036]: https://processmaker.atlassian.net/browse/FOUR-15036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ