### PR TITLE
bugfix/FOUR-15999: Default logo and default chart are not visible after upgrade in launch pad

### DIFF
--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -216,11 +216,11 @@ export default {
           const launchpadProperties = unparseProperties ? JSON.parse(unparseProperties) : "";
           if (launchpadProperties && Object.keys(launchpadProperties).length > 0) {
             this.selectedSavedChart = {
-              id: launchpadProperties.saved_chart_id ?? this.defaultChart.id,
-              title: launchpadProperties.saved_chart_title ?? this.defaultChart.title,
+              id: (launchpadProperties.saved_chart_id || launchpadProperties.saved_chart_id !== "") ? launchpadProperties.saved_chart_id : this.defaultChart.id,
+              title: (launchpadProperties.saved_chart_title || launchpadProperties.saved_chart_title !== "") ? launchpadProperties.saved_chart_title : this.defaultChart.title,
             };
-            this.selectedLaunchpadIcon = launchpadProperties.icon ?? this.defaultIcon;
-            this.selectedLaunchpadIconLabel = launchpadProperties.icon_label ?? this.defaultIcon;
+            this.selectedLaunchpadIcon = (launchpadProperties.icon || launchpadProperties.icon !== "") ? launchpadProperties.icon : this.defaultIcon;
+            this.selectedLaunchpadIconLabel = (launchpadProperties.icon_label || launchpadProperties.icon_label !== "") ? launchpadProperties.icon_label : this.defaultIcon;
             this.selectedScreen = {
               id: launchpadProperties.screen_id ?? this.defaultScreen.id,
               uuid: launchpadProperties.screen_uuid ?? this.defaultScreen.uuid,

--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -216,17 +216,19 @@ export default {
           const launchpadProperties = unparseProperties ? JSON.parse(unparseProperties) : "";
           if (launchpadProperties && Object.keys(launchpadProperties).length > 0) {
             this.selectedSavedChart = {
-              id: (launchpadProperties.saved_chart_id || launchpadProperties.saved_chart_id !== "") ? launchpadProperties.saved_chart_id : this.defaultChart.id,
-              title: (launchpadProperties.saved_chart_title || launchpadProperties.saved_chart_title !== "") ? launchpadProperties.saved_chart_title : this.defaultChart.title,
+              id: this.verifyProperty(launchpadProperties.saved_chart_id) ? this.defaultChart.id : launchpadProperties.saved_chart_id,
+              title: this.verifyProperty(launchpadProperties.saved_chart_title)
+                ? this.defaultChart.title : launchpadProperties.saved_chart_title,
             };
-            this.selectedLaunchpadIcon = (launchpadProperties.icon || launchpadProperties.icon !== "") ? launchpadProperties.icon : this.defaultIcon;
-            this.selectedLaunchpadIconLabel = (launchpadProperties.icon_label || launchpadProperties.icon_label !== "") ? launchpadProperties.icon_label : this.defaultIcon;
+            this.selectedLaunchpadIcon = this.verifyProperty(launchpadProperties.icon) ? this.defaultIcon : launchpadProperties.icon;
+            this.selectedLaunchpadIconLabel = this.verifyProperty(launchpadProperties.icon_label)
+              ? this.defaultIcon : launchpadProperties.icon_label;
             this.selectedScreen = {
-              id: launchpadProperties.screen_id ?? this.defaultScreen.id,
-              uuid: launchpadProperties.screen_uuid ?? this.defaultScreen.uuid,
-              title: launchpadProperties.screen_title ?? this.defaultScreen.title,
+              id: this.verifyProperty(launchpadProperties.screen_id) ? this.defaultScreen.id : launchpadProperties.screen_id,
+              uuid: this.verifyProperty(launchpadProperties.screen_uuid) ? this.defaultScreen.uuid : launchpadProperties.screen_uuid,
+              title: this.verifyProperty(launchpadProperties.screen_title) ? this.defaultScreen.title : launchpadProperties.screen_title,
             };
-            this.$refs["icon-dropdown"].setIcon(launchpadProperties.icon);
+            this.$refs["icon-dropdown"].setIcon(this.selectedLaunchpadIcon);
           } else {
             this.selectedSavedChart = {
               id: this.defaultChart.id,
@@ -250,6 +252,12 @@ export default {
           });
           this.$refs["image-carousel"].setProcessId(this.processId);
         });
+    },
+    /**
+     * Verify if the property has any value
+     */
+    verifyProperty(property) {
+      return property === undefined || property === null || property === "";
     },
     showModal() {
       this.subject = "";


### PR DESCRIPTION
## Issue & Reproduction Steps
The default icon and default chart fields are empty after the upgrade

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15999

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next