### PR TITLE
Error in Group/Users

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/GroupController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupController.php
@@ -348,7 +348,8 @@ class GroupController extends Controller
             $query->where(function ($query) use ($filter) {
                 $query->Where('username', 'like', $filter)
                     ->orWhere('firstname', 'like', $filter)
-                    ->orWhere('lastname', 'like', $filter);
+                    ->orWhere('lastname', 'like', $filter)
+                    ->orWhereRaw("trim(concat(firstname, ' ', lastname)) like '{$filter}'");
             });
         }
 

--- a/resources/js/admin/groups/components/GroupsInGroupListing.vue
+++ b/resources/js/admin/groups/components/GroupsInGroupListing.vue
@@ -66,7 +66,7 @@
         fields: [
           {
             title: () => this.$t("ID"),
-            name: "id"
+            name: "member_id"
           },
           {
             title: () => this.$t("Name"),

--- a/resources/js/admin/groups/components/UsersInGroupListing.vue
+++ b/resources/js/admin/groups/components/UsersInGroupListing.vue
@@ -65,7 +65,7 @@
         fields: [
           {
             title: () => this.$t("ID"),
-            name: "id"
+            name: "member_id"
           },
           {
             title: () => this.$t("Username"),


### PR DESCRIPTION
## Issue & Reproduction Steps
The id of the assigning users and groups do not show the correct ID.
The search is not performed by fullname

## Solution
- Change attr id to member_id

## How to Test
Assign users or groups to a group and check that it has the correct ID.
In the users section, search by fullname

## Related Tickets & Packages
- [FOUR-5817](https://processmaker.atlassian.net/browse/FOUR-5817)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy

[FOUR-5817]: https://processmaker.atlassian.net/browse/FOUR-5817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ