### PR TITLE
Enhance Screen Template Name Uniqueness Validation

### DIFF
--- a/ProcessMaker/Models/Template.php
+++ b/ProcessMaker/Models/Template.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
@@ -115,7 +116,10 @@ class Template extends ProcessMakerModel
 
     public static function rules($existing = null, $table = null)
     {
-        $unique = Rule::unique($table ?? 'templates')->ignore($existing);
+        $user = Auth::user();
+        $unique = Rule::unique($table ?? 'templates')->where(function ($query) use ($user) {
+            return $query->where('user_id', $user->id);
+        })->ignore($existing);
 
         return [
             'name' => ['required', $unique, 'alpha_spaces', 'max:255'],

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -459,8 +459,17 @@ class ScreenTemplate implements TemplateInterface
     {
         $templateId = $request->id;
         $name = $request->name;
+        $isPublic = $request->isPublic;
+        $user = Auth::user();
 
-        $template = ScreenTemplates::where(['name' => $name])->where('id', '!=', $templateId)->first();
+        $query = ScreenTemplates::where(['name' => $name])->where('id', '!=', $templateId);
+
+        if (!$isPublic) {
+            $query->where('is_public', 0)->where('user_id', $user->id);
+        }
+
+        $template = $query->first();
+
         if ($template !== null) {
             // If same asset has been Saved as Template previously,
             // offer to choose between “Update Template” and “Save as New Template”

--- a/resources/js/processes/screens/components/ScreenTemplateOptions.vue
+++ b/resources/js/processes/screens/components/ScreenTemplateOptions.vue
@@ -71,6 +71,7 @@ export default {
       template: {},
       selectedTemplateId: null,
       defaultTemplateId: null,
+      cancelToken: null,
     };
   },
   computed: {
@@ -119,12 +120,21 @@ export default {
         url = `templates/screen?screen_type=${this.selectedScreenType}&is_public=0`;
       }
 
+      if (this.cancelToken !== null) {
+        this.cancelToken();
+        this.cancelToken = null;
+      }
+      const { CancelToken } = ProcessMaker.apiClient;
       // Load from our API client
       ProcessMaker.apiClient
         .get(
           `${url}&per_page=1000`
             + `&filter=${this.filter}&order_by=${this.orderBy}&order_direction=${this.orderDirection}`,
-        )
+            {
+              cancelToken: new CancelToken((c) => {
+                this.cancelToken = c;
+              }),
+          })
         .then(response => {
           this.blankTemplate[0].screen_type = this.selectedScreenType;
           this.blankTemplate[0].is_public = this.isDefaultTemplatePublic;
@@ -132,6 +142,9 @@ export default {
           this.apiDataLoading = false;
           this.apiNoResults = false;
           this.getDefaultTemplates();
+        })
+        .catch(error => {
+          console.log("error: " + error);
         })
         .finally(() => {
           this.loading = false;


### PR DESCRIPTION
This PR implements an update to the screen template rules to validate template name uniqueness per user. Previously, template names had to be unique across all users, leading to restrictions when creating templates with meaningful names. With this enhancement, users can create templates without restrictions based on other users' template names. This change improves the flexibility and user experience of the screen template feature.

## Solution

- Updated screen template rules to validate template name uniqueness per user.

## How to Test
1. Create multiple users with access to screen templates.
2. Ensure no two users have a screen template with the same name.
3. Log in as each user and attempt to create a screen template with a name that another user has used.
4. Verify that the template creation is successful without any uniqueness validation errors.
5. Ensure each user can create screen templates with names meaningful to them, without restrictions based on other users' template names.

## Related Tickets & Packages
- [FOUR-15061](https://processmaker.atlassian.net/browse/FOUR-15061)

ci:next
ci:deploy


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
