### PR TITLE
FOUR-17008: [next] Define a value when the config is Email Server 1, 2

### DIFF
--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -430,6 +430,7 @@ class Setting extends ProcessMakerModel implements HasMedia
     public static function updateAllSettingsGroupId()
     {
         Setting::whereNull('group_id')->chunk(100, function ($settings) {
+            $defaultId = SettingsMenus::EMAIL_MENU_GROUP;
             foreach ($settings as $setting) {
                 // Define the value of 'menu_group' based on 'group'
                 switch ($setting->group) {
@@ -466,7 +467,11 @@ class Setting extends ProcessMakerModel implements HasMedia
                         $id = null;
                         break;
                     default: // The default value
-                        $id = SettingsMenus::getId(SettingsMenus::EMAIL_MENU_GROUP);
+                        if (preg_match('/^Email Server/', $setting->group)) {
+                            $id = SettingsMenus::getId(SettingsMenus::EMAIL_MENU_GROUP);
+                        } else {
+                            $id = SettingsMenus::getId($defaultId);
+                        }
                         break;
                 }
                 if ($id !== null) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Define a value when the config is `Email Server 1, 2...`

## Related Tickets & Packages
- FOUR-17008

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next