### PR TITLE
FOUR-17129: Images in slide show does not save  correctly in alternat…

### DIFF
--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -226,7 +226,7 @@ class Media extends MediaLibraryModel
             ];
             if ($mediaType === 'slideshow') {
                 $customProperties['node_id'] = $properties['node_id'] ?? '';
-                $customProperties['alternative'] = $properties['alternative'] ?? '';                
+                $customProperties['alternative'] = $properties['alternative'] ?? '';
             }
             // Store the images related move to MEDIA
             $process->addMediaFromBase64($properties['url'])

--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -226,6 +226,7 @@ class Media extends MediaLibraryModel
             ];
             if ($mediaType === 'slideshow') {
                 $customProperties['node_id'] = $properties['node_id'] ?? '';
+                $customProperties['alternative'] = $properties['alternative'] ?? '';                
             }
             // Store the images related move to MEDIA
             $process->addMediaFromBase64($properties['url'])


### PR DESCRIPTION
## Solution
- Add other custom property  in DB for slideshow media files

## How to Test
- Open the modeler
- Open slideshow mode
- Select a task and add new image
- switch to alternative B
- Select the same task and add a new image

- Verify the images in alt A & alt B

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:package-slideshow:feature/FOUR-17129
ci:deploy