### PR TITLE
FOUR-15156:Comments is disable in Request and Task

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -446,7 +446,7 @@
                 <div class="ml-md-3 mt-md-0 mt-3 collapse-content">
                   <template v-if="panCommentInVueOptionsComponents">
                     <comment-container
-                      commentable_id="{{ $request->getKey() }}"
+                      :commentable_id="request.id"
                       commentable_type="{{ get_class($request) }}"
                       name="{{ $request->name }}"
                       :readonly="request.status === 'COMPLETED'"


### PR DESCRIPTION
## Issue & Reproduction Steps
Comments is disable in Request and Task

## Solution
- The comments tab should be enable to put comments to users in Request and Task

## How to Test

1. Log in with Super admin user
2. Import a process
3. Create a request
4. Go to comments tab

## Related Tickets & Packages
- [FOUR-15156](https://processmaker.atlassian.net/browse/FOUR-15156)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:deploy
ci:package-comments:bugfix/FOUR-15156

[FOUR-15156]: https://processmaker.atlassian.net/browse/FOUR-15156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ