### PR TITLE
FOUR-17013 Icon for templates card does not have the correct size

### DIFF
--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -219,13 +219,15 @@ export default {
   }
 }
 .icon-process {
-  width: 24px;
-  height: 24px;
+  width: 40px;
+  height: 48px;
   margin-bottom: 16px;
 
   @media (max-width: $lp-breakpoint) {
     margin-bottom: 0;
-    margin-right: 10px;
+    margin-right: 10px;  
+    width: 24px;
+    height: 24px;
   }
 }
 .title-process {


### PR DESCRIPTION
https://processmaker.atlassian.net/browse/FOUR-17013

Icon for templates card does not have the correct size

Normal size is 40x48 
Mobile size is 24x24

ci:next
