### PR TITLE
Correctly handle files in drafts

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -115,7 +115,7 @@ class ProcessRequestFileController extends Controller
 
     private function filter($media, $filter, $name, $id)
     {
-        return $media->reject(function ($item, $key) use ($filter, $name, $id) {
+        return $media->reject(function ($item) use ($filter, $name, $id) {
             if ($filter === $name) {
                 if ($item->custom_properties['data_name'] != $name) {
                     return true;

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -109,22 +109,25 @@ class ProcessRequestFileController extends Controller
         if (!$filter) {
             return new ResourceCollection($media);
         } else {
-            $filtered = $media->reject(function ($item, $key) use ($filter, $name, $id) {
-                if ($filter === $name) {
-                    if ($item->custom_properties['data_name'] != $name) {
-                        return true;
-                    }
-                } elseif ($filter === $id) {
-                    if ($item->id != $id) {
-                        return true;
-                    }
-                }
-
-                return false;
-            });
-
-            return new ResourceCollection($filtered);
+            return new ResourceCollection($this->filter($media, $filter, $name, $id));
         }
+    }
+
+    private function filter($media, $filter, $name, $id)
+    {
+        return $media->reject(function ($item, $key) use ($filter, $name, $id) {
+            if ($filter === $name) {
+                if ($item->custom_properties['data_name'] != $name) {
+                    return true;
+                }
+            } elseif ($filter === $id) {
+                if ($item->id != $id) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -246,6 +246,7 @@ class TaskController extends Controller
             //Call the manager to trigger the start event
             $process = $task->process;
             $instance = $task->processRequest;
+            TaskDraft::moveDraftFiles($task);
             WorkflowManager::completeTask($process, $instance, $task, $data);
 
             return new Resource($task->refresh());

--- a/ProcessMaker/Http/Controllers/Api/TaskDraftController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskDraftController.php
@@ -3,25 +3,36 @@
 namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
-use ProcessMaker\Models\TaskDraft;
 use ProcessMaker\Models\ProcessRequestToken;
-use Illuminate\Support\Arr;
+use ProcessMaker\Models\TaskDraft;
 
 class TaskDraftController extends Controller
 {
     public function update(Request $request, ProcessRequestToken $task)
     {
         $search = ['task_id' => $task->id];
-        $draft = TaskDraft::updateOrCreate($search,['data' => $request->all()]);
+        $draft = TaskDraft::firstOrNew($search, ['data' => []]);
+        // Do not overwrite __deleted_files
+        $deletedFiles = Arr::get($draft->data, '__deleted_files');
+        $data = $request->all();
+        if ($deletedFiles) {
+            $data['__deleted_files'] = $deletedFiles;
+        }
+        $draft->data = $data;
+        $draft->saveOrFail();
 
         return new ApiResource($draft);
     }
+
     public function delete(ProcessRequestToken $task)
     {
-        TaskDraft::where('task_id', $task->id)->delete();
+        // Use get()->each to fire the delete event for each draft
+        TaskDraft::where('task_id', $task->id)->get()->each->delete();
+
         return response([], 204);
     }
 }

--- a/ProcessMaker/Http/Controllers/Api/TaskDraftController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskDraftController.php
@@ -33,6 +33,8 @@ class TaskDraftController extends Controller
         // Use get()->each to fire the delete event for each draft
         TaskDraft::where('task_id', $task->id)->get()->each->delete();
 
-        return response([], 204);
+        $requestFiles = $task->processRequest->requestFiles();
+
+        return response(['request_files' => $requestFiles], 200);
     }
 }

--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -236,7 +236,8 @@ class Media extends MediaLibraryModel
         } elseif ($this->model_type == ProcessRequest::class) {
             return $this->model->id;
         }
-        abort(404, 'No process request id for ' . $this->model_type);
+
+        return null;
     }
 
     public function toArray()

--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -236,7 +236,7 @@ class Media extends MediaLibraryModel
         } elseif ($this->model_type == ProcessRequest::class) {
             return $this->model->id;
         }
-        throw new \Exception('No process request id for ' . $this->model_type);
+        abort(404, 'No process request id for ' . $this->model_type);
     }
 
     public function toArray()

--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -222,7 +222,7 @@ class Media extends MediaLibraryModel
         $requestTokenIds = [$request->id];
         if ($request->collaboration && $request->collaboration->requests()) {
             // Get all processes and subprocesses request token id's ..
-            $requestTokenIds = $request->collaboration->requests->pluck('id');
+            $requestTokenIds = $request->collaboration->requests->pluck('id')->toArray();
         }
 
         // Return a single file when $id is set

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -47,10 +47,10 @@ use Throwable;
  * @property string $status
  * @property array $data
  * @property string $collaboration_uuid
- * @property \Carbon\Carbon $initiated_at
- * @property \Carbon\Carbon $completed_at
- * @property \Carbon\Carbon $updated_at
- * @property \Carbon\Carbon $created_at
+ * @property Carbon $initiated_at
+ * @property Carbon $completed_at
+ * @property Carbon $updated_at
+ * @property Carbon $created_at
  * @property Process $process
  * @property ProcessRequestLock[] $locks
  * @property ProcessRequestToken $ownerTask
@@ -562,7 +562,7 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
         $errors[] = $error;
         $this->errors = $errors;
         $this->status = 'ERROR';
-        \Log::error($exception);
+        Log::error($exception);
         if (!$this->isNonPersistent()) {
             $this->save();
         }
@@ -740,7 +740,7 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
                     ->whereIn('user_id', function ($subquery) use ($value, $expression) {
                         $subquery->select('id')
                             ->from('users')
-                            ->whereRaw("CONCAT(firstname, ' ', lastname) " . $expression->operator . " ?", [$value]);
+                            ->whereRaw("CONCAT(firstname, ' ', lastname) " . $expression->operator . ' ?', [$value]);
                     })
                     ->whereIn('element_type', ['task', 'userTask', 'startEvent']);
             });
@@ -914,7 +914,7 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
      */
     public function requestFiles(bool $includeToken = false)
     {
-        $media = \ProcessMaker\Models\Media::getFilesRequest($this);
+        $media = Media::getFilesRequest($this);
 
         return (object) $media->mapToGroups(function ($file) use ($includeToken) {
             $dataName = $file->getCustomProperty('data_name');
@@ -934,11 +934,7 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     public function downloadFile($fileId)
     {
         // Get all files for process and all subprocesses ..
-        $media = Media::getFilesRequest($this);
-
-        $filtered = $media->filter(function ($value) use ($fileId) {
-            return $value->id == $fileId;
-        })->first();
+        $filtered = Media::getFilesRequest($this, $fileId);
 
         if (!$filtered) {
             return null;
@@ -951,7 +947,7 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
 
     public function getMedia(string $collectionName = 'default', $filters = []): Collection
     {
-        return \ProcessMaker\Models\Media::getFilesRequest($this);
+        return Media::getFilesRequest($this);
     }
 
     public function getErrors()

--- a/ProcessMaker/Models/TaskDraft.php
+++ b/ProcessMaker/Models/TaskDraft.php
@@ -3,11 +3,15 @@
 namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Arr;
 use ProcessMaker\Models\ProcessMakerModel;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 
-class TaskDraft extends ProcessMakerModel
+class TaskDraft extends ProcessMakerModel implements HasMedia
 {
     use HasFactory;
+    use InteractsWithMedia;
 
     protected $guarded = [
         'id',
@@ -26,6 +30,59 @@ class TaskDraft extends ProcessMakerModel
 
     public function processRequestToken()
     {
-        return $this->belongsTo(ProcessRequestToken::class);
+        return $this->belongsTo(ProcessRequestToken::class, 'task_id');
+    }
+
+    /**
+     * If any files were added or deleted to a task draft, we handle
+     * them here, after the task has been submitted.
+     *
+     * @param ProcessRequestToken $task
+     * @return void
+     */
+    public static function moveDraftFiles(ProcessRequestToken $task)
+    {
+        $draft = $task->draft;
+        if (!$draft) {
+            return;
+        }
+
+        // Handle deleted files
+        foreach (Arr::get($draft->data, '__deleted_files', []) as $fileId) {
+            $file = Media::find($fileId);
+            if ($file) {
+                $file->delete();
+            }
+        }
+
+        // Associate draft files with the actual process request
+        foreach ($draft->getMedia() as $mediaItem) {
+            $processRequestId = $mediaItem->getCustomProperty('parent_process_request_id');
+            if ($processRequestId) {
+                $processRequest = ProcessRequest::find($processRequestId);
+                if ($processRequest) {
+                    // Keep track to previous files to delete
+                    $delete = [];
+                    foreach ($task->processRequest->getMedia() as $existingMediaItem) {
+                        if (
+                            $existingMediaItem->getCustomProperty('data_name') === $mediaItem->getCustomProperty('data_name') &&
+                            !$mediaItem->getCustomProperty('is_multiple')
+                        ) {
+                            $delete[] = $existingMediaItem;
+                        }
+                    }
+
+                    $mediaItem->model_type = ProcessRequest::class;
+                    $mediaItem->model_id = $processRequest->id;
+                    $mediaItem->forgetCustomProperty('parent_process_request_id');
+                    $mediaItem->saveOrFail();
+
+                    // Delete previous files
+                    foreach ($delete as $existingMediaItem) {
+                        $existingMediaItem->delete();
+                    }
+                }
+            }
+        }
     }
 }

--- a/resources/js/modules/autosave/draftFileUploadMixin.js
+++ b/resources/js/modules/autosave/draftFileUploadMixin.js
@@ -19,7 +19,7 @@ export default {
      * The response from DELETE /drafts returns the list of request files.
      */
     resetRequestFiles(response) {
-      const requestFiles = response?.data?.requestFiles;
+      const requestFiles = response?.data?.requestFiles ?? {};
       console.log("Got Request Files", requestFiles);
       _.set(window, 'PM4ConfigOverrides.requestFiles', requestFiles);
     },

--- a/resources/js/modules/autosave/draftFileUploadMixin.js
+++ b/resources/js/modules/autosave/draftFileUploadMixin.js
@@ -1,14 +1,27 @@
-/**
- * Set a global variable to keep track of the current task.
- * 
- * This is used by the file-upload control for saving files for drafts.
- */
 export default {
   watch: {
+    /**
+     * Set a global variable to keep track of the current task.
+     * 
+     * This is used by the file-upload control for saving files for drafts.
+     */
     task: {
       handler() {
         window._current_task_id = this.task?.id || 0;
       },
     },
-  }
+  },
+  methods: {
+    /**
+     * When a draft is deleted, we need to reset the global request files
+     * to what they are in the persisted request.
+     * 
+     * The response from DELETE /drafts returns the list of request files.
+     */
+    resetRequestFiles(response) {
+      const requestFiles = response?.data?.requestFiles;
+      console.log("Got Request Files", requestFiles);
+      _.set(window, 'PM4ConfigOverrides.requestFiles', requestFiles);
+    },
+  },
 };

--- a/resources/js/modules/autosave/draftFileUploadMixin.js
+++ b/resources/js/modules/autosave/draftFileUploadMixin.js
@@ -20,7 +20,6 @@ export default {
      */
     resetRequestFiles(response) {
       const requestFiles = response?.data?.requestFiles ?? {};
-      console.log("Got Request Files", requestFiles);
       _.set(window, 'PM4ConfigOverrides.requestFiles', requestFiles);
     },
   },

--- a/resources/js/modules/autosave/draftFileUploadMixin.js
+++ b/resources/js/modules/autosave/draftFileUploadMixin.js
@@ -1,0 +1,14 @@
+/**
+ * Set a global variable to keep track of the current task.
+ * 
+ * This is used by the file-upload control for saving files for drafts.
+ */
+export default {
+  watch: {
+    task: {
+      handler() {
+        window._current_task_id = this.task?.id || 0;
+      },
+    },
+  }
+};

--- a/resources/js/tasks/components/PreviewMixin.js
+++ b/resources/js/tasks/components/PreviewMixin.js
@@ -235,7 +235,8 @@ const PreviewMixin = {
         case "clear-draft":
           ProcessMaker.apiClient
             .delete("drafts/" + this.task.id)
-            .then(() => {
+            .then(response => {
+              this.resetRequestFiles(response);
               this.isLoading = setTimeout(() => {
                 this.stopFrame = true;
                 this.taskTitle = this.$t("Task Lorem");

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -405,7 +405,8 @@ export default {
     eraseDraft() {
       ProcessMaker.apiClient
         .delete("drafts/" + this.task.id)
-        .then(() => {
+        .then(response => {
+          this.resetRequestFiles(response);
           this.isLoading = setTimeout(() => {
             this.stopFrame = true;
             this.taskTitle = this.$t("Task Lorem");

--- a/resources/js/tasks/show.js
+++ b/resources/js/tasks/show.js
@@ -12,6 +12,7 @@ import QuickFillPreview from "./components/QuickFillPreview.vue";
 import TasksList from "./components/TasksList.vue";
 import TaskSavePanel from "./components/TaskSavePanel.vue";
 import autosaveMixins from "../modules/autosave/autosaveMixin";
+import draftFileUploadMixin from "../modules/autosave/draftFileUploadMixin";
 
 Vue.use(Vuex);
 Vue.use("task", Task);
@@ -26,6 +27,7 @@ Vue.component("TasksList", TasksList);
 Vue.component("TaskSavePanel", TaskSavePanel);
 
 Vue.mixin(autosaveMixins);
+Vue.mixin(draftFileUploadMixin);
 
 window.debounce = debounce;
 window.Vuex = Vuex;

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -702,7 +702,8 @@
             this.formDataWatcherActive = false;
             ProcessMaker.apiClient
               .delete("drafts/" + this.task.id)
-              .then(() => {
+              .then(response => {
+                this.resetRequestFiles(response);
                 this.task.draft = null;
                 const taskComponent = this.$refs.task;
                 taskComponent.loadTask();


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-15242

When saving drafts, we didn't consider how to handle file uploads, which is a tricky process given our current file handling architecture.

## Solution
This PR associates files to a TaskDraft first. Only when the task is saved, it moves the files from TaskDraft to be associated with a ProcessRequest. There is also additional handling for deleting files in drafts.

This also solves a long standing issue in production. Previously, if a user edits a task and changes a file, but does not complete the task, the changed file is still saved in the processes request. This PR fixes that. If the user clear's their draft, the original file will be restored.

Also tested in web entry, even though web entry does not support drafts.

## How to Test
- Create a 2 task process with file upload, file download, and file previews. Check that clearing a task reverts to the original file.
- Test with web entry too.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15242
- REQUIRES
  - https://github.com/ProcessMaker/package-files/pull/124
  - https://github.com/ProcessMaker/screen-builder/pull/1582

ci:next
ci:deploy
ci:package-files:bugfix/FOUR-15242
ci:screen-builder:bugfix/FOUR-15242

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
