### PR TITLE
FOUR-14051: When deleting users, they don't get inactivated (For develop branch)

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -150,7 +150,19 @@ class User extends Authenticatable implements HasMedia
     public static function boot()
     {
         parent::boot();
+
+        static::deleting(function ($user) {
+            $user->status = 'INACTIVE';
+            $user->save();
+        });
+
+        static::restoring(function ($user) {
+            $user->status = 'ACTIVE';
+            $user->save();
+        });
+
         static::deleted(function ($user) {
+            $user->status = 'INACTIVE';
             $user->removeFromGroups();
         });
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
When a user is deleted, his status is still set to 'ACTIVE'

Current behavior:

The user gets into the “deleted users” list, but remains active.

Expected behavior

The user gets into the “deleted users” list and is inactive.

## Solution
- Added logic for setting a user status as INACTIVE when deleted and ACTIVE when restored.


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14051

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:develop