### PR TITLE
FOUR-17157: [Fall 24] Action by email screen are not imported

### DIFF
--- a/ProcessMaker/Assets/ScreensInProcess.php
+++ b/ProcessMaker/Assets/ScreensInProcess.php
@@ -39,6 +39,18 @@ class ScreensInProcess
             $ref = $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'interstitialScreenRef');
             $references[] = [Screen::class, $ref];
         }
+        // Used abe email screen
+        $nodes = $xpath->query("//*[@pm:screenEmailRef!='']");
+        foreach ($nodes as $node) {
+            $ref = $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'screenEmailRef');
+            $references[] = [Screen::class, $ref];
+        }
+        // Used abe email screen for completed
+        $nodes = $xpath->query("//*[@pm:screenCompleteRef!='']");
+        foreach ($nodes as $node) {
+            $ref = $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'screenCompleteRef');
+            $references[] = [Screen::class, $ref];
+        }
         // Add cancel screen
         if ($process->cancel_screen_id) {
             $references[] = [Screen::class, $process->cancel_screen_id];

--- a/ProcessMaker/ImportExport/DependentType.php
+++ b/ProcessMaker/ImportExport/DependentType.php
@@ -10,6 +10,10 @@ abstract class DependentType
 
     const SCREENS = 'screens';
 
+    const EMAIL_SCREENS = 'email_screen';
+
+    const EMAIL_COMPLETED_SCREENS = 'email_completed_screen';
+
     const INTERSTITIAL_SCREEN = 'interstitial_screen';
 
     const NOTIFICATION_SETTINGS = 'process_notification_settings';

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -26,6 +26,8 @@ class ProcessExporter extends ExporterBase
 
     const BPMN_MANUAL_TASK = 'bpmn:manualTask';
 
+    const PM_INTERSTITIAL_SCREEN = 'pm:interstitialScreenRef';
+
     public function export() : void
     {
         $process = $this->model;
@@ -319,7 +321,8 @@ class ProcessExporter extends ExporterBase
             foreach ($screenTypes as $attribute => $dependentType) {
                 $screenId = $element->getAttribute($attribute);
 
-                if ($attribute == 'pm:interstitialScreenRef' && $element->getAttribute('pm:allowInterstitial') !== 'true') {
+                if ($attribute == self::PM_INTERSTITIAL_SCREEN
+                    && $element->getAttribute('pm:allowInterstitial') !== 'true') {
                     continue;
                 }
 
@@ -345,7 +348,7 @@ class ProcessExporter extends ExporterBase
         if ($this->getDependents(DependentType::INTERSTITIAL_SCREEN)) {
             foreach ($this->getDependents(DependentType::INTERSTITIAL_SCREEN) as $interDependent) {
                 $path = $interDependent->meta['path'];
-                Utils::setAttributeAtXPath($this->model, $path, 'pm:interstitialScreenRef', $interDependent->model->id);
+                Utils::setAttributeAtXPath($this->model, $path, self::PM_INTERSTITIAL_SCREEN, $interDependent->model->id);
             }
         }
 

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -312,6 +312,8 @@ class ProcessExporter extends ExporterBase
             $screenId = $element->getAttribute('pm:screenRef');
             $interstitialScreenId = $element->getAttribute('pm:interstitialScreenRef');
             $allowInterstitial = $element->getAttribute('pm:allowInterstitial');
+            $screenEmailId = $element->getAttribute('pm:screenEmailRef');
+            $screenCompletedId = $element->getAttribute('pm:screenCompleteRef');
 
             if (is_numeric($screenId)) {
                 $screen = Screen::find($screenId);
@@ -331,6 +333,24 @@ class ProcessExporter extends ExporterBase
                     Log::debug("Interstitial screenId: {$interstitialScreenId} not exists");
                 }
             }
+            // Let's check if email screen exist
+            if (is_numeric($screenEmailId)) {
+                $screen = Screen::find($screenEmailId);
+                if ($screen) {
+                    $this->addDependent(DependentType::EMAIL_SCREENS, $screen, ScreenExporter::class, $meta);
+                } else {
+                    Log::debug("ScreenId: {$screenId} not exists");
+                }
+            }
+            // Let's check if email completed screen exist
+            if (is_numeric($screenCompletedId)) {
+                $screen = Screen::find($screenCompletedId);
+                if ($screen) {
+                    $this->addDependent(DependentType::EMAIL_COMPLETED_SCREENS, $screen, ScreenExporter::class, $meta);
+                } else {
+                    Log::debug("ScreenId: {$screenId} not exists");
+                }
+            }
         }
     }
 
@@ -345,6 +365,20 @@ class ProcessExporter extends ExporterBase
             foreach ($this->getDependents(DependentType::INTERSTITIAL_SCREEN) as $interDependent) {
                 $path = $interDependent->meta['path'];
                 Utils::setAttributeAtXPath($this->model, $path, 'pm:interstitialScreenRef', $interDependent->model->id);
+            }
+        }
+
+        if ($this->getDependents(DependentType::EMAIL_SCREENS)) {
+            foreach ($this->getDependents(DependentType::EMAIL_SCREENS) as $interDependent) {
+                $path = $interDependent->meta['path'];
+                Utils::setAttributeAtXPath($this->model, $path, 'pm:screenEmailRef', $interDependent->model->id);
+            }
+        }
+
+        if ($this->getDependents(DependentType::EMAIL_COMPLETED_SCREENS)) {
+            foreach ($this->getDependents(DependentType::EMAIL_COMPLETED_SCREENS) as $interDependent) {
+                $path = $interDependent->meta['path'];
+                Utils::setAttributeAtXPath($this->model, $path, 'pm:screenCompleteRef', $interDependent->model->id);
             }
         }
     }

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -312,8 +312,12 @@ class ProcessExporter extends ExporterBase
             $screenId = $element->getAttribute('pm:screenRef');
             $interstitialScreenId = $element->getAttribute('pm:interstitialScreenRef');
             $allowInterstitial = $element->getAttribute('pm:allowInterstitial');
-            $screenEmailId = $element->getAttribute('pm:screenEmailRef');
-            $screenCompletedId = $element->getAttribute('pm:screenCompleteRef');
+            $screenEmailId = $screenCompletedId = null;
+            $configEmail = json_decode($element->getProperty('configEmail'), true);
+            if (!empty($configEmail)) {
+                $screenEmailId = $configEmail['screenEmailRef'] ?? null;
+                $screenCompletedId = $configEmail['screenCompleteRef'] ?? null;
+            }
 
             if (is_numeric($screenId)) {
                 $screen = Screen::find($screenId);

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -188,8 +188,8 @@ class TokenRepository implements TokenRepositoryInterface
                     $tokenAbe = $abeRequestToken->updateOrCreate([
                         'process_request_id' => $token->process_request_id,
                         'process_request_token_id' => $token->getKey(),
-                        'require_login' => $configEmail['requireLogin'] === true ? 1 : 0,
-                        'completed_screen_id' => $configEmail['screenCompleteRef'] ?? 0,
+                        'require_login' => $configEmail['requireLogin'] == 'true' ? 1 : 0,
+                        'completed_screen_id' => $configEmail['screenCompleteRef'] ?? null,
                     ]);
                     $data = $token->getInstance()->getDataStore()->getData();
                     // Set custom variables defined in the link


### PR DESCRIPTION
## Issue & Reproduction Steps
ABE screens are not imported in a process

## Solution
- Export the screens related to the Action by email

## How to Test
Create a process
Add task form 
Configure the task with ABE 
Assign email screen to ABE
Publish the changes 
Export the process 
Import the process 
Navigate to the process imported
Verify the email setting configurations (ABE Configuration)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17157

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:APP_DEBUG=true