### PR TITLE
Implement API Request Cancellation for Multiple Requests for Screen Templates

### DIFF
--- a/resources/js/processes/screens/components/ScreenTemplateOptions.vue
+++ b/resources/js/processes/screens/components/ScreenTemplateOptions.vue
@@ -71,6 +71,7 @@ export default {
       template: {},
       selectedTemplateId: null,
       defaultTemplateId: null,
+      cancelToken: null,
     };
   },
   computed: {
@@ -119,12 +120,21 @@ export default {
         url = `templates/screen?screen_type=${this.selectedScreenType}&is_public=0`;
       }
 
+      if (this.cancelToken !== null) {
+        this.cancelToken();
+        this.cancelToken = null;
+      }
+      const { CancelToken } = ProcessMaker.apiClient;
       // Load from our API client
       ProcessMaker.apiClient
         .get(
           `${url}&per_page=1000`
             + `&filter=${this.filter}&order_by=${this.orderBy}&order_direction=${this.orderDirection}`,
-        )
+            {
+              cancelToken: new CancelToken((c) => {
+                this.cancelToken = c;
+              }),
+          })
         .then(response => {
           this.blankTemplate[0].screen_type = this.selectedScreenType;
           this.blankTemplate[0].is_public = this.isDefaultTemplatePublic;
@@ -132,6 +142,9 @@ export default {
           this.apiDataLoading = false;
           this.apiNoResults = false;
           this.getDefaultTemplates();
+        })
+        .catch(error => {
+          console.log("error: " + error);
         })
         .finally(() => {
           this.loading = false;


### PR DESCRIPTION
This PR introduces API request cancellation for multiple requests using Axios's CancelToken feature. It addresses the issue of unintended data changes when multiple requests to retrieve "Shared Templates" and "My Templates" are triggered, especially on slower networks. With this implementation, only the latest request will be executed, improving the overall user experience.

## Solution

- Introduced API request cancellation using Axios's CancelToken feature.

## How to Test

1. Ensure you have templates created for both "My Templates" and "Shared Templates".
2. Navigate to Designer > Screen.
3. Open your Network panel and, if needed, update your network to use 'Slow 3G' to mimic a slower network.
4. Select the '+ Screen' button.
5. Before the templates are loaded, change the template type from "Shared Templates" to "My Templates".
6. Ensure the correct data for "My Templates" is loaded without flashing the "Shared Templates" data.
7. Ensure in your network panel that the request to load the "Shared Templates" has been canceled.

## Related Tickets & Packages
- [FOUR-15049](https://processmaker.atlassian.net/browse/FOUR-15049)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15049]: https://processmaker.atlassian.net/browse/FOUR-15049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ