### PR TITLE
FOUR-15218 | Guided Templates: Process Helper Direct Link Not Working

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -218,7 +218,7 @@ export default {
     selectCategorie(value) {
       const url = new URL(window.location.href);
 
-      // If url has Guided Template Params or Template Params, don't replace state.
+      // If url has Template Params, don't replace state.
       if (!this.hasTemplateParams(url)) {
         window.history.replaceState(null, null, "/process-browser");
         this.key += 1;

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -116,12 +116,10 @@ export default {
     };
   },
   computed: {
-    hasGuidedTemplateParams() {
-      return window.location.search.includes("?guided_templates=true");
-    },
   },
   mounted() {
-    if (this.hasGuidedTemplateParams) {
+    const url = new URL(window.location.href);
+    if (this.hasGuidedTemplateParamsOnly(url) || this.hasTemplateParams(url)) {
       // Loaded from URL with guided template parameters to show guided templates
       // Dynamically load the component
       this.wizardTemplatesSelected(true);
@@ -221,20 +219,17 @@ export default {
      * Select a category and show display
      */
     selectCategorie(value) {
-      window.history.replaceState(null, null, "/process-browser");
-      this.key += 1;
-      this.category = value;
-      this.selectedProcess = null;
-      this.showCardProcesses = true;
-      this.guidedTemplates = false;
-      this.showWizardTemplates = false;
+      const url = new URL(window.location.href);
 
-      // Remove guided_templates and template parameters from the URL
-      if (value !== undefined) {
-        const url = new URL(window.location.href);
-        url.searchParams.delete("guided_templates");
-        url.searchParams.delete("template");
-        history.pushState(null, "", url); // Update the URL without triggering a page reload
+      // If url has Guided Template Params or Template Params, don't replace state.
+      if (!this.hasTemplateParams(url) && !this.hasGuidedTemplateParamsOnly(url)) {
+        window.history.replaceState(null, null, "/process-browser");
+        this.key += 1;
+        this.category = value;
+        this.selectedProcess = null;
+        this.showCardProcesses = true;
+        this.guidedTemplates = false;
+        this.showWizardTemplates = false;
       }
 
       this.showProcess = false;
@@ -292,6 +287,12 @@ export default {
       }
 
       return screenId !== 0;
+    },
+    hasGuidedTemplateParamsOnly(url) {
+      return url.search.includes("?guided_templates=true") && !url.search.includes("?guided_templates=true&template=");
+    },
+    hasTemplateParams(url) {
+      return url.search.includes("&template=");
     },
   },
 };

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -115,8 +115,6 @@ export default {
       categoryCount: 0,
     };
   },
-  computed: {
-  },
   mounted() {
     const url = new URL(window.location.href);
     if (this.hasGuidedTemplateParamsOnly(url) || this.hasTemplateParams(url)) {


### PR DESCRIPTION
# Issue
Ticket: [FOUR-15218](https://processmaker.atlassian.net/browse/FOUR-15218)

When navigating to Guided Templates by pasting a url into the browser, i.e. `https://next-qa.processmaker.net/process-browser?guided_templates=true&template=invoice_approval`, the link redirects to `/process-browser`.

# Solution
- In `ProcessCatalogue.vue`, added a method `hasTemplateParams()` to evaluate if the current URL contains `&template=`.
- In the `selectCategorie()` method, we are calling `window.history.replaceState()`, which redirects to `/process-browser`.
	- If the current URL `hasTemplateParams` or `hasGuidedTemplateParamsOnly`, we do not `replaceState()`.

# How to Test
1. Go to branch `observation/FOUR-15218` in `processmaker`.
2. Go to Processes. Click on a Guided Template. When the Help Process Modal opens, copy the link.
	- The link should contain `guided_templates` and `template` params like this: `https://processmaker.test/process-browser?guided_templates=true&template=invoice_approval`
3. Open another window or a different browser.
4. Paste the link into the browser.
	- You should be taken to the Helper Process Modal for the Guided Template you selected.

ci:next
ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-15218]: https://processmaker.atlassian.net/browse/FOUR-15218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ