### PR TITLE
FOUR-15982: Chart searcher stop to work in launchpad

### DIFF
--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -357,7 +357,7 @@ export default {
           }
         })
         .catch((error) => {
-          this.dropdownSavedCharts = [];
+          this.dropdownSavedCharts = [this.defaultChart];
         });
     },
     /**
@@ -381,7 +381,7 @@ export default {
           }
         })
         .catch((error) => {
-          this.dropdownSavedScreen = [];
+          this.dropdownSavedScreen = [this.defaultScreen];
         });
     },
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Chart searcher stop to work in launch pad


## Solution
Assign the default value when the API give errors

## How to Test
- Create chart in saved search
- Go to Process catalog
- Open Edit launchpad settings 
- Write in the input to chart search 
- Wait to search is completed

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15982

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy