### PR TITLE
FOUR-15080:Re Run Wizard does not align correctly when is a ipad

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessOptions.vue
+++ b/resources/js/processes-catalogue/components/ProcessOptions.vue
@@ -1,18 +1,20 @@
 <template>
   <div class="section-options">
-    <process-counter :process="process" />
-    <b-button
-      v-if="createdFromWizardTemplate"
-      class="mt-2 wizard-link"
-      variant="link"
-      @click="getHelperProcess"
-    >
-      <img
-        src="../../../img/wizard-icon.svg"
-        :alt="$t('Guided Template Icon')"
+    <div class="counter-wizard">
+      <process-counter :process="process" />
+      <b-button
+        v-if="createdFromWizardTemplate"
+        class="mt-2 wizard-link"
+        variant="link"
+        @click="getHelperProcess"
       >
-      {{ $t('Re-run Wizard') }}
-    </b-button>
+        <img
+          src="../../../img/wizard-icon.svg"
+          :alt="$t('Guided Template Icon')"
+        >
+        {{ $t('Re-run Wizard') }}
+      </b-button>
+    </div>
     <chart-save-search :process="process" />
     <wizard-helper-process-modal
       v-if="createdFromWizardTemplate"
@@ -55,6 +57,7 @@ export default {
 .section-options {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
 }
 @media (width < 1200px) {
   .section-options {


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-15080](https://processmaker.atlassian.net/browse/FOUR-15080)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:next

[FOUR-15080]: https://processmaker.atlassian.net/browse/FOUR-15080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ