### PR TITLE
observation/FOUR-15275 The red box of required fields is lost 

### DIFF
--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -338,6 +338,9 @@ export default {
         .catch((error) => {
           this.disabled = false;
           this.addError = error.response?.data.errors;
+          if (error?.response?.status && error?.response?.status === 422) {
+            this.errors = error.response.data.errors;
+          }
         });
     },
     handleSuccessMessageAndRedirect(data) {


### PR DESCRIPTION
## Issue & Reproduction Steps
The red box of required fields is lost with screen Template in Screen modal 

## Solution
Added the required validation when a template is selected

## How to Test

1. Go to Screens
2. Click on + Screen 
3. Select one template
4. Do not fill out the required fields
5. Press Save button

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15275

ci:deploy
ci:next