### PR TITLE
FOUR-16117 | When Creating Processes From a Template, the Process View is Not Displayed

### DIFF
--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -56,6 +56,7 @@ class ProcessTemplate implements TemplateInterface
                 'process_templates.editing_process_uuid',
                 'process_templates.user_id',
                 'process_templates.process_category_id',
+                'process_templates.svg',
                 'process_templates.is_system',
                 'process_templates.asset_type',
                 'process_templates.created_at',

--- a/tests/Feature/Templates/Api/ProcessTemplateTest.php
+++ b/tests/Feature/Templates/Api/ProcessTemplateTest.php
@@ -45,6 +45,9 @@ class ProcessTemplateTest extends TestCase
         $data = $content['data'];
         $this->assertCount(10, $data);
 
+        // Assert that the data contains the svg field, for template image rendering in the UI.
+        $this->assertArrayHasKey('svg', $data[0]);
+
         // Assert that the data does not contain the manifest field, to optimize the load.
         $this->assertArrayNotHasKey('manifest', $data[0]);
     }

--- a/tests/Feature/Templates/Api/ProcessTemplateTest.php
+++ b/tests/Feature/Templates/Api/ProcessTemplateTest.php
@@ -45,8 +45,7 @@ class ProcessTemplateTest extends TestCase
         $data = $content['data'];
         $this->assertCount(10, $data);
 
-        // Assert that the data does not contain these fields to optimize the load.
-        $this->assertArrayNotHasKey('svg', $data[0]);
+        // Assert that the data does not contain the manifest field, to optimize the load.
         $this->assertArrayNotHasKey('manifest', $data[0]);
     }
 


### PR DESCRIPTION
# Issue
Ticket: [FOUR-16117](https://processmaker.atlassian.net/browse/FOUR-16117)

When creating a new Process by selecting a Process Template, the preview image associated with the template is not displayed in the `SelectTemplateModal`. This makes it difficult for users to visually identify the desired template during selection.

# Solution
- Update the Process Templates query (see `ProcessTemplate.php`) to fetch `process_templates.svg` for UI rendering.

# How to Test

1. Go to branch `observation/FOUR-16117` in `processmaker`.
2. Go to Designer → Process → +PROCESS → Select a Template.
3. In the Template Details, the Template Preview should display.

ci:next
ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-16117]: https://processmaker.atlassian.net/browse/FOUR-16117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ