### PR TITLE
FOUR-15867 Refactor API Route Definitions for Version 1.1

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/TaskController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Api\V1_1;
+
+use Illuminate\Http\Request;
+use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Models\ProcessRequestToken;
+
+class TaskController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $query = ProcessRequestToken::select('id');
+
+        return $query->paginate();
+    }
+}

--- a/ProcessMaker/Providers/RouteServiceProvider.php
+++ b/ProcessMaker/Providers/RouteServiceProvider.php
@@ -89,6 +89,8 @@ class RouteServiceProvider extends ServiceProvider
     {
         Route::middleware('api')
             ->group(base_path('routes/api.php'));
+        Route::middleware('auth:api')
+            ->group(base_path('routes/v1_1/api.php'));
     }
 
     /**

--- a/routes/v1_1/api.php
+++ b/routes/v1_1/api.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use ProcessMaker\Http\Controllers\Api\V1_1\TaskController;
+
+// Define the prefix and name for version 1.1 of the API routes
+Route::prefix('api/1.1')
+    ->name('api.1.1.')
+    ->group(function () {
+        // Tasks Endpoints
+        Route::name('tasks.')->group(function () {
+            // Route to list tasks
+            Route::get('tasks', [TaskController::class, 'index'])
+                ->name('index');
+        });
+    });


### PR DESCRIPTION
## Refactor API Route Definitions for Version 1.1

### Overview
This PR refactors the API route definitions for version 1.1 of our application. The changes include:

- Grouping `use` statements together for better organization.
- Applying middleware to the entire route group, making it clearer and easier to manage.
- Improving route naming conventions for better readability and consistency.
- Adding detailed comments to provide better context and understanding of the code.

### Changes
1. Create a minimilized middleware for the v1.1 endpoints.
2. Defined a route group with middleware to apply it to all relevant routes within the group.
3. Create a first simple `tasks.index`

## How to Test
- Try the endpoint `/api/1.1/tasks`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15867

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
