### PR TITLE
FOUR-13564: POC for Notification Integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "processmaker/nayra": "1.10.0",
         "processmaker/pmql": "1.12.1",
         "psr/http-message": "^1.1",
+        "psr/log": "^2.0",
         "psr/simple-cache": "^2.0",
         "pusher/pusher-php-server": "^7.0",
         "ralouphie/getallheaders": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f55b16420adaaa289496d998fb9500d6",
+    "content-hash": "e9f2d8aa22fa1e04dc91fdb1638c4d12",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -7932,16 +7932,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
                 "shasum": ""
             },
             "require": {
@@ -7950,7 +7950,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -7976,9 +7976,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -15574,5 +15574,5 @@
         "php": "^8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
When installing the `phrity/websocket` package within the IDP Connector, an error in versioning occurs. 

```
phrity/websocket[2.1.0, ..., 2.1.3] require psr/log ^1.0 | ^2.0 -> found psr/log[1.0.0, ..., 1.1.4, 2.0.0] but the package is fixed to 3.0.0 (lock file version) by a partial update and that version does not match.
```

## Solution
- Downgrade require psr/log to version ^2.0

## How to Test
- Ensure that the IDP Connector is properly installed with no errors.
- Ensure that psr 2.0 is installed `composer require psr/log:^2.0`
- Ensure no errors occur when running `composer install` in Core.

## Related Tickets & Packages
- Ticket: [FOUR-13564](https://processmaker.atlassian.net/browse/FOUR-13564)
- [IDP Package](https://github.com/ProcessMaker/connector-idp/pull/35)
- ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-13564]: https://processmaker.atlassian.net/browse/FOUR-13564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ