### PR TITLE
[SUMMER] feature/FOUR-15727 Options Ellipsis on tasks page and Launchpad

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -1,11 +1,13 @@
 <template>
   <b-dropdown
     v-if="filterActions.length > 0"
+    v-b-tooltip.hover="{ placement: 'bottom', title: 'Options', variant: 'secondary', customClass: 'ellipsis-tooltip' }"
     :variant="variant ? variant : 'outlined-secondary'"
     toggle-class="static-header"
     no-flip
     lazy
     right
+    no-caret
     offset="0"
     class="ellipsis-dropdown-main static-header"
     :popper-opts="{ placement: 'bottom-end' }"
@@ -26,8 +28,7 @@
     </template>
     <template v-else #button-content>
       <span class="text-capitalize screen-toolbar-button">
-        <i class="fas fa-cog" />
-        {{ $t("Options") }}
+        <i class="fas fa-ellipsis-h ellipsis-menu-icon p-0" />
       </span>
     </template>
     <div v-if="divider === true">
@@ -292,5 +293,19 @@ export default {
 <style>
 .static-header {
   position: static !important;
+  width: 40px;
+  height: 40px;
+  box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  background-color: #FFFFFF;
+}
+.static-header:hover {
+  background-color: #EBEEF2;
+}
+.ellipsis-tooltip {
+  border-radius: 4px;
+}
+.ellipsis-tooltip .arrow {
+  display: none;
 }
 </style>

--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -3,7 +3,7 @@
     v-if="filterActions.length > 0"
     v-b-tooltip.hover="{ placement: 'bottom', title: 'Options', variant: 'secondary', customClass: 'ellipsis-tooltip' }"
     :variant="variant ? variant : 'outlined-secondary'"
-    toggle-class="static-header"
+    :toggle-class="['static-header', { 'contracted-menu': !lauchpad }, { 'expanded-menu': lauchpad }]"
     no-flip
     lazy
     right
@@ -24,7 +24,10 @@
       </span>
     </template>
     <template v-else-if="lauchpad" #button-content>
-      <i class="fas fa-ellipsis-h ellipsis-menu-icon p-0" />
+      <i class="fas fa-ellipsis-v ellipsis-menu-icon p-0 ellipsis-icon-v" />
+      <span>
+        {{ $t('Options') }}
+      </span>
     </template>
     <template v-else #button-content>
       <span class="text-capitalize screen-toolbar-button">
@@ -293,6 +296,8 @@ export default {
 <style>
 .static-header {
   position: static !important;
+}
+.contracted-menu {
   width: 40px;
   height: 40px;
   box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.15);
@@ -301,6 +306,17 @@ export default {
 }
 .static-header:hover {
   background-color: #EBEEF2;
+  border-radius: 4px;
+}
+.expanded-menu {
+  color: #556271;
+  text-transform: none;
+  border-radius: 4px;
+  font-size: 16px;
+}
+.ellipsis-icon-v {
+  height: 16px;
+  width: 16px;
 }
 .ellipsis-tooltip {
   border-radius: 4px;

--- a/resources/js/processes-catalogue/components/scss/processes.css
+++ b/resources/js/processes-catalogue/components/scss/processes.css
@@ -44,12 +44,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: white;
-  border: 1px solid #CDDDEE;
-  border-radius: 19px;
-  width: 32px;
-  height: 32px;
-  margin: 0px 8px;
+  margin-right: 5px;
 }
 .ellipsis-border .dropdown-toggle::after {
     display:none;


### PR DESCRIPTION
## Issue & Reproduction Steps
As a user, I want a streamlined way to access additional actions and settings without overwhelming the interface, so that I can efficiently navigate through information and focus on completing my work.

## Solution
Changed the ellipsis menu style in tables  and in launchpad

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15727
https://processmaker.atlassian.net/browse/FOUR-15728

ci:next
ci:deploy