### PR TITLE
QA Observation bugfix/FOUR-15053: Copy-icon does not copy the pmql correctly

### DIFF
--- a/resources/js/components/shared/PmqlInput.vue
+++ b/resources/js/components/shared/PmqlInput.vue
@@ -427,7 +427,7 @@ export default {
         });
     },
     copyToClipboard() {
-      const textToCopy = document.getElementById("textToCopy").textContent;
+      const textToCopy = document.getElementById("textToCopy").textContent.replace(/\n/g, "");
       const textArea = document.createElement("textarea");
       textArea.value = textToCopy;
       document.body.appendChild(textArea);


### PR DESCRIPTION
## How to Test
1.Go to requests
2.Copy name Any process
3.Paste in search and enter
4.Click on PMQL
5.Click on icon copy
6.Clear and paste in search
7.Enter

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15053

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next