### PR TITLE
FOUR-13976: Web entry link not redirecting to the screen when using default SSO SAML authentication

### DIFF
--- a/ProcessMaker/Http/Controllers/HomeController.php
+++ b/ProcessMaker/Http/Controllers/HomeController.php
@@ -31,4 +31,14 @@ class HomeController extends Controller
             return redirect('/requests');
         }
     }
+
+    public function redirectToIntended()
+    {
+        $url = request()->cookie('processmaker_intended');
+        if ($url) {
+            return redirect($url)->withCookie(\Cookie::forget('processmaker_intended'));
+        }
+
+        return redirect()->route('requests.index');
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -131,6 +131,7 @@ Route::middleware('auth', 'session_kill', 'sanitize', 'force_change_password', '
     Route::get('modeler/{process}/inflight/{request?}', [ModelerController::class, 'inflight'])->name('modeler.inflight')->middleware('can:view,request');
 
     Route::get('/', [HomeController::class, 'index'])->name('home');
+    Route::get('/redirect-to-intended', [HomeController::class, 'redirectToIntended'])->name('redirect_to_intended');
 
     Route::post('/keep-alive', [LoginController::class, 'keepAlive'])->name('keep-alive');
 
@@ -208,3 +209,4 @@ Route::get('/unavailable', [UnavailableController::class, 'show'])->name('error.
 
 // SAML Metadata Route
 Route::resource('/saml/metadata', MetadataController::class)->only('index');
+


### PR DESCRIPTION
## Issue & Reproduction Steps

- Configure SAML on your environment
- Enable the option Default SSO Login to use SAML
- Prepare a process for using web entry (with authentication mode) in the start event
- Use the web entry link (you can use an incognito window to confirm you do not have any session)
- At this point, you will be redirected to the home page instead of the screen of the web entry.

**Current Behavior:**
The web entry link is redirected to the home page after logging in with the SAML authentication instead of showing the screen. You have to see the video to understand the behavior.

**Expected Behavior:**

The web entry link for start events or tasks should be redirected to the screen when using SAML authentication.

## Solution
The SAML authentication providers calls the acs endpoint with no  cookie data, so a new endpoint that reads the cookie when it comes in the request has been created.


## How to Test

The cause of this is the configuration Default SSO Login when this variable is set to SAML this behavior happens, if this one is Null then the issue is not reproduced, make sure to have it enabled in the option SAML. 

The client stated that they have this redirection working for standard requests but not for web entry ones only.

Test with different authentication providers (onlogin, okta, etc.)

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13976

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:package-auth:bugfix/FOUR-13976
