### PR TITLE
observation/FOUR-15029 Table column widths not reset after resize the screen 

### DIFF
--- a/resources/js/components/shared/FilterTable.vue
+++ b/resources/js/components/shared/FilterTable.vue
@@ -148,19 +148,19 @@ export default {
     data: [],
     unread: {
       type: String,
-      default: function () {
+      default() {
         return "";
       }
     },
     loading: {
       type: Boolean,
-      default: function () {
+      default() {
         return false;
       }
     },
     tableName: {
       type: String,
-      default: function () {
+      default() {
         return "";
       }
     },
@@ -203,12 +203,17 @@ export default {
   },
   methods: {
     handleWindowResize() {
-      this.calculateColumnWidth();
+      const zoomFactor = window.devicePixelRatio;
+      let widthAdjust = 1;
+      if (zoomFactor < 1) {
+        widthAdjust = Math.min(zoomFactor, this.minZoom);
+      }
+      this.calculateColumnWidth(widthAdjust);
     },
-    calculateColumnWidth() {
+    calculateColumnWidth(widthAdjust = 1) {
       this.visibleHeaders.forEach((headerColumn, index) => {
         if (this.calculateContent(index) !== 0) {
-          headerColumn.width = this.calculateContent(index) - 32;
+          headerColumn.width = (this.calculateContent(index) * widthAdjust) - 32;
         }
       });
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
Table column widths not reset after resize the screen 

## Solution
Added a Zoom adjust to calculate the width of the columns

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15029

ci:deploy
ci:next