### PR TITLE
FOUR-15274 Fix ALTER table for adding INDEX based on the pmql is affecting the DataBase performance

### DIFF
--- a/ProcessMaker/JsonColumnIndex.php
+++ b/ProcessMaker/JsonColumnIndex.php
@@ -12,7 +12,7 @@ class JsonColumnIndex
         $indexName = $column . '_' . $path;
 
         if ($this->indexExists($table, $indexName)) {
-            return;
+            return false;
         }
 
         $sql = <<<SQL
@@ -23,7 +23,7 @@ class JsonColumnIndex
 
         if (!config('database.enable_index_json_columns')) {
             Log::warning('Indexing JSON columns is disabled. The following index was not created: ' . $sql);
-            return;
+            return false;
         }
 
         return DB::statement($sql);

--- a/ProcessMaker/JsonColumnIndex.php
+++ b/ProcessMaker/JsonColumnIndex.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker;
 
 use DB;
+use Illuminate\Support\Facades\Log;
 
 class JsonColumnIndex
 {
@@ -19,6 +20,11 @@ class JsonColumnIndex
                 LEFT({$column}->>"{$path}", 255) COLLATE utf8mb4_bin
             )) USING BTREE;
         SQL;
+
+        if (!config('database.enable_index_json_columns')) {
+            Log::warning('Indexing JSON columns is disabled. The following index was not created: ' . $sql);
+            return;
+        }
 
         return DB::statement($sql);
     }

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -797,8 +797,8 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                 $field = $expression->field->toEloquent();
                 $operator = $expression->operator;
 
-                $requests = ProcessRequest::where($field, $operator, $value)->get();
-                $query->whereIn('process_request_id', $requests->pluck('id'));
+                $requestIds = ProcessRequest::where($field, $operator, $value)->pluck('id');
+                $query->whereIn('process_request_id', $requestIds);
             };
         } else {
             if (stripos($expression->field->field(), 'data.') === 0) {
@@ -813,8 +813,8 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                 $pmql = "{$field} {$operator} {$value}";
 
                 return function ($query) use ($pmql) {
-                    $requests = ProcessRequest::pmql($pmql)->get();
-                    $query->whereIn('process_request_id', $requests->pluck('id'));
+                    $requestIds = ProcessRequest::pmql($pmql)->pluck('id');
+                    $query->whereIn('process_request_id', $requestIds);
                 };
             }
         }

--- a/ProcessMaker/Traits/Indexable.php
+++ b/ProcessMaker/Traits/Indexable.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Traits;
 
+use DomainException;
 use Facades\ProcessMaker\JsonColumnIndex;
 
 trait Indexable
@@ -66,18 +67,16 @@ trait Indexable
         // If table is saved search, return the corresponding table
         switch ($type) {
             case 'request':
-                return 'process_requests';
-                break;
             case 'task':
-                return 'process_request_tokens';
-                break;
+                return 'process_requests';
             case 'collection':
                 if ($meta && isset($meta->collection_id)) {
                     $collectionId = $meta->collection_id;
 
                     return 'collection_' . $collectionId;
                 }
-                break;
+            default:
+                throw new DomainException('Unknown saved search type: ' . $type);
         }
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -141,6 +141,8 @@ return [
 
     'upgrades' => 'upgrade_migrations',
 
+    'enable_index_json_columns' => filter_var(env('ENABLE_INDEXED_JSON_COLUMNS', true), FILTER_VALIDATE_BOOLEAN),
+
     /*
     |--------------------------------------------------------------------------
     | Redis Databases


### PR DESCRIPTION
## ALTER table for adding INDEX based on the pmql is affecting the DataBase performance

- And index is incorrectly applied to the process_request_tokens table

## Solution
- Add and environment variable to enable/disable json data index.
- Fix the table used to index the json data when a Tasks Saved Search is created/updated
- Improve some queries

## How to Test
- Create a Saved Search from Tasks
- Add or change the pmql to include filter by a data variable. E.g. `data.form_input_1="test"`
- Test this two steps with `ENABLE_INDEXED_JSON_COLUMNS=false` in .env
- Test this two steps with `ENABLE_INDEXED_JSON_COLUMNS=true` in .env

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15274

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
