### PR TITLE
FOUR-16287: Forcing HTTPS

### DIFF
--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvi
 use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Facades;
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\URL;
 use Laravel\Dusk\DuskServiceProvider;
 use Laravel\Horizon\Horizon;
 use Laravel\Passport\Passport;
@@ -43,6 +43,8 @@ class ProcessMakerServiceProvider extends ServiceProvider
         static::extendValidators();
 
         static::extendDrivers();
+
+        static::forceHttps();
 
         $this->setupFactories();
 
@@ -190,7 +192,7 @@ class ProcessMakerServiceProvider extends ServiceProvider
             Facades\Log::debug('Broadcasting Notification ' . $event->broadcastType() . 'on channel(s) ' . $channels);
         });
 
-        //Fire job when task is assigned to a user
+        // Fire job when task is assigned to a user
         Facades\Event::listen(ActivityAssigned::class, function ($event) {
             $task_id = $event->getProcessRequestToken()->id;
             // Dispatch the SmartInbox job with the processRequestToken as parameter
@@ -330,5 +332,15 @@ class ProcessMakerServiceProvider extends ServiceProvider
         Facades\Hash::extend('pm', function () {
             return resolve(PmHash::class);
         });
+    }
+
+    /**
+     * Force HTTPS schema if configured to do so.
+     */
+    public static function forceHttps(): void
+    {
+        if (config('app.force_https')) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -49,7 +49,7 @@ return [
     // TODO Does the ProcessMakerSerializer class exist, if so, we need to fix its namespace :)
     'serialize_fractal' => env('SERIALIZE_FRACTAL', ProcessMaker\Transformers\ProcessMakerSerializer::class),
 
-    //Option Fractal, paginator
+    // Option Fractal, paginator
     'paginate_fractal' => env('PAGINATE_FRACTAL', League\Fractal\Pagination\IlluminatePaginatorAdapter::class),
 
     // The processmaker identifier of the web client application
@@ -232,4 +232,6 @@ return [
     'node_bin_path' => env('NODE_BIN_PATH', '/usr/bin/node'),
 
     'task_drafts_enabled' => env('TASK_DRAFTS_ENABLED', true),
+
+    'force_https' => env('FORCE_HTTPS', false),
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -233,5 +233,5 @@ return [
 
     'task_drafts_enabled' => env('TASK_DRAFTS_ENABLED', true),
 
-    'force_https' => env('FORCE_HTTPS', false),
+    'force_https' => env('FORCE_HTTPS', true),
 ];


### PR DESCRIPTION
## Issue & Reproduction Steps
When migrating from the Classic Load Balancer to the Application Load Balancer, mixed content issues arose, which were resolved by using `URL::forceScheme('https');`. 

## Solution
- This PR adds a way to configure this setting from the .env file. 
- This also solves issues related to SSO. 
- The force_https variable will be enabled as true by default.

## How to Test
- There should be no issues with mixed content or SSO on servers with the Application Load Balancer.

## Related Tickets & Packages
- [FOUR-16287](https://processmaker.atlassian.net/browse/FOUR-16287)
- [FOUR-16286](https://processmaker.atlassian.net/browse/FOUR-16286)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy

[FOUR-16287]: https://processmaker.atlassian.net/browse/FOUR-16287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-16286]: https://processmaker.atlassian.net/browse/FOUR-16286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ