### PR TITLE
FOUR-15220: Adjust the lines that pass through the carousel slides

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCarousel.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCarousel.vue
@@ -100,23 +100,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-#processes-carousel {
-  .carousel-indicators {
-    li {
-      background-color: #EDEDED;
-      width: 27px;
-      height: 8px;
-      border-radius: 5px;
-      border-top: 0;
-      border-bottom: 0;
-      opacity: 0.5;
-    }
-    .active {
-      background-color: #9C9C9C;
-      opacity: 1;
-    }
-  }
-}
 .carousel-inner {
   overflow: hidden;
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1082,3 +1082,15 @@ nav {
 #screenConfigsScreenType .multiselect__tags {
   padding: 6px 40px 0 6px;
 }
+
+.carousel-indicators li {
+  background-color: #ededed;
+  width: 32px;
+  height: 8px;
+  border-radius: 4px;
+  border-top: 0;
+  border-bottom: 0;
+}
+.carousel-indicators .active {
+  background-color: #9c9c9c;
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
The  lines that pass through the carousel slides are too thin, they need to be adjusted as figma desig:

figma design:

![image](https://github.com/ProcessMaker/processmaker/assets/5005237/48b718e2-607b-431a-af18-1b93acc69775)


Actual Design:
![image](https://github.com/ProcessMaker/processmaker/assets/5005237/dd321757-1bd0-4c72-b2ce-cc37c4bbdc05)

## Solution
- Add styles to indicators in the carousel. 
NOTE: this change will be affect styles related  with carousel in all plataform

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-15220](https://processmaker.atlassian.net/browse/FOUR-15220)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-15220]: https://processmaker.atlassian.net/browse/FOUR-15220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ