### PR TITLE
FOUR-15350: Screen Template CSS Preview not working

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -11,7 +11,6 @@ use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\Screen as ScreenResource;
 use ProcessMaker\ImportExport\Exporter;
-use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Jobs\ExportScreen;
 use ProcessMaker\Jobs\ImportScreen;
 use ProcessMaker\Models\Screen;
@@ -231,9 +230,9 @@ class ScreenController extends Controller
         $screen->saveOrFail();
         $screen->syncProjectAsset($request, Screen::class);
 
-        //Creating temporary Key to store multiple id categories
+        // Creating temporary Key to store multiple id categories
         $newScreen['tmp_screen_category_id'] = $request->input('screen_category_id');
-        //Call event to store New Screen data in LOG
+        // Call event to store New Screen data in LOG
         ScreenCreated::dispatch($newScreen->getAttributes());
 
         return new ApiResource($screen);
@@ -279,10 +278,10 @@ class ScreenController extends Controller
         $screen->saveOrFail();
         $screen->syncProjectAsset($request, Screen::class);
 
-        //Call event to store Screen Changes into Log
+        // Call event to store Screen Changes into Log
         $request->validate(Screen::rules($screen));
         $changes = $screen->getChanges();
-        //Creating temporary Key to store multiple id categories
+        // Creating temporary Key to store multiple id categories
         $changes['tmp_screen_category_id'] = $request->input('screen_category_id');
         ScreenUpdated::dispatch($screen, $changes, $original);
         $this->updateScreenTemplate($screen);
@@ -429,7 +428,7 @@ class ScreenController extends Controller
     public function destroy(Screen $screen)
     {
         $screen->delete();
-        //Call new event to store changes in LOG
+        // Call new event to store changes in LOG
         ScreenDeleted::dispatch($screen);
 
         return response([], 204);
@@ -593,14 +592,17 @@ class ScreenController extends Controller
             ->update(['is_default_template' => 0]);
     }
 
-    private function updateScreenTemplate($screen)
+    private function updateScreenTemplate(Screen $screen): void
     {
         if ($screen->is_template && $screen->asset_type === 'SCREEN_TEMPLATE') {
             $screen->update(['is_template' => 0, 'asset_type' => null]);
             $exporter = new Exporter();
             $exporter->exportScreen($screen);
             ScreenTemplates::where('editing_screen_uuid', $screen->uuid)
-                ->update(['manifest' => json_encode($exporter->payload())]);
+                ->update([
+                    'manifest' => json_encode($exporter->payload()),
+                    'screen_custom_css' => $screen->custom_css,
+                ]);
             $screen->update(['is_template' => 1, 'asset_type' => 'SCREEN_TEMPLATE']);
         }
     }


### PR DESCRIPTION
## Issue & Reproduction Steps

CSS Preview not working when a screen template is edited and CSS is updated.

1. Edit an existing screen template
2. Add CSS
3. Save the screen template
4. Preview the CSS of that template

## Solution
- When a Screen Template is updated, only the associated screen is updated. The proposed solution is to also update the `custom_css` field in the screen_templates table.

## How to Test
- Follow the reproduction steps on deployed QA server.

ci:next
ci:deploy

## Related Tickets & Packages
- [FOUR-15350](https://processmaker.atlassian.net/browse/FOUR-15350)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15350]: https://processmaker.atlassian.net/browse/FOUR-15350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ