### PR TITLE
FOUR-15845: 500 error exporting Processes, LaunchPad as the root cause

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
@@ -15,7 +15,8 @@ class ProcessLaunchpadExporter extends ExporterBase
         $this->addDependent('user', $this->model->user, UserExporter::class);
 
         $properties = json_decode($this->model->properties, true);
-        $launchScreen = Screen::where('uuid', $properties['screen_uuid'])->first();
+        $screenUuid = $properties['screen_uuid'] ?? null;
+        $launchScreen = Screen::where('uuid', $screenUuid)->first();
         if ($launchScreen) {
             $this->addDependent('screen', $launchScreen, ScreenExporter::class);
         }


### PR DESCRIPTION
## Issue & Reproduction Steps

Processes created before 4.10.0 and that don’t have launchpad configured can’t be exported, a 500 error is returned.

## Solution
- Prevent the "Undefined array key" error when working with arrays that might not have certain keys, using null coalesce operator to provide a default value if the key does not exist.

## How to Test
1. Have processes created before 4.10.0.
2. Make sure they don’t have the`process_launchpad` configured.
3. Try to export the process and see the 500 error.

`php artisan test --filter ProcessLaunchpadExporterTest` should pass as well.

## Related Tickets & Packages
- [FOUR-15845](https://processmaker.atlassian.net/browse/FOUR-15845)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy

[FOUR-15845]: https://processmaker.atlassian.net/browse/FOUR-15845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ