### PR TITLE
feature/FOUR-16807: Parser the mustache and data for the Email Screen defined in Action By email used in the EMAIL

### DIFF
--- a/ProcessMaker/Mail/TaskActionByEmail.php
+++ b/ProcessMaker/Mail/TaskActionByEmail.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Mail;
 
+use Log;
 use Mustache_Engine;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Packages\Connectors\ActionsByEmail\EmailProvider;

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -181,7 +181,7 @@ class TokenRepository implements TokenRepositoryInterface
                 $configEmail = json_decode($activity->getProperty('configEmail'), true);
                 if (!empty($configEmail)) {
                     // Send Email
-                    return (new TaskActionByEmail())->sendAbeEmail($configEmail, 'luciana.nunez@processmaker.com', $token->getInstance()->getDataStore()->getData());
+                    return (new TaskActionByEmail())->sendAbeEmail($configEmail, $to, $token->getInstance()->getDataStore()->getData());
                 }
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
## Issue & Reproduction Steps
When you create a Screen Email some controls can have MUSTACHE VARIABLES and SOME URL are waiting for values like:

We need to user the following magic variable {{_request.id}} 

We need to create a custom magic variable {{_task.id}}

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16807

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:connector-send-email:feature/FOUR-15510
ci:next