### PR TITLE
Develop: Resolve Mobile Redirect Issue for Custom Dashboard Assignment

### DIFF
--- a/ProcessMaker/Http/Controllers/HomeController.php
+++ b/ProcessMaker/Http/Controllers/HomeController.php
@@ -12,15 +12,8 @@ class HomeController extends Controller
     public function index(Request $request)
     {
         if (Auth::check()) {
-            $isMobile = (
-                isset($_SERVER['HTTP_USER_AGENT']) && MobileHelper::isMobile($_SERVER['HTTP_USER_AGENT'])
-            ) ? true : false;
-            // If is mobile redirect to view mobile request
-            if ($isMobile) {
-                return redirect('/requests');
-            }
             // Redirect to home dynamic only if the package was enable
-            if (!$isMobile && hasPackage('package-dynamic-ui')) {
+            if (hasPackage('package-dynamic-ui')) {
                 $user = \Auth::user();
                 $homePage = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::getHomePage($user);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves an issue where users were redirected to the `/requests` page on mobile devices, even when a custom dashboard was assigned. The root cause was a conditional redirect specific to mobile devices. This update removes that conditional, allowing users to be redirected to their custom dashboard upon login, regardless of the device used.

Note: This change does not affect the redirect functionality when switching to the mobile version of the site.

## Solution
- Removed the mobile redirect conditional that forced a redirect to `/requests`.

## How to Test

1. Assign a custom dashboard to a user.
2. On a mobile device, log in as the user.
3. Verify that you are redirected to the assigned custom dashboard.
4. Ensure that the redirect functionality works correctly when switching to the mobile version of the site, and that it remains unaffected by this change. - Mobile version can be access via the Menu 'Switch to Mobile Version' button

## Related Tickets & Packages
- [FOUR-16869](https://processmaker.atlassian.net/browse/FOUR-16869)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-16869]: https://processmaker.atlassian.net/browse/FOUR-16869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ