### PR TITLE
FOUR-15341: Server error when creating case with configuration in expression in AB Settings

### DIFF
--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -15,6 +15,7 @@ use ProcessMaker\BpmnEngine;
 use ProcessMaker\Models\Process as Definitions;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestLock;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Throwable;
 
 abstract class BpmnAction implements ShouldQueue
@@ -65,6 +66,9 @@ abstract class BpmnAction implements ShouldQueue
 
             // Run engine to the next state
             $this->engine->runToNextState();
+        } catch (HttpException $exception) {
+            Log::error($exception->getMessage());
+            throw $exception;
         } catch (Throwable $exception) {
             Log::error($exception->getMessage());
             // Change the Request to error status
@@ -72,7 +76,6 @@ abstract class BpmnAction implements ShouldQueue
             if ($request) {
                 $request->logError($exception, $element);
             }
-            throw $exception;
         } finally {
             $this->unlock();
         }

--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -60,10 +60,10 @@ abstract class BpmnAction implements ShouldQueue
             $this->engine = $engine;
             $this->instance = $instance;
 
-            //Do the action
+            // Do the action
             $response = App::call([$this, 'action'], compact('definitions', 'instance', 'token', 'process', 'element', 'data', 'processModel'));
 
-            //Run engine to the next state
+            // Run engine to the next state
             $this->engine->runToNextState();
         } catch (Throwable $exception) {
             Log::error($exception->getMessage());
@@ -72,6 +72,7 @@ abstract class BpmnAction implements ShouldQueue
             if ($request) {
                 $request->logError($exception, $element);
             }
+            throw $exception;
         } finally {
             $this->unlock();
         }
@@ -86,7 +87,7 @@ abstract class BpmnAction implements ShouldQueue
      */
     private function loadContext()
     {
-        //Load the process definition
+        // Load the process definition
         if (isset($this->instanceId)) {
             $instance = $this->lockInstance($this->instanceId);
             $processModel = $instance->process;
@@ -100,7 +101,7 @@ abstract class BpmnAction implements ShouldQueue
             $instance = null;
         }
 
-        //Load the instances of the process and its collaborators
+        // Load the instances of the process and its collaborators
         if ($instance && $instance->collaboration) {
             $activeRequests = $instance->collaboration->requests()->where('status', 'ACTIVE')->get();
             foreach ($activeRequests as $request) {
@@ -110,13 +111,13 @@ abstract class BpmnAction implements ShouldQueue
             }
         }
 
-        //Get the BPMN process instance
+        // Get the BPMN process instance
         $process = null;
         if (isset($this->processId)) {
             $process = $definitions->getProcess($this->processId);
         }
 
-        //Load token and element
+        // Load token and element
         $token = null;
         $element = null;
         if ($instance && isset($this->tokenId)) {
@@ -132,7 +133,7 @@ abstract class BpmnAction implements ShouldQueue
             $element = $definitions->getElementInstanceById($this->elementId);
         }
 
-        //Load data
+        // Load data
         $data = isset($this->data) ? $this->data : null;
 
         return compact('definitions', 'instance', 'token', 'process', 'element', 'data', 'processModel', 'engine');

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -7,9 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Schema;
 use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessMakerModel;
 use ProcessMaker\Models\ProcessRequest;
-use ProcessMaker\Models\Process;
 
 trait HasVersioning
 {
@@ -89,7 +89,7 @@ trait HasVersioning
                     $this->hasAlternative()
                     ? ['alternative' => $alternative]
                     : []
-                )
+                ),
             ],
             $attributes
         );
@@ -153,7 +153,7 @@ trait HasVersioning
         $implementation = WorkflowManager::NAYRA_PUBLISHER . get_class($this);
         $existsCustomPublisher = $implementation
             && WorkflowManager::existsServiceImplementation($implementation);
-        if ($existsCustomPublisher) {
+        if ($existsCustomPublisher && $data !== []) {
             $response = WorkflowManager::runServiceImplementation(
                 $implementation,
                 $data,
@@ -161,6 +161,7 @@ trait HasVersioning
                     'process' => $this,
                 ],
             );
+
             return $response['publishedVersion'];
         }
 
@@ -197,6 +198,7 @@ trait HasVersioning
     public function getDraftVersion(string $alternative = null)
     {
         $alternative = $alternative ?: ($this->alternative ?? null);
+
         return $this->versions()
             ->when(
                 $this->hasAlternative(),

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -154,16 +154,6 @@ trait HasVersioning
         $existsCustomPublisher = $implementation
             && WorkflowManager::existsServiceImplementation($implementation);
         if ($existsCustomPublisher) {
-            if ($data === []) {
-                abort(
-                    422,
-                    __(
-                        'Oops! It looks like there was an error setting up the variables for your A/B test. ' .
-                        'Please contact the Administrator for assistance'
-                    )
-                );
-            }
-
             $response = WorkflowManager::runServiceImplementation(
                 $implementation,
                 $data,

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -7,9 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Schema;
 use ProcessMaker\Facades\WorkflowManager;
-use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessMakerModel;
 use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\Process;
 
 trait HasVersioning
 {
@@ -89,7 +89,7 @@ trait HasVersioning
                     $this->hasAlternative()
                     ? ['alternative' => $alternative]
                     : []
-                ),
+                )
             ],
             $attributes
         );
@@ -153,7 +153,7 @@ trait HasVersioning
         $implementation = WorkflowManager::NAYRA_PUBLISHER . get_class($this);
         $existsCustomPublisher = $implementation
             && WorkflowManager::existsServiceImplementation($implementation);
-        if ($existsCustomPublisher && $data !== []) {
+        if ($existsCustomPublisher) {
             $response = WorkflowManager::runServiceImplementation(
                 $implementation,
                 $data,
@@ -161,7 +161,6 @@ trait HasVersioning
                     'process' => $this,
                 ],
             );
-
             return $response['publishedVersion'];
         }
 
@@ -198,7 +197,6 @@ trait HasVersioning
     public function getDraftVersion(string $alternative = null)
     {
         $alternative = $alternative ?: ($this->alternative ?? null);
-
         return $this->versions()
             ->when(
                 $this->hasAlternative(),

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -155,7 +155,13 @@ trait HasVersioning
             && WorkflowManager::existsServiceImplementation($implementation);
         if ($existsCustomPublisher) {
             if ($data === []) {
-                abort(422, __('Oops! It looks like there was an error setting up the variables for your A/B test. Please contact the Administrator for assistance'));
+                abort(
+                    422,
+                    __(
+                        'Oops! It looks like there was an error setting up the variables for your A/B test. ' .
+                        'Please contact the Administrator for assistance'
+                    )
+                );
             }
 
             $response = WorkflowManager::runServiceImplementation(

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -7,9 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Schema;
 use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessMakerModel;
 use ProcessMaker\Models\ProcessRequest;
-use ProcessMaker\Models\Process;
 
 trait HasVersioning
 {
@@ -89,7 +89,7 @@ trait HasVersioning
                     $this->hasAlternative()
                     ? ['alternative' => $alternative]
                     : []
-                )
+                ),
             ],
             $attributes
         );
@@ -154,6 +154,10 @@ trait HasVersioning
         $existsCustomPublisher = $implementation
             && WorkflowManager::existsServiceImplementation($implementation);
         if ($existsCustomPublisher) {
+            if ($data === []) {
+                abort(422, __('Oops! It looks like there was an error setting up the variables for your A/B test. Please contact the Administrator for assistance'));
+            }
+
             $response = WorkflowManager::runServiceImplementation(
                 $implementation,
                 $data,
@@ -161,6 +165,7 @@ trait HasVersioning
                     'process' => $this,
                 ],
             );
+
             return $response['publishedVersion'];
         }
 
@@ -197,6 +202,7 @@ trait HasVersioning
     public function getDraftVersion(string $alternative = null)
     {
         $alternative = $alternative ?: ($this->alternative ?? null);
+
         return $this->versions()
             ->when(
                 $this->hasAlternative(),


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Import attached process
2. Search process and edit
3. Enable alternative B
4. Click on publish button
5. Click on A+B Alternatives
6. Go to A/B Settings
7. Type `age>21` in Expression field
8. Click on save and publish button
9. Go to +Case button
10. Type name of process 
11. Click on Start button

We get the next error: `Undefined variable "age". Variable "age" is not valid around position 1 for expression age>21`.

## Solution
- The alternative B is required when the age is over 21. However, when the process starts, the "age" variable is not present in the request data, causing the server error.
- The proposed solution shows the error message.

## How to Test
Follow the reproduction steps of above.

ci:next
ci:deploy
ci:package-ab-testing:observation/FOUR-15341

## Related Tickets & Packages
- [FOUR-15341](https://processmaker.atlassian.net/browse/FOUR-15341)
- [Package AB Testing PR](https://github.com/ProcessMaker/package-ab-testing/pull/60)

[FOUR-15341]: https://processmaker.atlassian.net/browse/FOUR-15341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ