### PR TITLE
FOUR-16637 Fix The summary screen of a request is not displayed

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -741,6 +741,14 @@ class ProcessRequestController extends Controller
         return new ApiResource($token);
     }
 
+    /**
+     * Retrieve the screens requested for a given process request.
+     *
+     * @param  Request  $httpRequest
+     * @param  ProcessRequest  $request
+     *
+     * @return ApiCollection
+     */
     public function screenRequested(Request $httpRequest, ProcessRequest $request)
     {
         $query = ProcessRequestToken::query();

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -25,6 +25,7 @@ use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\ProcessRequests as ProcessRequestResource;
 use ProcessMaker\Jobs\CancelRequest;
 use ProcessMaker\Jobs\TerminateRequest;
+use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -261,12 +262,12 @@ class ProcessRequestController extends Controller
     /**
      * Retry the service, script, and other tasks for a given request
      *
-     * @param  \ProcessMaker\Models\ProcessRequest  $request
-     * @param  \Illuminate\Http\Request  $httpRequest
+     * @param  ProcessRequest  $request
+     * @param  Request  $httpRequest
      *
-     * @return \Illuminate\Http\JsonResponse
-     * @throws \Illuminate\Auth\Access\AuthorizationException
-     * @throws \Illuminate\Validation\ValidationException
+     * @return JsonResponse
+     * @throws AuthorizationException
+     * @throws ValidationException
      */
     public function retry(ProcessRequest $request, Request $httpRequest): JsonResponse
     {
@@ -592,7 +593,7 @@ class ProcessRequestController extends Controller
      * Cancel all tokens of request.
      *
      * @param ProcessRequest $request
-     * @throws \Throwable
+     * @throws Throwable
      */
     private function cancelRequestToken(ProcessRequest $request)
     {
@@ -608,7 +609,7 @@ class ProcessRequestController extends Controller
      * Manually complete a request
      *
      * @param ProcessRequest $request
-     * @throws \Throwable
+     * @throws Throwable
      */
     private function completeRequest(ProcessRequest $request)
     {
@@ -738,5 +739,37 @@ class ProcessRequestController extends Controller
         }
 
         return new ApiResource($token);
+    }
+
+    public function screenRequested(Request $httpRequest, ProcessRequest $request)
+    {
+        $query = ProcessRequestToken::query();
+        $query->select('id', 'element_id', 'process_id', 'process_request_id', 'data')
+            ->where('process_request_id', $request->id)
+            ->whereNotIn('element_type', ['startEvent', 'end_event', 'scriptTask'])
+            ->where('status', 'CLOSED')
+            ->orderBy('completed_at');
+
+        $response =
+            $query->orderBy(
+                $httpRequest->input('order_by', 'id'),
+                $httpRequest->input('order_direction', 'asc')
+            )->paginate($httpRequest->input('per_page', 10));
+
+        $response->getCollection()->transform(function ($token) {
+            $definition = $token->getDefinition();
+            if (array_key_exists('screenRef', $definition)) {
+                $screen = $token->getScreenVersion();
+                if ($screen) {
+                    $dataManager = new DataManager();
+                    $screen->data = $dataManager->getData($token, true);
+                    $screen->screen_id = $screen->id;
+
+                    return $screen;
+                }
+            }
+        });
+
+        return new ApiCollection($response);
     }
 }

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -176,7 +176,6 @@ class RequestController extends Controller
         $files = \ProcessMaker\Models\Media::getFilesRequest($request);
 
         $canPrintScreens = $this->canUserPrintScreen($request);
-        $screenRequested = $canPrintScreens ? $request->getScreensRequested() : [];
 
         $manager = app(ScreenBuilderManager::class);
         event(new ScreenBuilderStarting($manager, ($request->summary_screen) ? $request->summary_screen->type : 'FORM'));
@@ -203,7 +202,6 @@ class RequestController extends Controller
                 'canRetry',
                 'manager',
                 'canPrintScreens',
-                'screenRequested',
                 'addons',
                 'isProcessManager',
                 'eligibleRollbackTask',
@@ -222,7 +220,6 @@ class RequestController extends Controller
             'canRetry',
             'manager',
             'canPrintScreens',
-            'screenRequested',
             'addons',
             'dataActionsAddons',
             'isProcessManager',

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -952,19 +952,26 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
         return Media::getFilesRequest($this);
     }
 
-    public function getErrors()
+    public function getErrors($limit = 10)
     {
         if ($this->errors) {
-            return $this->errors;
+            return array_slice($this->errors, -$limit);
         }
 
         // select tokens with errors
         return $this->tokens()
             ->select('token_properties->error as message', 'created_at', 'element_name')
             ->where('status', '=', ActivityInterface::TOKEN_STATE_FAILING)
-            ->limit(10)
+            ->limit($limit)
             ->get()
             ->toArray();
+    }
+
+    public function getRequestAsArray()
+    {
+        $array = $this->toArray();
+        unset($array['process_version']['svg']);
+        return $array;
     }
 
     /**

--- a/resources/js/requests/components/RequestScreens.vue
+++ b/resources/js/requests/components/RequestScreens.vue
@@ -132,43 +132,41 @@ export default {
       this.$refs.screens.toggleDetailRow(data.id);
     },
     fetch() {
-      Vue.nextTick(() => {
-        this.loading = true;
-        let endpoint = `/requests/${this.id}/details-screen-request`;
-        // Load from our api client
-        ProcessMaker.apiClient
-          .get(
-            `${endpoint}?page=` +
-              this.page +
-              "&per_page=" +
-              this.perPage +
-              "&filter=" +
-              this.filter +
-              "&order_by=" +
-              this.orderBy +
-              "&order_direction=asc"
-          )
-          .then((response) => {
-            this.data = this.transform(response.data);
-            this.screens = this.data.data;
-            this.screens.forEach((item) => {
-              item.view = false;
-              return item;
-            });
-            this.loading = false;
-          })
-          .catch((error) => {
-            this.data = [];
-            this.loading = false;
-            if (_.has(error, "response.data.message")) {
-              ProcessMaker.alert(error.response.data.message, "danger");
-            } else if (_.has(error, "response.data.error")) {
-              return;
-            } else {
-              throw error;
-            }
+      this.loading = true;
+      let endpoint = `/requests/${this.id}/details-screen-request`;
+      // Load from our api client
+      ProcessMaker.apiClient
+        .get(
+          `${endpoint}?page=` +
+            this.page +
+            "&per_page=" +
+            this.perPage +
+            "&filter=" +
+            this.filter +
+            "&order_by=" +
+            this.orderBy +
+            "&order_direction=asc"
+        )
+        .then((response) => {
+          this.data = this.transform(response.data);
+          this.screens = this.data.data;
+          this.screens.forEach((item) => {
+            item.view = false;
+            return item;
           });
-      });
+          this.loading = false;
+        })
+        .catch((error) => {
+          this.data = [];
+          this.loading = false;
+          if (_.has(error, "response.data.message")) {
+            ProcessMaker.alert(error.response.data.message, "danger");
+          } else if (_.has(error, "response.data.error")) {
+            return;
+          } else {
+            throw error;
+          }
+        });
     },
   },
 };

--- a/resources/js/requests/components/RequestScreens.vue
+++ b/resources/js/requests/components/RequestScreens.vue
@@ -1,117 +1,144 @@
 <template>
   <div class="data-table">
-    <vuetable
-      :dataManager="dataManager"
-      :noDataTemplate="$t('No Data Available')"
-      :sortOrder="sortOrder"
-      :css="css"
-      :api-mode="false"
-      @vuetable:pagination-data="onPaginationData"
-      :fields="fields"
-      :data="data"
-      data-path="data"
-      detail-row-component="screen-detail"
-      @vuetable:cell-clicked="previewScreen"
-      ref="screens"
-      pagination-path="meta">
-
-      <template slot="actions" slot-scope="props">
-        <div class="actions">
-          <div class="popout">
-            <b-btn
-              variant="link"
-              @click="previewScreen(props.rowData)"
-              v-b-tooltip.hover
-              :title="$t('Details')">
-              <i v-if="!props.rowData.view" class="fas fa-search-plus fa-lg fa-fw"></i>
-              <i v-else class="fas fa-search-minus fa-lg fa-fw"></i>
-            </b-btn>
-            <b-btn
-              variant="link"
-              @click="preview(props.rowData)"
-              v-b-tooltip.hover
-              :title="$t('Print')">
-              <i class="fas fa-print fa-lg fa-fw"></i>
-            </b-btn>
+    <data-loading
+      :for="/details-screen-request\?page/"
+      v-show="shouldShowLoader"
+      :empty="$t('No Data Available')"
+      :empty-desc="$t('')"
+      empty-icon="noData"
+    />
+    <div
+      v-show="!shouldShowLoader"
+      class="card card-body scripts-table-card"
+      data-cy="screen-requested-table"
+    >
+      <vuetable
+        :dataManager="dataManager"
+        :noDataTemplate="$t('No Data Available')"
+        :sortOrder="sortOrder"
+        :css="css"
+        :api-mode="false"
+        @vuetable:pagination-data="onPaginationData"
+        :fields="fields"
+        :data="data"
+        data-path="data"
+        detail-row-component="screen-detail"
+        @vuetable:cell-clicked="previewScreen"
+        ref="screens"
+        pagination-path="meta"
+      >
+        <template slot="actions" slot-scope="props">
+          <div class="actions">
+            <div class="popout">
+              <b-btn
+                variant="link"
+                @click="previewScreen(props.rowData)"
+                v-b-tooltip.hover
+                :title="$t('Details')"
+              >
+                <i
+                  v-if="!props.rowData.view"
+                  class="fas fa-search-plus fa-lg fa-fw"
+                ></i>
+                <i v-else class="fas fa-search-minus fa-lg fa-fw"></i>
+              </b-btn>
+              <b-btn
+                variant="link"
+                @click="preview(props.rowData)"
+                v-b-tooltip.hover
+                :title="$t('Print')"
+              >
+                <i class="fas fa-print fa-lg fa-fw"></i>
+              </b-btn>
+            </div>
           </div>
-        </div>
-      </template>
-    </vuetable>
-    <pagination
-      :single="$t('Screen')"
-      :plural="$t('Screens')"
-      :perPageSelectEnabled="true"
-      @changePerPage="changePerPage"
-      @vuetable-pagination:change-page="onPageChange"
-      ref="pagination">
-    </pagination>
+        </template>
+      </vuetable>
+      <pagination
+        :single="$t('Screen')"
+        :plural="$t('Screens')"
+        :perPageSelectEnabled="true"
+        @changePerPage="changePerPage"
+        @vuetable-pagination:change-page="onPageChange"
+        ref="pagination"
+      >
+      </pagination>
+    </div>
   </div>
-
 </template>
 
 <script>
-  import Vue from "vue";
-  import datatableMixin from "../../components/common/mixins/datatable";
-  import ScreenDetail from '../components/screenDetail';
+import Vue from "vue";
+import datatableMixin from "../../components/common/mixins/datatable";
+import dataLoadingMixin from "../../components/common/mixins/apiDataLoading";
+import ScreenDetail from "../components/screenDetail";
 
-  Vue.component('screen-detail', ScreenDetail);
+Vue.component("screen-detail", ScreenDetail);
 
-  export default {
-    mixins: [datatableMixin],
-    props: ["id", "information", "permission"],
-    data() {
-      return {
-        orderBy: "completed_at",
-        screens: [],
-        filter: '',
-        dupScreen: {
-          title: "",
-          description: ""
+export default {
+  mixins: [datatableMixin, dataLoadingMixin],
+  props: ["id", "information", "permission"],
+  data() {
+    return {
+      orderBy: "completed_at",
+      screens: [],
+      filter: "",
+      dupScreen: {
+        title: "",
+        description: "",
+      },
+      errors: [],
+      sortOrder: [
+        {
+          field: "title",
+          sortField: "title",
+          direction: "asc",
         },
-        errors: [],
-        sortOrder: [
-          {
-            field: "title",
-            sortField: "title",
-            direction: "asc"
-          }
-        ],
+      ],
 
-        fields: [
-          {
-            title: () => this.$t("Screen"),
-            name: "title",
-            field: "title",
-          },
-          {
-            title: () => this.$t("Description"),
-            name: "description",
-          },
-          {
-            name: "__slot:actions",
-            title: ""
-          }
-        ]
-      };
+      fields: [
+        {
+          title: () => this.$t("Screen"),
+          name: "title",
+          field: "title",
+        },
+        {
+          title: () => this.$t("Description"),
+          name: "description",
+        },
+        {
+          name: "__slot:actions",
+          title: "",
+        },
+      ],
+    };
+  },
+  mounted() {
+    this.fetch();
+  },
+  methods: {
+    preview(data) {
+      window.open(
+        "/requests/" +
+          this.id +
+          "/task/" +
+          data.id +
+          "/screen/" +
+          data.screen_id
+      );
     },
-    mounted() {
-      this.fetch();
+    previewScreen(data) {
+      data.view = !data.view;
+      this.$refs.screens.toggleDetailRow(data.id);
     },
-    methods: {
-      preview(data) {
-        window.open('/requests/' + this.id + '/task/' + data.id + '/screen/' + data.screen_id);
-      },
-      previewScreen(data) {
-        data.view = !data.view;
-        this.$refs.screens.toggleDetailRow(data.id);
-      },
-      fetch() {
-        Vue.nextTick(() => {
-          let endpoint = `/requests/${this.id}/details-screen-request`;
-          // Load from our api client
-          ProcessMaker.apiClient
-            .get(
-              `${endpoint}?page=` +
+    fetch() {
+      Vue.nextTick(() => {
+        this.loading = true;
+        let endpoint = `/requests/${this.id}/details-screen-request`;
+        // Load from our api client
+        ProcessMaker.apiClient
+          .get(
+            `${endpoint}?page=` +
               this.page +
               "&per_page=" +
               this.perPage +
@@ -119,30 +146,32 @@
               this.filter +
               "&order_by=" +
               this.orderBy +
-              "&order_direction=asc" 
-            )
-            .then((response) => {
-              this.data = this.transform(response.data);
-              this.screens = this.data.data;
-              this.screens.forEach(item => {
-                item.view = false;
-                return item;
-              });
-              
-            }).catch((error) => {
-              this.data = [];
-              if (_.has(error, 'response.data.message')) {
-                ProcessMaker.alert(error.response.data.message, 'danger');
-              } else if (_.has(error, 'response.data.error')) {
-                return;
-              } else {
-                throw error;
-              }
+              "&order_direction=asc"
+          )
+          .then((response) => {
+            this.data = this.transform(response.data);
+            this.screens = this.data.data;
+            this.screens.forEach((item) => {
+              item.view = false;
+              return item;
             });
-        });
-      },
+            this.loading = false;
+          })
+          .catch((error) => {
+            this.data = [];
+            this.loading = false;
+            if (_.has(error, "response.data.message")) {
+              ProcessMaker.alert(error.response.data.message, "danger");
+            } else if (_.has(error, "response.data.error")) {
+              return;
+            } else {
+              throw error;
+            }
+          });
+      });
     },
-  };
+  },
+};
 </script>
 
 <style lang="scss" scoped>

--- a/resources/js/requests/components/RequestScreens.vue
+++ b/resources/js/requests/components/RequestScreens.vue
@@ -1,53 +1,52 @@
 <template>
   <div class="data-table">
-    <div>
-      <vuetable
-        :dataManager="dataManager"
-        :noDataTemplate="$t('No Data Available')"
-        :sortOrder="sortOrder"
-        :css="css"
-        :api-mode="false"
-        @vuetable:pagination-data="onPaginationData"
-        :fields="fields"
-        :data="data"
-        data-path="data"
-        detail-row-component="screen-detail"
-        @vuetable:cell-clicked="previewScreen"
-        ref="screens"
-        pagination-path="meta">
+    <vuetable
+      :dataManager="dataManager"
+      :noDataTemplate="$t('No Data Available')"
+      :sortOrder="sortOrder"
+      :css="css"
+      :api-mode="false"
+      @vuetable:pagination-data="onPaginationData"
+      :fields="fields"
+      :data="data"
+      data-path="data"
+      detail-row-component="screen-detail"
+      @vuetable:cell-clicked="previewScreen"
+      ref="screens"
+      pagination-path="meta">
 
-        <template slot="actions" slot-scope="props">
-          <div class="actions">
-            <div class="popout">
-              <b-btn
-                variant="link"
-                @click="previewScreen(props.rowData)"
-                v-b-tooltip.hover
-                :title="$t('Details')">
-                <i v-if="!props.rowData.view" class="fas fa-search-plus fa-lg fa-fw"></i>
-                <i v-else class="fas fa-search-minus fa-lg fa-fw"></i>
-              </b-btn>
-              <b-btn
-                variant="link"
-                @click="preview(props.rowData)"
-                v-b-tooltip.hover
-                :title="$t('Print')">
-                <i class="fas fa-print fa-lg fa-fw"></i>
-              </b-btn>
-            </div>
+      <template slot="actions" slot-scope="props">
+        <div class="actions">
+          <div class="popout">
+            <b-btn
+              variant="link"
+              @click="previewScreen(props.rowData)"
+              v-b-tooltip.hover
+              :title="$t('Details')">
+              <i v-if="!props.rowData.view" class="fas fa-search-plus fa-lg fa-fw"></i>
+              <i v-else class="fas fa-search-minus fa-lg fa-fw"></i>
+            </b-btn>
+            <b-btn
+              variant="link"
+              @click="preview(props.rowData)"
+              v-b-tooltip.hover
+              :title="$t('Print')">
+              <i class="fas fa-print fa-lg fa-fw"></i>
+            </b-btn>
           </div>
-        </template>
-      </vuetable>
-      <pagination
-        single="Screen"
-        plural="Screens"
-        :perPageSelectEnabled="true"
-        @changePerPage="changePerPage"
-        @vuetable-pagination:change-page="onPageChange"
-        ref="pagination">
-      </pagination>
-    </div>
+        </div>
+      </template>
+    </vuetable>
+    <pagination
+      :single="$t('Screen')"
+      :plural="$t('Screens')"
+      :perPageSelectEnabled="true"
+      @changePerPage="changePerPage"
+      @vuetable-pagination:change-page="onPageChange"
+      ref="pagination">
+    </pagination>
   </div>
+
 </template>
 
 <script>
@@ -59,10 +58,12 @@
 
   export default {
     mixins: [datatableMixin],
-    props: ["id", "information", "permission", "screens"],
+    props: ["id", "information", "permission"],
     data() {
       return {
-        orderBy: "title",
+        orderBy: "completed_at",
+        screens: [],
+        filter: '',
         dupScreen: {
           title: "",
           description: ""
@@ -93,7 +94,9 @@
         ]
       };
     },
-
+    mounted() {
+      this.fetch();
+    },
     methods: {
       preview(data) {
         window.open('/requests/' + this.id + '/task/' + data.id + '/screen/' + data.screen_id);
@@ -103,12 +106,41 @@
         this.$refs.screens.toggleDetailRow(data.id);
       },
       fetch() {
-        this.screens.forEach(item => {
-          item.view = false;
-          return item;
+        Vue.nextTick(() => {
+          let endpoint = `/requests/${this.id}/details-screen-request`;
+          // Load from our api client
+          ProcessMaker.apiClient
+            .get(
+              `${endpoint}?page=` +
+              this.page +
+              "&per_page=" +
+              this.perPage +
+              "&filter=" +
+              this.filter +
+              "&order_by=" +
+              this.orderBy +
+              "&order_direction=asc" 
+            )
+            .then((response) => {
+              this.data = this.transform(response.data);
+              this.screens = this.data.data;
+              this.screens.forEach(item => {
+                item.view = false;
+                return item;
+              });
+              
+            }).catch((error) => {
+              this.data = [];
+              if (_.has(error, 'response.data.message')) {
+                ProcessMaker.alert(error.response.data.message, 'danger');
+              } else if (_.has(error, 'response.data.error')) {
+                return;
+              } else {
+                throw error;
+              }
+            });
         });
-        this.data = this.screens;
-      }
+      },
     },
   };
 </script>

--- a/resources/js/requests/components/screenDetail.vue
+++ b/resources/js/requests/components/screenDetail.vue
@@ -94,11 +94,16 @@
         const json = JSON.parse(JSON.stringify(this.rowData.config));
         return this.disableForm(json);
       },
-      formData() {
-        if(this.iFramePostedData) {
-          return this.iFramePostedData;
+      formData: {
+        get() {
+          if(this.iFramePostedData) {
+            return this.iFramePostedData;
+          }
+          return this.rowData.data ? this.rowData.data : {};
+        }, 
+        set() {
+
         }
-        return this.rowData.data ? this.rowData.data : {};
       },
       printablePages() {
         const pages = [0];

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -225,8 +225,7 @@
             </div>
             <div class="tab-pane fade card card-body border-top-0 p-0" id="forms" role="tabpanel"
               aria-labelledby="forms-tab" v-show="canViewPrint">
-              <request-screens :id="requestId" :information="dataSummary" :screens="screenRequested"
-                ref="forms">
+              <request-screens :id="requestId" :information="dataSummary" ref="forms">
               </request-screens>
             </div>
             <div v-if="activeTab === 'overview'" class="tab-pane fade p-0" id="overview" role="tabpanel"
@@ -499,7 +498,6 @@
           showJSONEditor: false,
           data: @json($request->getRequestData()),
           requestId: @json($request->getKey()),
-          screenRequested: @json($screenRequested),
           request: @json($request),
           files: @json($files),
           refreshTasks: 0,

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -498,7 +498,7 @@
           showJSONEditor: false,
           data: @json($request->getRequestData()),
           requestId: @json($request->getKey()),
-          request: @json($request),
+          request: @json($request->getRequestAsArray()),
           files: @json($files),
           refreshTasks: 0,
           canCancel: @json($canCancel),

--- a/routes/api.php
+++ b/routes/api.php
@@ -220,7 +220,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::delete('requests/{request}', [ProcessRequestController::class, 'destroy'])->name('requests.destroy')->middleware('can:destroy,request');
     Route::get('requests/{request}/tokens', [ProcessRequestController::class, 'getRequestToken'])->name('requests.getRequestToken')->middleware('can:view,request');
     Route::post('requests/{request}/events/{event}', [ProcessRequestController::class, 'activateIntermediateEvent'])->name('requests.update,request');
-    Route::get('requests/{request}/details-screen-request', [ProcessRequestController::class, 'screenRequested'])->name('requests.detail.screen');
+    Route::get('requests/{request}/details-screen-request', [ProcessRequestController::class, 'screenRequested'])->name('requests.detail.screen')->middleware('can:view,request');
 
     // Request Files
     Route::get('requests/{request}/files', [ProcessRequestFileController::class, 'index'])->name('requests.files.index')->middleware('can:view,request');

--- a/routes/api.php
+++ b/routes/api.php
@@ -220,6 +220,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::delete('requests/{request}', [ProcessRequestController::class, 'destroy'])->name('requests.destroy')->middleware('can:destroy,request');
     Route::get('requests/{request}/tokens', [ProcessRequestController::class, 'getRequestToken'])->name('requests.getRequestToken')->middleware('can:view,request');
     Route::post('requests/{request}/events/{event}', [ProcessRequestController::class, 'activateIntermediateEvent'])->name('requests.update,request');
+    Route::get('requests/{request}/details-screen-request', [ProcessRequestController::class, 'screenRequested'])->name('requests.detail.screen');
 
     // Request Files
     Route::get('requests/{request}/files', [ProcessRequestFileController::class, 'index'])->name('requests.files.index')->middleware('can:view,request');


### PR DESCRIPTION
## The summary screen of a request is not displayed

## Solution
- Remove preloading of filled screens (Requires: FOUR-16639)
- Limit the number of errors to show in the summary

## How to Test
- Create a process with a loop
- Generate tens of thousands of loops
- Open the request (or go to the request summary) 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16637

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
