### PR TITLE
Observation/FOUR-15118: When generating a process from AI, modeler is loaded twice.

### DIFF
--- a/ProcessMaker/PackageHelper.php
+++ b/ProcessMaker/PackageHelper.php
@@ -50,6 +50,8 @@ class PackageHelper
 
     const PM_PACKAGE_DECISION_ENGINE = 'ProcessMaker\Package\PackageDecisionEngine\PackageServiceProvider';
 
+    const PM_PACKAGE_AB_TESTING = 'ProcessMaker\Package\PackageABTesting\PackageServiceProvider';
+
     public static function isPackageInstalled(string $serviceProviderClass): bool
     {
         if (!$serviceProviderClass) {

--- a/resources/js/components/templates/SelectTemplateModal.vue
+++ b/resources/js/components/templates/SelectTemplateModal.vue
@@ -31,6 +31,7 @@
       :selected-template="selectedTemplate" 
       :template-data="templateData" 
       :isProjectsInstalled="isProjectsInstalled"
+      :isAbTestingInstalled="isAbTestingInstalled"
       @resetModal="resetModal()"
       :projectId="projectId"
       />
@@ -44,7 +45,7 @@
 
   export default {
     components: { Modal, TemplateSearch, CreateProcessModal },
-    props: ['type', 'countCategories', 'packageAi', 'isProjectsInstalled', 'hideAddBtn', 'projectId'],
+    props: ['type', 'countCategories', 'packageAi', 'isProjectsInstalled', 'hideAddBtn', 'projectId', 'isAbTestingInstalled'],
     data: function() {
       return {
         title: '',

--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -115,6 +115,7 @@ export default {
     "templateData",
     "generativeProcessData",
     "isProjectsInstalled",
+    "isAbTestingInstalled",
     "categoryType",
     "callFromAiModeler",
     "isProjectSelectionRequired",
@@ -310,16 +311,27 @@ export default {
             this.appendProjectIdToURL(url, this.projectId);
             this.handleRedirection(url, response.data);
           } else {
-            window.location =
-              this.isAiGenerated
-                ? "/modeler/" + response.data.id + "?ai=true"
-                : "/modeler/" + response.data.id;
+            const url = this.getRedirectUrlForAi(response.data.id);
+            window.location = url;
           }
         })
         .catch((error) => {
           this.disabled = false;
           this.addError = error.response.data.errors;
         });
+    },
+    getRedirectUrlForAi(processId) {
+      let redirectUrl = `/modeler/${processId}`;
+
+      if (this.isAbTestingInstalled) {
+        redirectUrl = `/modeler/${processId}/alternative/A`;
+      }
+
+      if (this.isAiGenerated) {
+        redirectUrl += "?ai=true";
+      }
+
+      return redirectUrl;
     },
     handleRedirection(url, data) {
       if (this.callFromAiModeler) {

--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -324,7 +324,7 @@ export default {
       let redirectUrl = `/modeler/${processId}`;
 
       if (this.isAbTestingInstalled) {
-        redirectUrl = `/modeler/${processId}/alternative/A`;
+        redirectUrl += "/alternative/A";
       }
 
       if (this.isAiGenerated) {

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -126,7 +126,7 @@ export default {
             projects: this.process.projects,
             bpmn: xml,
             svg: svgString,
-            alternative: window.ProcessMaker.AbTesting.alternative || window.ProcessMaker.modeler.draftAlternative || "A",
+            alternative: window.ProcessMaker.AbTesting?.alternative || window.ProcessMaker.modeler.draftAlternative || "A",
           });
           this.process.updated_at = response.data.updated_at;
           window.ProcessMaker.EventBus.$emit("save-changes", redirectUrl, nodeId, generatingAssets);
@@ -244,7 +244,6 @@ export default {
 
       if (redirectUrl && nodeId && this.isVersionsInstalled) {
         this.handleAutosave(true, false, redirectUrl, nodeId);
-        window.ProcessMaker.EventBus.$emit("save-changes", redirectUrl, nodeId, generatingAssets);
         return;
       }
 
@@ -252,7 +251,6 @@ export default {
         window.ProcessMaker.EventBus.$emit("open-modal-versions", redirectUrl, nodeId);
         return;
       }
-
       if (this.externalEmit.includes("open-modal-versions") && generatingAssets) {
         window.ProcessMaker.EventBus.$emit("new-changes");
         this.refreshSession();

--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -242,7 +242,7 @@ export default {
       this.dataXmlSvg.xml = xml;
       this.dataXmlSvg.svg = svg;
 
-      if (redirectUrl && nodeId) {
+      if (redirectUrl && nodeId && this.isVersionsInstalled) {
         this.handleAutosave(true, false, redirectUrl, nodeId);
         window.ProcessMaker.EventBus.$emit("save-changes", redirectUrl, nodeId, generatingAssets);
         return;

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -28,8 +28,12 @@
                             :type="__('Process')"
                             :count-categories="@json($config->countCategories)"
                             :package-ai="{{ hasPackage('package-ai') ? '1' : '0' }}"
-                            is-projects-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(\ProcessMaker\PackageHelper::PM_PACKAGE_PROJECTS)}}"
-                            is-ab-testing-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(\ProcessMaker\PackageHelper::PM_PACKAGE_AB_TESTING)}}"
+                            is-projects-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(
+                                \ProcessMaker\PackageHelper::PM_PACKAGE_PROJECTS
+                            )}}"
+                            is-ab-testing-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(
+                                \ProcessMaker\PackageHelper::PM_PACKAGE_AB_TESTING
+                            )}}"
                             >
                             </select-template-modal>
                     @endcan

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -29,6 +29,7 @@
                             :count-categories="@json($config->countCategories)"
                             :package-ai="{{ hasPackage('package-ai') ? '1' : '0' }}"
                             is-projects-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(\ProcessMaker\PackageHelper::PM_PACKAGE_PROJECTS)}}"
+                            is-ab-testing-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(\ProcessMaker\PackageHelper::PM_PACKAGE_AB_TESTING)}}"
                             >
                             </select-template-modal>
                     @endcan


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduced:**

- Go to process
- Create a new process from AI
- Generate a process and use model
- Complete name process and save

**Current Behavior:**
The modeler is loaded twice.

## Solution
- Verify if AB testing is installed and redirect to AB testing URL version

## How to Test
- Follow steps above
 
## Related Tickets & Packages
- [FOUR-15118](https://processmaker.atlassian.net/browse/FOUR-15118)
- [package-ai PR](https://github.com/ProcessMaker/package-ai/pull/148)
- [core PR](https://github.com/ProcessMaker/processmaker/pull/6722)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-15118]: https://processmaker.atlassian.net/browse/FOUR-15118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ