### PR TITLE
FOUR-17047: Add an Analytics Tab to the ProcessMaker Platform (next)

### DIFF
--- a/ProcessMaker/Managers/MenuManager.php
+++ b/ProcessMaker/Managers/MenuManager.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Managers;
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\View;
 
 class MenuManager extends \Lavary\Menu\Menu
@@ -33,6 +34,9 @@ class MenuManager extends \Lavary\Menu\Menu
 
         // Make the instance available in all views
         View::share($name, $this->menu[$name]);
+
+        // Dispatching the created event
+        Event::dispatch("menu.created.{$name}");
 
         return $this->menu[$name];
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR is part of: https://github.com/ProcessMaker/package-analytics-reporting/pull/71

## Solution
- Dispatch menu created event in order to add the Analytics menu item into the top navigation menu.

## Related Tickets & Packages
- [FOUR-17047](https://processmaker.atlassian.net/browse/FOUR-17047)
- [FOUR-16604](https://processmaker.atlassian.net/browse/FOUR-16604)

ci:next
ci:package-analytics-reporting:task/FOUR-16604-next

[FOUR-17047]: https://processmaker.atlassian.net/browse/FOUR-17047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-16604]: https://processmaker.atlassian.net/browse/FOUR-16604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ