### PR TITLE
FOUR-17077: The documentation of the elements are not shown in the doc-circle modal

### DIFF
--- a/resources/js/processes/modeler/components/ProcessMap.vue
+++ b/resources/js/processes/modeler/components/ProcessMap.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div id="modeler-app">
     <div class="h-100">
       <div
         class="overflow-hidden position-relative p-0 vh-100"
@@ -8,6 +8,7 @@
         <ProcessMapTooltip
           v-show="showTooltip"
           ref="tooltip"
+          :enabled="enableTooltip"
           :node-id="tooltip.nodeId"
           :node-name="tooltip.nodeName"
           :request-id="requestId"
@@ -25,6 +26,7 @@
           :request-in-progress-nodes="requestInProgressNodes"
           :request-idle-nodes="requestIdleNodes"
           :read-only="true"
+          :for-documenting="forDocumenting"
           @set-xml-manager="xmlManager = $event"
           @click="handleClick"
         />
@@ -39,6 +41,16 @@ import ProcessMapTooltip from "./ProcessMapTooltip.vue";
 
 export default {
   name: "ProcessMap",
+  props: {
+    forDocumenting: {
+      type: Boolean,
+      default: false,
+    },
+    enableTooltip: {
+      type: Boolean,
+      default: true,
+    },
+  },
   components: {
     Modeler,
     ProcessMapTooltip,
@@ -80,7 +92,7 @@ export default {
         : true;
     },
     showTooltip() {
-      return this.tooltip.isActive;
+      return this.enableTooltip && this.tooltip.isActive;
     },
   },
   watch: {

--- a/resources/js/processes/modeler/components/ProcessMapTooltip.vue
+++ b/resources/js/processes/modeler/components/ProcessMapTooltip.vue
@@ -68,7 +68,7 @@ export default {
     enabled: {
       type: Boolean,
       default() {
-        true;
+        return true;
       },
     },
     nodeId: {

--- a/resources/js/processes/modeler/components/ProcessMapTooltip.vue
+++ b/resources/js/processes/modeler/components/ProcessMapTooltip.vue
@@ -65,6 +65,12 @@ import moment from "moment";
 export default {
   name: "ProcessMapTooltip",
   props: {
+    enabled: {
+      type: Boolean,
+      default() {
+        true;
+      },
+    },
     nodeId: {
       type: String,
       default() {
@@ -95,6 +101,9 @@ export default {
   },
   watch: {
     nodeId() {
+      if (!this.enabled) {
+        return;
+      }
       this.getRequestTokens();
     },
     isLoading(value) {

--- a/resources/js/processes/modeler/process-map.js
+++ b/resources/js/processes/modeler/process-map.js
@@ -3,6 +3,15 @@ import ProcessMap from "./components/ProcessMap.vue";
 
 window.ProcessMaker.i18nPromise.then(() => {
   new Vue({
-    render: (h) => h(ProcessMap),
+    render: (h) => h(ProcessMap, {
+      props: {
+        enableTooltip: (window.document
+                          .getElementById("modeler-app")
+                          .getAttribute("enable-tooltip") ?? "true") === "true",
+        forDocumenting: (window.document
+                          .getElementById("modeler-app")
+                          .getAttribute("for-documenting") ?? "false") === "true",
+      },
+    }),
   }).$mount("#modeler-app");
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
1.Create a  process
2.Open in modeler
3.Click on options
4.Click on documentation
5.Move the mouse to the pop-up

## Solution
- Added flags in ProcessMap to know if it is used in documenting.

## How to Test
Reproduce the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17077

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
