### PR TITLE
Bugfix/FOUR-15004: PMQL in record list doesnt work with pm variables:

### DIFF
--- a/resources/js/components/shared/PmqlInput.vue
+++ b/resources/js/components/shared/PmqlInput.vue
@@ -243,6 +243,8 @@ export default {
         promptTokens: 0,
         totalTokens: 0,
       },
+      promptSessionId: "",
+      currentNonce: "",
       get,
     };
   },
@@ -312,6 +314,9 @@ export default {
     this.filtersPmql = this.filtersValue;
     this.inputAriaLabel = this.ariaLabel;
 
+    this.promptSessionId = localStorage.promptSessionId;
+    this.currentNonce = localStorage.currentNonce;
+    
     this.$root.$on("bv::collapse::state", (collapseId, isJustShown) => {
       this.query = this.value;
       this.pmql = this.value;
@@ -325,6 +330,48 @@ export default {
   },
 
   methods: {
+    getNonce() {
+      const max = 999999999999999;
+      const nonce = Math.floor(Math.random() * max);
+      this.currentNonce = nonce;
+      localStorage.currentNonce = this.currentNonce;
+    },
+    getPromptSession() {
+      const url = "/package-ai/getPromptSessionHistory";
+
+      let params = {
+        server: window.location.host,
+      };
+
+      if (this.promptSessionId?.startsWith("ss")) {
+        this.promptSessionId = "";
+      }
+
+      if (
+        this.promptSessionId
+        && this.promptSessionId !== null
+        && this.promptSessionId !== ""
+      ) {
+        params = {
+          promptSessionId: this.promptSessionId,
+        };
+      }
+
+      ProcessMaker.apiClient
+        .post(url, params)
+        .then((response) => {
+          this.promptSessionId = response.data.promptSessionId;
+          localStorage.promptSessionId = response.data.promptSessionId;
+          this.runNLQToPMQL();
+        })
+        .catch((error) => {
+          if (error.response.status === 404) {
+            localStorage.promptSessionId = "";
+            this.promptSessionId = "";
+            this.getPromptSession();
+          }
+        });
+    },
     onFiltersPmqlChange(value) {
       this.filtersPmql = value[0];
       this.selectedFilters = value[1];
@@ -381,7 +428,7 @@ export default {
         this.$emit("submit", this.query);
         this.$emit("input", this.query);
       } else if (this.aiEnabledLocal) {
-        this.runNLQToPMQL();
+        this.getPromptSession();
       } else if (!this.query.isPMQL() && !this.aiEnabledLocal) {
         const fullTextSearch = `(fulltext LIKE "%${this.query}%")`;
         this.pmql = fullTextSearch;
@@ -395,10 +442,13 @@ export default {
       this.runSearch();
     },
     runNLQToPMQL() {
+      this.getNonce();
       const params = {
-        question: this.query,
+        search: this.query,
         type: this.searchType,
         classifySearch: false,
+        promptSessionId: this.promptSessionId,
+        nonce: this.currentNonce,
       };
 
       this.aiLoading = true;
@@ -406,8 +456,8 @@ export default {
       ProcessMaker.apiClient
         .post("/package-ai/naturalLanguageToPmql", params)
         .then((response) => {
-          this.pmql = response.data.result;
-          this.usage = response.data.usage;
+          this.pmql = response.data.result[0].result.pmql;
+          this.usage = response.data.result[0].usage;
           this.$emit("submit", this.pmql);
           this.$emit("input", this.pmql);
           this.aiLoading = false;


### PR DESCRIPTION
## Issue & Reproduction Steps

Please see https://processmaker.atlassian.net/browse/FOUR-15004

To reproduce:
- Create a screen 
- Add an input with a default and name it **user** (you can use your custom example)
- Add a select list of type data connector (you can use the users endpoint)
- Configure Options Variable: response.data
- Type of Value Returned: Object
- Content {{data.username}}
- Data connector: Users
- Endpoint ListAll
- Add a PMQL: **data.username="{{user}}"** (user is the name of the input you added before)
- Go to preview and type some valid user in the input to make the pmql trigger and change the option list of the select

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/2fa1ce60-a5e5-44b8-9d45-4389aa603c6a


## Solution
- Fix PMQL render and code refactor for dataconnector
- Fix issue with cacheEnabled
- Fix NL to PMQL to call microservice for PMQL input in select lists
- Add nonce to use last call in select list dataconnector

## How to Test
- Follow steps above. You can test also type collections for data source

## Related Tickets & Packages
- [FOUR-15004](https://processmaker.atlassian.net/browse/FOUR-15004)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/6936)
- [Screen builder PR](https://github.com/ProcessMaker/screen-builder/pull/1614)
- [Vue form elements PR](https://github.com/ProcessMaker/vue-form-elements/pull/424)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:develop
ci:screen-builder:bugfix/FOUR-15004-b
ci:vue-form-elements:bugfix/FOUR-15004-b

[FOUR-15004]: https://processmaker.atlassian.net/browse/FOUR-15004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ