### PR TITLE
FOUR-15207: Fix Screen Template config update

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -140,7 +140,10 @@ class TemplateController extends Controller
             // Call event to log Template Config changes
             TemplateUpdated::dispatch($changes, $original, false, $template);
         } elseif ($type === 'screen') {
-            $existingTemplate = $this->checkForExistingTemplates($type, $request);
+            if (!$request->media_collection) {
+                $existingTemplate = $this->checkForExistingTemplates($type, $request);
+            }
+
             if (!empty($existingTemplate)) {
                 return $existingTemplate;
             }


### PR DESCRIPTION
## Issue Description
When attempting to modify the description within the configuration of a Screen Template, the system does not allow changes to be made. A validation error message appears, preventing the update.

## Steps to Reproduce
1. Navigate to the screen list.
2. Create a new screen form.
3. Save the created screen as a template.
4. Go to the template list.
5. Search for and select the template created.
6. Open the configuration of the template.
7. Attempt to make changes to the template. DO NOT CHANGE THE NAME
8. Save the new configuration.

## Current Behavior
It is currently not possible to change the configuration of a screen template. Upon attempting to save the updated configuration, the following error message is displayed:  
`The template name must be unique.`

## Expected Behavior
Users should be able to change the configuration of a screen template without encountering errors. This includes being able to update all aspects of the template's configuration.

## How to Test
Please follow the Steps to Reproduce and ensure that the Expected Behavior is met.

## Related Tickets & Packages
- Ticket [FOUR-15207](https://processmaker.atlassian.net/browse/FOUR-15207)
- ci:next
- ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15207]: https://processmaker.atlassian.net/browse/FOUR-15207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ