### PR TITLE
bugfix/FOUR-15405 Quick fill, the columns from preview are cut

### DIFF
--- a/resources/js/tasks/components/QuickFillPreview.vue
+++ b/resources/js/tasks/components/QuickFillPreview.vue
@@ -51,6 +51,7 @@
           :columns="columns"
           :fetch-on-created="false"
           :selected-row-quick="selectedRowQuick"
+          :table-name="tasksListName"
           @selected="selected"
           :pmql="pmql"
           :advanced-filter-prop="quickFilter"
@@ -207,6 +208,7 @@ export default {
             value: "processRequest.case_number",
           },
           order_column: "process_requests.case_number",
+          width: 100,
         },
         {
           label: "Case title",
@@ -217,6 +219,7 @@ export default {
             value: "processRequest.case_title",
           },
           order_column: "process_requests.case_title",
+          width: 180,
         },
         {
           label: "Completed",
@@ -226,10 +229,12 @@ export default {
             type: "Field",
             value: "completed_at",
           },
+          width: 140,
         },
       ],
       dataTasks: {},
       disclaimer: this.$t("This is a Beta version and when using Quickfill, it may replace the pre-filled information in the form."),
+      tasksListName: "preview-table",
     };
   },
   mounted() {

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -10,6 +10,7 @@
         :unread="unreadColumnName"
         :loading="shouldShowLoader"
         :selected-row="selectedRow"
+        :table-name="tableName"
         @table-row-click="handleRowClick"
         @table-row-mouseover="handleRowMouseover"
         @table-row-mouseleave="handleRowMouseleave"
@@ -289,6 +290,10 @@ export default {
     openQuickFillFromRow: {
       type: Boolean,
       default: false,
+    },
+    tableName: {
+      type: String,
+      default: "",
     },
   },
   data() {


### PR DESCRIPTION
## Issue & Reproduction Steps
Quick fill, the columns from preview are cut

## Solution
The size of the tasks list columns is independent from the quickfill preview 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15405

ci:deploy
ci:next