### PR TITLE
FOUR-16993 Fix admin user factory, must be administrator

### DIFF
--- a/database/factories/ProcessMaker/Models/UserFactory.php
+++ b/database/factories/ProcessMaker/Models/UserFactory.php
@@ -48,7 +48,9 @@ class UserFactory extends Factory
     public function admin()
     {
         return $this->state(function () {
-            return ['is_administrator' => false];
+            return [
+                'is_administrator' => true,
+            ];
         });
     }
 }


### PR DESCRIPTION
## The admin user factory was invalid.

This caused some tests to fail.

## Solution
- Fix admin user factory, must be administrator, enabling the `is_administrator` property.

## How to Test
Run the tests.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16993

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
