### PR TITLE
FOUR-15227: Fix Shared Template option

### DIFF
--- a/resources/js/processes/screen-templates/components/CreateScreenTemplateForm.vue
+++ b/resources/js/processes/screen-templates/components/CreateScreenTemplateForm.vue
@@ -131,7 +131,7 @@ export default {
     },
     computed: {
         canMakePublicTemplates() {
-            return this.permission.includes('publish-screen-templates');
+            return this.permission.includes('create-screens');
         }
 
     },

--- a/resources/js/processes/screen-templates/components/CreateScreenTemplateForm.vue
+++ b/resources/js/processes/screen-templates/components/CreateScreenTemplateForm.vue
@@ -131,7 +131,7 @@ export default {
     },
     computed: {
         canMakePublicTemplates() {
-            return this.permission.includes('create-screens');
+            return this.permission.includes('publish-screen-templates');
         }
 
     },

--- a/resources/views/processes/screen-builder/screen.blade.php
+++ b/resources/views/processes/screen-builder/screen.blade.php
@@ -31,7 +31,7 @@
     <div id="screen-container" style="display: contents !important">
         <component :is="'{{ $screen->builderComponent() }}'" :screen="{{ $screen }}"
                    ref="screenBuilder"
-                   :permission="{{ \Auth::user()->hasPermissionsFor('screens') }}"
+                   :permission="{{ \Auth::user()->hasPermissionsFor('screens', 'screen-templates') }}"
                    :auto-save-delay="{{ $autoSaveDelay }}"
                    :is-versions-installed="@json($isVersionsInstalled)"
                    :is-draft="@json($isDraft)"


### PR DESCRIPTION
## Description
The "Share Template" option does not appear in the modal template from the Save as Template Option in the Modeler. This issue affects users with designer roles trying to share templates directly from the screen editing interface.

## Steps to Reproduce
1. Log in with a designer user.
2. Navigate to 'Screens'.
3. Create a new screen.
4. Add some controls to the screen.
5. Save the changes.
6. Click on 'Options'.
7. Select 'Save as Template'.

## Current Behavior
The "Share Template" option does not appear in the template modal opened from screen edit.
![Screenshot 2024-04-23 at 5 29 32 PM](https://github.com/ProcessMaker/processmaker/assets/5769433/9f334df7-a4bf-4493-93e4-562983414d60)

## Expected Behavior
The "Share Template" option should appear in the template modal open from screen edit if the user is the owner of the template.

![Screenshot 2024-04-23 at 5 29 46 PM](https://github.com/ProcessMaker/processmaker/assets/5769433/999dd633-254e-406e-b8f9-b75e3ae41c59)


## How to Test
- Please follow the Steps to Reproduce and ensure that the Current Behavior is met.

## Related Tickets & Packages
- Ticket: [FOUR-15227](https://processmaker.atlassian.net/browse/FOUR-15227)
- ci:next
- ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15227]: https://processmaker.atlassian.net/browse/FOUR-15227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ