### PR TITLE
FOUR-15305 Prevent to call multiple consecutive times the tables fetch

### DIFF
--- a/resources/js/tasks/components/ListMixin.js
+++ b/resources/js/tasks/components/ListMixin.js
@@ -7,10 +7,6 @@ const ListMixin = {
       return "";
     },
   },
-  created() {
-    // debounce fetch
-    this.fetch = _.debounce(this.fetch, 2000);
-  },
   methods: {
     getSortParam() {
       if (this.sortOrder instanceof Array && this.sortOrder.length > 0) {

--- a/resources/js/tasks/components/ListMixin.js
+++ b/resources/js/tasks/components/ListMixin.js
@@ -7,6 +7,10 @@ const ListMixin = {
       return "";
     },
   },
+  created() {
+    // debounce fetch
+    this.fetch = _.debounce(this.fetch, 2000);
+  },
   methods: {
     getSortParam() {
       if (this.sortOrder instanceof Array && this.sortOrder.length > 0) {

--- a/resources/js/tasks/index.js
+++ b/resources/js/tasks/index.js
@@ -58,7 +58,6 @@ new Vue({
     ProcessMaker.EventBus.$on('advanced-search-addition', (component) => {
       this.additions.push(component);
     });
-    this.onInbox();
   },
   created() {
     const params = new URL(document.location).searchParams;


### PR DESCRIPTION
## Prevent to call multiple consecutive times the tables fetch

When loading the Tasks page, it it calling two times the fetch of the table during the components mount.

## Solution
- Debounce the fetch.

## How to Test
- In a ci-deploy or qa environment go to Tasks page

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15305

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
