### PR TITLE
FOUR-16564 Fix When a new instance is created, the column alternative shows up by default

### DIFF
--- a/ProcessMaker/Http/Resources/ProcessRequests.php
+++ b/ProcessMaker/Http/Resources/ProcessRequests.php
@@ -9,6 +9,7 @@ class ProcessRequests extends ApiResource
     public function toArray($request)
     {
         $array = parent::toArray($request);
+        $array['process_version_alternative'] = $this->processVersionAlternative;
         $include = explode(',', $request->input('include', ''));
 
         if (in_array('data', $include)) {

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -1050,10 +1050,6 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
 
     public function getProcessVersionAlternativeAttribute(): string | null
     {
-        if (class_exists('ProcessMaker\Package\PackageABTesting\Models\Alternative')) {
-            return $this->processVersion?->alternative;
-        }
-
-        return null;
+        return $this->processVersion?->alternative ?? 'A';
     }
 }

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -259,18 +259,6 @@ export default {
           truncate: true,
         },
         {
-          label: "Alternative",
-          field: "process_version_alternative",
-          sortable: true,
-          default: true,
-          width: 150,
-          truncate: true,
-          filter_subject: {
-            type: "Relationship",
-            value: "processVersion.alternative",
-          },
-        },
-        {
           label: "Task",
           field: "active_tasks",
           sortable: false,

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -398,7 +398,7 @@ export default {
         <span 
           class="badge badge-${color} status-${badge}"
         >
-          Alternative ${value}
+          ${this.$t('Alternative')} ${value}
         </span>`;
     },
     transform(dataInput) {


### PR DESCRIPTION
## Fix When a new instance is created, the column alternative shows up by default

## Solution
- Add alternative as selectable column

## How to Test
- By default Alternative is not present
- Edit the configuration of Requests
- Add Alternative column

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16564

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:package-savedsearch:FOUR-16564N