### PR TITLE
FOUR-15233: When select a Screen Launchpad the process appears bookmarked

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
+++ b/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
@@ -28,11 +28,11 @@ class ProcessesCatalogueController extends Controller
         $manager = app(ScreenBuilderManager::class);
         event(new ScreenBuilderStarting($manager, 'DISPLAY'));
         $launchpad = null;
-        $bookmarkId = 0;
+        $bookmark_id = 0;
         $currentUser = Auth::user()->only(['id', 'username', 'fullname', 'firstname', 'lastname', 'avatar']);
         if (!is_null($process)) {
             $process->launchpad = ProcessLaunchpad::getLaunchpad(true, $process->id);
-            $process->bookmarkId = Bookmark::getBookmarked(true, $process->id, $currentUser['id']);
+            $process->bookmark_id = Bookmark::getBookmarked(true, $process->id, $currentUser['id']);
         }
         return view('processes-catalogue.index', compact('process', 'currentUser', 'manager'));
     }

--- a/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
+++ b/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
@@ -28,7 +28,6 @@ class ProcessesCatalogueController extends Controller
         $manager = app(ScreenBuilderManager::class);
         event(new ScreenBuilderStarting($manager, 'DISPLAY'));
         $launchpad = null;
-        $bookmark_id = 0;
         $currentUser = Auth::user()->only(['id', 'username', 'fullname', 'firstname', 'lastname', 'avatar']);
         if (!is_null($process)) {
             $process->launchpad = ProcessLaunchpad::getLaunchpad(true, $process->id);

--- a/resources/js/processes-catalogue/components/mixins/ProcessesMixin.js
+++ b/resources/js/processes-catalogue/components/mixins/ProcessesMixin.js
@@ -32,7 +32,7 @@ const ProcessHeader = {
     bookmarkIcon() {
       this.labelTooltip = this.process.bookmark_id !== 0
         ? this.$t("Remove from My Bookmarks") : this.$t("Add to My Bookmarks");
-      this.showBookmarkIcon = this.process.bookmark_id !== 0;
+      this.showBookmarkIcon = this.process.bookmark_id ? this.process.bookmark_id!== 0 : 0;
     },
     /**
      * Check the bookmark to add bookmarked list or remove it

--- a/resources/js/processes-catalogue/components/mixins/ProcessesMixin.js
+++ b/resources/js/processes-catalogue/components/mixins/ProcessesMixin.js
@@ -32,7 +32,7 @@ const ProcessHeader = {
     bookmarkIcon() {
       this.labelTooltip = this.process.bookmark_id !== 0
         ? this.$t("Remove from My Bookmarks") : this.$t("Add to My Bookmarks");
-      this.showBookmarkIcon = this.process.bookmark_id ? this.process.bookmark_id!== 0 : 0;
+      this.showBookmarkIcon = this.process.bookmark_id !== 0;
     },
     /**
      * Check the bookmark to add bookmarked list or remove it


### PR DESCRIPTION
## Issue & Reproduction Steps
After the refresh the bookmark is enable but the process was not bookmarked

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next