### PR TITLE
feature/FOUR-16724: All the configurations related to the ABE needs to save and create a method to get this information

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -145,6 +145,8 @@ class TokenRepository implements TokenRepositoryInterface
             }
         }
 
+        $this->getAcionByEmail($activity);
+
         //Default 3 days of due date
         $due = $this->getDueVariable($activity, $token);
         $token->due_at = $due ? Carbon::now()->addHours($due) : null;
@@ -157,6 +159,24 @@ class TokenRepository implements TokenRepositoryInterface
         $request = $token->getInstance();
         $request->notifyProcessUpdated('ACTIVITY_ACTIVATED');
         $this->instanceRepository->persistInstanceUpdated($token->getInstance());
+    }
+
+    /**
+     * Get action by email configuration
+     *
+     * @param ActivityInterface $activity
+     */
+    private function getAcionByEmail(ActivityInterface $activity)
+    {
+        $isActionsByEmail = $activity->getProperty('isActionsByEmail', false);
+        if ($isActionsByEmail) {
+            $configEmail =  json_decode($activity->getProperty('configEmail', []));
+            // Get the parameters to send the email
+            $emailserver = $configEmail->emailServer ?? 0;
+            $subject = $configEmail->subject ?? '';
+            $emailScreen = $configEmail->screenEmailRef ?? 0;
+            $emailScreenCompleted = $configEmail->screenCompleteRef ?? 0;
+        }
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
When you configure the action by email the following fields was updated:
- isActionsByEmail
- configEmail
Create a method to get this information when is routing to the next task

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16724

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next