### PR TITLE
feature/FOUR-16649: Cases link is not marked as active when Cases page is visited

### DIFF
--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -40,7 +40,7 @@ class GenerateMenus
                 $request_items->add(
                     __('Cases'),
                     ['route' => 'cases.index', 'id' => 'requests']
-                )->active('requests/*');
+                )->active('cases/*');
             });
             //@TODO change the index to the correct blade
             $menu->group(['prefix' => 'tasks'], function ($request_items) {
@@ -140,7 +140,7 @@ class GenerateMenus
             $submenu = $menu->add(__('Processes'));
         });
         Menu::make('sidebar_request', function ($menu) {
-            $submenu = $menu->add(__('Request'));
+            $submenu = $menu->add(__('Cases'));
             $submenu->add(__('My Cases'), [
                 'route' => ['cases_by_type', ''],
                 'icon' => 'fa-id-badge',


### PR DESCRIPTION
## Issue & Reproduction Steps

Cases link is not marked as active when Cases page is visited 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16649

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next