### PR TITLE
FOUR-15339: Improve saved search sorting performance

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -281,8 +281,6 @@ class TaskController extends Controller
 
         preg_match($regex, $e->getMessage(), $m);
 
-        dump($m);
-
         $message = __('PMQL Is Invalid.');
 
         if (count($m) > 1) {

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -122,9 +122,12 @@ class TaskController extends Controller
 
         $this->applyForCurrentUser($query, $user);
 
+        // Count up the total results
+        $totalCount = $query->count();
+
         // If only the total is being requested (by a Saved Search), send it now
         if ($getTotal === true) {
-            return $query->count();
+            return $totalCount;
         }
 
         // Apply filter overdue
@@ -133,7 +136,7 @@ class TaskController extends Controller
         // If we should manually add pagination to the
         // query in advance (also used by saved search)
         if ($this->isPaginationEnabled()) {
-            $query->paginate($request->input('per_page', 10));
+            $query->limit($request->input('per_page', 10));
         }
 
         try {
@@ -153,7 +156,7 @@ class TaskController extends Controller
 
         $response->inOverdue = $inOverdueQuery->count();
 
-        return new TaskCollection($response);
+        return new TaskCollection($response, $totalCount);
     }
 
     /**


### PR DESCRIPTION
## Issue
Sorting for saved searches with a large results (generally 1000+ tasks) are slow (3+ secs) when sorted.

### Reproduction Steps
1. Log in 
2. Go to Tasks page
3. Have 1000 or more tasks
4. Filters works to status column
5. Create a saved search
6. Use Filters to status column

## Solution
There were duplicate queries for selecting and counting the results of the saved search query, deduplicating them improve performance.

## How to Test
Resort the same saved search and notice the improved speed.

## Related Tickets & Packages
- [FOUR-15339](https://processmaker.atlassian.net/browse/FOUR-15339)
- [package-savedsearch PR](https://github.com/ProcessMaker/package-savedsearch/pull/438)

#### CICD
ci:next
ci:deploy
ci:package-savedsearch:bugfix/FOUR-15339

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

.


[FOUR-15339]: https://processmaker.atlassian.net/browse/FOUR-15339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ