### PR TITLE
Observation/FOUR-15354: Getting Timeout Exceeded of 5000ms When trying to upload Image to Package-AI from Slow Connection

### DIFF
--- a/resources/views/layouts/ai-qr-mobile.blade.php
+++ b/resources/views/layouts/ai-qr-mobile.blade.php
@@ -46,38 +46,35 @@
     <link href="/css/bpmn-symbols/css/bpmn.css" rel="stylesheet">
     @yield('css')
     <script type="text/javascript">
-    @if(Auth::user())
-      window.Processmaker = {
-        csrfToken: "{{csrf_token()}}",
-        userId: "{{\Auth::user()->id}}",
-        messages: [],
-        apiTimeout: {{config('app.api_timeout')}}
+    window.Processmaker = {
+      csrfToken: "{{csrf_token()}}",
+      messages: [],
+      apiTimeout: {{config('app.api_timeout')}}
+    };
+    @if(config('broadcasting.default') == 'redis')
+      window.Processmaker.broadcasting = {
+        broadcaster: "socket.io",
+        host: "{{config('broadcasting.connections.redis.host')}}",
+        key: "{{config('broadcasting.connections.redis.key')}}"
       };
-      @if(config('broadcasting.default') == 'redis')
-        window.Processmaker.broadcasting = {
-          broadcaster: "socket.io",
-          host: "{{config('broadcasting.connections.redis.host')}}",
-          key: "{{config('broadcasting.connections.redis.key')}}"
-        };
+    @endif
+    @if(config('broadcasting.default') == 'pusher')
+      window.Processmaker.broadcasting = {
+        broadcaster: "pusher",
+        key: "{{config('broadcasting.connections.pusher.key')}}",
+        cluster: "{{config('broadcasting.connections.pusher.options.cluster')}}",
+        forceTLS: {{config('broadcasting.connections.pusher.options.use_tls') ? 'true' : 'false'}},
+        debug: {{config('broadcasting.connections.pusher.options.debug') ? 'true' : 'false'}},
+        enabledTransports: ['ws', 'wss'],
+        disableStats: true,
+      };
+      
+      @if(config('broadcasting.connections.pusher.options.host'))
+        window.Processmaker.broadcasting.wsHost = "{{config('broadcasting.connections.pusher.options.host')}}";
+        window.Processmaker.broadcasting.wsPort = "{{config('broadcasting.connections.pusher.options.port')}}";
+        window.Processmaker.broadcasting.wssPort = "{{config('broadcasting.connections.pusher.options.port')}}";
       @endif
-      @if(config('broadcasting.default') == 'pusher')
-        window.Processmaker.broadcasting = {
-          broadcaster: "pusher",
-          key: "{{config('broadcasting.connections.pusher.key')}}",
-          cluster: "{{config('broadcasting.connections.pusher.options.cluster')}}",
-          forceTLS: {{config('broadcasting.connections.pusher.options.use_tls') ? 'true' : 'false'}},
-          debug: {{config('broadcasting.connections.pusher.options.debug') ? 'true' : 'false'}},
-          enabledTransports: ['ws', 'wss'],
-          disableStats: true,
-        };
-        
-        @if(config('broadcasting.connections.pusher.options.host'))
-          window.Processmaker.broadcasting.wsHost = "{{config('broadcasting.connections.pusher.options.host')}}";
-          window.Processmaker.broadcasting.wsPort = "{{config('broadcasting.connections.pusher.options.port')}}";
-          window.Processmaker.broadcasting.wssPort = "{{config('broadcasting.connections.pusher.options.port')}}";
-        @endif
 
-      @endif
     @endif
   </script>
     @isset($addons)


### PR DESCRIPTION
## Issue & Reproduction Steps
When uploading large images in slow connections using the phone we get a timeout error

## Solution
- Removed the validation if user exists in our custom layout for AI mobile feature to correctly configure the timeout using the env variable

## How to Test
- You will need to inspect the browser on your phone. Go to network tab and simulate a throttling slow connection.
- Select an image and press Use this image button. 

## Related Tickets & Packages
- [FOUR-15354](https://processmaker.atlassian.net/browse/FOUR-15354)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
