### PR TITLE
FOUR-16604: Integrate Automatic Sign-In with PM Platform - Frontend and Backend Tasks (develop)

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/ProcessIntelligenceController.php
+++ b/ProcessMaker/Http/Controllers/Admin/ProcessIntelligenceController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Admin;
+
+use Illuminate\View\View;
+use ProcessMaker\Http\Controllers\Api\ProcessIntelligenceController as ApiProcessIntelligenceController;
+use ProcessMaker\Http\Controllers\Controller;
+
+class ProcessIntelligenceController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): View
+    {
+        $response = resolve(ApiProcessIntelligenceController::class)->getJweToken();
+        $data = json_decode($response->getContent(), true);
+
+        return view('admin.process-intelligence.index', [
+            'token' => $data['token'],
+        ]);
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/ProcessIntelligenceController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessIntelligenceController.php
@@ -8,11 +8,9 @@ use ProcessMaker\Services\JweService;
 
 class ProcessIntelligenceController extends Controller
 {
-    protected $jweService;
-
-    public function __construct(JweService $jweService)
-    {
-        $this->jweService = $jweService;
+    public function __construct(
+        protected JweService $jweService
+    ) {
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/ProcessIntelligenceController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessIntelligenceController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Services\JweService;
+
+class ProcessIntelligenceController extends Controller
+{
+    protected $jweService;
+
+    public function __construct(JweService $jweService)
+    {
+        $this->jweService = $jweService;
+    }
+
+    /**
+     * Retrieves a JWE token.
+     */
+    public function getJweToken(): JsonResponse
+    {
+        $additionalData = [];
+        $jweToken = $this->jweService->generateToken($additionalData);
+
+        return response()->json([
+            'token' => $jweToken,
+        ]);
+    }
+}

--- a/ProcessMaker/Services/JweService.php
+++ b/ProcessMaker/Services/JweService.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace ProcessMaker\Services;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\UnencryptedToken;
+
+class JweService
+{
+    private $jwtConfig;
+
+    private $jwtSecretKey;
+
+    private $jweEncryptionKey;
+
+    public function __construct()
+    {
+        $this->jwtSecretKey = config('process_intelligence.secret_key');
+        $this->jweEncryptionKey = config('process_intelligence.encryption_key');
+
+        $this->jwtConfig = Configuration::forSymmetricSigner(
+            new Sha256(),
+            InMemory::plainText($this->jwtSecretKey)
+        );
+    }
+
+    /**
+     * Generates a token with the given data and encrypts it.
+     */
+    public function generateToken(array $data): string
+    {
+        $payload = array_merge($data, $this->getInstanceMetadata());
+
+        $now = new DateTimeImmutable();
+        $token = $this->jwtConfig->builder()
+            ->issuedBy(config('app.url'))
+            ->issuedAt($now)
+            ->withClaim('data', $payload)
+            ->getToken($this->jwtConfig->signer(), $this->jwtConfig->signingKey());
+
+        $jwt = $token->toString();
+
+        return $this->encrypt($jwt);
+    }
+
+    /**
+     * Encrypts a JWT using AES-256-GCM encryption.
+     *
+     * @throws InvalidArgumentException If encryption fails.
+     */
+    public function encrypt(string $jwt): string
+    {
+        // Initialization Vector 12 bytes for AES-256-GCM.
+        $iv = random_bytes(12);
+
+        // Tag will be filled with the authentication tag by openssl_encrypt.
+        $tag = null;
+
+        // Perform the encryption.
+        $ciphertext = openssl_encrypt(
+            $jwt,
+            'aes-256-gcm',
+            $this->jweEncryptionKey,
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag
+        );
+
+        if ($ciphertext === false) {
+            throw new InvalidArgumentException('Encryption failed.');
+        }
+
+        // Concatenate the IV, tag and ciphertext.
+        $combinedData = $iv . $tag . $ciphertext;
+
+        // Encode the combined data in base64.
+        // This ensures compatibility with text-based systems and protocols.
+        return base64_encode($combinedData);
+    }
+
+    /**
+     * Validates a token by decrypting it and extracting the data claims.
+     */
+    public function validateToken(string $token): array
+    {
+        $decodedToken = $this->decrypt($token);
+
+        $jwt = $this->jwtConfig->parser()->parse($decodedToken);
+        assert($jwt instanceof UnencryptedToken);
+
+        return $jwt->claims()->get('data');
+    }
+
+    /**
+     * Decrypts a JWE (JSON Web Encryption) string.
+     *
+     * @throws InvalidArgumentException If the decryption fails.
+     */
+    public function decrypt(string $jwe): string
+    {
+        $data = base64_decode($jwe);
+        $iv = substr($data, 0, 12);
+        $tag = substr($data, 12, 16);
+        $ciphertext = substr($data, 28);
+
+        $jwt = openssl_decrypt(
+            $ciphertext,
+            'aes-256-gcm',
+            $this->jweEncryptionKey,
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag
+        );
+
+        if ($jwt === false) {
+            throw new InvalidArgumentException('Decryption failed.');
+        }
+
+        return $jwt;
+    }
+
+    /**
+     * Retrieves the metadata of the instance.
+     */
+    public function getInstanceMetadata(): array
+    {
+        return [
+            'company_name' => config('process_intelligence.company_name'),
+            'company_bucket' => config('process_intelligence.company_bucket'),
+        ];
+    }
+}

--- a/ProcessMaker/Services/JweService.php
+++ b/ProcessMaker/Services/JweService.php
@@ -2,8 +2,6 @@
 
 namespace ProcessMaker\Services;
 
-use DateTimeImmutable;
-use InvalidArgumentException;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Signer\Key\InMemory;
@@ -15,12 +13,12 @@ class JweService
 
     private $jwtSecretKey;
 
-    private $jweEncryptionKey;
+    private $jweSecretKey;
 
     public function __construct()
     {
         $this->jwtSecretKey = base64_decode(config('process_intelligence.secret_key'));
-        $this->jweEncryptionKey = base64_decode(config('process_intelligence.encryption_key'));
+        $this->jweSecretKey = base64_decode(config('process_intelligence.encryption_key'));
 
         $this->jwtConfig = Configuration::forSymmetricSigner(
             new Sha256(),
@@ -29,108 +27,43 @@ class JweService
     }
 
     /**
-     * Generates a token with the given data and encrypts it.
+     * Generates a token with the given data.
      */
     public function generateToken(array $data): string
     {
         $payload = array_merge($data, $this->getInstanceMetadata());
 
-        $now = new DateTimeImmutable();
         $token = $this->jwtConfig->builder()
-            ->issuedBy(config('app.url'))
-            ->issuedAt($now)
-            ->withClaim('data', $payload)
+            ->withClaim('company_name', $payload['company_name'])
+            ->withClaim('company_database', $payload['company_database'])
             ->getToken($this->jwtConfig->signer(), $this->jwtConfig->signingKey());
 
         $jwt = $token->toString();
 
-        return $this->encrypt($jwt);
-    }
+        $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length('aes-256-cbc'));
 
-    /**
-     * Encrypts a JWT using AES-256-GCM encryption.
-     *
-     * @throws InvalidArgumentException If encryption fails.
-     */
-    public function encrypt(string $jwt): string
-    {
-        // Initialization Vector 12 bytes for AES-256-GCM.
-        $iv = random_bytes(12);
-
-        // Tag will be filled with the authentication tag by openssl_encrypt.
-        $tag = null;
-
-        // Perform the encryption.
         $ciphertext = openssl_encrypt(
             $jwt,
-            'aes-256-gcm',
-            $this->jweEncryptionKey,
+            'aes-256-cbc',
+            $this->jweSecretKey,
             OPENSSL_RAW_DATA,
-            $iv,
-            $tag
+            $iv
         );
 
-        if ($ciphertext === false) {
-            throw new InvalidArgumentException('Encryption failed.');
-        }
-
-        // JWE Header.
-        $header = json_encode(['alg' => 'dir', 'enc' => 'A256GCM']);
-
-        // Encode each part in base64url and concatenate with dots.
-        return sprintf(
-            '%s.%s.%s.%s.%s',
-            $this->base64UrlEncode($header),
-            '', // No Encrypted Key for 'dir' algorithm
-            $this->base64UrlEncode($iv),
-            $this->base64UrlEncode($ciphertext),
-            $this->base64UrlEncode($tag)
-        );
+        return rtrim(strtr(base64_encode($iv . $ciphertext), '+/', '-_'), '=');
     }
 
     /**
-     * Validates a token by decrypting it and extracting the data claims.
+     * Validates a token and extracts the data claims.
      */
     public function validateToken(string $token): array
     {
-        $decodedToken = $this->decrypt($token);
-
-        $jwt = $this->jwtConfig->parser()->parse($decodedToken);
+        $jwt = $this->jwtConfig->parser()->parse($token);
         assert($jwt instanceof UnencryptedToken);
 
+        $this->jwtConfig->validator()->assert($jwt, ...$this->jwtConfig->validationConstraints());
+
         return $jwt->claims()->get('data');
-    }
-
-    /**
-     * Decrypts a JWE (JSON Web Encryption) string.
-     *
-     * @throws InvalidArgumentException If the decryption fails.
-     */
-    public function decrypt(string $jwe): string
-    {
-        $parts = explode('.', $jwe);
-        if (count($parts) !== 5) {
-            throw new InvalidArgumentException('Invalid JWE format.');
-        }
-
-        $iv = $this->base64UrlDecode($parts[2]);
-        $ciphertext = $this->base64UrlDecode($parts[3]);
-        $tag = $this->base64UrlDecode($parts[4]);
-
-        $jwt = openssl_decrypt(
-            $ciphertext,
-            'aes-256-gcm',
-            $this->jweEncryptionKey,
-            OPENSSL_RAW_DATA,
-            $iv,
-            $tag
-        );
-
-        if ($jwt === false) {
-            throw new InvalidArgumentException('Decryption failed.');
-        }
-
-        return $jwt;
     }
 
     /**
@@ -149,14 +82,7 @@ class JweService
      */
     private function base64UrlEncode(string $data): string
     {
-        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
-    }
-
-    /**
-     * Decodes data using base64 URL decoding.
-     */
-    private function base64UrlDecode(string $data): string
-    {
-        return base64_decode(strtr($data, '-_', '+/'));
+        // return strtr(base64_encode($data), '+/', '-_');
+        return base64_encode($data);
     }
 }

--- a/ProcessMaker/Services/JweService.php
+++ b/ProcessMaker/Services/JweService.php
@@ -19,8 +19,8 @@ class JweService
 
     public function __construct()
     {
-        $this->jwtSecretKey = config('process_intelligence.secret_key');
-        $this->jweEncryptionKey = config('process_intelligence.encryption_key');
+        $this->jwtSecretKey = base64_decode(config('process_intelligence.secret_key'));
+        $this->jweEncryptionKey = base64_decode(config('process_intelligence.encryption_key'));
 
         $this->jwtConfig = Configuration::forSymmetricSigner(
             new Sha256(),
@@ -130,7 +130,7 @@ class JweService
     {
         return [
             'company_name' => config('process_intelligence.company_name'),
-            'company_bucket' => config('process_intelligence.company_bucket'),
+            'company_database' => config('process_intelligence.company_database'),
         ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "laravel/ui": "^4.2",
         "laravelcollective/html": "^6.4",
         "lavary/laravel-menu": "^1.8",
-        "lcobucci/jwt": "^4.2",
+        "lcobucci/jwt": "^5.3",
         "league/flysystem-aws-s3-v3": "^3.15",
         "mateusjunges/laravel-kafka": "^1.11",
         "microsoft/microsoft-graph": "^1.77",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f197ec23dcba0a370cfd51eb8222536f",
+    "content-hash": "80ce77d2caabc985313aad76c24374fd",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4149,39 +4149,38 @@
         },
         {
             "name": "lcobucci/jwt",
-            "version": "4.3.0",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "4d7de2fe0d51a96418c0d04004986e410e87f6b4"
+                "reference": "08071d8d2c7f4b00222cc4b1fb6aa46990a80f83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/4d7de2fe0d51a96418c0d04004986e410e87f6b4",
-                "reference": "4d7de2fe0d51a96418c0d04004986e410e87f6b4",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/08071d8d2c7f4b00222cc4b1fb6aa46990a80f83",
+                "reference": "08071d8d2c7f4b00222cc4b1fb6aa46990a80f83",
                 "shasum": ""
             },
             "require": {
-                "ext-hash": "*",
-                "ext-json": "*",
-                "ext-mbstring": "*",
                 "ext-openssl": "*",
                 "ext-sodium": "*",
-                "lcobucci/clock": "^2.0 || ^3.0",
-                "php": "^7.4 || ^8.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "psr/clock": "^1.0"
             },
             "require-dev": {
-                "infection/infection": "^0.21",
-                "lcobucci/coding-standard": "^6.0",
-                "mikey179/vfsstream": "^1.6.7",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/php-invoker": "^3.1",
-                "phpunit/phpunit": "^9.5"
+                "infection/infection": "^0.27.0",
+                "lcobucci/clock": "^3.0",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2.9",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^10.2.6"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.0"
             },
             "type": "library",
             "autoload": {
@@ -4207,7 +4206,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lcobucci/jwt/issues",
-                "source": "https://github.com/lcobucci/jwt/tree/4.3.0"
+                "source": "https://github.com/lcobucci/jwt/tree/5.3.0"
             },
             "funding": [
                 {
@@ -4219,7 +4218,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-01-02T13:28:00+00:00"
+            "time": "2024-04-11T23:07:54+00:00"
         },
         {
             "name": "league/commonmark",
@@ -6306,16 +6305,16 @@
         },
         {
             "name": "paragonie/constant_time_encoding",
-            "version": "v2.6.3",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/constant_time_encoding.git",
-                "reference": "58c3f47f650c94ec05a151692652a868995d2938"
+                "reference": "52a0d99e69f56b9ec27ace92ba56897fe6993105"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/58c3f47f650c94ec05a151692652a868995d2938",
-                "reference": "58c3f47f650c94ec05a151692652a868995d2938",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/52a0d99e69f56b9ec27ace92ba56897fe6993105",
+                "reference": "52a0d99e69f56b9ec27ace92ba56897fe6993105",
                 "shasum": ""
             },
             "require": {
@@ -6369,7 +6368,7 @@
                 "issues": "https://github.com/paragonie/constant_time_encoding/issues",
                 "source": "https://github.com/paragonie/constant_time_encoding"
             },
-            "time": "2022-06-14T06:56:20+00:00"
+            "time": "2024-05-08T12:18:48+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -7082,20 +7081,20 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.34",
+            "version": "3.0.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "56c79f16a6ae17e42089c06a2144467acc35348a"
+                "reference": "211ebc399c6e73c225a018435fe5ae209d1d1485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/56c79f16a6ae17e42089c06a2144467acc35348a",
-                "reference": "56c79f16a6ae17e42089c06a2144467acc35348a",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/211ebc399c6e73c225a018435fe5ae209d1d1485",
+                "reference": "211ebc399c6e73c225a018435fe5ae209d1d1485",
                 "shasum": ""
             },
             "require": {
-                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/constant_time_encoding": "^1|^2|^3",
                 "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
                 "php": ">=5.6.1"
             },
@@ -7172,7 +7171,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.34"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.39"
             },
             "funding": [
                 {
@@ -7188,7 +7187,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-27T11:13:31+00:00"
+            "time": "2024-06-24T06:27:33+00:00"
         },
         {
             "name": "pion/laravel-chunk-upload",

--- a/config/process_intelligence.php
+++ b/config/process_intelligence.php
@@ -9,9 +9,10 @@ return [
     // The secret key used to sign the JWT. This should be at least 256 bits (32 bytes) for HS256 base64-encoded.
     'secret_key' => env('PROCESS_INTELLIGENCE_JWT_SIGNATURE_SECRET_KEY'),
 
+    // The encryption key used to encrypt the JWT base64-encoded.
     'encryption_key' => env('PROCESS_INTELLIGENCE_JWE_ENCRYPTION_KEY'),
 
     'company_name' => env('PROCESS_INTELLIGENCE_COMPANY_NAME', 'Company Name'),
 
-    'company_bucket' => env('PROCESS_INTELLIGENCE_COMPANY_DATABASE', 'company-database'),
+    'company_database' => env('PROCESS_INTELLIGENCE_COMPANY_DATABASE', 'company-database'),
 ];

--- a/config/process_intelligence.php
+++ b/config/process_intelligence.php
@@ -1,17 +1,17 @@
 <?php
 
 /**
- * Configuration file for Process Intelligence.
+ * Process Intelligence Configuration
  *
- * This file contains the configuration options for Process Intelligence.
+ * This file defines the configuration options for the Process Intelligence integration.
  */
 return [
-    // The secret key used to sign the JWT. This should be at least 256 bits (32 bytes) for HS256.
+    // The secret key used to sign the JWT. This should be at least 256 bits (32 bytes) for HS256 base64-encoded.
     'secret_key' => env('PROCESS_INTELLIGENCE_JWT_SIGNATURE_SECRET_KEY'),
 
     'encryption_key' => env('PROCESS_INTELLIGENCE_JWE_ENCRYPTION_KEY'),
 
-    'company_name' => env('PROCESS_INTELLIGENCE_COMPANY_NAME'),
+    'company_name' => env('PROCESS_INTELLIGENCE_COMPANY_NAME', 'Company Name'),
 
-    'company_bucket' => env('PROCESS_INTELLIGENCE_COMPANY_BUCKET'),
+    'company_bucket' => env('PROCESS_INTELLIGENCE_COMPANY_DATABASE', 'company-database'),
 ];

--- a/config/process_intelligence.php
+++ b/config/process_intelligence.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Configuration file for Process Intelligence.
+ *
+ * This file contains the configuration options for Process Intelligence.
+ */
+return [
+    // The secret key used to sign the JWT. This should at least 256 bits (32 bytes) for HS256.
+    'secret_key' => env('PROCESS_INTELLIGENCE_JWT_SIGNATURE_SECRET_KEY'),
+
+    'encryption_key' => env('PROCESS_INTELLIGENCE_JWE_ENCRYPTION_KEY'),
+
+    'company_name' => env('PROCESS_INTELLIGENCE_COMPANY_NAME'),
+
+    'company_bucket' => env('PROCESS_INTELLIGENCE_COMPANY_BUCKET'),
+];

--- a/config/process_intelligence.php
+++ b/config/process_intelligence.php
@@ -6,7 +6,7 @@
  * This file contains the configuration options for Process Intelligence.
  */
 return [
-    // The secret key used to sign the JWT. This should at least 256 bits (32 bytes) for HS256.
+    // The secret key used to sign the JWT. This should be at least 256 bits (32 bytes) for HS256.
     'secret_key' => env('PROCESS_INTELLIGENCE_JWT_SIGNATURE_SECRET_KEY'),
 
     'encryption_key' => env('PROCESS_INTELLIGENCE_JWE_ENCRYPTION_KEY'),

--- a/resources/views/admin/process-intelligence/index.blade.php
+++ b/resources/views/admin/process-intelligence/index.blade.php
@@ -18,7 +18,7 @@
 @endsection
 @section('content')
   <iframe
-    src="https://dev-app.workfellow.com/automatic-sign-in?jwe={{ $token }}"
+    src="https://dev-app.workfellow.com/automatic-sign-in?token={{ $token }}"
     title="{{ __('Process Intelligence') }}"
     width="100%"
     height="600"

--- a/resources/views/admin/process-intelligence/index.blade.php
+++ b/resources/views/admin/process-intelligence/index.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.layout')
+
+@section('title')
+  {{ __('Process Intelligence') }}
+@endsection
+
+@section('sidebar')
+  @include('layouts.sidebar', ['sidebar' => Menu::get('sidebar_admin')])
+@endsection
+
+@section('breadcrumbs')
+  @include('shared.breadcrumbs', [
+      'routes' => [
+          __('Admin') => route('admin.index'),
+          __('Process Intelligence') => null,
+      ],
+  ])
+@endsection
+@section('content')
+  <iframe
+    src="https://dev-app.workfellow.com/automatic-sign-in?jwe={{ $token }}"
+    title="{{ __('Process Intelligence') }}"
+    width="100%"
+    height="600"
+  ></iframe>
+@endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,10 +14,10 @@ use ProcessMaker\Http\Controllers\Api\GroupMemberController;
 use ProcessMaker\Http\Controllers\Api\ImportController;
 use ProcessMaker\Http\Controllers\Api\InboxRulesController;
 use ProcessMaker\Http\Controllers\Api\NotificationController;
-use ProcessMaker\Http\Controllers\Api\OpenAIController;
 use ProcessMaker\Http\Controllers\Api\PermissionController;
 use ProcessMaker\Http\Controllers\Api\ProcessCategoryController;
 use ProcessMaker\Http\Controllers\Api\ProcessController;
+use ProcessMaker\Http\Controllers\Api\ProcessIntelligenceController;
 use ProcessMaker\Http\Controllers\Api\ProcessLaunchpadController;
 use ProcessMaker\Http\Controllers\Api\ProcessRequestController;
 use ProcessMaker\Http\Controllers\Api\ProcessRequestFileController;
@@ -178,7 +178,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::put('process_categories/{process_category}', [ProcessCategoryController::class, 'update'])->name('process_categories.update')->middleware('can:edit-process-categories');
     Route::delete('process_categories/{process_category}', [ProcessCategoryController::class, 'destroy'])->name('process_categories.destroy')->middleware('can:delete-process-categories');
 
-    //Process Launchpad
+    // Process Launchpad
     Route::get('processes/{process}/media', [ProcessController::class, 'getMediaImages'])->name('processes.media')->middleware('can:view-processes');
     Route::delete('processes/{process}/media', [ProcessController::class, 'deleteMediaImages'])->name('processes.delete-media')->middleware('can:view-processes');
 
@@ -341,6 +341,9 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('processes/{processId}/export/translation/{language}', [ProcessTranslationController::class, 'export'])->name('process-translation.export')->middleware('can:export-process-translations');
     Route::post('processes/{processId}/import/translation/validation', [ProcessTranslationController::class, 'preimportValidation'])->name('process-translation.preImport')->middleware('can:import-process-translations');
     Route::post('processes/{processId}/import/translation', [ProcessTranslationController::class, 'import'])->name('process-translation.import')->middleware('can:import-process-translations');
+
+    // Process Intelligence
+    Route::get('process-intelligence/get-jwe-token', [ProcessIntelligenceController::class, 'getJweToken'])->name('process-intelligence.get-jwe-token');
 
     // debugging javascript errors
     Route::post('debug', [DebugController::class, 'store'])->name('debug.store')->middleware('throttle');

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use ProcessMaker\Http\Controllers\Admin\AuthClientController;
 use ProcessMaker\Http\Controllers\Admin\CssOverrideController;
 use ProcessMaker\Http\Controllers\Admin\GroupController;
 use ProcessMaker\Http\Controllers\Admin\LdapLogsController;
+use ProcessMaker\Http\Controllers\Admin\ProcessIntelligenceController;
 use ProcessMaker\Http\Controllers\Admin\QueuesController;
 use ProcessMaker\Http\Controllers\Admin\ScriptExecutorController;
 use ProcessMaker\Http\Controllers\Admin\SettingsController;
@@ -37,7 +38,6 @@ use ProcessMaker\Http\Controllers\TaskController;
 use ProcessMaker\Http\Controllers\TemplateController;
 use ProcessMaker\Http\Controllers\TestStatusController;
 use ProcessMaker\Http\Controllers\UnavailableController;
-use ProcessMaker\Http\Middleware\NoCache;
 
 Route::middleware('auth', 'session_kill', 'sanitize', 'force_change_password', '2fa')->group(function () {
     // Routes related to Authentication (password reset, etc)
@@ -63,6 +63,9 @@ Route::middleware('auth', 'session_kill', 'sanitize', 'force_change_password', '
         // temporary, should be removed
         Route::get('security-logs/download/all', [ProcessMaker\Http\Controllers\Api\SecurityLogController::class, 'downloadForAllUsers'])->middleware('can:view-security-logs');
         Route::get('security-logs/download/{user}', [ProcessMaker\Http\Controllers\Api\SecurityLogController::class, 'downloadForUser'])->middleware('can:view-security-logs');
+
+        // Process Intelligence
+        Route::get('pi-test', [ProcessIntelligenceController::class, 'index'])->name('process-intelligence.index');
     });
 
     Route::get('admin', [AdminController::class, 'index'])->name('admin.index');
@@ -98,13 +101,13 @@ Route::middleware('auth', 'session_kill', 'sanitize', 'force_change_password', '
     Route::get('process-browser/{process?}', [ProcessesCatalogueController::class, 'index'])
        ->name('process.browser.index')
        ->middleware('can:view-process-catalog');
-    //------------------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------------------
     // Below route is for backward compatibility with old format routes. PLEASE DO NOT REMOVE
-    //------------------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------------------
     Route::get('processes-catalogue/{process?}', function ($process = null) {
         return redirect()->route('process.browser.index', [$process]);
     })->name('processes.catalogue.index');
-    //------------------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------------------
 
     Route::get('processes', [ProcessController::class, 'index'])->name('processes.index');
     Route::get('processes/{process}/edit', [ProcessController::class, 'edit'])->name('processes.edit')->middleware('can:edit-processes');
@@ -210,4 +213,3 @@ Route::get('/unavailable', [UnavailableController::class, 'show'])->name('error.
 
 // SAML Metadata Route
 Route::resource('/saml/metadata', MetadataController::class)->only('index');
-

--- a/tests/Feature/Api/ProcessIntelligenceControllerTest.php
+++ b/tests/Feature/Api/ProcessIntelligenceControllerTest.php
@@ -2,13 +2,11 @@
 
 namespace Tests\Feature\Api;
 
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
 class ProcessIntelligenceControllerTest extends TestCase
 {
-    use WithFaker;
     use RequestHelper;
 
     public function testGetJweToken()

--- a/tests/Feature/Api/ProcessIntelligenceControllerTest.php
+++ b/tests/Feature/Api/ProcessIntelligenceControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class ProcessIntelligenceControllerTest extends TestCase
+{
+    use WithFaker;
+    use RequestHelper;
+
+    public function testGetJweToken()
+    {
+        $route = route('api.process-intelligence.get-jwe-token');
+
+        $response = $this->apiCall('GET', $route);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(
+            [
+                'token',
+            ]
+        );
+    }
+}

--- a/tests/Feature/Api/ProcessIntelligenceControllerTest.php
+++ b/tests/Feature/Api/ProcessIntelligenceControllerTest.php
@@ -11,6 +11,9 @@ class ProcessIntelligenceControllerTest extends TestCase
 
     public function testGetJweToken()
     {
+        // Set a fake secret key for the tests.
+        config(['process_intelligence.secret_key' => base64_encode(random_bytes(32))]);
+
         $route = route('api.process-intelligence.get-jwe-token');
 
         $response = $this->apiCall('GET', $route);

--- a/tests/unit/ProcessMaker/Services/JweServiceTest.php
+++ b/tests/unit/ProcessMaker/Services/JweServiceTest.php
@@ -13,6 +13,9 @@ class JweServiceTest extends TestCase
     {
         parent::setUp();
 
+        // Set a fake secret key for the tests.
+        config(['process_intelligence.secret_key' => base64_encode(random_bytes(32))]);
+
         $this->jweService = new JweService();
     }
 

--- a/tests/unit/ProcessMaker/Services/JweServiceTest.php
+++ b/tests/unit/ProcessMaker/Services/JweServiceTest.php
@@ -34,13 +34,7 @@ class JweServiceTest extends TestCase
         ];
 
         $token = $this->jweService->generateToken($data);
-
         $decodedData = $this->jweService->validateToken($token);
-
-        dd([
-            'token' => $token,
-            'decodedData' => $decodedData,
-        ]);
 
         $this->assertArrayHasKey('company_name', $decodedData);
         $this->assertArrayHasKey('company_bucket', $decodedData);

--- a/tests/unit/ProcessMaker/Services/JweServiceTest.php
+++ b/tests/unit/ProcessMaker/Services/JweServiceTest.php
@@ -20,7 +20,7 @@ class JweServiceTest extends TestCase
     {
         $expected = [
             'company_name' => config('process_intelligence.company_name'),
-            'company_bucket' => config('process_intelligence.company_bucket'),
+            'company_database' => config('process_intelligence.company_database'),
         ];
 
         $this->assertEquals($expected, $this->jweService->getInstanceMetadata());
@@ -37,7 +37,7 @@ class JweServiceTest extends TestCase
         $decodedData = $this->jweService->validateToken($token);
 
         $this->assertArrayHasKey('company_name', $decodedData);
-        $this->assertArrayHasKey('company_bucket', $decodedData);
+        $this->assertArrayHasKey('company_database', $decodedData);
         $this->assertEquals(1, $decodedData['user_id']);
         $this->assertEquals('john.doe', $decodedData['username']);
     }

--- a/tests/unit/ProcessMaker/Services/JweServiceTest.php
+++ b/tests/unit/ProcessMaker/Services/JweServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\unit\ProcessMaker\Services;
+
+use ProcessMaker\Services\JweService;
+use Tests\TestCase;
+
+class JweServiceTest extends TestCase
+{
+    public $jweService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->jweService = new JweService();
+    }
+
+    public function testGetInstanceMetadata()
+    {
+        $expected = [
+            'company_name' => config('process_intelligence.company_name'),
+            'company_bucket' => config('process_intelligence.company_bucket'),
+        ];
+
+        $this->assertEquals($expected, $this->jweService->getInstanceMetadata());
+    }
+
+    public function testGenerateToken()
+    {
+        $data = [
+            'user_id' => 1,
+            'username' => 'john.doe',
+        ];
+
+        $token = $this->jweService->generateToken($data);
+
+        $decodedData = $this->jweService->validateToken($token);
+
+        dd([
+            'token' => $token,
+            'decodedData' => $decodedData,
+        ]);
+
+        $this->assertArrayHasKey('company_name', $decodedData);
+        $this->assertArrayHasKey('company_bucket', $decodedData);
+        $this->assertEquals(1, $decodedData['user_id']);
+        $this->assertEquals('john.doe', $decodedData['username']);
+    }
+
+    public function testEncryptToken()
+    {
+        $jwt = 'test.jwt.token';
+        $encrypted = $this->jweService->encrypt($jwt);
+
+        $this->assertNotEmpty($encrypted, 'Encrypted value should not be empty');
+
+        $decrypted = $this->jweService->decrypt($encrypted);
+
+        $this->assertEquals($jwt, $decrypted, 'Decrypted value should match the original JWT');
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Start implementing authentication between the PI and PM platforms, using an iframe and passing a JWE as a query parameter for authentication.

## Solution
- Generate a JWT using the `lcobucci/jwt` package, with the HS256/A256GCM algorithm and payload.
- Encrypt the JWT and create a JWE.
- Add an endpoint to obtain the token and pass it in the iframe.

## How to Test
- _TBD_
- Run unit tests: `php artisan test --filter ProcessIntelligenceControllerTest` and `php artisan test --filter JweServiceTest`

## Related Tickets & Packages
- [FOUR-16604](https://processmaker.atlassian.net/browse/FOUR-16604)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-16604]: https://processmaker.atlassian.net/browse/FOUR-16604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ