### PR TITLE
Bugfix/FOUR-16559: When I Quick-Fill a task, the signature is also filled and it is observed by the audit.

### DIFF
--- a/resources/js/tasks/components/QuickFillPreview.vue
+++ b/resources/js/tasks/components/QuickFillPreview.vue
@@ -293,7 +293,7 @@ export default {
           // use the value from the quick fill
           quickFillValue = _.get(quickFillData, field, null);
         }
-
+        // Set the value. This handles nested values using dot notation in 'field' string
         _.set(draftData, field, quickFillValue);
       });
 

--- a/resources/js/tasks/components/QuickFillPreview.vue
+++ b/resources/js/tasks/components/QuickFillPreview.vue
@@ -269,6 +269,10 @@ export default {
       }
       this.$emit("close");
     },
+    validateBase64(field) {
+      var regex = /^data:image\/\w+;base64,/;
+      return regex.test(field) ? true : false;
+    },
     buttonThisDataFromFullTask(quickFillData) {
       // If the task does not have a draft yet, use the task data
       const dataToUse = this.task.draft?.data ?? this.task.data;
@@ -283,6 +287,9 @@ export default {
         } else {
           // use the value from the quick fill
           quickFillValue = _.get(quickFillData, field, null);
+        }
+        if(this.validateBase64(quickFillValue)) {
+          return;
         }
         // Set the value. This handles nested values using dot notation in 'field' string
         _.set(draftData, field, quickFillValue);

--- a/resources/js/tasks/components/QuickFillPreview.vue
+++ b/resources/js/tasks/components/QuickFillPreview.vue
@@ -280,6 +280,11 @@ export default {
       const draftData = {};
       this.screenFields.forEach((field) => {
         const existingValue = _.get(dataToUse, field, null);
+
+        if(this.validateBase64(existingValue)) {
+          _.set(draftData, field, existingValue);
+          return;
+        }
         let quickFillValue;
         if (existingValue) {
           // If the value exists in the task data (or task draft data), don't overwrite it
@@ -288,10 +293,7 @@ export default {
           // use the value from the quick fill
           quickFillValue = _.get(quickFillData, field, null);
         }
-        if(this.validateBase64(quickFillValue)) {
-          return;
-        }
-        // Set the value. This handles nested values using dot notation in 'field' string
+
         _.set(draftData, field, quickFillValue);
       });
 

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -474,7 +474,6 @@
               if (event.detail.hasOwnProperty(key)) {
                 let value = event.detail[key];
                 if (this.validateBase64(value)) {
-                  delete this.formData[key];
                   delete event.detail[key];
                 }
               }

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -428,6 +428,10 @@
               this.sendEvent('taskReady', this.task?.id);
             });
           },
+          validateBase64(field) {
+            var regex = /^data:image\/\w+;base64,/;
+            return regex.test(field) ? true : false;
+          },
         },
         mounted() {
           this.prepareData();
@@ -438,6 +442,8 @@
 
           window.addEventListener('fillData', event => {
             const newData = {};
+            console.log("Event Detail: ", event.detail);
+            console.log("screenFields: ", screenFields);
             screenFields.forEach((field) => {
 
               const existingValue = _.get(this.formData, field, null);
@@ -450,6 +456,9 @@
                 // use the value from the quick fill(event.detail)
                 quickFillValue = _.get(event.detail, field, null);
               }
+              if(this.validateBase64(quickFillValue)) {
+                return;
+              }
               // Set the value. This handles nested values using dot notation in 'field' string
               _.set(newData, field, quickFillValue);
             });
@@ -461,6 +470,15 @@
           // want to use all data saved in the inbox rule db record, regardless
           // if the field exists or not.
           window.addEventListener('fillDataOverwriteExistingFields', event => {
+            for (let key in event.detail) {
+              if (event.detail.hasOwnProperty(key)) {
+                let value = event.detail[key];
+                if (this.validateBase64(value)) {
+                  delete this.formData[key];
+                  delete event.detail[key];
+                }
+              }
+            }
             this.formData = _.merge(_.cloneDeep(this.formData), event.detail);
           });
 

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -442,11 +442,14 @@
 
           window.addEventListener('fillData', event => {
             const newData = {};
-            console.log("Event Detail: ", event.detail);
-            console.log("screenFields: ", screenFields);
             screenFields.forEach((field) => {
 
               const existingValue = _.get(this.formData, field, null);
+
+              if(this.validateBase64(existingValue)) {
+                _.set(newData, field, existingValue);
+                return;
+              }
               let quickFillValue;
 
               if (existingValue) {
@@ -455,9 +458,6 @@
               } else {
                 // use the value from the quick fill(event.detail)
                 quickFillValue = _.get(event.detail, field, null);
-              }
-              if(this.validateBase64(quickFillValue)) {
-                return;
               }
               // Set the value. This handles nested values using dot notation in 'field' string
               _.set(newData, field, quickFillValue);


### PR DESCRIPTION
## Solution
- In Quickfill option, signatures will no longer be taken into account

## How to Test
- Have a process with Form with signature component
- Use Quickfill option with process has signatures into their Form

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16559

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next