### PR TITLE
Bugfix/FOUR-14265: Drafts being lost after renaming the process

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -431,6 +431,10 @@ class ProcessController extends Controller
      */
     public function update(Request $request, Process $process)
     {
+        $lastVersion = $process->getDraftOrPublishedLatestVersion($request->input('alternative'));
+        $process->bpmn = $lastVersion->bpmn;
+        $process->alternative = $lastVersion->alternative;
+
         $rules = Process::rules($process);
         if (!$request->has('name')) {
             unset($rules['name']);

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -431,7 +431,7 @@ class ProcessController extends Controller
      */
     public function update(Request $request, Process $process)
     {
-        $lastVersion = $process->getDraftOrPublishedLatestVersion($request->input('alternative'));
+        $lastVersion = $process->getDraftOrPublishedLatestVersion();
         $process->bpmn = $lastVersion->bpmn;
         $process->alternative = $lastVersion->alternative;
 

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -106,7 +106,14 @@ class ProcessController extends Controller
         $canEditData = $this->listCan('EditData', $process);
         $addons = $this->getPluginAddons('edit', compact(['process']));
 
-        return view('processes.edit', compact(['process', 'categories', 'screenRequestDetail', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons', 'assignedProjects']));
+        $lastDraftOrPublishedVersion = $process->getDraftOrPublishedLatestVersion();
+
+        $isDraft = 0;
+        if ($lastDraftOrPublishedVersion) {
+            $isDraft = $lastDraftOrPublishedVersion->draft;
+        }
+
+        return view('processes.edit', compact(['process', 'categories', 'screenRequestDetail', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons', 'assignedProjects', 'isDraft']));
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -113,7 +113,19 @@ class ProcessController extends Controller
             $isDraft = $lastDraftOrPublishedVersion->draft;
         }
 
-        return view('processes.edit', compact(['process', 'categories', 'screenRequestDetail', 'screenCancel', 'list', 'canCancel', 'canStart', 'canEditData', 'addons', 'assignedProjects', 'isDraft']));
+        return view('processes.edit', compact([
+            'process',
+            'categories',
+            'screenRequestDetail',
+            'screenCancel',
+            'list',
+            'canCancel',
+            'canStart',
+            'canEditData',
+            'addons',
+            'assignedProjects',
+            'isDraft'
+        ]));
     }
 
     /**

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2095,6 +2095,7 @@
   "You are about to import a Screen.": "You are about to import a Screen.",
   "You are about to import": "You are about to import",
   "You are not part of a project yet": "You are not part of a project yet",
+  "You are about to publish a draft version. Are you sure you want to proceed?": "You are about to publish a draft version. Are you sure you want to proceed?",
   "You are receiving this email because we received a password reset request for your account.": "You are receiving this email because we received a password reset request for your account.",
   "You are trying to place a nested screen within CAPTCHA elements inside a loop. CAPTCHA controls cannot be placed within a Loop control.": "You are trying to place a nested screen within CAPTCHA elements inside a loop. CAPTCHA controls cannot be placed within a Loop control.",
   "You can also authenticate by :otherMethods.": "You can also authenticate by :otherMethods.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1427,7 +1427,7 @@
   "Save Script": "Save Script",
   "Save Versions": "Save Versions",
   "Save": "Save",
-  "Save & Publish": "Save & Publish",
+  "Save and publish": "Save and publish",
   "Saved Search": "Saved Search",
   "Scheduled": "Scheduled",
   "Screen Categories": "Screen categories",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1427,6 +1427,7 @@
   "Save Script": "Save Script",
   "Save Versions": "Save Versions",
   "Save": "Save",
+  "Save & Publish": "Save & Publish",
   "Saved Search": "Saved Search",
   "Scheduled": "Scheduled",
   "Screen Categories": "Screen categories",

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -195,7 +195,7 @@
                             </div>
                             <div class="d-flex justify-content-end mt-2">
                                 {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
-                                {!! Form::button(__('Save'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
+                                {!! Form::button(__('Save and publish'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
                             </div>
                         </div>
 
@@ -422,7 +422,7 @@
                             </div>
                             <div class="d-flex justify-content-end mt-2">
                                 {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
-                                {!! Form::button(__('Save'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
+                                {!! Form::button(__('Save and publish'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
                             </div>
                         </div>
 

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -195,7 +195,10 @@
                             </div>
                             <div class="d-flex justify-content-end mt-2">
                                 {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
-                                {!! Form::button(__('Save and publish'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
+                                {!! Form::button(__('Save and publish'), [
+                                    'class' => 'btn btn-secondary ml-2',
+                                    '@click' => 'onUpdate'
+                                ]) !!}
                             </div>
                         </div>
 
@@ -422,7 +425,10 @@
                             </div>
                             <div class="d-flex justify-content-end mt-2">
                                 {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
-                                {!! Form::button(__('Save and publish'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
+                                {!! Form::button(__('Save and publish'), [
+                                    'class' => 'btn btn-secondary ml-2',
+                                    '@click' => 'onUpdate'
+                                ]) !!}
                             </div>
                         </div>
 

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -455,6 +455,7 @@
                 return {
                     formData: @json($process),
                     assignedProjects: @json($assignedProjects),
+                    isDraft: @json($isDraft),
                     selectedProjects: '',
                     dataGroups: [],
                     value: [],
@@ -578,6 +579,21 @@
                     return (item && item.id) ? item.id : null
                 },
                 onUpdate() {
+                    let shouldDelete = false;
+                    if (this.isDraft) {
+                        ProcessMaker.confirmModal(
+                            this.$t("Caution!"),
+                            this.$t("You are about to publish a draft version. Are you sure you want to proceed?"),
+                            "",
+                            () => {
+                                this.handleUpdate();
+                            }
+                        );
+                    } else {
+                        this.handleUpdate();
+                    }
+                },
+                handleUpdate() {
                     this.resetErrors();
                     let that = this;
                     this.formData.cancel_request = this.formatAssigneePermissions(this.canCancel);
@@ -585,6 +601,7 @@
                     this.formData.cancel_screen_id = this.formatValueScreen(this.screenCancel);
                     this.formData.request_detail_screen_id = this.formatValueScreen(this.screenRequestDetail);
                     this.formData.manager_id = this.formatValueScreen(this.manager);
+                    console.log(this.formData);
                     ProcessMaker.apiClient.put('processes/' + that.formData.id, that.formData)
                     .then(response => {
                         ProcessMaker.alert(this.$t('The process was saved.'), 'success', 5, true);

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -607,7 +607,6 @@
                     this.formData.cancel_screen_id = this.formatValueScreen(this.screenCancel);
                     this.formData.request_detail_screen_id = this.formatValueScreen(this.screenRequestDetail);
                     this.formData.manager_id = this.formatValueScreen(this.manager);
-                    console.log(this.formData);
                     ProcessMaker.apiClient.put('processes/' + that.formData.id, that.formData)
                     .then(response => {
                         ProcessMaker.alert(this.$t('The process was saved.'), 'success', 5, true);


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a new process.
- Add some elements to the process (such as a start event, a couple of tasks, and an end event).
- You can refresh your screen to validate that your changes are still there.
- Go to the process configuration and change the name of the process.

**Current Behavior:**
All the changes will be lost

**Expected Behavior:**
The draft with the recent changes should still be there after renaming.

**Notes for QA:**
The information lost only occurs on unpublished versions. However, these changes exist in the version history as drafts before renaming the process.

## Solution
- When saving in configuration, now we get the last version of the process and we update the BPMN.
- The button in configuration changed from **Save** to **Save and publish**
- If a draft exist for the process, when clicking in Save and publish, we show a confirmation modal to let the user decide if must continue.

## How to Test
- Create a process.
- Go to modeler and do some changes (add elements), wait the autosave
- Go to the process configuration and change the process name and save

- Do the same test as before with draft Processes and Published processes
- Do the same test as before with one alternative as a draft
- Do the same test as before with two alternatives as a draft (modify only the B)
- Do the same test as before with two alternatives as a draft (modify only the A)
- Do the same test as before with two alternatives as a draft (modify both)

Ensure the processes and the alternatives keeps the changes after renaming the process.
Ensure the confirmation modal shows in the configuration when saving if the process is draft

## Related Tickets & Packages
- [FOUR-14265](https://processmaker.atlassian.net/browse/FOUR-14265)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-14265]: https://processmaker.atlassian.net/browse/FOUR-14265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ