### PR TITLE
FOUR-15228 | Add Data Test Attributes to Create Screen Modal

### DIFF
--- a/resources/js/components/templates/ScreenTemplateCard.vue
+++ b/resources/js/components/templates/ScreenTemplateCard.vue
@@ -4,7 +4,7 @@
       no-body
       bg-variant="transparent"
       class="screen-template-card p-0"
-      data-cy="screen-template-card"
+      :data-cy="`${template.name}-card`"
     >
       <b-card-body>
         <div @click="selectTemplate" class="template-container">

--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -74,6 +74,7 @@
                   autofocus
                   name="title"
                   required
+                  data-cy="create_screen_name"
                 />
               </b-form-group>
               <b-form-group
@@ -89,6 +90,7 @@
                   name="description"
                   required
                   rows="3"
+                  data-cy="create_screen_description"
                 />
               </b-form-group>
               <category-select
@@ -98,6 +100,7 @@
                 api-get="screen_categories"
                 api-list="screen_categories"
                 name="category"
+                data-cy="create_screen_category_select"
               />
               <project-select
                 v-if="isProjectsInstalled"
@@ -108,18 +111,21 @@
                 :required="isProjectSelectionRequired"
                 api-get="projects"
                 api-list="projects"
+                data-cy="create_screen_project_select"
               />
             </div>
             <div class="w-100 m-0 d-flex mt-auto">
               <button
                 type="button"
                 class="btn btn-outline-secondary ml-auto"
+                data-cy="create_screen_cancel_btn"
                 @click="close"
               >
                 {{ $t('Cancel') }}
               </button>
               <a
                 class="btn btn-secondary ml-3"
+                data-cy="create_screen_save_btn"
                 @click="onSubmit"
               >
                 {{ $t('Save') }}

--- a/resources/js/processes/screens/components/ScreenTypeDropdown.vue
+++ b/resources/js/processes/screens/components/ScreenTypeDropdown.vue
@@ -17,7 +17,7 @@
     @input="emitSelectedType"
   >
     <template slot="singleLabel" slot-scope="props">
-      <div class="type-container">
+      <div class="type-container" :data-cy="`type-container-${props.option.typeHuman}`">
         <i class="type-icon-placeholder pr-3" :class="props.option.icon" />
         <span class="type-desc">
           <span class="type-title-placeholder">{{ props.option.typeHuman }}</span>
@@ -26,7 +26,7 @@
       </div>
     </template>
     <template slot="option" slot-scope="props">
-      <div class="type-container">
+      <div class="type-container" :data-cy="`type-container-${props.option.typeHuman}`">
         <i class="type-icon p-3" :class="props.option.icon" />
         <span class="type-desc">
           <span class="type-title-option">{{ props.option.typeHuman }}</span>

--- a/resources/js/processes/screens/components/TemplateTypeDropdown.vue
+++ b/resources/js/processes/screens/components/TemplateTypeDropdown.vue
@@ -14,7 +14,7 @@
     @input="emitSelectedTemplate"
   >
     <template slot="singleLabel" slot-scope="props">
-      <div class="type-container">
+      <div class="type-container" :data-cy="`type-container-${props.option.type}`">
         <TemplateIcon class="template-type-icon" />
         <span class="type-desc">
           <span class="template-type-placeholder">{{ props.option.type }}</span>
@@ -22,7 +22,7 @@
       </div>
     </template>
     <template slot="option" slot-scope="props">
-      <div class="type-container">
+      <div class="type-container" :data-cy="`type-container-${props.option.typeHuman}`">
         <span class="type-desc">
           <span class="type-title-option">{{ props.option.type }}</span>
         </span>

--- a/resources/js/processes/screens/components/TemplateTypeDropdown.vue
+++ b/resources/js/processes/screens/components/TemplateTypeDropdown.vue
@@ -22,7 +22,7 @@
       </div>
     </template>
     <template slot="option" slot-scope="props">
-      <div class="type-container" :data-cy="`type-container-${props.option.typeHuman}`">
+      <div class="type-container" :data-cy="`type-container-${props.option.type}`">
         <span class="type-desc">
           <span class="type-title-option">{{ props.option.type }}</span>
         </span>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-15228](https://processmaker.atlassian.net/browse/FOUR-15228)

The Create Screen Modal is missing data-cy attributes that are necessary for testing.

# Solution
- Add data-cy attributes to the Screen Template Card, Screen Type Dropdown, and Template Type Dropdown components.

# How to Test
1. Go to branch `observation/FOUR-15228` in `processmaker`.
2. Go to Designer → Screens → +SCREEN.
3. Open your console to view the data-cy attributes that have been added to the modal elements listed above.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-15228]: https://processmaker.atlassian.net/browse/FOUR-15228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ