### PR TITLE
FOUR-16884 Fix launchpad category filtering

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -235,7 +235,11 @@ export default {
     onFilter(value, showEmpty = false) {
       this.processList = [];
       this.currentPage = 1;
-      this.pmql = `(fulltext LIKE "%${value}%")`;
+      if (value) {
+        this.pmql = `(fulltext LIKE "%${value}%")`;
+      } else {
+        this.pmql = "";
+      }
       this.filter = value;
       this.showEmpty = showEmpty;
       this.loadCard();
@@ -258,7 +262,6 @@ export default {
   display: flex;
   flex-wrap: wrap;
   position: relative;
-  height: 100%;
   overflow: unset;
   justify-content: flex-start;
 

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -94,7 +94,7 @@ export default {
       category: null,
       selectedProcess: null,
       guidedTemplates: false,
-      numCategories: 100,
+      numCategories: 20,
       page: 1,
       key: 0,
       totalPages: 1,
@@ -114,6 +114,10 @@ export default {
     if (!this.isMobile) {
       this.showMenu = true;
     }
+
+    this.$root.$on('filter-categories', (filter) => {
+      this.filterCategories(filter);
+    });
   },
   watch: {
     category: {
@@ -124,9 +128,6 @@ export default {
           this.showMenu = false;
         }
       }
-    },
-    listCategories() {
-      this.$root.categories = this.listCategories;
     },
   },
   computed: {
@@ -151,8 +152,10 @@ export default {
      */
     filterCategories(filter = "") {
       this.page = 1;
-      this.listCategories = [];
       this.filter = filter;
+      if (filter === null) {
+        this.$root.filteredCategories = null;
+      }
       this.getCategories();
     },
     /**
@@ -166,8 +169,13 @@ export default {
             + "&order_direction=asc"
             + `&page=${this.page}`
             + `&per_page=${this.numCategories}`
-            + `&filter=${this.filter}`)
+            + `&filter=${this.filter || ''}`)
           .then((response) => {
+
+            if (this.filter) {
+              this.$root.filteredCategories = response.data.data;
+              return;
+            }
 
             const loadedCategories = response.data.data.filter(category => {
               // filter if category exists in the default options

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -121,7 +121,6 @@ export default {
   width: 27vw;
   height: 232px;
   margin-top: 1rem;
-  margin-right: 1rem;
   margin-left: 1rem;
   border-radius: 16px;
   background-image: url("/img/launchpad-images/process_background.svg");

--- a/resources/js/processes-catalogue/components/utils/SearchCards.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCards.vue
@@ -27,10 +27,10 @@
         </b-button>
       </b-input-group-append>
     </b-input-group>
-    <div v-if="filteredCategories !== null"
+    <div v-if="$root.filteredCategories !== null"
          class="category-button-container">
-      <template v-if="filteredCategories.length > 0">
-        <b-button v-for="category in filteredCategories"
+      <template v-if="$root.filteredCategories.length > 0">
+        <b-button v-for="category in $root.filteredCategories"
           :key="category.id"
           class="category-button"
           variant="light"
@@ -54,17 +54,22 @@ export default {
   data() {
     return {
       filter: "",
-      filteredCategories: null,
     };
+  },
+  mounted() {
+    this.$root.filteredCategories = null;
   },
   methods: {
     fetch() {
+      if (this.filter === "") {
+        this.clearSearch();
+        return;
+      }
       this.filterPmql(this.filter, true);
       this.filterCategories();
     },
     clearSearch() {
-      this.filter = "";
-      this.filterCategories();
+      this.filter = null;
       this.fetch();
     },
     selectCategory(category) {
@@ -75,15 +80,7 @@ export default {
       this.clearSearch();
     },
     filterCategories() {
-      if (!this.filter) {
-        this.filteredCategories = null;
-        return;
-      }
-      this.filteredCategories = this.$root.categories.filter((category) => {
-        return category.name
-          .toLowerCase()
-          .includes(this.filter.toLowerCase());
-      });
+      this.$root.$emit("filter-categories", this.filter);
     },
   },
 };

--- a/resources/js/processes-catalogue/index.js
+++ b/resources/js/processes-catalogue/index.js
@@ -42,7 +42,7 @@ new Vue({
     return {
       permission: window.ProcessMaker.permission,
       isDocumenterInstalled: window.ProcessMaker.isDocumenterInstalled,
-      categories: [],
+      filteredCategories: null,
       mobileSearchVisible: false,
     };
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
Some categories were not showing in the search results because we load them all at once (limit 100) and then filter only on those.

## Solution
- Refactor to use backend filtering for categories.

## How to Test
- Have a category that does not show up in the initial list of 20 categories in launchpad
- Try to find that category using the search field

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16884

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
