### PR TITLE
FOUR-15401:The request list disappears with the selection of 30 or 50 items per page, LaunchPad

### DIFF
--- a/resources/js/components/shared/PaginationTable.vue
+++ b/resources/js/components/shared/PaginationTable.vue
@@ -93,6 +93,7 @@ export default {
         },
       ],
       pageInput: "",
+      defaulPage: 1,
     };
   },
   computed: {
@@ -140,6 +141,7 @@ export default {
       this.$emit("page-change", page);
     },
     changePerPage(value) {
+      this.goToPage(this.defaulPage);
       this.$emit("per-page-change", value);
     },
     redirectPage(value) {

--- a/resources/js/components/shared/PaginationTable.vue
+++ b/resources/js/components/shared/PaginationTable.vue
@@ -93,7 +93,7 @@ export default {
         },
       ],
       pageInput: "",
-      defaulPage: 1,
+      defaultPage: 1,
     };
   },
   computed: {
@@ -141,7 +141,7 @@ export default {
       this.$emit("page-change", page);
     },
     changePerPage(value) {
-      this.goToPage(this.defaulPage);
+      this.goToPage(this.defaultPage);
       this.$emit("per-page-change", value);
     },
     redirectPage(value) {


### PR DESCRIPTION
## Issue & Reproduction Steps
1.Go to /process-browser
2.Find a process with more than 15 requests created (eg: Verify Message Events)
3.Click on the process and see the requests
4.Go to the second page of the requests
5.Select 30 or 50 items

**Current Behavior:**

The list of requests disappears.

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-15401](https://processmaker.atlassian.net/browse/FOUR-15401)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:deploy

[FOUR-15401]: https://processmaker.atlassian.net/browse/FOUR-15401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ