### PR TITLE
FOUR-15092 The "Type Value" field disappears from the participants co…

### DIFF
--- a/resources/js/components/PMColumnFilterPopover/PMColumnFilterForm.vue
+++ b/resources/js/components/PMColumnFilterPopover/PMColumnFilterForm.vue
@@ -262,6 +262,10 @@
             item.value = this.viewConfig[i].input;
           }
         }
+        //If it is not found, we establish a default.
+        if (item.viewControl === "") {
+          item.viewControl = "PMColumnFilterOpInput";
+        }
       },
       updatedScroll() {
         if (this.viewItemsChanged === true) {


### PR DESCRIPTION
https://processmaker.atlassian.net/browse/FOUR-15092

The "Type Value" field disappears from the participants column

1. Go to requests
2. Copy Any participant
3. Click on Participants
4. paste participating in the "Type Value" field
5. Click on Apply
6. Click on Participants

Note:
This is reproducible when we use custom column types such as array, file, password, etc. Please see the 'Custom Column' section in the saved search.

ci:next
