### PR TITLE
QA Observation bugfix/FOUR-15471: The pager of the listed requests of a process from launch pad Processes, is shown very close to the edge of the frame

### DIFF
--- a/resources/js/processes-catalogue/components/RequestTab.vue
+++ b/resources/js/processes-catalogue/components/RequestTab.vue
@@ -11,6 +11,7 @@
         @table-row-click="handleRowClick"
       />
       <pagination-table
+        class="custom-pagination"
         :meta="dataRequests.meta"
         @page-change="changePageRequests"
         @per-page-change="changePerPage"
@@ -252,9 +253,19 @@ export default {
   },
 };
 </script>
-<style>
+<style scoped>
 .text-style {
   margin-bottom: 10px;
   color: #556271;
+}
+.custom-pagination{
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  margin-top: 10px;
+  font-weight: 400;
+  font-size: 15px;
+  color: #5C5C63;
+  padding-bottom: 10px;
 }
 </style>

--- a/resources/js/processes-catalogue/components/RequestTab.vue
+++ b/resources/js/processes-catalogue/components/RequestTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      class="bg-white"
+      class="bg-white class-container"
       v-if="!showTabRequests"
     >
       <filter-table
@@ -267,5 +267,8 @@ export default {
   font-size: 15px;
   color: #5C5C63;
   padding-bottom: 10px;
+}
+.class-container{
+  padding-left: 8px;
 }
 </style>

--- a/resources/js/processes-catalogue/components/TaskTab.vue
+++ b/resources/js/processes-catalogue/components/TaskTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      class="bg-white"
+      class="bg-white class-container"
       v-if="!showTabTasks"
     >
       <filter-table
@@ -294,5 +294,8 @@ export default {
   font-size: 15px;
   color: #5C5C63;
   padding-bottom: 10px;
+}
+.class-container{
+  padding-left: 8px;
 }
 </style>

--- a/resources/js/processes-catalogue/components/TaskTab.vue
+++ b/resources/js/processes-catalogue/components/TaskTab.vue
@@ -10,6 +10,7 @@
         table-name="task-tab"
       />
       <pagination-table
+        class="custom-pagination"
         :meta="dataTasks.meta"
         @page-change="changePageTasks"
         @per-page-change="changePerPage"
@@ -279,9 +280,19 @@ export default {
   },
 };
 </script>
-<style>
+<style scoped>
 .text-style {
   margin-bottom: 10px;
   color: #556271;
+}
+.custom-pagination{
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  margin-top: 10px;
+  font-weight: 400;
+  font-size: 15px;
+  color: #5C5C63;
+  padding-bottom: 10px;
 }
 </style>


### PR DESCRIPTION
## Solution
- Space was added between Paginator and bottom edge of screen

## How to Test
- Log in
- Go To Process Browser (Launchpad window)
- Select Request and Task Tabs
- Check paginator, there must be a little space between paginator and bottom edge of screen

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15471

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next