### PR TITLE
FOUR-14196 Added a migration to set the anonymous user to be in UTC

### DIFF
--- a/database/migrations/2024_05_08_153742_update_anonymous_user_timezone_to_u_t_c.php
+++ b/database/migrations/2024_05_08_153742_update_anonymous_user_timezone_to_u_t_c.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use ProcessMaker\Models\User;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        User::where('username', '_pm4_anon_user')->update([
+            'timezone' => 'UTC'
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        User::where('username', '_pm4_anon_user')->update([
+            'timezone' => 'America/Los_Angeles'
+        ]);
+    }
+};


### PR DESCRIPTION
## Solution
- For anonymous user, we want the timezone to be in UTC, to stop guessing where the user is located physically.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14196
- https://processmaker.atlassian.net/browse/FOUR-14060

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:vue-form-elements:FOUR-14060-1
