### PR TITLE
[31012] Inactive users are listed when reassigning task

### DIFF
--- a/resources/js/components/SelectFromApi.vue
+++ b/resources/js/components/SelectFromApi.vue
@@ -84,8 +84,9 @@ export default {
         filter: typeof filter === "string" ? filter : '',
         exclude_ids: this.exclude_ids.join(','),
       };
+      const separator = this.api.includes('?') ? '&' : '?';
       window.ProcessMaker.apiClient
-        .get(this.api + '?' +
+        .get(this.api + separator +
           Object.keys(query).
           filter(par => query[par], '').
           map(par => `${par}=${encodeURIComponent(query[par])}`).

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -308,7 +308,7 @@
                       id='user'
                       v-model="selectedUser"
                       placeholder="{{__('Select the user to reassign to the task')}}"
-                      api="users"
+                      api="users?status=ACTIVE"
                       :multiple="false"
                       :show-labels="false"
                       :searchable="true"


### PR DESCRIPTION
## Issue & Reproduction Steps
Inactive users are displayed in the list of users to reassign.

## Solution
- add the query parameter status in the reassign section.

## How to Test
create a process, set a task allow reassign.
create a case.
in task reassign y review the list of users all are of status active.

## Related Tickets & Packages
- [FOUR-7633](https://processmaker.atlassian.net/browse/FOUR-7633)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-7633]: https://processmaker.atlassian.net/browse/FOUR-7633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ