### PR TITLE
Remove status column, update copy, and fix badges on inbox rules

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -37,6 +37,7 @@ class Task extends ApiResource
         'bpmnTagName',
         'interstitial',
         'userRequestPermission',
+        'process',
     ];
 
     private $process = null;

--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -106,7 +106,7 @@ trait TaskResourceIncludes
         return ['definition' => $this->getDefinition()];
     }
 
-    private function includebpmnTagName()
+    private function includeBpmnTagName()
     {
         return ['bpmn_tag_name' => $this->getbpmndefinition()->localname];
     }

--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -106,9 +106,14 @@ trait TaskResourceIncludes
         return ['definition' => $this->getDefinition()];
     }
 
-    private function includeBpmnTagName()
+    private function includebpmnTagName()
     {
-        return ['bpmn_tag_name' => $this->getBpmnDefinition()->localName];
+        return ['bpmn_tag_name' => $this->getbpmndefinition()->localname];
+    }
+
+    private function includeProcess()
+    {
+        return ['process' => $this->process];
     }
 
     private function includeInterstitial()

--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -108,7 +108,7 @@ trait TaskResourceIncludes
 
     private function includeBpmnTagName()
     {
-        return ['bpmn_tag_name' => $this->getbpmndefinition()->localname];
+        return ['bpmn_tag_name' => $this->getBpmnDefinition()->localName];
     }
 
     private function includeProcess()

--- a/resources/js/components/PMBadgesFilters.vue
+++ b/resources/js/components/PMBadgesFilters.vue
@@ -43,7 +43,8 @@
     props: [
       "value",
       "advancedFilterProp",
-      "showPmqlBadge"
+      "showPmqlBadge",
+      "task"
     ],
     data() {
       return {
@@ -87,7 +88,7 @@
       formatAdvancedFilterForBadges() {
         let result = [];
         if (Array.isArray(this.advancedFilter)) {
-          this.formatForBadge(this.advancedFilter, result);
+          result = this.formatForBadge(this.advancedFilter, result);
         }
         return result;
       }
@@ -132,9 +133,31 @@
             this.formatForBadge(filter.or, result);
           }
         }
+        return this.makeUserFriendly(result);
       },
       formatBadgeSubject(filter) {
         return get(filter, '_column_label', get(filter, 'subject.value', ''));
+      },
+      makeUserFriendly(result) {
+        return result.map(badge => {
+          const modified = _.cloneDeep(badge);
+          switch(badge[0]) {
+            case 'user_id':
+              modified[0] = 'User';
+              modified[1][0].name = window.ProcessMaker.user.fullName;
+              return modified;
+            case 'process_id':
+              modified[0] = 'Process';
+              modified[1][0].name = this.task.process.name.substring(0, 30);
+              return modified;
+            case 'element_id':
+              modified[0] = 'Task';
+              modified[1][0].name = this.task.element_name.substring(0, 30);
+              return modified;
+            default:
+              return badge;
+          }
+        });
       }
     }
   }

--- a/resources/js/inbox-rules/components/InboxRuleFilters.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFilters.vue
@@ -52,7 +52,6 @@
               <span class="no-rule-class-text">
                 {{ $t("But that's OK. You can still create this this Inbox Rule to apply to future tasks that match the above filters.") }}
               </span>
-              </span>
             </template>
           </PMMessageScreen>
         </template>

--- a/resources/js/inbox-rules/components/InboxRuleFilters.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFilters.vue
@@ -6,7 +6,8 @@
           <img src="/img/funnel-fill-elements-blue.svg" 
                :alt="$t('Select a saved search above.')"/>
           <b class="no-rule-class-title">{{ $t('Select a saved search above.') }}</b>
-          <span class="no-rule-class-text" v-html="$t('Choose a saved search to see the tasks that you can use with an Inbox Rule.')">
+          <span class="no-rule-class-text">
+            {{ $t('Choose a saved search to see the tasks that you can use with an Inbox Rule.') }}
           </span>
         </template>
       </PMMessageScreen>

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -387,7 +387,7 @@ export default {
           record["element_name"] = this.formatActiveTask(record);
         }
       }
-      this.$emit('count', newData.meta?.count);
+      this.$emit('count', newData.meta?.total);
       this.$emit("tab-count", newData.meta?.total);
     },
     shouldShowLoader(value) {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2254,5 +2254,9 @@
   "Must be a valid Date" : "Must be a valid Date",
   "Should NOT have more than {max} items" : "Should NOT have more than {max} items",
   "Must have at least {min}" : "Must have at least {min}",
-  "Invalid type" : "Invalid type"
+  "Invalid type" : "Invalid type",
+  "Your In-Progress tasks in the saved search {{title}}": "Your In-Progress tasks in the saved search {{title}}",
+  "Choose a saved search to see the tasks that you can use with an Inbox Rule.": "Choose a saved search to see the tasks that you can use with an Inbox Rule.",
+  "No tasks to show.": "No tasks to show.",
+  "But that's OK. You can still create this this Inbox Rule to apply to future tasks that match the above filters.": "But that's OK. You can still create this this Inbox Rule to apply to future tasks that match the above filters."
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
- Status column was showing when creating a new inbox rule. Its unnecessary and confusing because only In Progress tasks can have an inbox rule.
- Wording was incorrect on Inbox Rule when there were no results
- Filter badges were not user friendly

## Solution
- Refactor to fix the above issues

## How to Test
- Ensure there is no Status column when creating a new inbox rule from a Task or Saved Search
- Ensure the badges look correct
- Ensure the no-results text that displays is correct

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15450

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next