### PR TITLE
FOUR-17114 Regenerate when the user enables recommendations

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -347,9 +347,7 @@ class UserController extends Controller
             $this->uploadAvatar($user, $request);
         }
 
-        if (!RecommendationEngine::shouldGenerateFor($user)) {
-            RecommendationUser::deleteFor($user);
-        }
+        RecommendationEngine::handleUserSettingChanges($user, $original);
 
         return response([], 204);
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
Recommendations are deleted when a user disables recommendations, however, they are not regenerated when the user enables recommendations.

## Solution
- Trigger the generate recommendations job when the user enables recommendations

## How to Test
- Generate recommendations
- Disable recommendations in the user profile settings - the recommendations should no longer display on the tasks page
- Enable recommendations
- Wait a minute for the job to complete
- Ensure the recommendations are visible again on the tasks page

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17114

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
