### PR TITLE
FOUR-15859: On Process End - Start a request for another selected process

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -38,6 +38,7 @@ class Task extends ApiResource
         'interstitial',
         'userRequestPermission',
         'process',
+        'elementDestination',
     ];
 
     private $process = null;

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -1057,9 +1057,9 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     /**
      * Retrieves the destination of the first closed end event.
      *
-     * @return ?string Returns a string value representing the element destination of the first closed end event.
+     * @return ?array Returns a string value representing the element destination of the first closed end event.
      */
-    public function getElementDestination(): ?string
+    public function getElementDestination(): ?array
     {
         $endEvents = $this->tokens()
             ->where('element_type', 'end_event')

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -136,7 +136,6 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
      */
     protected $appends = [
         'advanceStatus',
-        'elementDestination',
     ];
 
     /**

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -136,7 +136,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
      */
     protected $appends = [
         'advanceStatus',
-        'elementDestination'
+        'elementDestination',
     ];
 
     /**
@@ -1196,13 +1196,14 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
      * @param elementDestinationType Used to determine the type of destination for an element.
      * @param elementDestinationProp Used to determine the properties of the destination for an element.
      *
-     * @return string|null Returns the destination URL.
+     * @return array|null Returns the destination URL.
      */
-    private function getElementDestination($elementDestinationType, $elementDestinationProp): ?string
+    private function getElementDestination($elementDestinationType, $elementDestinationProp): ?array
     {
         $elementDestination = null;
 
         switch ($elementDestinationType) {
+            case 'anotherProcess':
             case 'customDashboard':
             case 'externalURL':
                 if (array_key_exists('value', $elementDestinationProp)) {
@@ -1227,7 +1228,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
             case 'processLaunchpad':
                 $elementDestination = route('process.browser.index', [
                     'process' => $this->process_id,
-                    'categorySelected' => -1
+                    'categorySelected' => -1,
                 ]);
                 break;
             case 'taskSource':
@@ -1236,18 +1237,20 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
             default:
                 $elementDestination = null;
                 break;
-
         }
 
-        return $elementDestination;
+        return [
+            'type' => $elementDestinationType,
+            'value' => $elementDestination,
+        ];
     }
 
     /**
      * Determines the destination URL based on the element destination type specified in the definition.
      *
-     * @return string|null
+     * @return array|null
      */
-    public function getElementDestinationAttribute(): ?string
+    public function getElementDestinationAttribute(): ?array
     {
         $definition = $this->getDefinition();
         $elementDestinationProp = $definition['elementDestination'] ?? null;

--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Http\Resources\ScreenVersion as ScreenVersionResource;
 use ProcessMaker\Http\Resources\Users;
 use ProcessMaker\Managers\DataManager;
+use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\TaskDraft;
 use ProcessMaker\ProcessTranslations\ProcessTranslation;
 use StdClass;
@@ -136,5 +137,17 @@ trait TaskResourceIncludes
         $userRequestPermission = $this->loadUserRequestPermission($this->processRequest, Auth::user(), []);
 
         return ['user_request_permission' => $userRequestPermission];
+    }
+
+    /**
+     * Include the element destination in the resource response.
+     *
+     * @return array
+     */
+    private function includeElementDestination()
+    {
+        $elementDestination = $this->resource->getElementDestinationAttribute();
+
+        return ['elementDestination' => $elementDestination];
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 

ent event must redirect to another process if have this configuration
Actual behavior: 

## Solution
- add another process redirect feature for end event


https://github.com/ProcessMaker/processmaker/assets/1401911/165fccb7-6aee-494c-a372-ffbab294c465



## How to Test
- create the process A
- create the process B
- assign to both process the same user to the first task
- in process A create a end event 
- add end event redirection as process
- select the process B
- select the start event B
- run the process

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-15859
- https://github.com/ProcessMaker/screen-builder/pull/1609 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next