### PR TITLE
FOUR-15306: Add index to `case_number` column for the `process_requests` table

### DIFF
--- a/database/migrations/2024_04_26_183624_add_index_to_case_number_column_in_process_requests_table.php
+++ b/database/migrations/2024_04_26_183624_add_index_to_case_number_column_in_process_requests_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('process_requests', function (Blueprint $table) {
+            $table->index('case_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('process_requests', function (Blueprint $table) {
+            $table->dropIndex('case_number');
+        });
+    }
+};

--- a/database/migrations/2024_04_26_183624_add_index_to_case_number_column_in_process_requests_table.php
+++ b/database/migrations/2024_04_26_183624_add_index_to_case_number_column_in_process_requests_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('process_requests', function (Blueprint $table) {
-            $table->index('case_number');
+            $table->index(['status', 'case_number']);
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('process_requests', function (Blueprint $table) {
-            $table->dropIndex('case_number');
+            $table->dropIndex(['status', 'case_number']);
         });
     }
 };


### PR DESCRIPTION
## Issue
This PR adds a database migration which adds an index to the `case_number` column to the `process_requests` table to improve the performance. Without the index, the performance of the tasks index API endpoint suffers.

ci:next

### Reproduction Steps
1. Login to your instance
2. Have 500+ tasks
3. Navigate to the "Tasks" page
4. Notice the slow response (2+ seconds)

## Solution
- Added the index in a migration file

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-15306](https://processmaker.atlassian.net/browse/FOUR-15306)
- [FOUR-15287](https://processmaker.atlassian.net/browse/FOUR-15287)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15306]: https://processmaker.atlassian.net/browse/FOUR-15306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-15287]: https://processmaker.atlassian.net/browse/FOUR-15287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ