### PR TITLE
[FOUR-15314] Bypass handleOrderByRequestName method in API Task Controller

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -277,43 +277,6 @@ class TaskController extends Controller
         ], 422);
     }
 
-    private function handleOrderByRequestName($request, $tasksList)
-    {
-        // Get the list of columns to order by - trimmed if spaces were added
-        $orderColumns = collect(explode(',', $request->input('order_by', 'updated_at')))
-            ->map(function ($value, $key) {
-                return trim($value);
-            });
-        $requestColumns = $orderColumns->filter(function ($value, $key) {
-            return Str::contains($value, 'process_requests.');
-        })->sort();
-
-        // if there ins't an order by request name, tasks are already ordered
-        if ($requestColumns->count() == 0) {
-            return $tasksList;
-        }
-
-        $requestQuery = ProcessRequest::query();
-
-        foreach ($requestColumns as $column) {
-            $columnName = trim(explode('.', $column)[1]);
-            $requestQuery->orderBy($columnName, $request->input('order_direction', 'asc'));
-        }
-
-        $orderedRequests = $requestQuery->get();
-        $orderedTasks = collect([]);
-
-        foreach ($orderedRequests as $item) {
-            $elements = $tasksList->filter(function ($value, $key) use ($item) {
-                return $value->process_request_id == $item->id;
-            });
-
-            $orderedTasks = $orderedTasks->merge($elements);
-        }
-
-        return $orderedTasks;
-    }
-
     public function getScreen(Request $request, ProcessRequestToken $task, Screen $screen)
     {
         // Authorized in policy

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -131,7 +131,7 @@ class TaskController extends Controller
         $query->overdue($request->input('overdue'));
 
         try {
-            $response = $this->handleOrderByRequestName($request, $query->get());
+            $response = $query->get();
         } catch (QueryException $e) {
             return $this->handleQueryException($e);
         }

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -133,7 +133,7 @@ trait TaskControllerIndexMethods
             $columnName = array_pop($parts);
             if (!Str::contains($column, '.')) {
                 $query->orderBy($column, $request->input('order_direction', 'asc'));
-            } elseif ($table === 'process_request' || $table === 'processRequest') {
+            } elseif ($table === 'process_requests' || $table === 'processRequests') {
                 if ($columnName === 'id') {
                     $query->orderBy(
                         'process_request_id',


### PR DESCRIPTION
See FOUR ticket: https://processmaker.atlassian.net/browse/FOUR-15314

ci:next
ci:deploy