### PR TITLE
FOUR-15325 Use getPublishedVersion to get the next subprocess version

### DIFF
--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -160,7 +160,7 @@ class CallActivity implements CallActivityInterface
      *
      * @return \ProcessMaker\Nayra\Contracts\Bpmn\CallableElementInterface
      */
-    public function getCalledElement(array $data = [])
+    public function getCalledElement(array $data = [], bool $evaluatePublisher = true)
     {
         $calledElementRef = $this->getProperty(CallActivityInterface::BPMN_PROPERTY_CALLED_ELEMENT);
         $refs = explode('-', $calledElementRef);
@@ -173,7 +173,10 @@ class CallActivity implements CallActivityInterface
             if ($this->subProcessRequestVersion) {
                 $definitions = $engine->getDefinition($this->subProcessRequestVersion);
             } else {
-                $definitions = $engine->getDefinition($process->getPublishedVersion($data));
+                $this->subProcessRequestVersion = $evaluatePublisher
+                    ? $process->getPublishedVersion($data)
+                    : $process->getLatestVersion();
+                $definitions = $engine->getDefinition($this->subProcessRequestVersion);
             }
             $response = $definitions->getElementInstanceById($refs[0]);
 

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -54,8 +54,6 @@ class CallActivity implements CallActivityInterface
      */
     protected function callSubprocess(TokenInterface $token, $startId)
     {
-        $callable = $this->getCalledElement();
-        $dataStore = $callable->getRepository()->createDataStore();
         // The entire data model is sent to the target
         $dataManager = new DataManager();
         $data = $dataManager->getData($token);
@@ -74,6 +72,8 @@ class CallActivity implements CallActivityInterface
             $config = json_decode($configString, true);
             $data['_parent']['config'] = $config;
         }
+        $callable = $this->getCalledElement($data);
+        $dataStore = $callable->getRepository()->createDataStore();
 
         $startEvent = $startId ? $callable->getOwnerDocument()->getElementInstanceById($startId) : null;
 
@@ -160,7 +160,7 @@ class CallActivity implements CallActivityInterface
      *
      * @return \ProcessMaker\Nayra\Contracts\Bpmn\CallableElementInterface
      */
-    public function getCalledElement()
+    public function getCalledElement(array $data = [])
     {
         $calledElementRef = $this->getProperty(CallActivityInterface::BPMN_PROPERTY_CALLED_ELEMENT);
         $refs = explode('-', $calledElementRef);
@@ -173,7 +173,7 @@ class CallActivity implements CallActivityInterface
             if ($this->subProcessRequestVersion) {
                 $definitions = $engine->getDefinition($this->subProcessRequestVersion);
             } else {
-                $definitions = $engine->getDefinition($process->getLatestVersion());
+                $definitions = $engine->getDefinition($process->getPublishedVersion($data));
             }
             $response = $definitions->getElementInstanceById($refs[0]);
 

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1561,7 +1561,8 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
      */
     private function validateCallActivity(CallActivity $callActivity)
     {
-        $targetProcess = $callActivity->getCalledElement();
+        // Get process version without evaluating alternative
+        $targetProcess = $callActivity->getCalledElement([], false);
         $config = json_decode($callActivity->getProperty('config'), true);
         $startId = is_array($config) && isset($config['startEvent']) ? $config['startEvent'] : null;
         if ($startId) {


### PR DESCRIPTION
## Use getPublishedVersion to get the next subprocess version

## Solution
- Use getPublishedVersion to get the next subprocess version

## How to Test
- Create a process with sub process
- The sub process must be published with two versions A/B
- Run the process, the sub process must follow the A/B configuration

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15325

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
