### PR TITLE
QA Observation Bugfix/four 15040: The eye view button overflows from the row in Quick fill list

### DIFF
--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -653,6 +653,11 @@ export default {
       const topAdjust = rectTableContainer.top;
 
       let elementHeight = 36;
+      const breadcrumbsDiv = document.getElementById('breadcrumbs');
+      const breadcrumbHeight = breadcrumbsDiv.offsetHeight;
+      if (breadcrumbHeight>65){
+        elementHeight = 15;
+      }
 
       this.isTooltipVisible = !this.disableRuleTooltip;
       this.tooltipRowData = row;

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -655,7 +655,7 @@ export default {
       let elementHeight = 36;
       const breadcrumbsDiv = document.getElementById('breadcrumbs');
       const breadcrumbHeight = breadcrumbsDiv.offsetHeight;
-      if (breadcrumbHeight>65){
+      if ( breadcrumbHeight > 65 ) {
         elementHeight = 15;
       }
 

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -652,18 +652,16 @@ export default {
       const rectTableContainer = tableContainer.getBoundingClientRect();
       const topAdjust = rectTableContainer.top;
 
-      let elementHeight = 36;
-      const breadcrumbsDiv = document.getElementById('breadcrumbs');
-      const breadcrumbHeight = breadcrumbsDiv.offsetHeight;
-      if ( breadcrumbHeight > 65 ) {
-        elementHeight = 15;
-      }
+      let elementHeight = 28;
 
       this.isTooltipVisible = !this.disableRuleTooltip;
       this.tooltipRowData = row;
 
       const rowElement = document.getElementById(`row-${row.id}`);
+      let yPosition = 0;
+
       const rect = rowElement.getBoundingClientRect();
+      yPosition = rect.top + window.scrollY;
 
       const selectedFiltersBar = document.querySelector(
         ".selected-filters-bar"
@@ -675,15 +673,16 @@ export default {
       elementHeight -= selectedFiltersBarHeight;
 
       let rightBorderX = rect.right;
-      let bottomBorderY = 0
+
+      let bottomBorderY = 0;
       if(this.fromButton === "" || this.fromButton === "previewTask"){
-        bottomBorderY = rect.bottom - topAdjust + 48 - elementHeight;
+        bottomBorderY = yPosition - topAdjust + 100 - elementHeight;
       }
       if(this.fromButton === "fullTask"){
-        bottomBorderY = rect.bottom - topAdjust + 200 - elementHeight;
+        bottomBorderY = yPosition;
       }
       if(this.fromButton === "inboxRules"){
-        bottomBorderY = rect.bottom - topAdjust + 100 - elementHeight;
+        bottomBorderY = rect.bottom - topAdjust + 90 - elementHeight;
       }
       this.rowPosition = {
         x: rightBorderX,


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
- Create a process with large name
- Create a request 
- Complete the request entering some values in the form 
- Create another request 
- Click on Quick Fill button
- Check on the list 
- Hover on the right  side of the row
- Check the eye button

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15040

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next