### PR TITLE
Fix Regression: Hide Inactive PM Blocks in Modeler Left Rail

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -60,6 +60,7 @@ class ModelerController extends Controller
         // Otherwise, render the default modeler interface view with prepared data
         return view($defaultView, $this->prepareModelerData($manager, $process, $request, 'A'));
     }
+
     /**
      * Prepare data for displaying a process in the modeler.
      *
@@ -89,7 +90,7 @@ class ModelerController extends Controller
         $countProcessCategories = ProcessCategory::where(['status' => 'ACTIVE', 'is_system' => false])->count();
 
         // Retrieve screen types and count screen categories for creating screen modal
-        $screenTypes = ScreenType::pluck('name')->map(fn($type) => __(ucwords(strtolower($type))))->sort()->toArray();
+        $screenTypes = ScreenType::pluck('name')->map(fn ($type) => __(ucwords(strtolower($type))))->sort()->toArray();
         $countScreenCategories = ScreenCategory::where(['status' => 'ACTIVE', 'is_system' => false])->count();
 
         // Check if Projects and AI packages are installed
@@ -122,8 +123,7 @@ class ModelerController extends Controller
             'manager' => $manager,
             'signalPermissions' => SignalManager::permissions($request->user()),
             'autoSaveDelay' => config('versions.delay.process', 5000),
-            'isVersionsInstalled' =>
-                PackageHelper::isPackageInstalled('ProcessMaker\Package\Versions\PluginServiceProvider'),
+            'isVersionsInstalled' => PackageHelper::isPackageInstalled('ProcessMaker\Package\Versions\PluginServiceProvider'),
             'isDraft' => $draft !== null,
             'draftAlternative' => $draft !== null ? $draft->alternative : null,
             'pmBlockList' => $pmBlockList,
@@ -138,8 +138,7 @@ class ModelerController extends Controller
             'isAiGenerated' => request()->query('ai'),
             'runAsUserDefault' => $runAsUserDefault,
             'alternative' => $alternative,
-            'abPublish' =>
-                PackageHelper::isPackageInstalled('ProcessMaker\Package\PackageABTesting\PackageServiceProvider'),
+            'abPublish' => PackageHelper::isPackageInstalled('ProcessMaker\Package\PackageABTesting\PackageServiceProvider'),
         ];
     }
 
@@ -219,7 +218,7 @@ class ModelerController extends Controller
         $pmBlockList = null;
         if (hasPackage('package-pm-blocks')) {
             $controller = new PmBlockController();
-            $newRequest = new Request(['per_page' => 10000]);
+            $newRequest = new Request(['status' => 'active', 'per_page' => 10000]);
             $response = $controller->index($newRequest);
             if ($response->response($newRequest)->status() === 200) {
                 $pmBlockList = json_decode($response->response()->content())->data;
@@ -276,7 +275,8 @@ class ModelerController extends Controller
         ]);
     }
 
-    private function getVersion($promptVersionId, $type) {
+    private function getVersion($promptVersionId, $type)
+    {
         $aiMicroserviceHost = config('app.ai_microservice_host');
         $url = $aiMicroserviceHost . '/pm/getPromptVersion';
 
@@ -293,7 +293,7 @@ class ModelerController extends Controller
                 'processVersionId' => $promptVersionId,
             ];
         }
-        
+
         return Http::withHeaders($headers)->post($url, $params);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses a regression where PM Blocks with the 'Inactive' status were still appearing in the Modeler left PM Block rail. The issue stemmed from a missing request parameter `status=active` when retrieving the PM Block list, causing inactive PM Blocks to be included in the response.


## Solution
To resolve this, the missing request parameter `status=active` has been added to ensure that only active PM Blocks are retrieved and displayed in the Modeler left rail.

## How to Test

1. Create a PM Block.
2. Configure the PM Block and update the status to 'INACTIVE'.
3. Save the configurations.
4. Open a process in Modeler.
5. Select 'PM Blocks' in the left rail menu.
6. Ensure that the inactive PM Block is not displayed in the left rail.
7. Repeat the test with multiple inactive PM Blocks to confirm consistent behavior.
8. Create and activate a PM Block to ensure it appears in the left rail.

## Related Tickets & Packages
- [FOUR-15468](https://processmaker.atlassian.net/browse/FOUR-15468)

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15468]: https://processmaker.atlassian.net/browse/FOUR-15468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ