### PR TITLE
FOUR-15232: When the admin updates a screen template, the ownership of the screen template is changed

### DIFF
--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -56,7 +56,10 @@ class ScreenTemplateTest extends TestCase
 
     public function testUpdateScreenTemplate()
     {
-        $screenTemplateId = ScreenTemplates::factory()->create()->id;
+        $nonAdminUser = User::factory()->create(['is_administrator' => false]);
+        $screenTemplateId = ScreenTemplates::factory()->create([
+            'user_id' => $nonAdminUser->id,
+        ])->id;
 
         $route = route('api.template.settings.update', ['screen', $screenTemplateId]);
         $data = [
@@ -65,12 +68,29 @@ class ScreenTemplateTest extends TestCase
             'version' => '1.0.1',
             'template_media' => [],
         ];
-        $response = $this->apiCall('PUT', $route, $data);
-        // Assert response status
+        $response = $this->actingAs($nonAdminUser, 'api')->call('PUT', $route, $data);
+
+        // Assert that our database has the screen template we updated.
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('screen_templates', [
+            'name' => 'Test Screen Template Update',
+            'user_id' => $nonAdminUser->id,
+        ]);
+
+        // Update the same template with the Admin user.
+        $adminUser = User::factory()->create(['is_administrator' => true]);
+        $data = [
+            'name' => 'Test Screen Template Update by Admin',
+            'description' => 'Test Screen Template Updated Description by Admin',
+            'version' => '1.0.2',
+        ];
+        $response = $this->actingAs($adminUser, 'api')->call('PUT', $route, $data);
         $response->assertStatus(200);
 
-        // Assert that our database has the screen template we updated
-        $this->assertDatabaseHas('screen_templates', ['name' => 'Test Screen Template Update']);
+        $this->assertDatabaseHas('screen_templates', [
+            'name' => 'Test Screen Template Update by Admin',
+            'user_id' => $nonAdminUser->id,
+        ]);
     }
 
     public function testDeleteScreenTemplate()


### PR DESCRIPTION
## Issue & Reproduction Steps
When accessing the configuration of a shared screen template with the ADMIN user who did not originally create it, if you update the screen template, the ownership of the screen template is changed.


## Solution
Since only an update is being performed on a preexisting template, there is no need to modify the user_id of the template.

## How to Test
- Follow the reproduction steps in the QA server.

ci:deploy
ci:next

## Related Tickets & Packages
- [FOUR-15232](https://processmaker.atlassian.net/browse/FOUR-15232)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15232]: https://processmaker.atlassian.net/browse/FOUR-15232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ