### PR TITLE
Process variable assignment not working when target user is set as out of office with delegation user configured

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1161,35 +1161,31 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         foreach ($this->start_events as $startEvent) {
             $webEntryProperties = (isset($startEvent['config']) && isset(json_decode($startEvent['config'])->web_entry) ? json_decode($startEvent['config'])->web_entry : null);
 
-            if ($webEntryProperties && isset($webEntryProperties->webentryRouteConfig)) {
-                switch ($webEntryProperties->webentryRouteConfig->urlType) {
-                    case 'standard-url':
-                        $this->deleteUnusedCustomRoutes(
-                            $webEntryProperties->webentryRouteConfig->firstUrlSegment,
-                            $webEntryProperties->webentryRouteConfig->processId,
-                            $webEntryProperties->webentryRouteConfig->nodeId
-                        );
-                        break;
+            if (!($webEntryProperties && isset($webEntryProperties->webentryRouteConfig))) {
+                continue;
+            }
 
-                    default:
-                        if ($webEntryProperties->webentryRouteConfig->firstUrlSegment !== '') {
-                            $webentryRouteConfig = $webEntryProperties->webentryRouteConfig;
-                            try {
-                                WebentryRoute::updateOrCreate(
-                                    [
-                                        'process_id' => $this->id,
-                                        'node_id' => $webentryRouteConfig->nodeId,
-                                    ],
-                                    [
-                                        'first_segment' => $webentryRouteConfig->firstUrlSegment,
-                                        'params' => $webentryRouteConfig->parameters,
-                                    ]
-                                );
-                            } catch (Exception $e) {
-                                \Log::info('*** Error: ' . $e->getMessage());
-                            }
-                        }
-                        break;
+            if ($webEntryProperties->webentryRouteConfig->urlType === 'standard-url') {
+                $this->deleteUnusedCustomRoutes(
+                    $webEntryProperties->webentryRouteConfig->firstUrlSegment,
+                    $webEntryProperties->webentryRouteConfig->processId,
+                    $webEntryProperties->webentryRouteConfig->nodeId
+                );
+            } elseif ($webEntryProperties->webentryRouteConfig->firstUrlSegment !== '') {
+                $webentryRouteConfig = $webEntryProperties->webentryRouteConfig;
+                try {
+                    WebentryRoute::updateOrCreate(
+                        [
+                            'process_id' => $this->id,
+                            'node_id' => $webentryRouteConfig->nodeId,
+                        ],
+                        [
+                            'first_segment' => $webentryRouteConfig->firstUrlSegment,
+                            'params' => $webentryRouteConfig->parameters,
+                        ]
+                    );
+                } catch (Exception $e) {
+                    \Log::info('*** Error: ' . $e->getMessage());
                 }
             }
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
Assignment is only allowed to users with ACTIVE status when an assignment is a process variable.

## Solution
- It is now allowed to assign users with the out_of_office status and assign them to the user that is available for delegation.

## How to Test
Steps in ticket.

## Related Tickets & Packages
- [FOUR-15164](https://processmaker.atlassian.net/browse/FOUR-15164)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15164]: https://processmaker.atlassian.net/browse/FOUR-15164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ