### PR TITLE
FOUR-14958: First time "auto validate" not working

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -120,6 +120,17 @@ class ProcessController extends Controller
             $processes = Process::active()->with($include);
         }
 
+        // The simplified parameter indicates to return just the main information of processes
+        if ($request->input('simplified_data', false)) {
+            $processes = Process::where('status', 'ACTIVE')->select('id', 'start_events')->get();
+            $modifiedCollection = $processes->map(function ($item) {
+                return [
+                    'id' => $item['id'],
+                    'events'=> $item['start_events']];
+            });
+            return new ApiCollection($modifiedCollection);
+        }
+
         $filter = $request->input('filter', '');
         if (!empty($filter)) {
             $processes->filter($filter);
@@ -153,12 +164,6 @@ class ProcessController extends Controller
             ->orderBy(...$orderBy)
             ->get()
             ->collect();
-
-        // the simplified parameter indicates to return just the main information of processes
-        if ($request->input('simplified_data', false)) {
-            return new ProcessCollection($processes);
-        }
-
 
         foreach ($processes as $key => $process) {
             // filter the start events that can be used manually (no timer start events);


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to process
- Open any process that does not have all screens assigned
- Click on "auto validate"

**Current Behavior:**

The first time auto validate doesn't work.



**Expected behavior:**

As in previous versions it should work the first time.


## Solution
- Added a request parameter to improve the speed of returning the list of processes


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14958

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
