### PR TITLE
QA Observation Bugfix/FOUR-16888: Launchpad > there is not a space between cards and collapsed sidebar

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -24,9 +24,8 @@
           :hideBookmark="categoryId === 'all_templates'"
         />
 
-          <div v-if="(index % perPage === perPage - 1) && processList.length >= perPage" class="separator-class">
-            
-              <Card v-if="((index + 1) === processList.length)"
+          <div v-if="(index % perPage === perPage - 1) && processList.length >= perPage" :class="separatorClass">
+              <Card v-if="(((index + 1) === processList.length))"
               :show-cards="false"
               :current-page="counterPage + Math.floor(index / perPage)"
               :total-pages="totalPages"
@@ -91,7 +90,18 @@ export default {
       showMoreVisible: false,
       cardMessage: "show-more",
       sumHeight: 0,
+      size: null,
+      minWidthCardContainer: 1414.
     };
+  },
+  computed: {
+    separatorClass() {
+      const classes = {
+        'separator-class': true,
+        'width-changed': this.size === this.minWidthCardContainer,
+      };
+      return classes;
+    },
   },
   watch: {
     async categoryId() {
@@ -114,12 +124,18 @@ export default {
           listCard.addEventListener("scrollend", () => this.handleScroll());
       });
     }, null);
+    this.$root.$on("sizeChanged", (val) => {
+      this.handleSizeChange(val);
+    });
   },
   destroyed() {
     const listCard = document.querySelector(".processes-info");
     listCard.removeEventListener("scrollend", this.handleScroll);
   },
   methods: {
+    handleSizeChange(valor) {
+      this.size = valor;
+    },
     loadCard(callback, message) {
       if(message === 'bookmark') {
         this.processList = [];
@@ -270,5 +286,8 @@ export default {
     height: auto;
     width: 100%;
   }
+}
+.separator-class.width-changed {
+  width: 93%;
 }
 </style>

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -24,10 +24,9 @@
           :hideBookmark="categoryId === 'all_templates'"
         />
 
-          <div v-if="(index % perPage === perPage - 1) && processList.length >= perPage" style="width: 75%;">
+          <div v-if="(index % perPage === perPage - 1) && processList.length >= perPage" class="separator-class">
             
               <Card v-if="((index + 1) === processList.length)"
-              style="width: 100%;"
               :show-cards="false"
               :current-page="counterPage + Math.floor(index / perPage)"
               :total-pages="totalPages"
@@ -38,7 +37,6 @@
 
               <Card
               v-else
-              style="width: 100%;"
               :show-cards="false"
               :current-page="counterPage + Math.floor(index / perPage)"
               :total-pages="totalPages"
@@ -244,6 +242,8 @@ export default {
   height: 100%;
   overflow: unset;
   justify-content: flex-start;
+  /*margin-left: 4%;
+  margin-right: 4%;*/
   @media (max-width: $lp-breakpoint) {
     display: block;
     height: auto;
@@ -257,5 +257,11 @@ export default {
   border-right-color: transparent;
   border-radius: 50%;
   animation: 0.75s linear infinite spinner-border;
+}
+.separator-class {
+  width: 90%;
+  @media (max-width: $lp-breakpoint) {
+    width: 94%;
+  }
 }
 </style>

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -242,8 +242,7 @@ export default {
   height: 100%;
   overflow: unset;
   justify-content: flex-start;
-  /*margin-left: 4%;
-  margin-right: 4%;*/
+
   @media (max-width: $lp-breakpoint) {
     display: block;
     height: auto;
@@ -259,9 +258,17 @@ export default {
   animation: 0.75s linear infinite spinner-border;
 }
 .separator-class {
-  width: 90%;
+  width: 85%;
   @media (max-width: $lp-breakpoint) {
+    display: block;
+    height: auto;
     width: 94%;
+  }
+
+  @media (min-width: 1870px) {
+    display: block;
+    height: auto;
+    width: 100%;
   }
 }
 </style>

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -10,6 +10,7 @@
       class="processList d-flex"
       ref="processListContainer"
     >
+      
       <template v-for="(process, index) in processList">
         <Card
           :key="`${index}_${renderKey}`"
@@ -24,24 +25,26 @@
           :hideBookmark="categoryId === 'all_templates'"
         />
 
-          <div v-if="(index % perPage === perPage - 1) && processList.length >= perPage" :class="separatorClass">
-              <Card v-if="(((index + 1) === processList.length))"
-              :show-cards="false"
-              :current-page="counterPage + Math.floor(index / perPage)"
-              :total-pages="totalPages"
-              :card-message="'show-more'"
-              :loading="loading"
-              @callLoadCard="loadCard"
-            />
+        <div v-if="(index % perPage === perPage - 1) && processList.length >= perPage" :class="separatorClass">
+          <Card
+            v-if="((index + 1) === processList.length) && ((index + 1) < totalPages * perPage)"
+            :show-cards="false"
+            :current-page="counterPage + Math.floor(index / perPage)"
+            :total-pages="totalPages"
+            :card-message="'show-more'"
+            :loading="loading"
+            @callLoadCard="loadCard"
+          />
 
-              <Card
-              v-else
-              :show-cards="false"
-              :current-page="counterPage + Math.floor(index / perPage)"
-              :total-pages="totalPages"
-              :card-message="cardMessage"
-              :loading="loading"
-              @callLoadCard="loadCard"
+          <div v-else-if="((index + 1) === processList.length) && currentPage === totalPages && ((index + 1) === processList.length)">
+          </div>
+          <Card v-else
+          :show-cards="false"
+            :current-page="counterPage + Math.floor(index / perPage)"
+            :total-pages="totalPages"
+            :card-message="cardMessage"
+            :loading="loading"
+            @callLoadCard="loadCard"
             />
         </div>
       </template>
@@ -90,15 +93,14 @@ export default {
       showMoreVisible: false,
       cardMessage: "show-more",
       sumHeight: 0,
-      size: null,
-      minWidthCardContainer: 1414.
+      sizeChange: false,
     };
   },
   computed: {
     separatorClass() {
       const classes = {
         'separator-class': true,
-        'width-changed': this.size === this.minWidthCardContainer,
+        'width-changed': this.sizeChange,
       };
       return classes;
     },
@@ -133,8 +135,8 @@ export default {
     listCard.removeEventListener("scrollend", this.handleScroll);
   },
   methods: {
-    handleSizeChange(valor) {
-      this.size = valor;
+    handleSizeChange(value) {
+      this.sizeChange = value;
     },
     loadCard(callback, message) {
       if(message === 'bookmark') {

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -30,13 +30,13 @@
         </div>
       </div>
       <div class="slide-control">
-        <a href="#" @click="showMenu = !showMenu">
+        <a href="#" @click="hideMenu">
           <i class="fa" :class="{ 'fa-caret-right' : !showMenu, 'fa-caret-left' : showMenu }"></i>
         </a>
       </div>
-      <div class="processes-info">
+      <div ref="processInfo" class="processes-info">
           <div class="mobile-menu-control" v-show="showMobileMenuControl">
-            <div class="menu-button" @click="showMenu = !showMenu">
+            <div class="menu-button" @click="hideMenu">
               <i class="fa fa-bars"></i>
               {{ category?.name || '' }}
             </div>
@@ -132,6 +132,9 @@ export default {
     }
   },
   methods: {
+    hideMenu() {
+      this.showMenu = !this.showMenu;
+    },
     /**
      * Add new page of categories
      */
@@ -420,7 +423,7 @@ export default {
 }
 .processes-info {
   width: 100%;
-  margin-right: -16px;
+  margin-right: 0px;
   height: calc(100vh - 145px);
   overflow-x: hidden;
   @media (max-width: $lp-breakpoint) {

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -101,6 +101,7 @@ export default {
       fromProcessList: false,
       categoryCount: 0,
       hideLaunchpad: true,
+      currentWidth: 0,
     };
   },
   mounted() {
@@ -134,6 +135,8 @@ export default {
   methods: {
     hideMenu() {
       this.showMenu = !this.showMenu;
+      this.currentWidth = this.$refs.processInfo.offsetWidth;
+      this.$root.$emit("sizeChanged", this.currentWidth);
     },
     /**
      * Add new page of categories

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -135,8 +135,7 @@ export default {
   methods: {
     hideMenu() {
       this.showMenu = !this.showMenu;
-      this.currentWidth = this.$refs.processInfo.offsetWidth;
-      this.$root.$emit("sizeChanged", this.currentWidth);
+      this.$root.$emit("sizeChanged", !this.showMenu);
     },
     /**
      * Add new page of categories

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -41,7 +41,7 @@
     </b-card-text>
   </b-card>
   <b-card v-else
-  class="text-center d-flex align-items-center justify-content-center card-process2">
+  class="d-flex text-center align-items-center justify-content-center card-process3">
     <span v-if="cardMessage === 'show-page'">Page {{ currentPage }} of {{ totalPages }}</span>
     <span v-if="cardMessage === 'show-more' && !loading"> {{ $t('Show More') }}</span>
     <span v-if="loading"><i class="fas fa-spinner fa-spin"></i> {{ $t('Loading') }}...</span>
@@ -117,11 +117,12 @@ export default {
 
 .card-process {
   max-width: 343px;
-  min-width: 296px;
+  min-width: 300px;
   width: 27vw;
   height: 232px;
   margin-top: 1rem;
   margin-right: 1rem;
+  margin-left: 1rem;
   border-radius: 16px;
   background-image: url("/img/launchpad-images/process_background.svg");
 
@@ -147,6 +148,23 @@ export default {
     min-width: none;
     border-radius: 8px;
     height: 40px;
+  }
+}
+.card-process3 {
+  height: 40px;
+  margin-top: 1rem;
+  margin-right: 13.5%;
+  border-radius: 8px;
+  background-color: #E5EDF3;
+  margin-left: 1rem;
+
+  @media (max-width: $lp-breakpoint) {
+    width: 100%;
+    max-width: none;
+    min-width: none;
+    border-radius: 8px;
+    height: 40px;
+    margin-right: 0;
   }
 }
 .card-process:hover {

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -41,7 +41,7 @@
     </b-card-text>
   </b-card>
   <b-card v-else
-  class="d-flex text-center align-items-center justify-content-center card-process3">
+  class="d-flex text-center align-items-center justify-content-center card-process2">
     <span v-if="cardMessage === 'show-page'">Page {{ currentPage }} of {{ totalPages }}</span>
     <span v-if="cardMessage === 'show-more' && !loading"> {{ $t('Show More') }}</span>
     <span v-if="loading"><i class="fas fa-spinner fa-spin"></i> {{ $t('Loading') }}...</span>
@@ -135,25 +135,11 @@ export default {
     margin-right: 5px;
   }
 }
+
 .card-process2 {
   height: 40px;
   margin-top: 1rem;
-  margin-right: 1rem;
-  border-radius: 8px;
-  background-color: #E5EDF3;
-
-  @media (max-width: $lp-breakpoint) {
-    width: 100%;
-    max-width: none;
-    min-width: none;
-    border-radius: 8px;
-    height: 40px;
-  }
-}
-.card-process3 {
-  height: 40px;
-  margin-top: 1rem;
-  margin-right: 13.5%;
+  margin-right: 7%;
   border-radius: 8px;
   background-color: #E5EDF3;
   margin-left: 1rem;


### PR DESCRIPTION
## Solution
- Left space was added to Cards section
- Separator for inifinite scroll bar was improved
- When there are only 12 cards, separator is not shown anymore

## How to Test
- Login to PM
- Go to processes and check cards visualization

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16888

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next