### PR TITLE
FOUR-17034: Dashboard in element destination redirects to the server from which the process was exported.

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -409,6 +409,7 @@ class ProcessExporter extends ExporterBase
             $this->importSubprocesses();
             $this->importAssignments();
             $this->importProcessLaunchpad();
+            $this->importElementDestination();
         }
     }
 
@@ -474,6 +475,55 @@ class ProcessExporter extends ExporterBase
     {
         foreach ($this->getDependents('process_launchpad') as $launchpad) {
             $launchpad->model->setAttribute('process_id', $this->model->id);
+        }
+    }
+
+    /**
+     * Imports element destinations from the model and updates specific elements.
+     *
+     * This method searches for elements with specific tags and updates their 'pm:elementDestination' attribute
+     * if it matches certain criteria. Specifically, it checks if the attribute is a JSON object with a 'type'
+     * of 'customDashboard' and updates it to a JSON object with a 'type' of 'summaryScreen' and a 'value' of null.
+     *
+     * @return void
+     */
+    public function importElementDestination(): void
+    {
+        // Tags to search for in the model definitions
+        $tags = [
+            'bpmn:task',
+            'bpmn:manualTask',
+            'bpmn:endEvent',
+        ];
+
+        // Get model definitions
+        $definitions = $this->model->getDefinitions(true);
+
+        // Get elements by specified tags
+        $elements = Utils::getElementByMultipleTags($definitions, $tags);
+
+        // Iterate through the elements
+        foreach ($elements as $element) {
+            $path = $element->getNodePath();
+            $elementDestination = $element->getAttribute('pm:elementDestination');
+
+            // If the element has a pm:elementDestination attribute
+            if ($elementDestination !== null) {
+                // Decode the JSON string in the attribute
+                $data = json_decode($elementDestination, true);
+
+                // Check for JSON errors and if the type is customDashboard
+                if (json_last_error() === JSON_ERROR_NONE && isset($data['type']) && $data['type'] === 'customDashboard') {
+                    // Create a new JSON string with updated values
+                    $newElementDestination = json_encode([
+                        'type' => 'summaryScreen',
+                        'value' => null,
+                    ]);
+
+                    // Set the new attribute value at the specified XPath
+                    Utils::setAttributeAtXPath($this->model, $path, 'pm:elementDestination', htmlspecialchars($newElementDestination, ENT_QUOTES));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION

## Issue & Reproduction Steps
Dashboard in element destination redirects to the server from which the process was exported.

## Solution
- for import Create import element destination method 
- clean pm:elementDestination property id type is custoDashboart


https://github.com/ProcessMaker/processmaker/assets/1401911/a87691fc-1641-456c-8335-2651d65e5cd9


## How to Test
Detailed in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17034

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
