### PR TITLE
feature/FOUR-15823: Send an ABE Email when the row in the process_request_tokens is created

### DIFF
--- a/ProcessMaker/Mail/TaskActionByEmail.php
+++ b/ProcessMaker/Mail/TaskActionByEmail.php
@@ -5,7 +5,6 @@ namespace ProcessMaker\Mail;
 use Mustache_Engine;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Packages\Connectors\ActionsByEmail\EmailProvider;
-use ProcessMaker\Packages\Connectors\ActionsByEmail\MessageParser;
 
 class TaskActionByEmail
 {
@@ -16,6 +15,21 @@ class TaskActionByEmail
         $this->emailProvider = new EmailProvider();
     }
 
+    /**
+     * Send an email based on the provided configuration and data.
+     *
+     * This method constructs and sends an email using the provided configuration,
+     * recipient email address, and additional data for rendering the email content.
+     *
+     * @param object $config Configuration object containing email settings, including:
+     *                       - emailServer: The email server ID (integer, optional, default: 0).
+     *                       - subject: The subject of the email (string, optional, default: '').
+     *                       - screenEmailRef: Reference ID to a custom email screen (integer, optional, default: 0).
+     * @param string $to Recipient email address.
+     * @param array $data Additional data for rendering the email content (optional).
+     *
+     * @return void
+     */
     public function sendAbeEmail($config, $to, $data)
     {
         try {
@@ -46,11 +60,12 @@ class TaskActionByEmail
             $this->emailProvider->send($emailConfig);
     
         } catch (\Exception $e) {
-            Log::error('ABE: Mailer Daemon Response Found As Incoming Mail. Aborting Error Message Reply', [
+            Log::error('Error sending ABE email', [
                 'to' => $to,
                 'emailServer' => $emailServer,
-                'Subjetc' => $subject,
+                'subject' => $subject,
                 'screen' => $emailScreenRef,
+                'error' => $e->getMessage(),
             ]);
         }
     }

--- a/ProcessMaker/Mail/TaskActionByEmail.php
+++ b/ProcessMaker/Mail/TaskActionByEmail.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ProcessMaker\Mail;
+
+use Mustache_Engine;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Packages\Connectors\ActionsByEmail\EmailProvider;
+use ProcessMaker\Packages\Connectors\ActionsByEmail\MessageParser;
+
+class TaskActionByEmail
+{
+    private $emailProvider;
+
+    private $messageParser;
+
+    public function __construct(EmailProvider $emailProvider, MessageParser $messageParser)
+    {
+        $this->emailProvider = $emailProvider;
+        $this->messageParser = $messageParser;
+    }
+
+    public function sendAbeEmail($config, $to, $data)
+    {
+        try {
+            // Get parameters to send the email
+            $emailServer = $config->emailServer ?? 0;
+            $subject = $config->subject ?? '';
+            $emailScreenRef = $config->screenEmailRef ?? 0;
+    
+            $emailConfig = [
+                'subject' => $this->mustache($subject, $data),
+                'addEmails' => $to,
+                'email' => $to,
+                'type' => 'html',
+                'json_data' => '{}',
+                'emailServer' => $emailServer,
+            ];
+    
+            if (!empty($emailScreenRef)) {
+                // Retrieve and render custom screen if specified
+                $customScreen = Screen::findOrFail($emailScreenRef);
+                $emailConfig['body'] = $this->emailProvider->screenRenderer($customScreen->config, $data);
+            } else {
+                // Default message if no custom screen is selected
+                $emailConfig['body'] = __('No screen selected');
+            }
+    
+            // Send the email using emailProvider
+            $this->emailProvider->send($emailConfig);
+    
+        } catch (\Exception $e) {
+            Log::error('ABE: Mailer Daemon Response Found As Incoming Mail. Aborting Error Message Reply', [
+                'to' => $to,
+                'emailServer' => $emailServer,
+                'Subjetc' => $subject,
+                'screen' => $emailScreenRef,
+            ]);
+        }
+    }
+
+    private function mustache($str, $data)
+    {
+        return (new Mustache_Engine())->render($str, $data);
+    }
+}

--- a/ProcessMaker/Mail/TaskActionByEmail.php
+++ b/ProcessMaker/Mail/TaskActionByEmail.php
@@ -11,12 +11,9 @@ class TaskActionByEmail
 {
     private $emailProvider;
 
-    private $messageParser;
-
-    public function __construct(EmailProvider $emailProvider, MessageParser $messageParser)
+    public function __construct()
     {
-        $this->emailProvider = $emailProvider;
-        $this->messageParser = $messageParser;
+        $this->emailProvider = new EmailProvider();
     }
 
     public function sendAbeEmail($config, $to, $data)

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -166,6 +166,7 @@ class TokenRepository implements TokenRepositoryInterface
      * Validate email configuration and Send Email
      *
      * @param ActivityInterface $activity
+     * @param string $to
      */
     private function validateAndSendActionByEmail(ActivityInterface $activity, string $to)
     {
@@ -173,12 +174,18 @@ class TokenRepository implements TokenRepositoryInterface
             $isActionsByEmail = $activity->getProperty('isActionsByEmail', false);
             if ($isActionsByEmail === "true") {
                 $configEmail = json_decode($activity->getProperty('configEmail', '{}'));
-                // Send Email
-                return (new TaskActionByEmail())->sendAbeEmail($configEmail, $to, []);
+                if (is_object($configEmail)) {
+                    // Send Email
+                    return (new TaskActionByEmail())->sendAbeEmail($configEmail, $to, []);
+                } else {
+                    throw new \Exception('Invalid configEmail format');
+                }
             }
         } catch (\Exception $e) {
-            // Cath an error
-        }
+            // Catch and log the error
+            Log::error('Failed to validate and send action by email', [
+                'error' => $e->getMessage(),
+            ]);
     }
 
     /**

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Mustache_Engine;
+use ProcessMaker\Mail\TaskActionByEmail;
 use ProcessMaker\Models\ProcessCollaboration;
 use ProcessMaker\Models\ProcessRequest as Instance;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -94,6 +95,8 @@ class TokenRepository implements TokenRepositoryInterface
             $user = null;
         } else {
             $user = $token->getInstance()->getProcess()->getOwnerDocument()->getModel()->getNextUser($activity, $token);
+            // Validate if the task is enable the action by email
+            $this->validateAndSendActionByEmail($activity, $user->email);
         }
         $this->addUserToData($token->getInstance(), $user);
         $this->addRequestToData($token->getInstance());
@@ -145,8 +148,6 @@ class TokenRepository implements TokenRepositoryInterface
             }
         }
 
-        $this->validateAndSendActionByEmail($activity);
-
         //Default 3 days of due date
         $due = $this->getDueVariable($activity, $token);
         $token->due_at = $due ? Carbon::now()->addHours($due) : null;
@@ -166,20 +167,18 @@ class TokenRepository implements TokenRepositoryInterface
      *
      * @param ActivityInterface $activity
      */
-    private function validateAndSendActionByEmail(ActivityInterface $activity)
+    private function validateAndSendActionByEmail(ActivityInterface $activity, string $to)
     {
-        $isActionsByEmail = $activity->getProperty('isActionsByEmail', false);
-        if ($isActionsByEmail) {
-            $configEmail = json_decode($activity->getProperty('configEmail', []));
-            // Get the parameters to send the email
-            $emailserver = $configEmail->emailServer ?? 0;
-            $subject = $configEmail->subject ?? '';
-            $emailScreen = $configEmail->screenEmailRef ?? 0;
-            $emailScreenCompleted = $configEmail->screenCompleteRef ?? 0;
-
-            //TODO send Email
+        try {
+            $isActionsByEmail = $activity->getProperty('isActionsByEmail', false);
+            if ($isActionsByEmail === "true") {
+                $configEmail = json_decode($activity->getProperty('configEmail', '{}'));
+                // Send Email
+                return (new TaskActionByEmail())->sendAbeEmail($configEmail, $to, []);
+            }
+        } catch (\Exception $e) {
+            // Cath an error
         }
-
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Send an ABE Email when the row in the process_request_tokens is created

## How to Test

1. Create a process
2. Configure an action by email for some task
3. Run a request
4. Review the email

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15823

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:screen-builder:feature/FOUR-15510
ci:connector-send-email:feature/FOUR-15510
ci:processmaker-bpmn-moddle:feature/FOUR-15510