### PR TITLE
QA Observation bugfix/FOUR-15288: The search process in Launchpad is very close to the top of the screen

### DIFF
--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="pb-3">
-      <b-input-group v-if="component === 'template-select-card'">
+      <b-input-group class="class-align-top" v-if="component === 'template-select-card'">
         <b-input-group-prepend>
           <b-btn class="btn-search-run px-2" :title="$t('Search Templates')" @click="fetch()">
             <i class="fas fa-search search-icon" />
@@ -318,5 +318,8 @@ export default {
   display: flex;
   flex-wrap: wrap;
   padding-left: 0;
+}
+.class-align-top {
+  margin-top: 15px;
 }
 </style>

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -302,6 +302,7 @@ export default {
   min-width: 304px;
   height: calc(100vh - 145px);
   overflow-y: auto;
+  margin-top: 15px;
 }
 .menu-title {
   color: #556271;

--- a/resources/js/processes-catalogue/components/utils/SearchCards.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCards.vue
@@ -49,6 +49,7 @@ export default {
 .search-group {
   display: flex;
   align-items: center;
+  margin-top: 15px;
 }
 .btn-input,
 #search-box {


### PR DESCRIPTION
## How to Test
- Go to Process Calatogue
- Click on All process
- Check the spaces in search engine of process

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15288

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next