### PR TITLE
FOUR-15151: Incorrect Template Reference When Creating Blank Screen with Default Template Configured

### DIFF
--- a/resources/js/components/templates/ScreenTemplateCard.vue
+++ b/resources/js/components/templates/ScreenTemplateCard.vue
@@ -118,7 +118,8 @@ export default {
     },
     emitDefaultTemplateSelected() {
       const defaultTemplateId = this.template?.id || null;
-      this.$emit('template-default-selected', defaultTemplateId);
+      this.$emit("template-default-selected", defaultTemplateId);
+      this.$emit("template-selected", defaultTemplateId);
     },
   },
 };

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -215,17 +215,14 @@ export default {
       return this.$t("Styles for the Screen Type").toUpperCase();
     },
     hasTemplateId() {
-      return this.formData.templateId !== null && this.formData.templateId !== undefined; 
+      return this.formData.templateId != null;
     },
     hasDefaultTemplateId() {
-      return this.formData.defaultTemplateId !== null;
-    },
-    otherTemplateSelected() {
-      return this.formData.selectedTemplate;
+      return this.formData.defaultTemplateId != null;
     },
     getTemplateId() {
       return this.hasTemplateId ? this.formData.templateId : this.formData.defaultTemplateId;
-    }
+    },
   },
   mounted() {
     this.resetFormData();
@@ -241,8 +238,6 @@ export default {
     if (this.callFromAiModeler === true) {
       this.screenTypes = this.types;
     }
-    this.formData.selectedTemplate = true;
-    this.formData.templateId = undefined;
   },
   methods: {
     show() {
@@ -255,7 +250,7 @@ export default {
         description: null,
         projects: [],
         templateId: null,
-        templateOptions: JSON.stringify(['CSS', 'Layout', 'Fields']),
+        templateOptions: JSON.stringify(["CSS", "Layout", "Fields"]),
       };
     },
     resetErrors() {
@@ -287,15 +282,11 @@ export default {
         this.formData.asset_type = null;
       }
       this.disabled = true;
-      if (  
-          this.otherTemplateSelected && this.hasTemplateId || 
-          this.hasDefaultTemplateId && !this.otherTemplateSelected || 
-          this.hasTemplateId || 
-          this.hasDefaultTemplateId
-        ) {
-          this.handleCreateFromTemplate();
-        } else {
-          this.handleCreateFromBlank();
+
+      if (this.hasTemplateId) {
+        this.handleCreateFromTemplate();
+      } else {
+        this.handleCreateFromBlank();
       }
     },
     handleCreateFromBlank() {
@@ -377,9 +368,8 @@ export default {
       this.formData.templateId = null;
     },
     handleSelectedTemplate(templateId) {
-      this.formData.templateId =  templateId;
-      this.formData.selectedTemplate = true;
-      this.formData.templateOptions = JSON.stringify(['CSS', 'Layout', 'Fields']);
+      this.formData.templateId = templateId;
+      this.formData.templateOptions = JSON.stringify(["CSS", "Layout", "Fields"]);
     },
     handleSelectedTemplateOptions(options) {
       this.formData.templateOptions = JSON.stringify(options);


### PR DESCRIPTION
## Issue & Reproduction Steps
When creating a blank screen with a default template other than the blank template configured, the default template is referenced instead of the blank template.

Expected Behavior: 
- A blank screen should be created when selected, regardless of the default template configuration.

Current Behavior: 
- A screen referencing the default template is created instead of the selected blank screen.

## Solution
- The UI interactions have been improved to determine when to create from a template and when to create from a Blank Template.

## How to Test
Conduct manual tests. Everything should work as expected, including the addition of the use case mentioned in this ticket.

ci:deploy
ci:next

## Related Tickets & Packages
- [FOUR-15151](https://processmaker.atlassian.net/browse/FOUR-15151)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15151]: https://processmaker.atlassian.net/browse/FOUR-15151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ