### PR TITLE
Fix deactivation date selector for inbox rules

### DIFF
--- a/resources/js/inbox-rules/components/InboxRules.vue
+++ b/resources/js/inbox-rules/components/InboxRules.vue
@@ -174,8 +174,8 @@
           return "N/A";
         }
         let timezone = ProcessMaker.user.timezone;
-        let config = ProcessMaker.user.datetime_format;
-        return moment(value).tz(timezone).format(config);
+        let config = ProcessMaker.user.datetime_format.split(" ")[0];
+        return moment.utc(value).tz(timezone).format(config);
       },
       onChangeStatus(value, row) {
         let params = {


### PR DESCRIPTION
## Issue & Reproduction Steps
Deactivation dates were changing when clicking back when editing an inbox rule.

## Solution
- Refactor deactivation dates component to better handle timezones.

## How to Test
- Set your user's timezone to UTC
- Reproduce steps in the jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15398

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next