### PR TITLE
FOUR-15203 Fix problems caused by an incorrect modeler URL when creating an new Process

### DIFF
--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -323,10 +323,6 @@ export default {
     getRedirectUrlForAi(processId) {
       let redirectUrl = `/modeler/${processId}`;
 
-      if (this.isAbTestingInstalled) {
-        redirectUrl += "/alternative/A";
-      }
-
       if (this.isAiGenerated) {
         redirectUrl += "?ai=true";
       }


### PR DESCRIPTION
## Fix problems caused by an incorrect modeler URL when creating an new Process

- Collaborative not working
- Launch Pad not opened

## Solution
- Fix modeler URL when a Process is created

## How to Test
- Create a new process
- Publish the process

Workaround: Fix the modeler URL after a process is created.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15203
- https://processmaker.atlassian.net/browse/FOUR-14910

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:deploy
ci:package-ab-testing:bugfix/FOUR-15203
