### PR TITLE
Bugfix/FOUR-16559: When I Quick-Fill a task, the signature is also filled and it is observed by the audit.

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -165,8 +165,12 @@ class TaskController extends Controller
 
     public function quickFillEdit(ProcessRequestToken $task)
     {
+        $screenVersion = $task->getScreenVersion();
+        $screenFields = $screenVersion ? $screenVersion->screenFilteredFields() : [];
+
         return view('tasks.editQuickFill', [
             'task' => $task,
+            'screenFields' => $screenFields,
         ]);
     }
 }

--- a/resources/js/tasks/components/QuickFillPreview.vue
+++ b/resources/js/tasks/components/QuickFillPreview.vue
@@ -86,9 +86,6 @@
                   <i class="fas fa-times" />
                 </b-button>
               </div>
-              <div class="header-container-warning">
-                <p>{{ disclaimer }}</p>
-              </div>
             </div>
             <div v-else style="width: 92%">
               <div class="header-container-quick">
@@ -130,9 +127,6 @@
                 >
                   <i class="fas fa-times" />
                 </b-button>
-              </div>
-              <div class="header-container-warning">
-                <p>{{ disclaimer }}</p>
               </div>
             </div>
           </template>
@@ -233,7 +227,6 @@ export default {
         },
       ],
       dataTasks: {},
-      disclaimer: this.$t("This is a Beta version and when using Quickfill, it may replace the pre-filled information in the form."),
       tasksListName: "preview-table",
     };
   },

--- a/resources/js/tasks/components/QuickFillPreview.vue
+++ b/resources/js/tasks/components/QuickFillPreview.vue
@@ -305,7 +305,7 @@ export default {
         });
     },
     validateBase64(field) {
-      var regex = /^data:image\/\w+;base64,/;
+      const regex = /^data:image\/\w+;base64,/;
       return regex.test(field);
     },
     /*

--- a/resources/js/tasks/components/QuickFillPreview.vue
+++ b/resources/js/tasks/components/QuickFillPreview.vue
@@ -270,10 +270,6 @@ export default {
       this.screenFields.forEach((field) => {
         const existingValue = _.get(dataToUse, field, null);
 
-        if(this.validateBase64(existingValue)) {
-          _.set(draftData, field, existingValue);
-          return;
-        }
         let quickFillValue;
         if (existingValue) {
           // If the value exists in the task data (or task draft data), don't overwrite it
@@ -281,6 +277,11 @@ export default {
         } else {
           // use the value from the quick fill
           quickFillValue = _.get(quickFillData, field, null);
+        }
+
+        if(this.validateBase64(quickFillValue)) {
+          _.set(draftData, field, existingValue);
+          return;
         }
         // Set the value. This handles nested values using dot notation in 'field' string
         _.set(draftData, field, quickFillValue);

--- a/resources/views/tasks/editQuickFill.blade.php
+++ b/resources/views/tasks/editQuickFill.blade.php
@@ -32,7 +32,8 @@
 <div v-cloak id="quickfill" class="container-fluid px-3">
     <quick-fill-preview
     class="quick-fill-preview"
-    :task="{{ $task }}"
+    :task="task"
+    :screen-fields="screenFields"
     :prop-from-button ="'fullTask'"
     :prop-columns="columns"
     :prop-filters="filters"
@@ -43,6 +44,9 @@
 <script src="{{mix('js/tasks/show.js')}}"></script>
 <script>
     let task = @json($task);
+    task.draft = @json($task->draft);
+    task.data = @json($task->processRequest->data);
+    const screenFields = @json($screenFields);
     const store = new Vuex.Store();
     const main = new Vue({
       store: store,
@@ -50,6 +54,8 @@
       data: {
           isDisabled: true,
           data: {},
+          task,
+          screenFields,
           filters: {
             order: { by: "created_at", direction: "desc" },
             filters:[

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -428,6 +428,10 @@
               this.sendEvent('taskReady', this.task?.id);
             });
           },
+          validateBase64(field) {
+            var regex = /^data:image\/\w+;base64,/;
+            return regex.test(field);
+          },
         },
         mounted() {
           this.prepareData();
@@ -437,7 +441,29 @@
           });
 
           window.addEventListener('fillData', event => {
-            this.formData = _.merge(_.cloneDeep(this.formData), event.detail);
+            const newData = {};
+            screenFields.forEach((field) => {
+
+              const existingValue = _.get(this.formData, field, null);
+
+              if(this.validateBase64(existingValue)) {
+                _.set(newData, field, existingValue);
+                return;
+              }
+              let quickFillValue;
+
+              if (existingValue) {
+                // If the value exists in the task data, don't overwrite it
+                quickFillValue = existingValue;
+              } else {
+                // use the value from the quick fill(event.detail)
+                quickFillValue = _.get(event.detail, field, null);
+              }
+              // Set the value. This handles nested values using dot notation in 'field' string
+              _.set(newData, field, quickFillValue);
+            });
+
+            this.formData = newData;
           });
 
           window.addEventListener('eraseData', event => {

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -429,7 +429,7 @@
             });
           },
           validateBase64(field) {
-            var regex = /^data:image\/\w+;base64,/;
+            const regex = /^data:image\/\w+;base64,/;
             return regex.test(field);
           },
         },

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -445,11 +445,7 @@
             screenFields.forEach((field) => {
 
               const existingValue = _.get(this.formData, field, null);
-
-              if(this.validateBase64(existingValue)) {
-                _.set(newData, field, existingValue);
-                return;
-              }
+              
               let quickFillValue;
 
               if (existingValue) {
@@ -460,7 +456,13 @@
                 quickFillValue = _.get(event.detail, field, null);
               }
               // Set the value. This handles nested values using dot notation in 'field' string
+
+              if(this.validateBase64(quickFillValue)) {
+                _.set(newData, field, existingValue);
+                return;
+              }
               _.set(newData, field, quickFillValue);
+
             });
 
             this.formData = newData;


### PR DESCRIPTION
## Solution
- In Quickfill option, signatures will no longer be taken into account


## How to Test
- Have a process with Form with signature component
- Use Quickfill option with process has signatures into their Form

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16559

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy