### PR TITLE
FOUR-15217

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/BookmarkController.php
+++ b/ProcessMaker/Http/Controllers/Api/BookmarkController.php
@@ -17,6 +17,7 @@ class BookmarkController extends Controller
     {
         // Get the user
         $user = Auth::user();
+        $perPage = $this->getPerPage($request);
         // Get the processes  active
         $processes = Process::nonSystem()->active();
         // Filter pmql
@@ -37,8 +38,7 @@ class BookmarkController extends Controller
             ->leftJoin('users as user', 'processes.user_id', '=', 'user.id') // Required for the pmql
             ->where('bookmark.user_id', $user->id)
             ->orderBy('processes.name', 'asc')
-            ->get()
-            ->collect();
+            ->paginate($perPage);
         
         foreach ($processes as $process) {
             // Get the launchpad configuration
@@ -46,6 +46,17 @@ class BookmarkController extends Controller
         }
 
         return new ProcessCollection($processes);
+    }
+
+    /**
+     * Get the size of the page.
+     *
+     * @param Request $request
+     * @return type
+     */
+    protected function getPerPage(Request $request)
+    {
+        return $request->input('per_page', 12);
     }
 
     public function store(Request $request, Process $process)


### PR DESCRIPTION
## Issue & Reproduction Steps
The bookmark list does not work correctly with the pagination

## Solution

1. Go to Processes
2. Go to Bookmkark List
3. Have more than 12 processes bookmarked

## How to Test
The bookmark needs to enable the pagination

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15217

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy