### PR TITLE
Bugfix/FOUR-15054: "Give me inspiration" in AI scripts does not show anything

### DIFF
--- a/resources/js/processes/scripts/components/GenerateScriptTextPrompt.vue
+++ b/resources/js/processes/scripts/components/GenerateScriptTextPrompt.vue
@@ -112,8 +112,7 @@ export default {
         });
     }, 500),
     onSuggestionApplied(suggestion) {
-      const cursorPosition = this.$refs.textArea.selectionStart;
-      this.prompt = `${this.prompt.slice(0, cursorPosition)} ${suggestion} ${this.prompt.slice(cursorPosition)}`;
+      this.text = suggestion;
     },
     fetchSuggestions() {
       if (this.suggestionsPages.length) {


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to scripts
- Create a script
- Click on generate script from text
- Click on "Give me inspiration"

**Current Behavior:**
This option does not show any type of suggestion, you see a blank space.

## Solution
- Fix on apply suggestion method

## How to Test
Follow steps above. 
- Also click on a suggestion and the suggestion should replace the textarea content.

## Related Tickets & Packages
- [FOUR-15054](https://processmaker.atlassian.net/browse/FOUR-15054)
- [Microservice PR](https://github.com/ProcessMaker/pm4_ai/pull/13)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/6909)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-15054]: https://processmaker.atlassian.net/browse/FOUR-15054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ