### PR TITLE
QA Observation Bugfix/FOUR-16891: Launchpad > Process Info does not have the same design when the screen size is greater than 2560px

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessOptions.vue
+++ b/resources/js/processes-catalogue/components/ProcessOptions.vue
@@ -30,10 +30,9 @@ export default {
   flex-direction: column;
   align-items: flex-start;
 }
-@media (max-width: 2560px) {
-  .section-options {
-    flex-direction: row;
-    justify-content: space-between;
-  }
+
+.section-options {
+  flex-direction: row;
+  justify-content: space-between;
 }
 </style>

--- a/resources/js/processes-catalogue/components/scss/processes.css
+++ b/resources/js/processes-catalogue/components/scss/processes.css
@@ -30,6 +30,12 @@
   border-bottom-right-radius: 8px;
 }
 
+@media (min-width: 2560px) {
+  .info-collapse {
+    padding: 32px 8vw;
+  }
+}
+
 .title-process {
   color: #556271;
   font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
## Solution
- Process Info page was adjust to have figma design when screen is greater than 2560px width

## How to Test
- Go to Processes menu
- Click over some process
- Open browser dev tools (F12)
- Select Emulator for Mobile and select responsive mode. Set width with 2560px
- The right and left space between Carousel images should be added.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16891

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next