### PR TITLE
FOUR-15117:Control modal's  are overflow with resize of the screen

### DIFF
--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -14,8 +14,8 @@
       <p class="text-info-custom">
         {{ $t('Here you can personalize how your process will be shown in the process browser') }}
       </p>
-      <div class="d-flex justify-content-between">
-        <div class="mr-3">
+      <div class="row">
+        <div class="col-sm-12 col-lg-6">
           <div
             md="12"
             class="no-padding"
@@ -24,7 +24,7 @@
             <input-image-carousel ref="image-carousel" />
           </div>
         </div>
-        <div class="options-launchpad">
+        <div class="col-sm-12 col-lg-6 options-launchpad">
           <label>{{ $t("Launch Screen") }}</label>
           <div class="multiselect-screen custom-multiselect">
             <b-input-group>


### PR DESCRIPTION
## Issue & Reproduction Steps
Control modal's are overflow with resize of the screen

## Solution
- Control modal's  should not be overflow with resize of the screen

## How to Test

1. Create a process 
2. Add alternatives
3. Click on publish to pen the modal
4. Wait to launchpad modal will be open 
5. Resize the screen 

## Related Tickets & Packages
- [FOUR-15117](https://processmaker.atlassian.net/browse/FOUR-15117)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:next


[FOUR-15117]: https://processmaker.atlassian.net/browse/FOUR-15117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ