### PR TITLE
Observation/FOUR-15321: review the filters of a Task in Smart Inbox

### DIFF
--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -9,13 +9,20 @@ import FilterTableBodyMixin from "../../shared/FilterTableBodyMixin";
 
 export default {
   mixins:[FilterTableBodyMixin],
+  props: {
+    fetchOnCreated: {
+      default: true,
+    },
+  },
   components: {
     Vuetable,
     Pagination,
   },
   created() {
     // Use our api to fetch our role listing
-    this.fetch();
+    if (this.fetchOnCreated) {
+      this.fetch();
+    }
   },
   watch: {
     filter: _.debounce(function () {

--- a/resources/js/tasks/components/QuickFillPreview.vue
+++ b/resources/js/tasks/components/QuickFillPreview.vue
@@ -49,6 +49,7 @@
           ref="taskList"
           class="custom-table-class"
           :columns="columns"
+          :fetch-on-created="false"
           :selected-row-quick="selectedRowQuick"
           @selected="selected"
           :pmql="pmql"


### PR DESCRIPTION
## Issue & Reproduction Steps

This is a race-case issue, with 2 competing API calls to tasks endpoint.
Please take a look to this comment for better understanding of the problem.

https://processmaker.atlassian.net/browse/FOUR-15321?focusedCommentId=398240


## Solution
- Added a prop `fetchOnCreated` to datatables mixin
- Set `fetchOnCreated` to `false` when calling from **Quick Fill**

## How to Test
- Have tasks from different requests
- Create a request and in a task open the Quick Fill feature
- Open the browser inspector in network tab, and take a look to the api call to tasks endpoint, you should see only one api call.

## Related Tickets & Packages
- [FOUR-15321](https://processmaker.atlassian.net/browse/FOUR-15321)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy

[FOUR-15321]: https://processmaker.atlassian.net/browse/FOUR-15321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

.