### PR TITLE
Fix task requests running without specifying user

### DIFF
--- a/resources/js/common/advancedFilterStatusMixin.js
+++ b/resources/js/common/advancedFilterStatusMixin.js
@@ -27,8 +27,7 @@ export default {
   methods: {
     setAdvancedFilter() {
       this.advancedFilter = get(this.advancedFilterProp, 'filters') || get(window, 'ProcessMaker.advanced_filter.filters', []);
-      const doNotFetchOnPmqlChange = true; 
-      this.$refs.pmqlInputFilters?.buildPmql(doNotFetchOnPmqlChange);
+      this.$refs.pmqlInputFilters?.buildPmql();
     },
     formatForBadge(filters, result) {
       for(const filter of filters) {

--- a/resources/js/components/shared/PmqlInputFilters.vue
+++ b/resources/js/components/shared/PmqlInputFilters.vue
@@ -346,14 +346,11 @@ export default {
         name: false,
         projects: false,
       },
-      doNotFetchOnPmqlChange: false,
     };
   },
   watch: {
     pmql(query) {
-      if (!this.doNotFetchOnPmqlChange) {
-        this.$emit("filterspmqlchange", [query, this.getSelectedFilters()]);
-      }
+      this.$emit("filterspmqlchange", [query, this.getSelectedFilters()]);
     },
   },
   created() {
@@ -490,18 +487,13 @@ export default {
       return this.selectedFilters;
     },
 
-    buildPmql(doNotFetchOnPmqlChange = false) {
-      this.doNotFetchOnPmqlChange = doNotFetchOnPmqlChange;
+    buildPmql() {
       switch (this.type) {
         case 'requests':
           this.buildRequestPmql();
           break;
         case 'tasks':
-          this.$nextTick(() => {
-            let advancedFilter = this.advancedFilter;
-            this.buildTaskPmql(advancedFilter);
-          });
-          
+          this.buildTaskPmql(this.advancedFilter);
           break;
         case 'projects':
           this.buildProjectPmql();

--- a/resources/js/tasks/index.js
+++ b/resources/js/tasks/index.js
@@ -59,6 +59,9 @@ new Vue({
     ProcessMaker.EventBus.$on('advanced-search-addition', (component) => {
       this.additions.push(component);
     });
+    this.$nextTick(() => {
+      this.$refs.taskList.fetch();
+    });
   },
   created() {
     const params = new URL(document.location).searchParams;
@@ -137,7 +140,6 @@ new Vue({
     onFiltersPmqlChange(value) {
       this.filtersPmql = value[0];
       this.fullPmql = this.getFullPmql();
-      this.onSearch();
     },
     onNLQConversion(query) {
       this.onChange(query);

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -150,6 +150,7 @@
                 :columns="columns"
                 :disable-tooltip="false"
                 :disable-quick-fill-tooltip="false"
+                :fetch-on-created="false"
                 @in-overdue="setInOverdueMessage"
                 @data-loading="dataLoading"
                 @tab-count="handleTabCount"


### PR DESCRIPTION
## Issue & Reproduction Steps

The pmql to filter by the current user was missing in the initial task load so we were showing all tasks to the admin user.

## Solution
- Do not load tasks when the component is created. Instead do it on mounted and wait for the nextTick to ensure all the pmql-input filters have been parsed.
- Remove unnecessary doNotFetchOnPmqlChange flag
- Remove unnecessary call to onSearch() to prevent duplicate task calls.

## How to Test
- Follow the steps in the jira issue
- Additionally, re-test https://processmaker.atlassian.net/browse/FOUR-14325

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15444
- Re-test: https://processmaker.atlassian.net/browse/FOUR-14325

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy