### PR TITLE
FOUR-14690 Fix Visibility Issue with 'Rule Expression' and 'Self Service' Assigned Tasks

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -94,19 +94,19 @@ class Task extends ApiResource
                                                 || count($array['assignable_users']) < 1;
         if (in_array('assignableUsers', $include) && $needToRecalculateAssignableUsers) {
             $definition = $this->getDefinition();
-            if (isset($definition['assignment']) && $definition['assignment'] == 'self_service') {
+            $config = json_decode($definition['config'], true) ?: [];
+            $isSelfService = $config['selfService'] ?? false;
+            if ($isSelfService) {
                 $users = [];
                 $selfServiceUsers = $array['self_service_groups']['users'];
                 $selfServiceGroups = $array['self_service_groups']['groups'];
 
                 if ($selfServiceUsers !== ['']) {
-                    $assignedUsers = $this->getAssignedUsers($selfServiceUsers);
-                    $users = array_unique(array_merge($users, $assignedUsers));
+                    $users = $this->addActiveAssignedUsers($selfServiceUsers, $users);
                 }
 
                 if ($selfServiceGroups !== ['']) {
-                    $assignedUsers = $this->getAssignedGroupMembers($selfServiceGroups);
-                    $users = array_unique(array_merge($users, $assignedUsers));
+                    $users = $this->addActiveAssignedGroupMembers($selfServiceGroups, $users);
                 }
                 $array['assignable_users'] = $users;
             }
@@ -127,26 +127,39 @@ class Task extends ApiResource
         return $permissions;
     }
 
-    private function getAssignedUsers($users)
+    /**
+     * Add the active users to the list of assigned users
+     *
+     * @param array $users List of users ids
+     * @param array $assignedUsers List of assigned users
+     *
+     * @return array List of assigned users with additional active users
+     */
+    private function addActiveAssignedUsers(array $users, array $assignedUsers)
     {
-        foreach ($users as $user) {
-            $assignedUsers[] = User::where('status', 'ACTIVE')->where('id', $user)->first();
+        $users = array_unique($users);
+        $userChunks = array_chunk($users, 1000);
+        foreach ($userChunks as $chunk) {
+            $activeUsers = User::select('id')
+                ->whereNotIn('status', Process::NOT_ASSIGNABLE_USER_STATUS)
+                ->whereIn('id', $chunk)
+                ->pluck('id')->toArray();
+            $assignedUsers = array_merge($assignedUsers,$activeUsers);
         }
 
         return $assignedUsers;
     }
 
-    private function getAssignedGroupMembers($groups)
+    /**
+     * Add the active group members to the list of assigned users
+     *
+     * @param array $groups List of group ids
+     * @param array $assignedUsers List of assigned users
+     * @return array List of assigned users with additional active users
+     */
+    private function addActiveAssignedGroupMembers(array $groups, array $assignedUsers)
     {
-        \Log::debug('groups', ['groups' =>$groups]);
-        foreach ($groups as $group) {
-            $groupMembers = GroupMember::where('group_id', $group)->get();
-            foreach ($groupMembers as $member) {
-                $assignedUsers[] = User::where('status', 'ACTIVE')->where('id', $member->member_id)->first();
-            }
-        }
-
-        return $assignedUsers;
+        return (new Process)->getConsolidatedUsers($groups, $assignedUsers);
     }
 
     private function getData()


### PR DESCRIPTION
## Issue & Reproduction Steps
Visibility Issue with 'Rule Expression' and 'Self Service' Assigned Tasks

## Solution
- Improve getConsolidatedUsers method and use in self service.

## How to Test
- Create a Process with a Simple Task and a SelfService Task with Assignment Rules.
<img width="1108" alt="image" src="https://github.com/ProcessMaker/processmaker/assets/8028650/db781566-5f24-4562-bd81-a4b9a04a51a2">
- Add an assignment rule to assign the second task to a group
- Run the process
- Submit
- Login with a user (could be non admin) that belongs to the group
- User must see the request In progress and in the All Request default saved search
<img width="1412" alt="image" src="https://github.com/ProcessMaker/processmaker/assets/8028650/555b73a3-5ac8-423d-a71c-287cf338b5e5">
- User can open the request
<img width="1345" alt="image" src="https://github.com/ProcessMaker/processmaker/assets/8028650/410d8671-1458-4557-a6ec-14a2aa354eac">
- User can claim the self service task
<img width="1422" alt="image" src="https://github.com/ProcessMaker/processmaker/assets/8028650/8eb4db69-60d3-42fb-952a-931f47a6bb49">

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14690

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
