### PR TITLE
Make minimum width 360px for mobile

### DIFF
--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -133,6 +133,8 @@ export default {
     border-radius: 8px;
     height: 72px;
     margin-right: 5px;
+    margin-left: 0;
+    background-image: none;
   }
 }
 

--- a/resources/views/layouts/mobile.blade.php
+++ b/resources/views/layouts/mobile.blade.php
@@ -21,6 +21,7 @@
     display: flex;
     flex-direction: column;
     height: 100vh;
+    min-width: 360px;
   }
   .mobile-container {
     flex: 1;


### PR DESCRIPTION
## Issue & Reproduction Steps

Minimum with should be 360px for launchpad process list in mobile. When the screen is smaller than 360 the list should not condense and instead overflow off screen.

## Solution
- Update CSS

## How to Test
- Login with a mobile device/emulator and switch to mobile view
- Go to the processes tab. Resize to less than 360px
- At 360px, the cards should not get smaller and start to overflow off screen

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next