### PR TITLE
FOUR-15465: When we enter the Templates tab, the more templates we have created, the longer it takes to show the list

### DIFF
--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -7,7 +7,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\View\View;
 use ProcessMaker\Events\TemplateCreated;
 use ProcessMaker\Http\Controllers\Api\ExportController;
 use ProcessMaker\ImportExport\Exporter;
@@ -47,7 +46,23 @@ class ProcessTemplate implements TemplateInterface
 
         $filter = $request->input('filter');
 
-        $templates = $templates->select('process_templates.*')
+        $templates = $templates
+            ->select(
+                'process_templates.id',
+                'process_templates.uuid',
+                'process_templates.key',
+                'process_templates.name',
+                'process_templates.description',
+                'process_templates.version',
+                'process_templates.process_id',
+                'process_templates.editing_process_uuid',
+                'process_templates.user_id',
+                'process_templates.process_category_id',
+                'process_templates.is_system',
+                'process_templates.asset_type',
+                'process_templates.created_at',
+                'process_templates.updated_at',
+            )
             ->leftJoin('process_categories as category', 'process_templates.process_category_id', '=', 'category.id')
             ->leftJoin('users as user', 'process_templates.user_id', '=', 'user.id')
             ->orderBy(...$orderBy)
@@ -457,9 +472,7 @@ class ProcessTemplate implements TemplateInterface
      */
     public function destroy(int $id) : bool
     {
-        $response = ProcessTemplates::where('id', $id)->delete();
-
-        return $response;
+        return ProcessTemplates::where('id', $id)->delete();
     }
 
     /**
@@ -501,9 +514,8 @@ class ProcessTemplate implements TemplateInterface
     public function getManifest(string $type, int $id) : array
     {
         $response = (new ExportController)->manifest($type, $id);
-        $content = json_decode($response->getContent(), true);
 
-        return $content;
+        return json_decode($response->getContent(), true);
     }
 
     /**

--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -4,7 +4,6 @@ namespace ProcessMaker\Templates;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Events\TemplateCreated;
@@ -16,7 +15,6 @@ use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessTemplates;
-use ProcessMaker\Models\Template;
 use ProcessMaker\Models\WizardTemplate;
 use ProcessMaker\Traits\HasControllerAddons;
 use SebastianBergmann\CodeUnit\Exception;
@@ -28,6 +26,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 class ProcessTemplate implements TemplateInterface
 {
     use HasControllerAddons;
+    use TemplateRequestHelperTrait;
 
     const PROJECT_ASSET_MODEL_CLASS = 'ProcessMaker\Package\Projects\Models\ProjectAsset';
 
@@ -40,14 +39,13 @@ class ProcessTemplate implements TemplateInterface
      */
     public function index(Request $request)
     {
-        $orderBy = $this->getRequestSortBy($request, 'name');
-        $include = $this->getRequestInclude($request);
-        $templates = ProcessTemplates::nonSystem()->with($include);
-
-        $filter = $request->input('filter');
-
-        $templates = $templates
-            ->select(
+        return ProcessTemplates::nonSystem()
+            ->with($this->getRequestInclude($request))
+            ->withFilters($request->input('filter'))
+            ->orderBy(...$this->getRequestSortBy($request, 'name'))
+            ->leftJoin('process_categories as category', 'process_templates.process_category_id', '=', 'category.id')
+            ->leftJoin('users as user', 'process_templates.user_id', '=', 'user.id')
+            ->select([
                 'process_templates.id',
                 'process_templates.uuid',
                 'process_templates.key',
@@ -62,28 +60,8 @@ class ProcessTemplate implements TemplateInterface
                 'process_templates.asset_type',
                 'process_templates.created_at',
                 'process_templates.updated_at',
-            )
-            ->leftJoin('process_categories as category', 'process_templates.process_category_id', '=', 'category.id')
-            ->leftJoin('users as user', 'process_templates.user_id', '=', 'user.id')
-            ->orderBy(...$orderBy)
-            ->where(function ($query) use ($filter) {
-                $query->where('process_templates.name', 'like', '%' . $filter . '%')
-                    ->orWhere('process_templates.description', 'like', '%' . $filter . '%')
-                    ->orWhere('user.firstname', 'like', '%' . $filter . '%')
-                    ->orWhere('user.lastname', 'like', '%' . $filter . '%')
-                    ->orWhereIn('process_templates.id', function ($qry) use ($filter) {
-                        $qry->select('assignable_id')
-                            ->from('category_assignments')
-                            ->leftJoin('process_categories', function ($join) {
-                                $join->on('process_categories.id', '=', 'category_assignments.category_id');
-                                $join->where('category_assignments.category_type', '=', ProcessCategory::class);
-                                $join->where('category_assignments.assignable_type', '=', ProcessTemplates::class);
-                            })
-                            ->where('process_categories.name', 'like', '%' . $filter . '%');
-                    });
-            })->get();
-
-        return $templates;
+            ])
+            ->get();
     }
 
     /**
@@ -500,51 +478,6 @@ class ProcessTemplate implements TemplateInterface
         } catch (\Exception $e) {
             return response()->json(['message' => $e->getMessage()], 422);
         }
-    }
-
-    /**
-     * Get process template manifest.
-     *
-     * @param string $type
-     *
-     * @param Request $request
-     *
-     * @return array
-     */
-    public function getManifest(string $type, int $id) : array
-    {
-        $response = (new ExportController)->manifest($type, $id);
-
-        return json_decode($response->getContent(), true);
-    }
-
-    /**
-     * Get included relationships.
-     *
-     * @param Request $request
-     *
-     * @return array
-     */
-    protected function getRequestSortBy(Request $request, $default) : array
-    {
-        $column = $request->input('order_by', $default);
-        $direction = $request->input('order_direction', 'asc');
-
-        return [$column, $direction];
-    }
-
-    /**
-     * Get included relationships.
-     *
-     * @param Request $request
-     *
-     * @return array
-     */
-    protected function getRequestInclude(Request $request) : array
-    {
-        $include = $request->input('include');
-
-        return $include ? explode(',', $include) : [];
     }
 
     /**

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Events\TemplateCreated;
 use ProcessMaker\Helpers\ScreenTemplateHelper;
-use ProcessMaker\Http\Controllers\Api\ExportController;
 use ProcessMaker\ImportExport\Importer;
 use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Models\Screen;
@@ -27,6 +26,7 @@ class ScreenTemplate implements TemplateInterface
 {
     use HasControllerAddons;
     use HideSystemResources;
+    use TemplateRequestHelperTrait;
 
     const PROJECT_ASSET_MODEL_CLASS = 'ProcessMaker\Package\Projects\Models\ProjectAsset';
 
@@ -481,47 +481,6 @@ class ScreenTemplate implements TemplateInterface
         }
 
         return null;
-    }
-
-    /**
-     * Get process template manifest.
-     *
-     * @param string $type
-     * @param Request $request
-     * @return array
-     */
-    public function getManifest(string $type, int $id) : array
-    {
-        $response = (new ExportController)->manifest($type, $id);
-
-        return json_decode($response->getContent(), true);
-    }
-
-    /**
-     * Get included relationships.
-     *
-     * @param Request $request
-     * @return array
-     */
-    protected function getRequestSortBy(Request $request, $default) : array
-    {
-        $column = $request->input('order_by', $default);
-        $direction = $request->input('order_direction', 'asc');
-
-        return [$column, $direction];
-    }
-
-    /**
-     * Get included relationships.
-     *
-     * @param Request $request
-     * @return array
-     */
-    protected function getRequestInclude(Request $request) : array
-    {
-        $include = $request->input('include');
-
-        return $include ? explode(',', $include) : [];
     }
 
     /**

--- a/ProcessMaker/Templates/TemplateRequestHelperTrait.php
+++ b/ProcessMaker/Templates/TemplateRequestHelperTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ProcessMaker\Templates;
+
+use Illuminate\Http\Request;
+use ProcessMaker\Http\Controllers\Api\ExportController;
+
+trait TemplateRequestHelperTrait
+{
+    /**
+     * Get process template manifest.
+     */
+    public function getManifest(string $type, int $id): array
+    {
+        $response = (new ExportController)->manifest($type, $id);
+
+        return json_decode($response->getContent(), true);
+    }
+
+    /**
+     * Get sort parameters from request.
+     */
+    protected function getRequestSortBy(Request $request, string $default): array
+    {
+        $column = $request->input('order_by', $default);
+        $direction = $request->input('order_direction', 'asc');
+
+        return [$column, $direction];
+    }
+
+    /**
+     * Get included relationships from request.
+     */
+    protected function getRequestInclude(Request $request) : array
+    {
+        $include = $request->input('include');
+
+        return $include ? explode(',', $include) : [];
+    }
+}

--- a/tests/Feature/Templates/Api/ProcessTemplateTest.php
+++ b/tests/Feature/Templates/Api/ProcessTemplateTest.php
@@ -26,6 +26,30 @@ class ProcessTemplateTest extends TestCase
     use HelperTrait;
     use WithFaker;
 
+    public function testIndex()
+    {
+        $this->addGlobalSignalProcess();
+        ProcessTemplates::factory()->count(10)->create();
+
+        $params = [
+            'per_page' => 10,
+            'filter' => '',
+            'order_by' => 'name',
+            'order_direction' => 'asc',
+            'include' => 'user,category,categories  ',
+        ];
+        $response = $this->apiCall('GET', route('api.template.index', ['type' => 'process']), $params);
+        $response->assertStatus(200);
+
+        $content = json_decode($response->getContent(), true);
+        $data = $content['data'];
+        $this->assertCount(10, $data);
+
+        // Assert that the data does not contain these fields to optimize the load.
+        $this->assertArrayNotHasKey('svg', $data[0]);
+        $this->assertArrayNotHasKey('manifest', $data[0]);
+    }
+
     public function testNotAllowingToSaveDuplicateTemplateWithTheSameName()
     {
         $this->addGlobalSignalProcess();
@@ -355,7 +379,7 @@ class ProcessTemplateTest extends TestCase
      */
     private function createProcessesFromTemplate($template, $user, $processCategoryId)
     {
-        $response = $this->apiCall(
+        return $this->apiCall(
             'POST',
             route('api.template.create', [
                 'type' => 'process',
@@ -371,8 +395,6 @@ class ProcessTemplateTest extends TestCase
                 'saveAssetMode' => 'saveAllAssets',
             ]
         );
-
-        return $response;
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
When we have more than 100 templates, when entering the Templates tab, it takes a while to enter the list of templates.

1. Click on Designer 
2. Click on Processes 
3. Click on Templates

## Solution
- The columns `svg` and `manifest` were excluded from the API index endpoint because their use is not necessary and they contain large amounts of data, which made the load excessive.

## How to Test
- Conduct tests with a large number of records in process_templates, both with and without the changes; you will notice that the response time of the request is considerably lower.

## Related Tickets & Packages
- [FOUR-15465](https://processmaker.atlassian.net/browse/FOUR-15465)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15465]: https://processmaker.atlassian.net/browse/FOUR-15465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ