### PR TITLE
Preserve Selected Template Type on Preview Template Back Button

### DIFF
--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -24,7 +24,7 @@
           cols="7"
           class="type-style-col"
         >
-          <div v-if="!showTemplatePreview">
+          <div v-show="!showTemplatePreview">
             <screen-type-dropdown
               v-model="formData.type"
               :copy-asset-mode="copyAssetMode"


### PR DESCRIPTION
This PR resolves an issue where clicking the back arrow button in the Preview Template modal of the Create Screen modal reset the selected template type from "My Templates" to "Shared Templates". 


## Solution
The solution involves changing the `v-if` directive to `v-show`, ensuring that the select list and template options remain intact when navigating back from the Preview Template modal.

## How to Test

1. Navigate to Designer > Screen.
2. Select the '+ Screen' button.
3. Update the template type from "Shared Templates" to "My Templates".
4. Select "Preview Template" for any template.
5. Click the back arrow button.
6. Ensure that the template type remains unchanged and is still "My Templates".

## Related Tickets & Packages
- [FOUR-15120](https://processmaker.atlassian.net/browse/FOUR-15120)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15120]: https://processmaker.atlassian.net/browse/FOUR-15120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ