### PR TITLE
FOUR-16877: The "View documentation" option from the process list is not updated.

### DIFF
--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -77,7 +77,7 @@ export default {
           value: "view-documentation",
           content: "View Documentation",
           link: true,
-          href: "/modeler/{{id}}/print",
+          href: ProcessMaker.packages.includes('package-ai') ? "/modeler/{{id}}/documentation" : "/modeler/{{id}}/print",
           permission: ["view-processes", "view-additional-asset-actions"],
           icon: "fas fa-sign",
           conditional: "isDocumenterInstalled",


### PR DESCRIPTION
## Issue & Reproduction Steps
1.Go to Process
3.Click on ellipsis
4.Select View Documentation

Current Behavior:

The documentation is not implemented.

Expected Behavior:

It should redirect to the documentation for generation with AI

## Solution
- Added code that detects if package-ai is installed. If so, the pacakge-ai documentaion UI is used.


## Related Tickets & Packages
Resolves:
- https://processmaker.atlassian.net/browse/FOUR-16877
- https://processmaker.atlassian.net/browse/FOUR-16878

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next