### PR TITLE
FOUR-13468: Allow users to disable recommendations engine

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -17,7 +17,9 @@ use ProcessMaker\Filters\SaveSession;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\Users as UserResource;
+use ProcessMaker\Models\RecommendationUser;
 use ProcessMaker\Models\User;
+use ProcessMaker\RecommendationEngine;
 use ProcessMaker\TwoFactorAuthentication;
 
 class UserController extends Controller
@@ -194,7 +196,7 @@ class UserController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return \Illuminate\Http\Response
      *
      *     @OA\Get(
@@ -332,6 +334,10 @@ class UserController extends Controller
             $user->is_administrator = $request->get('is_administrator');
         }
 
+        if (empty($fields['meta'])) {
+            $user->meta = null;
+        }
+
         $user->saveOrFail();
         $changes = $user->getChanges();
 
@@ -339,6 +345,10 @@ class UserController extends Controller
         UserUpdated::dispatch($user, $changes, $original);
         if ($request->has('avatar')) {
             $this->uploadAvatar($user, $request);
+        }
+
+        if (!RecommendationEngine::shouldGenerateFor($user)) {
+            RecommendationUser::deleteFor($user);
         }
 
         return response([], 204);

--- a/ProcessMaker/Jobs/GenerateUserRecommendations.php
+++ b/ProcessMaker/Jobs/GenerateUserRecommendations.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Models\Recommendation;
 use ProcessMaker\Models\User;
 use ProcessMaker\RecommendationEngine;
 
@@ -33,6 +34,9 @@ class GenerateUserRecommendations implements ShouldQueue
     public function handle(): void
     {
         $user = User::findOrFail($this->user_id);
+        if (!RecommendationEngine::shouldGenerateFor($user)) {
+            return;
+        }
         RecommendationEngine::for($user)->generate();
     }
 }

--- a/ProcessMaker/Jobs/SmartInbox.php
+++ b/ProcessMaker/Jobs/SmartInbox.php
@@ -9,6 +9,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use ProcessMaker\InboxRules\MatchingTasks;
 use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\RecommendationEngine;
 
 class SmartInbox implements ShouldQueue
 {
@@ -41,6 +42,9 @@ class SmartInbox implements ShouldQueue
             SmartInboxApplyAction::dispatchSync($this->incomingTaskId, $inboxRule->id);
         }
 
-        GenerateUserRecommendations::dispatch($incomingTask->user_id)->onQueue('low');
+        // Only generate recommendations after inbox rules have been applied.
+        if (RecommendationEngine::shouldGenerateFor($incomingTask->user)) {
+            GenerateUserRecommendations::dispatch($incomingTask->user_id);
+        }
     }
 }

--- a/ProcessMaker/Models/RecommendationUser.php
+++ b/ProcessMaker/Models/RecommendationUser.php
@@ -54,4 +54,9 @@ class RecommendationUser extends ProcessMakerModel
 
         $this->saveOrFail();
     }
+
+    public static function deleteFor(User $user): void
+    {
+        static::where('user_id', $user->id)->delete();
+    }
 }

--- a/ProcessMaker/Providers/RecommendationsServiceProvider.php
+++ b/ProcessMaker/Providers/RecommendationsServiceProvider.php
@@ -25,10 +25,10 @@ class RecommendationsServiceProvider extends ServiceProvider
         Event::listen(ActivityCompleted::class, function ($event) {
             // Without relations to prevent huge sets of unnecessary
             // data from being serialized and passed to the job
-            $processRequestToken = $event->getProcessRequestToken()->withoutRelations();
+            $processRequestToken = $event->getProcessRequestToken();
 
             // Dispatch the job to the low-priority queue
-            if ($processRequestToken->user_id) {
+            if (RecommendationEngine::shouldGenerateFor($processRequestToken->user)) {
                 GenerateUserRecommendations::dispatch($processRequestToken->user_id)->onQueue('low');
             }
         });

--- a/ProcessMaker/RecommendationEngine.php
+++ b/ProcessMaker/RecommendationEngine.php
@@ -149,4 +149,17 @@ class RecommendationEngine
     {
         return config('app.recommendations_enabled') === false;
     }
+
+    public static function shouldGenerateFor(User|null $user): bool
+    {
+        if (!$user || self::disabled()) {
+            return false;
+        }
+
+        if (isset($user->meta->disableRecommendations) && $user->meta->disableRecommendations) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/database/factories/ProcessMaker/Models/RecommendationUserFactory.php
+++ b/database/factories/ProcessMaker/Models/RecommendationUserFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories\ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use ProcessMaker\Models\Recommendation;
+use ProcessMaker\Models\User;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\ProcessMaker\Models\RecommendationUser>
@@ -16,6 +18,13 @@ class RecommendationUserFactory extends Factory
      */
     public function definition(): array
     {
-        return [];
+        return [
+            'user_id' => function () {
+                return User::factory()->create()->getKey();
+            },
+            'recommendation_id' => function () {
+                return Recommendation::factory()->create()->getKey();
+            },
+        ];
     }
 }

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="data-table">
-    <Recommendations if="showRecommendations" />
+    <Recommendations v-if="showRecommendations" />
     <div
       v-show="true"
       data-cy="tasks-table"

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -320,6 +320,21 @@
           state2FA() {
             return typeof this.formData.preferences_2fa != "undefined" && this.formData.preferences_2fa != null
                 && this.formData.preferences_2fa.length > 0;
+          },
+          disableRecommendations: {
+            get() {
+              return this.formData?.meta?.disableRecommendations ?? false;
+            },
+            set(value) {
+              if (value === true) {
+                if (!this.formData.meta) {
+                  this.$set(this.formData, 'meta', {});
+                }
+                this.$set(this.formData.meta, 'disableRecommendations', true);
+              } else {
+                this.$delete(this.formData.meta, 'disableRecommendations');
+              }
+            }
           }
         },
         mounted() {

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -240,6 +240,21 @@
                 state2FA() {
                     return typeof this.formData.preferences_2fa != "undefined" &&
                         this.formData.preferences_2fa != null && this.formData.preferences_2fa.length > 0;
+                },
+                disableRecommendations: {
+                  get() {
+                    return this.formData?.meta?.disableRecommendations ?? false;
+                  },
+                  set(value) {
+                    if (value === true) {
+                      if (!this.formData.meta) {
+                        this.$set(this.formData, 'meta', {});
+                      }
+                      this.$set(this.formData.meta, 'disableRecommendations', true);
+                    } else {
+                      this.$delete(this.formData.meta, 'disableRecommendations');
+                    }
+                  }
                 }
             }
         });

--- a/resources/views/shared/users/sidebar.blade.php
+++ b/resources/views/shared/users/sidebar.blade.php
@@ -140,6 +140,16 @@
                     @{{errors.status}}
                 </div>
             </div>
+            
+            <div class="form-group">
+                {!! Form::label('status', __('Recommendations')) !!}
+                <b-form-select
+                    id="status"
+                    v-model="disableRecommendations"
+                    class="form-control"
+                    :options="[{value: false, text: 'Enabled'}, {value: true, text: 'Disabled'}]">
+                </b-form-select>
+            </div>
 
             @isset($addonsSettings)
                 @foreach ($addonsSettings as $addon)

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature\Api;
 use Database\Seeders\PermissionSeeder;
 use Faker\Factory as Faker;
 use Illuminate\Http\UploadedFile;
+use ProcessMaker\Models\Recommendation;
+use ProcessMaker\Models\RecommendationUser;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
@@ -774,5 +776,25 @@ class UsersTest extends TestCase
 
         // Check that it has changed
         $this->assertNotEquals($verify, $verifyNew);
+    }
+
+    public function testDisableRecommendations()
+    {
+        RecommendationUser::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->assertEquals(1, RecommendationUser::where('user_id', $this->user->id)->count());
+
+        $url = self::API_TEST_URL . '/' . $this->user->id;
+        $data = [
+            ...$this->getUpdatedData(),
+            'meta' => [
+                'disableRecommendations' => true,
+            ],
+        ];
+        $this->apiCall('PUT', $url, $data);
+
+        $this->assertEquals(0, RecommendationUser::where('user_id', $this->user->id)->count());
     }
 }


### PR DESCRIPTION
See https://processmaker.atlassian.net/browse/FOUR-13468

Adds enable/disable on `profile/edit` and `admin/users/{user_id}/edit`

When disabled, no recommendation engine jobs should be run for that user and any existing recommendations should be deleted.

<img width="262" alt="image" src="https://github.com/ProcessMaker/processmaker/assets/2546850/5347db48-5e66-467e-9c06-508ceafbc787">

See recommendations engine testing instructions in https://github.com/ProcessMaker/processmaker/pull/6999

ci:next