### PR TITLE
Bugfix/FOUR-16291: Error in Saved search configuration 

### DIFF
--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -109,6 +109,9 @@ export default {
     // Some controllers return each row as a json object to preserve integer keys (ie saved search)
     jsonRows(rows) {
       if (rows.length === 0 || !(_.has(_.head(rows), "_json"))) {
+        if (!Array.isArray(rows) && typeof rows === "object") {
+          return Object.values(rows);
+        }
         return rows;
       }
       return rows.map((row) => JSON.parse(row._json));


### PR DESCRIPTION
## Issue & Reproduction Steps

- Log in to PM4
- Go to Request or Task
- Open any saved search  in left menu

**Current Behavior**
See the error attached in the ticket

## Solution
- When is object return the values.

## How to Test
- Follow steps above


## Related Tickets & Packages
- [FOUR-16291](https://processmaker.atlassian.net/browse/FOUR-16291)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/6943)
- [Package savedsearch PR](https://github.com/ProcessMaker/package-savedsearch/pull/448)
- [Package Collections](https://github.com/ProcessMaker/package-collections/pull/388)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-savedsearch:bugfix/FOUR-16291
ci:package-collections:bugfix/FOUR-16291
ci:deploy

[FOUR-16291]: https://processmaker.atlassian.net/browse/FOUR-16291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ