### PR TITLE
FOUR-16002 Improve show request complete view

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -355,8 +355,20 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
             ->orderBy('completed_at')
             ->get();
         $screens = [];
+        $definitions = [];
         foreach ($tokens as $token) {
-            $definition = $token->getDefinition();
+            // Get process related to token
+            $request = $token->processRequest ?: $token->getInstance();
+            $process = $request->processVersion ?: $request->process;
+
+            // Get the definition
+            if (!empty($definitions[$process->id])) {
+                $definition = $definitions[$process->id];
+            } else {
+                $definition = $definitions[$process->id] = $token->getDefinition();
+            }
+
+            // Get the screen realated to token
             if (array_key_exists('screenRef', $definition)) {
                 $screen = $token->getScreenVersion();
                 if ($screen) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Method "ProcessRequest::getScreensRequested" not optimal

## Solution
Parse definitions from the BPMN for each token is not optimal, only parse BPMN once for each process related to the token

## How to Test
Open a request that have a lot of tokens in completed status.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16002

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
