### PR TITLE
SSO not working with 2FA

### DIFF
--- a/ProcessMaker/Http/Middleware/TwoFactorAuthentication.php
+++ b/ProcessMaker/Http/Middleware/TwoFactorAuthentication.php
@@ -20,7 +20,8 @@ class TwoFactorAuthentication
         if (config('password-policies.2fa_enabled', false) &&
             !empty(config('password-policies.2fa_method', [])) &&
             !session()->get(TwoFactorAuthController::TFA_VALIDATED, false) &&
-            TwoFactorAuthController::check2faByGroups()
+            TwoFactorAuthController::check2faByGroups() &&
+            session('sso_driver') === null
         ) {
             // If not validated display the 2FA code screen
             return redirect()->route('2fa');


### PR DESCRIPTION
## Issue & Reproduction Steps
When the user logs in using SSO, the 2FA authentication method must not be enabled.

## Solution
- Validate if the user was logged by SSO.

## How to Test
Configure SSO Login and Authentication 2FA.
loggin by SSO
the method of authentication 2FA must not be enabled.

## Related Tickets & Packages
- [FOUR-15329](https://processmaker.atlassian.net/browse/FOUR-15329)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:deploy

[FOUR-15329]: https://processmaker.atlassian.net/browse/FOUR-15329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ