### PR TITLE
FOUR-15214 Move ab-testing alternatives table migration into core

### DIFF
--- a/database/migrations/2024_04_22_203320_create_alternatives_table.php
+++ b/database/migrations/2024_04_22_203320_create_alternatives_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('alternatives', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('process_id')->constrained('processes');
+            $table->unsignedInteger('process_version_a_id')->constrained('process_versions')->nullable();
+            $table->unsignedInteger('process_version_b_id')->constrained('process_versions')->nullable();
+            $table->enum('published_version', ['A', 'B', 'AB']);
+            $table->text('settings');
+            $table->boolean('version_b_enabled')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('alternatives');
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
There is a problem when the package ab testing is installed but not enabled in license.

Please consider to move the alternatives table into core to keep the schema consistency required for the Process model and its relationship with Alternative model.

## Related Tickets & Packages
[FOUR-15214](https://processmaker.atlassian.net/browse/FOUR-15214)
https://github.com/ProcessMaker/package-ab-testing/pull/52

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:package-ab-testing:FOUR-15214



[FOUR-15214]: https://processmaker.atlassian.net/browse/FOUR-15214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ