### PR TITLE
feature/FOUR-15231: There is a botton scroll in Guide Templates

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="process-info-main">
     <process-collapse-info
       :process="process"
       :permission="permission"
@@ -47,3 +47,9 @@ export default {
   },
 };
 </script>
+
+<style lang="css" scoped>
+.process-info-main {
+  overflow-y: auto;
+}
+</style>

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -315,7 +315,6 @@ export default {
   width: 100%;
   margin-right: 16px;
   height: calc(100vh - 145px);
-  overflow-y: auto;
   padding-left: 32px;
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
There should not be a scroll if it is not necessary in Guide Templates

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15231

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next