### PR TITLE
Allow disabling task drafts with env var setting

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -13,6 +13,7 @@ use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Managers\ScreenBuilderManager;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\TaskDraft;
 use ProcessMaker\Models\UserResourceView;
 use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
 use ProcessMaker\Package\SavedSearch\Http\Controllers\SavedSearchController;
@@ -63,7 +64,9 @@ class TaskController extends Controller
             $defaultColumns = null;
         }
 
-        return view('tasks.index', compact('title', 'userFilter', 'defaultColumns'));
+        $taskDraftsEnabled = TaskDraft::draftsEnabled();
+
+        return view('tasks.index', compact('title', 'userFilter', 'defaultColumns', 'taskDraftsEnabled'));
     }
 
     public function edit(ProcessRequestToken $task, string $preview = '')
@@ -155,6 +158,7 @@ class TaskController extends Controller
                 'dataActionsAddons' => $this->getPluginAddons('edit.dataActions', []),
                 'currentUser' => $currentUser,
                 'screenFields' => $screenFields,
+                'taskDraftsEnabled' => TaskDraft::draftsEnabled(),
             ]);
         }
     }

--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -3,27 +3,43 @@
 namespace ProcessMaker\Http\Resources;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\Screen as ScreenResource;
-use ProcessMaker\Http\Resources\ScreenVersion as ScreenVersionResource;
-use ProcessMaker\Http\Resources\Users;
 use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
-use ProcessMaker\Models\TaskDraft;
 use ProcessMaker\Models\User;
-use ProcessMaker\ProcessTranslations\Languages;
-use ProcessMaker\ProcessTranslations\ProcessTranslation;
-use StdClass;
+use ProcessMaker\Traits\TaskResourceIncludes;
 
 class Task extends ApiResource
 {
+    use TaskResourceIncludes;
+
     private $loadedData = null;
 
-    private static $screenFields = [];
+    /**
+     * A list of includes that have methods `include{Name}`
+     * in the TaskResourceIncludes trait.
+     */
+    private $includeMethods = [
+        'data',
+        'user',
+        'requestor',
+        'processRequest',
+        'draft',
+        'component',
+        'screen',
+        'requestData',
+        'loopContext',
+        'definition',
+        'bpmnTagName',
+        'interstitial',
+        'userRequestPermission',
+    ];
+
+    private $process = null;
 
     /**
      * Transform the resource into an array.
@@ -33,97 +49,41 @@ class Task extends ApiResource
      */
     public function toArray($request)
     {
-        $dataManager = new DataManager();
         $array = parent::toArray($request);
         $include = explode(',', $request->input('include', ''));
-        if (in_array('data', $include)) {
-            $array['data'] = $this->getData();
-        }
-        if (in_array('user', $include)) {
-            $array['user'] = new Users($this->user);
-        }
-        if (in_array('requestor', $include)) {
-            $array['requestor'] = new Users($this->processRequest->user);
-        }
-        if (in_array('processRequest', $include)) {
-            $array['process_request'] = new Users($this->processRequest);
-        }
-        if (in_array('draft', $include)) {
-            $draft = $this->draft;
-            $array['draft'] = $draft;
-            if ($draft && !TaskDraft::draftsEnabled()) {
-                // Drafts are used to get data from quick-fill to the screen,
-                // but drafts are disabled so we need to delete it now that
-                // it's been accessed.
-                $draft->delete();
+
+        $this->process = Process::findOrFail($this->processRequest->process_id);
+
+        foreach ($this->includeMethods as $key) {
+            if (!in_array($key, $include)) {
+                continue;
             }
-        }
-
-        $parentProcessRequest = $this->processRequest->parentRequest;
-        $array['can_view_parent_request'] = $parentProcessRequest && $request->user()->can('view', $parentProcessRequest);
-        $process = Process::findOrFail($this->processRequest->process_id);
-
-        if (in_array('component', $include)) {
-            $array['component'] = $this->getScreenVersion() ? $this->getScreenVersion()->parent->renderComponent() : null;
-        }
-        if (in_array('screen', $include)) {
-            $screen = $this->getScreenVersion();
-            if ($screen) {
-                if ($screen->type === 'ADVANCED') {
-                    $array['screen'] = $screen;
-                } else {
-                    $resource = new ScreenVersionResource($screen);
-                    $array['screen'] = $resource->toArray($request);
-                }
+            $method = 'include' . ucfirst($key);
+            $result = $this->$method($request);
+            if (count($result) === 1) {
+                $resultKey = array_key_first($result);
+                $array[$resultKey] = $result[$resultKey];
             } else {
-                $array['screen'] = null;
-            }
-
-            if ($array['screen']) {
-                // Apply translations to screen
-                $processTranslation = new ProcessTranslation($process);
-                $array['screen']['config'] = $processTranslation->applyTranslations($array['screen']);
-
-                // Apply translations to nested screens
-                if (array_key_exists('nested', $array['screen'])) {
-                    foreach ($array['screen']['nested'] as &$nestedScreen) {
-                        $nestedScreen['config'] = $processTranslation->applyTranslations($nestedScreen);
-                    }
-                }
+                $array = array_merge($array, $result);
             }
         }
 
-        if (in_array('requestData', $include)) {
-            $data = new StdClass();
-            if ($this->processRequest->data) {
-                $task = $this->resource->loadTokenInstance();
-                $data = $dataManager->getData($task);
-            }
-            $array['request_data'] = $data;
-        }
-        if (in_array('loopContext', $include)) {
-            $array['loop_context'] = $this->getLoopContext();
-        }
-        if (in_array('definition', $include)) {
-            $array['definition'] = $this->getDefinition();
-        }
-        if (in_array('bpmnTagName', $include)) {
-            $array['bpmn_tag_name'] = $this->getBpmnDefinition()->localName;
-        }
-        if (in_array('interstitial', $include)) {
-            $interstitial = $this->getInterstitial();
-            $array['allow_interstitial'] = $interstitial['allow_interstitial'];
+        $this->addCanViewParentRequest($array, $request);
 
-            // Translate interstitials
-            $processTranslation = new ProcessTranslation($process);
-            $translatedConf = $processTranslation->applyTranslations($interstitial['interstitial_screen']);
-            $interstitial['interstitial_screen']['config'] = $translatedConf;
+        $this->addAssignableUsers($array, $include);
 
-            $array['interstitial_screen'] = $interstitial['interstitial_screen'];
-        }
-        if (in_array('userRequestPermission', $include)) {
-            $array['user_request_permission'] = $this->loadUserRequestPermission($this->processRequest, Auth::user(), []);
-        }
+        return $array;
+    }
+
+    private function addCanViewParentRequest(&$array, $request)
+    {
+        $parentProcessRequest = $this->processRequest->parentRequest;
+        $array['can_view_parent_request'] =
+            $parentProcessRequest && $request->user()->can('view', $parentProcessRequest);
+    }
+
+    private function addAssignableUsers(&$array, $include)
+    {
         /**
          * @deprecated since 4.1 Use instead `/api/1.0/users`
          */
@@ -132,7 +92,6 @@ class Task extends ApiResource
         $needToRecalculateAssignableUsers = !array_key_exists('assignable_users', $array)
                                                 || count($array['assignable_users']) < 1;
         if (in_array('assignableUsers', $include) && $needToRecalculateAssignableUsers) {
-            $nivel = array_search('request', array_column(debug_backtrace(), 'function'));
             $definition = $this->getDefinition();
             if (isset($definition['assignment']) && $definition['assignment'] == 'self_service') {
                 $users = [];
@@ -151,11 +110,9 @@ class Task extends ApiResource
                 $array['assignable_users'] = $users;
             }
         }
-
-        return $array;
     }
 
-    private function loadUserRequestPermission(ProcessRequest $request, User $user = null, array $permissions)
+    private function loadUserRequestPermission(ProcessRequest $request, User $user, array $permissions)
     {
         $permissions[] = [
             'process_request_id' => $request->id,
@@ -167,23 +124,6 @@ class Task extends ApiResource
         }
 
         return $permissions;
-    }
-
-    private function addUser($data, $user)
-    {
-        if (!$user) {
-            return $data;
-        }
-
-        $userData = $user->attributesToArray();
-        unset($userData['remember_token']);
-
-        $data = array_merge($data, ['_user' => $userData]);
-        if (!empty($this->token_properties['data'])) {
-            $data = array_merge($data, $this->token_properties['data']);
-        }
-
-        return $data;
     }
 
     private function getAssignedUsers($users)

--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -13,6 +13,7 @@ use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\TaskDraft;
 use ProcessMaker\Models\User;
 use ProcessMaker\ProcessTranslations\Languages;
 use ProcessMaker\ProcessTranslations\ProcessTranslation;
@@ -48,7 +49,14 @@ class Task extends ApiResource
             $array['process_request'] = new Users($this->processRequest);
         }
         if (in_array('draft', $include)) {
-            $array['draft'] = $this->draft;
+            $draft = $this->draft;
+            $array['draft'] = $draft;
+            if ($draft && !TaskDraft::draftsEnabled()) {
+                // Drafts are used to get data from quick-fill to the screen,
+                // but drafts are disabled so we need to delete it now that
+                // it's been accessed.
+                $draft->delete();
+            }
         }
 
         $parentProcessRequest = $this->processRequest->parentRequest;

--- a/ProcessMaker/Models/TaskDraft.php
+++ b/ProcessMaker/Models/TaskDraft.php
@@ -107,4 +107,9 @@ class TaskDraft extends ProcessMakerModel implements HasMedia
             $existingMediaItem->delete();
         }
     }
+
+    public static function draftsEnabled()
+    {
+        return config('app.task_drafts_enabled');
+    }
 }

--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace ProcessMaker\Traits;
+
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Http\Resources\ScreenVersion as ScreenVersionResource;
+use ProcessMaker\Http\Resources\Users;
+use ProcessMaker\Managers\DataManager;
+use ProcessMaker\Models\TaskDraft;
+use ProcessMaker\ProcessTranslations\ProcessTranslation;
+use StdClass;
+
+trait TaskResourceIncludes
+{
+    private function includeData()
+    {
+        return ['data' => $this->getData()];
+    }
+
+    private function includeUser()
+    {
+        return ['user' => new Users($this->user)];
+    }
+
+    private function includeRequestor()
+    {
+        return ['requestor' => new Users($this->processRequest->user)];
+    }
+
+    private function includeProcessRequest()
+    {
+        return ['process_request' => new Users($this->processRequest)];
+    }
+
+    private function includeDraft()
+    {
+        $draft = $this->draft;
+        if ($draft && !TaskDraft::draftsEnabled()) {
+            // Drafts are used to get data from quick-fill to the screen,
+            // but drafts are disabled so we need to delete it now that
+            // it's been accessed.
+            $draft->delete();
+        }
+
+        return ['draft' => $draft];
+    }
+
+    private function includeComponent()
+    {
+        $component = $this->getScreenVersion() ? $this->getScreenVersion()->parent->renderComponent() : null;
+
+        return ['component' => $component];
+    }
+
+    private function includeScreen($request)
+    {
+        $array = ['screen' => null];
+
+        $screen = $this->getScreenVersion();
+        if ($screen) {
+            if ($screen->type === 'ADVANCED') {
+                $array['screen'] = $screen;
+            } else {
+                $resource = new ScreenVersionResource($screen);
+                $array['screen'] = $resource->toArray($request);
+            }
+        } else {
+            $array['screen'] = null;
+        }
+
+        if ($array['screen']) {
+            // Apply translations to screen
+            $processTranslation = new ProcessTranslation($this->process);
+            $array['screen']['config'] = $processTranslation->applyTranslations($array['screen']);
+
+            // Apply translations to nested screens
+            if (array_key_exists('nested', $array['screen'])) {
+                foreach ($array['screen']['nested'] as &$nestedScreen) {
+                    $nestedScreen['config'] = $processTranslation->applyTranslations($nestedScreen);
+                }
+            }
+        }
+
+        return $array;
+    }
+
+    private function includeRequestData()
+    {
+        $dataManager = new DataManager();
+        $data = new StdClass();
+        if ($this->processRequest->data) {
+            $task = $this->resource->loadTokenInstance();
+            $data = $dataManager->getData($task);
+        }
+
+        return ['request_data' => $data];
+    }
+
+    private function includeLoopContext()
+    {
+        return ['loop_context' => $this->getLoopContext()];
+    }
+
+    private function includeDefinition()
+    {
+        return ['definition' => $this->getDefinition()];
+    }
+
+    private function includeBpmnTagName()
+    {
+        return ['bpmn_tag_name' => $this->getBpmnDefinition()->localName];
+    }
+
+    private function includeInterstitial()
+    {
+        $interstitial = $this->getInterstitial();
+
+        // Translate interstitials
+        $processTranslation = new ProcessTranslation($this->process);
+        $translatedConf = $processTranslation->applyTranslations($interstitial['interstitial_screen']);
+        $interstitial['interstitial_screen']['config'] = $translatedConf;
+
+        return [
+            'allow_interstitial' => $interstitial['allow_interstitial'],
+            'interstitial_screen' => $interstitial['interstitial_screen'],
+        ];
+    }
+
+    private function includeUserRequestPermission()
+    {
+        $userRequestPermission = $this->loadUserRequestPermission($this->processRequest, Auth::user(), []);
+
+        return ['user_request_permission' => $userRequestPermission];
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -230,4 +230,6 @@ return [
     'queue_imports' => env('QUEUE_IMPORTS', true),
 
     'node_bin_path' => env('NODE_BIN_PATH', '/usr/bin/node'),
+
+    'task_drafts_enabled' => env('TASK_DRAFTS_ENABLED', true),
 ];

--- a/resources/js/components/common/DataLoading.vue
+++ b/resources/js/components/common/DataLoading.vue
@@ -61,10 +61,10 @@
         props: ['loading', 'desc', 'icon', 'empty', 'emptyDesc', 'emptyIcon', 'for', 'dataLoadingId'],
         watch: {
             dataLoading() {
-                ProcessMaker.EventBus.$emit('api-data-loading', this.dataLoading);
+                ProcessMaker.EventBus.$emit('api-data-loading', this.dataLoading, this.dataLoadingId);
             },
             noResults() {
-                ProcessMaker.EventBus.$emit('api-data-no-results', this.noResults);
+                ProcessMaker.EventBus.$emit('api-data-no-results', this.noResults, this.dataLoadingId);
             }
         },
 
@@ -109,6 +109,7 @@
                 if (this.dataLoadingId === request.dataLoadingId) {
                     return true;
                 }
+                return false;
             },
             responseIdCheck(response) {
                 if (!this.dataLoadingId) {

--- a/resources/js/components/common/mixins/apiDataLoading.js
+++ b/resources/js/components/common/mixins/apiDataLoading.js
@@ -17,11 +17,18 @@ export default {
     },
   },
   mounted() {
-    ProcessMaker.EventBus.$on("api-data-loading", (val) => {
-      this.apiDataLoading = val;
+    ProcessMaker.EventBus.$on("api-data-loading", (val, id) => {
+      // Restrict the flag to the specified id, but only if an ID
+      // was sent. This is used when there are multiple DataLoading
+      // components on the page.
+      if (typeof id === "undefined" || this.dataLoadingId === id) {
+        this.apiDataLoading = val;
+      }
     });
-    ProcessMaker.EventBus.$on("api-data-no-results", (val) => {
-      this.apiNoResults = val;
+    ProcessMaker.EventBus.$on("api-data-no-results", (val, id) => {
+      if (typeof id === "undefined" || this.dataLoadingId === id) {
+        this.apiNoResults = val;
+      }
     });
   },
 };

--- a/resources/js/modules/autosave/autosaveMixin.js
+++ b/resources/js/modules/autosave/autosaveMixin.js
@@ -27,4 +27,9 @@ export default {
       }
     },
   },
+  computed: {
+    taskDraftsEnabled() {
+      return window.ProcessMaker?.taskDraftsEnabled ?? false;
+    },
+  },
 };

--- a/resources/js/tasks/components/PreviewMixin.js
+++ b/resources/js/tasks/components/PreviewMixin.js
@@ -1,5 +1,3 @@
-import { computed } from "vue";
-
 const PreviewMixin = {
   data() {
     return {

--- a/resources/js/tasks/components/PreviewMixin.js
+++ b/resources/js/tasks/components/PreviewMixin.js
@@ -1,3 +1,5 @@
+import { computed } from "vue";
+
 const PreviewMixin = {
   data() {
     return {
@@ -44,7 +46,7 @@ const PreviewMixin = {
       showReassignment: false,
       taskDefinition: {},
       user: {},
-      disableNavigation: false,
+      disableNavigationValue: false,
       actions: [
         {
           value: "clear-draft",
@@ -270,6 +272,19 @@ const PreviewMixin = {
       }
       this.ellipsisButton = false;
       return this.convertPercentageToPx(this.size) - 550;
+    },
+  },
+  computed: {
+    disableNavigation: {
+      get() {
+        if (this.taskDraftsEnabled === false) {
+          return false;
+        }
+        return this.disableNavigationValue;
+      },
+      set(value) {
+        this.disableNavigationValue = value;
+      },
     },
   },
 };

--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -100,6 +100,7 @@
                     variant="light"
                     v-b-tooltip.hover title="Clear Draft"
                     @click="eraseDraft()"
+                    v-if="taskDraftsEnabled"
                   >
                     <img src="/img/smartinbox-images/eraser.svg" :alt="$t('No Image')">
                   </b-button>
@@ -382,6 +383,9 @@ export default {
       });
     },
     autosaveApiCall() {
+      if (!this.taskDraftsEnabled) {
+        return;
+      }
       this.options.is_loading = true;
       const draftData = _.omitBy(this.formData, (value, key) => key.startsWith("_"));
       return ProcessMaker.apiClient
@@ -406,7 +410,9 @@ export default {
       ProcessMaker.apiClient
         .delete("drafts/" + this.task.id)
         .then(response => {
-          this.resetRequestFiles(response);
+          // No need to run resetRequestFiles here
+          // because the iframe gets reloaded after
+          // the draft is cleared
           this.isLoading = setTimeout(() => {
             this.stopFrame = true;
             this.taskTitle = this.$t("Task Lorem");

--- a/resources/js/tasks/index.js
+++ b/resources/js/tasks/index.js
@@ -53,6 +53,7 @@ new Vue({
         "_hide_badge": true
       }
     ],
+    taskDraftsEnabled: window.ProcessMaker.taskDraftsEnabled,
   },
   mounted() {
     ProcessMaker.EventBus.$on('advanced-search-addition', (component) => {

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -211,6 +211,7 @@
                                 type="button"
                                 class="btn btn-block button-actions"
                                 @click="eraseDraft()"
+                                v-if="taskDraftsEnabled"
                               >
                                 <img src="/img/smartinbox-images/eraser.svg" :alt="$t('No Image')">
                                 {{ __('Clear Draft') }}
@@ -227,7 +228,7 @@
                               <p class="section-title">@{{$t(dueLabel)}} @{{ moment().to(moment(completedAt)) }}</p>
                               @{{ moment(completedAt).format() }}
                             </li>
-                            <li class="list-group-item">
+                            <li class="list-group-item" v-if="taskDraftsEnabled">
                               <task-save-panel
                                 :options="options"
                                 :task="task"
@@ -375,6 +376,7 @@
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
     const userIsProcessManager = {{ Auth::user()->id === $task->process?->manager_id ? "true": "false" }};
     var screenFields = @json($screenFields);
+    window.ProcessMaker.taskDraftsEnabled = @json($taskDraftsEnabled);
 
   </script>
     @foreach($manager->getScripts() as $script)
@@ -665,6 +667,9 @@
             });
           },
           autosaveApiCall() {
+            if (!this.taskDraftsEnabled) {
+              return;
+            }
             this.options.is_loading = true;
             const draftData = {};
 

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -67,6 +67,7 @@
               @click.prevent="!isDataLoading ? switchTab('draft') : null"
               aria-selected="true"
               :class="{ 'active': draft }"
+              v-if="taskDraftsEnabled"
             >
               {{ __('Drafts') }}
             </a>
@@ -165,6 +166,7 @@
 
 @section('js')
     <script>
+      window.ProcessMaker.taskDraftsEnabled = @json($taskDraftsEnabled);
       window.ProcessMaker.advanced_filter = @json($userFilter);
       window.Processmaker.defaultColumns = @json($defaultColumns);
     </script>

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -428,16 +428,6 @@
               this.sendEvent('taskReady', this.task?.id);
             });
           },
-          autosaveApiCall() {
-            return ProcessMaker.apiClient
-            .put("drafts/" + this.task.id, this.formData)
-            .then(() => {
-              this.is_loading = true;
-            })
-            .finally(() => {
-              this.is_loading = false;
-            });
-          },
         },
         mounted() {
           this.prepareData();


### PR DESCRIPTION
## Issue & Reproduction Steps

We anticipate some clients will not want to use the task drafts feature

## Solution
- Allow disabling drafts by setting `TASK_DRAFTS_ENABLED` to false

## How to Test
This CI instance has drafts disabled. Ensure drafts are not being saved or loaded

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15349

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:TASK_DRAFTS_ENABLED=false