### PR TITLE
FOUR-15858 On Process End - Override Behavior

### DIFF
--- a/ProcessMaker/Events/ProcessCompleted.php
+++ b/ProcessMaker/Events/ProcessCompleted.php
@@ -17,6 +17,8 @@ class ProcessCompleted implements ShouldBroadcastNow
 
     private $processRequest;
 
+    public $endEventDestination;
+
     /**
      * Create a new event instance.
      *
@@ -26,6 +28,7 @@ class ProcessCompleted implements ShouldBroadcastNow
     {
         $this->payloadUrl = route('api.requests.show', ['request' => $processRequest->getKey()]);
         $this->processRequest = $processRequest;
+        $this->endEventDestination = $processRequest->getElementDestination();
     }
 
     /**

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -1053,4 +1053,23 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
 
         return null;
     }
+
+    /**
+     * Retrieves the destination of the first closed end event.
+     *
+     * @return ?string Returns a string value representing the element destination of the first closed end event.
+     */
+    public function getElementDestination(): ?string
+    {
+        $endEvents = $this->tokens()
+            ->where('element_type', 'end_event')
+            ->where('status', 'CLOSED')
+            ->get();
+
+        if ($endEvents->count(0) === 0) {
+            return null;
+        }
+
+        return $endEvents->first()->elementDestination;
+    }
 }

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1190,7 +1190,15 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         event(new ActivityAssigned($this));
     }
 
-    private function getElementDestination($elementDestinationType, $elementDestinationProp)
+    /**
+     * Determines the destination based on the type of element destination property
+     *
+     * @param elementDestinationType Used to determine the type of destination for an element.
+     * @param elementDestinationProp Used to determine the properties of the destination for an element.
+     *
+     * @return string|null Returns the destination URL.
+     */
+    private function getElementDestination($elementDestinationType, $elementDestinationProp): ?string
     {
         $elementDestination = null;
 

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -522,11 +522,17 @@
             `element_id=${this.task.element_id}&` +
             `process_id=${this.task.process_id}`;
           },
-          completed(processRequestId) {
+          completed(processRequestId, endEventDestination = null) {
             // avoid redirection if using a customized renderer
-            if(this.task.component && this.task.component === 'AdvancedScreenFrame') {
+            if (this.task.component && this.task.component === 'AdvancedScreenFrame') {
               return;
             }
+
+            if (endEventDestination) {
+              this.redirect(endEventDestination);
+              return;
+            }
+
             this.redirect(`/requests/${processRequestId}`);
           },
           error(processRequestId) {


### PR DESCRIPTION
## Issue & Reproduction Steps
When the user reaches the end of a process, He wants to be redirected to a specific summary screen based on predefined settings.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
[FOUR-15858](https://processmaker.atlassian.net/browse/FOUR-15858)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
