### PR TITLE
observation/FOUR-17156 Hover options are not displayed in the empty column

### DIFF
--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -233,7 +233,7 @@ import PMColumnFilterIconAsc from "../../components/PMColumnFilterPopover/PMColu
 import PMColumnFilterIconDesc from "../../components/PMColumnFilterPopover/PMColumnFilterIconDesc.vue";
 import FilterTableBodyMixin from "../../components/shared/FilterTableBodyMixin";
 import TaskListRowButtons from "./TaskListRowButtons.vue";
-import { get } from "lodash";
+import { cloneDeep, get } from "lodash";
 import Recommendations from "../../components/Recommendations.vue";
 
 const uniqIdsMixin = createUniqIdsMixin();
@@ -501,6 +501,17 @@ export default {
     },
     getColumns() {
       if (this.columns && this.columns.length > 0) {
+        const exists = this.columns.some((column) => column.field === "options");
+        if (!exists) {
+          const customColumns = cloneDeep(this.columns);
+          customColumns.push({
+            label: "",
+            field: "options",
+            sortable: false,
+            width: 180,
+          });
+          return customColumns;
+        }
         return this.columns;
       }
       // from query string status=CLOSED


### PR DESCRIPTION
## Issue & Reproduction Steps
Hover options are not displayed in the empty column

## Solution
added the option column if that column does not exists

## How to Test
Go to Tasks page
Hover in the row
Scroll right 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17156

ci:next