### PR TITLE
QA Observation Bugfix/FOUR-16889: launchpad > Process Chart is not in the correct site

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessOptions.vue
+++ b/resources/js/processes-catalogue/components/ProcessOptions.vue
@@ -31,8 +31,15 @@ export default {
   align-items: flex-start;
 }
 
-.section-options {
+/* .section-options {
   flex-direction: row;
   justify-content: space-between;
+} */
+
+@media (min-width: 769px) {
+  .section-options {
+    flex-direction: row;
+    justify-content: space-between;
+  }
 }
 </style>

--- a/resources/js/processes-catalogue/components/ProcessOptions.vue
+++ b/resources/js/processes-catalogue/components/ProcessOptions.vue
@@ -30,12 +30,9 @@ export default {
   flex-direction: column;
   align-items: flex-start;
 }
-
-/* .section-options {
-  flex-direction: row;
-  justify-content: space-between;
-} */
-
+/*
+  When Screen Width is less than 769px Chart section moves below Details
+*/
 @media (min-width: 769px) {
   .section-options {
     flex-direction: row;


### PR DESCRIPTION
## Solution
- Chart section was fixed moviving below Details section when screen reaches 768px or less according mockup.

## How to Test
-Go to Processes
-Select some process
-Open process in a window with 653px like issue is reported by QA.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16889

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next