### PR TITLE
Server error displayed when opening processes in sidebar menu

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -4,7 +4,6 @@ namespace ProcessMaker\Http\Controllers;
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
@@ -13,7 +12,6 @@ use ProcessMaker\Jobs\ImportV2;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
-use ProcessMaker\Models\ProcessTemplates;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\User;
 use ProcessMaker\Traits\HasControllerAddons;
@@ -64,13 +62,11 @@ class ProcessController extends Controller
         ];
 
         $listConfig = (object) [
-            'processes' => Process::all(),
             'countCategories' => ProcessCategory::where(['status' => 'ACTIVE', 'is_system' => false])->count(),
             'status' => $request->input('status'),
         ];
 
         $listTemplates = (object) [
-            'process-templates' => ProcessTemplates::all(),
             'permissions' => [
                 'view'   => $request->user()->can('view-process-templates'),
                 'create' => $request->user()->can('create-process-templates'),


### PR DESCRIPTION
## Issue & Reproduction Steps
The page Processes is not displayed.

## Solution
- Remove unnecessary calls ProcesTemplate and Process

## How to Test
visit url /processes
The page Processes must be displayed correctly.

## Related Tickets & Packages
- [FOUR-15432](https://processmaker.atlassian.net/browse/FOUR-15432)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy


[FOUR-15432]: https://processmaker.atlassian.net/browse/FOUR-15432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ