### PR TITLE
Fix requests page default advanced filter

### DIFF
--- a/resources/js/common/advancedFilterStatusMixin.js
+++ b/resources/js/common/advancedFilterStatusMixin.js
@@ -37,7 +37,7 @@ export default {
         }
         result.push([
           this.formatBadgeSubject(filter),
-          [{name: filter.value, operator: filter.operator, advanced_filter: true}]
+          [{name: this.formatBadgeValue(filter), operator: filter.operator, advanced_filter: true}]
         ]);
 
         if (filter.or && filter.or.length > 0) {
@@ -48,6 +48,12 @@ export default {
     formatBadgeSubject(filter) {
       return get(filter, '_column_label', get(filter, 'subject.value', ''));
     },
+    formatBadgeValue(filter) {
+      if ('_display_value' in filter) {
+        return filter._display_value;
+      }
+      return filter.value
+    }
   },
   computed: {
     formatAdvancedFilterForBadges() {

--- a/resources/js/common/setDefaultAdvancedFilterStatus.js
+++ b/resources/js/common/setDefaultAdvancedFilterStatus.js
@@ -1,10 +1,10 @@
 import { get } from "lodash";
 
-export default (status, ignoreSavedFilter = false) => {
+export default (status, ignoreSavedFilter = false, requester = null) => {
   let advancedFilter = get(window, 'ProcessMaker.advanced_filter.filters', []);
   if (ignoreSavedFilter) {
     // Remove any Status filters that might be set by the user
-    advancedFilter = advancedFilter.filter(f => f.subject?.type !== "Status");
+    advancedFilter = advancedFilter.filter(f => f.subject?.type !== "Status" && f.subject?.value !== 'user_id');
   } else if (advancedFilter.some(f => f.subject?.type === "Status")) {
     // Already has a status filter set by the user
     return;
@@ -18,6 +18,21 @@ export default (status, ignoreSavedFilter = false) => {
     _column_field: "status",
     _column_label: "Status"
   });
+
+  if (requester) {
+    advancedFilter.push({
+      subject: {
+        type: "Field",
+        value: 'user_id'
+      },
+      operator: "=",
+      value: requester.id,
+      _column_field: "requester",
+      _column_label: "Requester",
+      _display_value: requester.username,
+    });
+  }
+
   window.ProcessMaker.advanced_filter.filters = advancedFilter;
 
 }

--- a/resources/js/requests/index.js
+++ b/resources/js/requests/index.js
@@ -40,7 +40,7 @@ new Vue({
     }
 
     if (status) {
-      setDefaultAdvancedFilterStatus(status, true);
+      setDefaultAdvancedFilterStatus(status, true, this.requester[0]);
     }
 
     const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
See https://processmaker.atlassian.net/browse/FOUR-15083

Fixes the default requests "My Requests" page showing all requests that the user participated in.

Solution was to add the current user to the default advanced filter for that page

ci:next