### PR TITLE
FOUR-16367: Add in the composer.json the specific branch to use the package-slideshow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,6 +165,7 @@
                 "package-savedsearch": "1.33.16",
                 "package-sentry": "1.8.0",
                 "package-signature": "1.12.0",
+                "package-slideshow": "dev-feature/FOUR-15522",
                 "package-testing": "1.2.22",
                 "package-translations": "2.9.0",
                 "package-versions": "1.10.1",


### PR DESCRIPTION
## Issue & Reproduction Steps
Add in the composer.json the specific branch to use the package-slideshow

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16367

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:package-slideshow:feature/FOUR-15522