### PR TITLE
FOUR-17113 Reload the users task lists when recommendation is applied

### DIFF
--- a/ProcessMaker/Events/TasksUpdated.php
+++ b/ProcessMaker/Events/TasksUpdated.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TasksUpdated implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(public $userId, public $message = null)
+    {
+    }
+
+    /**
+     * Set the event name
+     *
+     * @return string
+     */
+    public function broadcastAs()
+    {
+        return 'TasksUpdated';
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('ProcessMaker.Models.User.' . $this->userId);
+    }
+}

--- a/resources/js/tasks/components/ListMixin.js
+++ b/resources/js/tasks/components/ListMixin.js
@@ -4,6 +4,17 @@ const ListMixin = {
     if (taskListCard) {
       taskListCard .addEventListener("scrollend", this.onScroll);
     }
+
+    // Reload the task list when tasks are updated in the backend
+    const channel = `ProcessMaker.Models.User.${window.ProcessMaker?.user?.id}`;
+    const event = ".TasksUpdated";
+    window.Echo.private(channel).listen(
+      event,
+      () => {
+        this.fetch();
+      },
+    );
+    
   },
   beforeDestroy() {
     const taskListCard = document.querySelector(".mobile-container");

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2319,5 +2319,7 @@
   "Welcome Screen": "Welcome Screen",
   ":count tasks were not reassigned because the task settings prevent them from being reassigned" : ":count tasks were not reassigned because the task settings prevent them from being reassigned",
   "Task :task_id could not be reassigned because the task settings prevent it from being reassigned": "Task :task_id could not be reassigned because the task settings prevent it from being reassigned",
-  "No items to show": "No items to show"
+  "No items to show": "No items to show",
+  "This actions is taking longer than expected. We will continue updating your tasks in the background.": "This actions is taking longer than expected. We will continue updating your tasks in the background.",
+  "No user selected": "No user selected"
 }

--- a/tests/unit/ProcessMaker/ApplyRecommendationTest.php
+++ b/tests/unit/ProcessMaker/ApplyRecommendationTest.php
@@ -59,7 +59,7 @@ class ApplyRecommendationTest extends TestCase
             'status' => 'ACTIVE',
         ]);
 
-        $userToReassignTo = User::factory()->create();
+        $userToReassignTo = User::factory()->create(['status' => 'ACTIVE']);
 
         $task = Mockery::mock(ProcessRequestToken::class);
         $task->shouldReceive('reassign')->once()->with($userToReassignTo->id, $user);


### PR DESCRIPTION
## Issue & Reproduction Steps
The users task list was not reloading when a recommendation was applied.

## Solution
- Keep the modal open with a spinner to show the recommendation is working
- Send a websocket event to reload the users taks when it completes

## How to Test
Reassign or mark-as-priority any recommendation. Ensure the task list reloads when its finished.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17113

ci:next
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
