### PR TITLE
FOUR-16725:Variable task due date does not validate that value will be a mustache syntax

### DIFF
--- a/resources/js/processes/modeler/components/inspector/TaskDueIn.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskDueIn.vue
@@ -93,12 +93,12 @@ export default {
      */
     dueInVariableSetter(event) {
       this.$set(this.node, "dueInVariable", event.target.value);
-      this.showError = this.valideteMustache(event.target.value);
+      this.showError = this.validateMustache(event.target.value);
     },
     /**
      * Validate if the value is a correct Mustache Syntaxis.
      */
-    valideteMustache(value) {
+    validateMustache(value) {
       const regex = /^{{(.*)}}/gm;
       return !regex.test(value);
     },

--- a/resources/js/processes/modeler/components/inspector/TaskDueIn.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskDueIn.vue
@@ -30,6 +30,12 @@
         @keydown="dueInValidate"
       >
       <small class="form-text text-muted">{{ $t("This field supports mustache syntax to send requests variables.") }}</small>
+      <div
+        v-show="showError"
+        :class="showError ? 'showError' : ''"
+      >
+        {{ $t('Must be mustache syntax') }}
+      </div>
     </template>
   </div>
 </template>
@@ -37,6 +43,11 @@
 <script>
 export default {
   props: ["value", "label", "helper", "property"],
+  data() {
+    return {
+      showError: false,
+    };
+  },
   computed: {
     dueInGetter() {
       return _.get(this.node, "dueIn");
@@ -82,10 +93,24 @@ export default {
      */
     dueInVariableSetter(event) {
       this.$set(this.node, "dueInVariable", event.target.value);
+      this.showError = this.valideteMustache(event.target.value);
+    },
+    /**
+     * Validate if the value is a correct Mustache Syntaxis.
+     */
+    valideteMustache(value) {
+      const regex = /^{{(.*)}}/gm;
+      return !regex.test(value);
     },
   },
 };
 </script>
 
 <style lang="scss" scoped>
+.showError {
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  color: #e50130;
+}
 </style>

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1001,6 +1001,7 @@
   "Multi-Instance (Sequential)": "Multi-Instance (Sequential)",
   "Multicolumn / Table": "Multicolumn / Table",
   "Must be unique": "Must be unique",
+  "Must be mustache syntax": "Must be mustache syntax",
   "My Cases": "My Cases",
   "My Bookmarks": "My Bookmarks",
   "My Projects": "My Projects",


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a screen 
2. Add a date picker 
3. Click on configuration
4. Go to Minimum Date
5. Try to add a variable not mustache (There is a validation)
6. Create a process 
7. Add task 
8. Go to variable due date

Variable task due date does not validate that value will be a mustache syntax 

## Solution
- Variable task in due data of a task should validate the syntax of mustache like date picker in Screens 

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-16725](https://processmaker.atlassian.net/browse/FOUR-16725)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:deploy

[FOUR-16725]: https://processmaker.atlassian.net/browse/FOUR-16725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ