### PR TITLE
FOUR-16996 Server error when creating a case after disabling the start event insterstitial

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -95,7 +95,7 @@ class Task extends ApiResource
                                                 || count($array['assignable_users']) < 1;
         if (in_array('assignableUsers', $include) && $needToRecalculateAssignableUsers) {
             $definition = $this->getDefinition();
-            $config = json_decode($definition['config'], true) ?: [];
+            $config = isset($definition['config']) ? json_decode($definition['config'], true) : [];
             $isSelfService = $config['selfService'] ?? false;
             if ($isSelfService) {
                 $users = [];


### PR DESCRIPTION
## Issue & Reproduction Steps
### Current behavior
A server error is displayed
![image](https://github.com/ProcessMaker/processmaker/assets/3604190/f208a189-4a6d-42ea-94bf-25dc693908c5)

## Solution
- add validation to definition for Rule expression and Self Service assigned tasks

## How to Test
1. Import attached process
2. Go to second task and assign other user
3. Click on publish button
4. Create a request of process
5. Go to designer page
6. Search process and edit
7. Disable interstitial(Display Next Assigned Task to Task Assignee)in start event
8. Click on publish button
9. Create a request of process

## Related Tickets & Packages
[FOUR-16996](https://processmaker.atlassian.net/browse/FOUR-16996)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-16996]: https://processmaker.atlassian.net/browse/FOUR-16996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ