### PR TITLE
FOUR-17089: Errors appear in the console when we click on the RPA from Forms

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -764,28 +764,32 @@ class ProcessRequestController extends Controller
                 $httpRequest->input('order_direction', 'asc')
             )->paginate($httpRequest->input('per_page', 10));
 
-        $response->getCollection()->transform(function ($token) {
-            $definition = $token->getDefinition();
-            if (array_key_exists('screenRef', $definition)) {
-                $screen = $token->getScreenVersion();
-                if ($screen) {
-                    $dataManager = new DataManager();
-                    $screen->data = $dataManager->getData($token, true);
-                    $screen->screen_id = $screen->id;
+        $collection = $response->getCollection()
+            ->transform(function ($token): ?object {
+                $definition = $token->getDefinition();
+                if (array_key_exists('screenRef', $definition)) {
+                    $screen = $token->getScreenVersion();
+                    if ($screen) {
+                        $dataManager = new DataManager();
+                        $screen->data = $dataManager->getData($token, true);
+                        $screen->screen_id = $screen->id;
 
-                    return $screen;
+                        return $screen;
+                    }
                 }
-            }
-        });
 
-        return new ApiCollection($response);
+                return null;
+            })
+            ->reject(fn ($item) => $item === null);
+
+        return new ApiCollection($collection);
     }
 
     /**
      * Adding abe flag
      * @param  int  $id
      *
-     * @return boolean
+     * @return bool
      */
     public function enableIsActionbyemail($id)
     {

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -947,12 +947,40 @@ class ProcessRequestsTest extends TestCase
     {
         //create a token
         $token = ProcessRequestToken::factory()->create([
-            'status' => 'ACTIVE'
+            'status' => 'ACTIVE',
         ]);
         $this->assertEquals($token->is_actionbyemail, 0);
 
         $res = (new ProcessRequestController)->enableIsActionbyemail($token->getKey());
 
         $this->assertTrue($res);
+    }
+
+    /**
+     * Test the screenRequested method of ProcessRequestController.
+     */
+    public function testScreenRequested()
+    {
+        $request = ProcessRequest::factory()->create();
+        ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'element_type' => 'userTask',
+            'status' => 'CLOSED',
+        ]);
+
+        $params = [
+            'page' => 1,
+            'per_page' => 10,
+            'order_by' => 'completed_at',
+            'order_direction' => 'asc',
+            'filter' => '',
+        ];
+        $route = route('api.requests.detail.screen', ['request' => $request->id]);
+        $response = $this->apiCall('GET', $route, $params);
+
+        $response->assertStatus(200);
+        // Assert empty because tokens does not have screens.
+        $data = $response->json()['data'];
+        $this->assertEmpty($data);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
When we click on the cell that corresponds to the RPA in the process completed in FORMS, we get an error in the console.

## Solution
- Records related to RPA were removed, specifically, any record that does not have an associated screen. This way, an empty record will not appear in the Forms tab.

https://github.com/user-attachments/assets/75f6f715-fb1d-40a1-83ed-d1a7c8aafc62

## How to Test
Follow the reproduction steps from the JIRA ticket.

## Related Tickets & Packages
- [FOUR-17089](https://processmaker.atlassian.net/browse/FOUR-17089)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-17089]: https://processmaker.atlassian.net/browse/FOUR-17089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ