### PR TITLE
FOUR-15035: if templateId !exist replace with default Option

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -324,6 +324,7 @@ class TemplateController extends Controller
 
     protected function createScreen(Request $request)
     {
+        $request['templateId'] = $request->templateId ?? $request->defaultTemplateId;
         $request->validate(Screen::rules($request->id));
         $response = $this->template->create('screen', $request);
 

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -287,10 +287,15 @@ export default {
         this.formData.asset_type = null;
       }
       this.disabled = true;
-      if (this.otherTemplateSelected && this.hasTemplateId || this.hasDefaultTemplateId && !this.otherTemplateSelected || this.hasTemplateId) {
-        this.handleCreateFromTemplate();
-      } else {
-        this.handleCreateFromBlank();
+      if (  
+          this.otherTemplateSelected && this.hasTemplateId || 
+          this.hasDefaultTemplateId && !this.otherTemplateSelected || 
+          this.hasTemplateId || 
+          this.hasDefaultTemplateId
+        ) {
+          this.handleCreateFromTemplate();
+        } else {
+          this.handleCreateFromBlank();
       }
     },
     handleCreateFromBlank() {


### PR DESCRIPTION
## Issue & Reproduction Steps

This pull request addresses a functionality error in the screen creation process within the Designer tool. Currently, when the 'Default Template' option is selected during the creation of a new screen, the system fails to reference the pre-configured default template and incorrectly defaults to a Blank Template. This issue persists even when a specific default template, which includes custom input configurations, is pre-set by the user.

## Steps to Reproduce
1. Navigate to Designer > Screen.
2. Ensure a default template is configured. This template should not be blank and must include specific input configurations.
3. Proceed to create a new screen but do not select any template thumbnail.
4. Fill out the necessary form fields to define the new screen.
5. Check the 'Default Template' option before finalizing the screen creation.
6. Create the screen and observe the referenced template.

## Expected Behavior
When the 'Default Template' option is selected during screen creation, the system should automatically use the pre-configured default template. This should occur without the need for the user to explicitly select the template thumbnail, ensuring a smooth and efficient setup process.

## Current Behavior
Despite selecting the 'Default Template' option, the system does not reference the configured default template. Instead, it applies an incorrect template, which does not align with the user's predefined settings.

## Proposed Fix
- Implement a validation check within the screen creation workflow to ensure the 'Default Template' option correctly references the configured default template.
- Adjust the logic that handles template selection to prioritize the configured default when 'Default Template' is checked.


## Related Tickets & Packages
- [FOUR-15035](https://processmaker.atlassian.net/browse/FOUR-15035)
- ci:next
- ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
