### PR TITLE
FOUR-17133: Clear out Folders When Other Configurations Are Deleted in Admin Settings

### DIFF
--- a/resources/js/admin/settings/components/SettingSelect.vue
+++ b/resources/js/admin/settings/components/SettingSelect.vue
@@ -1,162 +1,217 @@
 <template>
-    <div class="setting-text">
-      <div v-if="input === null || !input.length" class="font-italic text-black-50">
-        Empty
-        <b-badge v-if="hasAuthorizedBadge" pill :variant="setting.ui.authorizedBadge ? 'success' : 'warning'">
-           <span v-if="setting.ui.authorizedBadge">{{ $t('Authorized') }}</span>
-           <span v-else>{{ $t('Not Authorized') }}</span>
-         </b-badge>
-      </div>
-      <div v-else>
-        {{ display }}
-         <b-badge v-if="hasAuthorizedBadge" pill :variant="setting.ui.authorizedBadge ? 'success' : 'warning'">
-           <span v-if="setting.ui.authorizedBadge">{{ $t('Authorized') }}</span>
-           <span v-else>{{ $t('Not Authorized') }}</span>
-         </b-badge>
-      </div>
-      <b-modal class="setting-object-modal" v-model="showModal" size="lg" @hidden="onModalHidden">
-        <template v-slot:modal-header class="d-block">
-          <div>
-            <h5 class="mb-0" v-if="setting.name">{{ $t(setting.name) }}</h5>
-            <h5 class="mb-0" v-else>{{ setting.key }}</h5>
-            <small class="form-text text-muted" v-if="setting.helper">{{ $t(setting.helper) }}</small>
-          </div>
-          <button type="button" :aria-label="$t('Close')" class="close" @click="onCancel">×</button>
-        </template>
-        <div>
-          <b-form-group>
-            <multiselect
-                v-model="transformed"
-                :placeholder="$t('Type to search')"
-                :options="options"
-                :multiple="true"
-                :show-labels="false"
-                :searchable="true"
-                :track-by="setting.ui.trackBy"
-                :label="setting.ui.label"
-            >
-            </multiselect>
-            <!-- <b-form-radio v-for="(option, value) in ui('options')" v-model="transformed" :key="value" :value="value">{{ option }}</b-form-radio> -->
-          </b-form-group>
-        </div>
-        <div slot="modal-footer" class="w-100 m-0 d-flex">
-          <button type="button" class="btn btn-outline-secondary ml-auto" @click="onCancel">
-              {{ $t('Cancel') }}
-          </button>
-          <button type="button" class="btn btn-secondary ml-3" @click="onSave" :disabled="! changed">
-              {{ $t('Save')}}
-          </button>
-        </div>
-      </b-modal>
+  <div class="setting-text">
+    <div
+      v-if="input === null || !input.length"
+      class="font-italic text-black-50"
+    >
+      Empty
+      <b-badge
+        v-if="hasAuthorizedBadge"
+        pill
+        :variant="setting.ui.authorizedBadge ? 'success' : 'warning'"
+      >
+        <span v-if="setting.ui.authorizedBadge">{{ $t('Authorized') }}</span>
+        <span v-else>{{ $t('Not Authorized') }}</span>
+      </b-badge>
     </div>
-  </template>
-  
-  <script>
-  import settingMixin from "../mixins/setting";
-  
-  export default {
-    mixins: [settingMixin],
-    props: ['value', 'setting'],
-    data() {
-      return {
-        input: null,
-        selected: null,
-        showModal: false,
-        transformed: null,
-      };
-    },
-    computed: {
-      variant() {
-        if (this.disabled) {
-          return 'secondary';
-        } else {
-          return 'success';
-        }
-      },
-      changed() {
-        return JSON.stringify(this.input) !== JSON.stringify(this.transformed);
-      },
-      display() {
-        const options = this.ui('options');
-        if (!options) {
-          return this.input;
-        }
-        const keys = Object.keys(options);
-        
-        if (keys.includes(this.input)) {
-          return options[this.input];
-        } else {
-            let display = [];
-            for (const [key, objValue] of Object.entries(this.input)) {
-                for (const [key, value] of Object.entries(objValue)) {
-                    if (key === this.setting.ui.label) {
-                        display.push(value);
-                    }
-                }
-            }
+    <div v-else>
+      {{ display }}
+      <b-badge
+        v-if="hasAuthorizedBadge"
+        pill
+        :variant="setting.ui.authorizedBadge ? 'success' : 'warning'"
+      >
+        <span v-if="setting.ui.authorizedBadge">{{ $t('Authorized') }}</span>
+        <span v-else>{{ $t('Not Authorized') }}</span>
+      </b-badge>
+    </div>
+    <b-modal
+      v-model="showModal"
+      class="setting-object-modal"
+      size="lg"
+      @hidden="onModalHidden"
+    >
+      <template
+        #modal-header
+        class="d-block"
+      >
+        <div>
+          <h5
+            v-if="setting.name"
+            class="mb-0"
+          >
+            {{ $t(setting.name) }}
+          </h5>
+          <h5
+            v-else
+            class="mb-0"
+          >
+            {{ setting.key }}
+          </h5>
+          <small
+            v-if="setting.helper"
+            class="form-text text-muted"
+          >{{ $t(setting.helper) }}</small>
+        </div>
+        <button
+          type="button"
+          :aria-label="$t('Close')"
+          class="close"
+          @click="onCancel"
+        >
+          ×
+        </button>
+      </template>
+      <div>
+        <b-form-group>
+          <multiselect
+            v-model="transformed"
+            :placeholder="$t('Type to search')"
+            :options="options"
+            :multiple="true"
+            :show-labels="false"
+            :searchable="true"
+            :track-by="setting.ui.trackBy"
+            :label="setting.ui.label"
+          />
+        </b-form-group>
+      </div>
+      <div
+        slot="modal-footer"
+        class="w-100 m-0 d-flex"
+      >
+        <button
+          type="button"
+          class="btn btn-outline-secondary ml-auto"
+          @click="onCancel"
+        >
+          {{ $t('Cancel') }}
+        </button>
+        <button
+          type="button"
+          class="btn btn-secondary ml-3"
+          :disabled="! changed"
+          @click="onSave"
+        >
+          {{ $t('Save') }}
+        </button>
+      </div>
+    </b-modal>
+  </div>
+</template>
 
-          return display.join(', ');;
+<script>
+import settingMixin from "../mixins/setting";
+
+export default {
+  mixins: [settingMixin],
+  props: {
+    value: {
+      type: [String, Object],
+      default: null,
+    },
+    setting: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      input: null,
+      selected: null,
+      showModal: false,
+      transformed: null,
+    };
+  },
+  computed: {
+    variant() {
+      if (this.disabled) {
+        return "secondary";
+      }
+      return "success";
+    },
+    changed() {
+      return JSON.stringify(this.input) !== JSON.stringify(this.transformed);
+    },
+    display() {
+      const options = this.ui("options");
+      if (!options) {
+        return this.input;
+      }
+      const keys = Object.keys(options);
+
+      if (keys.includes(this.input)) {
+        return options[this.input];
+      }
+      const display = [];
+      for (const [key, objValue] of Object.entries(this.input)) {
+        for (const [key, value] of Object.entries(objValue)) {
+          if (key === this.setting.ui.label) {
+            display.push(value);
+          }
         }
-      },
-      hasAuthorizedBadge() {
-        if (!this.setting) {
-          return false;
-        }
-        // Prevent authorization badge from showing on 'standard' authentication
-        const hasAuthorizedBadge = _.has(this.setting, 'ui.authorizedBadge') && this.setting.config !== '0' ? true : false;
-        return hasAuthorizedBadge;
-      },
-      options() {
-        if (this.setting.ui.options) {
-           return JSON.parse(this.setting.ui.options);
-        } 
-        return [];
       }
+
+      return display.join(", ");
     },
-    watch: {
-      value: {
-        handler: function(value) {
-          this.input = value;
-        },
+    hasAuthorizedBadge() {
+      if (!this.setting) {
+        return false;
       }
+      // Prevent authorization badge from showing on 'standard' authentication
+      const hasAuthorizedBadge = !!(_.has(this.setting, "ui.authorizedBadge") && this.setting.config !== "0");
+      return hasAuthorizedBadge;
     },
-    methods: {
-      onCancel() {
-        this.showModal = false;
-      },
-      onEdit() {
-        this.showModal = true;
-      },
-      onModalHidden() {
-        this.transformed = this.copy(this.input);
-      },
-      onSave() {
-        this.input = this.copy(this.transformed);
-        this.showModal = false;
-        this.emitSaved(this.input);
+    options() {
+      if (this.setting.ui.options) {
+        return JSON.parse(this.setting.ui.options);
+      }
+      return [];
+    },
+  },
+  watch: {
+    value: {
+      handler(value) {
+        this.input = value;
       },
     },
-    mounted() {
-      if (this.value === null) {
-        this.input = '';
-      } else {
-        this.input = this.value;
-      }
+  },
+  mounted() {
+    if (this.value === null) {
+      this.input = "";
+    } else {
+      this.input = this.value;
+    }
+    this.transformed = this.copy(this.input);
+  },
+  methods: {
+    onCancel() {
+      this.showModal = false;
+    },
+    onEdit() {
+      this.showModal = true;
+    },
+    onModalHidden() {
       this.transformed = this.copy(this.input);
-    }
-  };
-  </script>
-  
-  <style lang="scss" scoped>
-    @import '../../../../sass/colors';
-  
-    $disabledBackground: lighten($secondary, 20%);
-  
-    .btn:disabled,
-    .btn.disabled {
-      background: $disabledBackground;
-      border-color: $disabledBackground;
-      opacity: 1 !important;
-    }
-  </style>
-  
+    },
+    onSave() {
+      this.input = this.copy(this.transformed);
+      this.showModal = false;
+      this.emitSaved(this.input);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@import '../../../../sass/colors';
+
+$disabledBackground: lighten($secondary, 20%);
+
+.btn:disabled,
+.btn.disabled {
+  background: $disabledBackground;
+  border-color: $disabledBackground;
+  opacity: 1 !important;
+}
+</style>

--- a/resources/js/admin/settings/components/SettingSelect.vue
+++ b/resources/js/admin/settings/components/SettingSelect.vue
@@ -107,8 +107,8 @@ export default {
   mixins: [settingMixin],
   props: {
     value: {
-      type: [String, Object],
-      default: null,
+      type: [String, Object, Array],
+      default: "",
     },
     setting: {
       type: Object,
@@ -172,17 +172,12 @@ export default {
   watch: {
     value: {
       handler(value) {
-        this.input = value;
+        this.updateInputAndTransformed(value);
       },
     },
   },
   mounted() {
-    if (this.value === null) {
-      this.input = "";
-    } else {
-      this.input = this.value;
-    }
-    this.transformed = this.copy(this.input);
+    this.updateInputAndTransformed(this.value);
   },
   methods: {
     onCancel() {

--- a/resources/js/admin/settings/components/SettingText.vue
+++ b/resources/js/admin/settings/components/SettingText.vue
@@ -174,10 +174,6 @@ export default {
     this.updateInputAndTransformed(this.value);
   },
   methods: {
-    updateInputAndTransformed(value) {
-      this.input = value === null ? "" : value;
-      this.transformed = this.copy(this.input);
-    },
     onCancel() {
       this.showModal = false;
     },

--- a/resources/js/admin/settings/components/SettingText.vue
+++ b/resources/js/admin/settings/components/SettingText.vue
@@ -138,19 +138,13 @@ export default {
   },
   computed: {
     variant() {
-      if (this.disabled) {
-        return "secondary";
-      }
-      return "success";
+      return this.disabled ? "secondary" : "success";
     },
     changed() {
       return JSON.stringify(this.input) !== JSON.stringify(this.transformed);
     },
     icon() {
-      if (this.type === "password") {
-        return "fa-eye";
-      }
-      return "fa-eye-slash";
+      return this.type === "password" ? "fa-eye" : "fa-eye-slash";
     },
     hidden() {
       return "•".repeat(this.input.length);
@@ -172,19 +166,18 @@ export default {
   watch: {
     value: {
       handler(value) {
-        this.input = value;
+        this.updateInputAndTransformed(value);
       },
     },
   },
   mounted() {
-    if (this.value === null) {
-      this.input = "";
-    } else {
-      this.input = this.value;
-    }
-    this.transformed = this.copy(this.input);
+    this.updateInputAndTransformed(this.value);
   },
   methods: {
+    updateInputAndTransformed(value) {
+      this.input = value === null ? "" : value;
+      this.transformed = this.copy(this.input);
+    },
     onCancel() {
       this.showModal = false;
     },
@@ -207,11 +200,7 @@ export default {
       this.emitSaved(this.input);
     },
     togglePassword() {
-      if (this.type === "text") {
-        this.type = "password";
-      } else {
-        this.type = "text";
-      }
+      this.type = this.type === "text" ? "password" : "text";
       this.$refs.input.focus();
     },
   },

--- a/resources/js/admin/settings/components/SettingText.vue
+++ b/resources/js/admin/settings/components/SettingText.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="setting-text">
-    <div v-if="input === null || !input.length" class="font-italic text-black-50">
+    <div
+      v-if="input === null || !input.length"
+      class="font-italic text-black-50"
+    >
       Empty
     </div>
     <div v-else>
@@ -11,36 +14,99 @@
         {{ hidden }}
       </template>
     </div>
-    <b-modal class="setting-object-modal" v-model="showModal" size="lg" @hidden="onModalHidden" @shown="onModalShown">
-      <template v-slot:modal-header class="d-block">
+    <b-modal
+      v-model="showModal"
+      class="setting-object-modal"
+      size="lg"
+      @hidden="onModalHidden"
+      @shown="onModalShown"
+    >
+      <template
+        #modal-header
+        class="d-block"
+      >
         <div>
-          <h5 class="mb-0" v-if="setting.name">{{ $t(setting.name) }}</h5>
-          <h5 class="mb-0" v-else>{{ setting.key }}</h5>
-          <small class="form-text text-muted" v-if="setting.helper">{{ $t(setting.helper) }}</small>
+          <h5
+            v-if="setting.name"
+            class="mb-0"
+          >
+            {{ $t(setting.name) }}
+          </h5>
+          <h5
+            v-else
+            class="mb-0"
+          >
+            {{ setting.key }}
+          </h5>
+          <small
+            v-if="setting.helper"
+            class="form-text text-muted"
+          >{{ $t(setting.helper) }}</small>
         </div>
-        <button type="button" :aria-label="$t('Close')" class="close" @click="onCancel">×</button>
+        <button
+          type="button"
+          :aria-label="$t('Close')"
+          class="close"
+          @click="onCancel"
+        >
+          ×
+        </button>
       </template>
       <template v-if="! ui('sensitive')">
         <b-form-group :invalid-feedback="invalidFeedback">
-          <b-form-input ref="input" v-model="transformed" @keyup.enter="onSave" spellcheck="false" autocomplete="off" type="text" :state="state"></b-form-input>
+          <b-form-input
+            ref="input"
+            v-model="transformed"
+            spellcheck="false"
+            autocomplete="off"
+            type="text"
+            :state="state"
+            @keyup.enter="onSave"
+          />
         </b-form-group>
       </template>
       <template v-else>
         <b-input-group>
-          <b-form-input class="border-right-0" ref="input" v-model="transformed" @keyup.enter="onSave" spellcheck="false" autocomplete="new-password" :type="type"></b-form-input>
+          <b-form-input
+            ref="input"
+            v-model="transformed"
+            class="border-right-0"
+            spellcheck="false"
+            :type="type"
+            @keyup.enter="onSave"
+          />
           <b-input-group-append>
-            <b-button :aria-label="$t('Toggle Show Password')" variant="secondary" @click="togglePassword">
-              <i class="fas" :class="icon"></i>
+            <b-button
+              :aria-label="$t('Toggle Show Password')"
+              variant="secondary"
+              @click="togglePassword"
+            >
+              <i
+                class="fas"
+                :class="icon"
+              />
             </b-button>
           </b-input-group-append>
         </b-input-group>
       </template>
-      <div slot="modal-footer" class="w-100 m-0 d-flex">
-        <button type="button" class="btn btn-outline-secondary ml-auto" @click="onCancel">
-            {{ $t('Cancel') }}
+      <div
+        slot="modal-footer"
+        class="w-100 m-0 d-flex"
+      >
+        <button
+          type="button"
+          class="btn btn-outline-secondary ml-auto"
+          @click="onCancel"
+        >
+          {{ $t('Cancel') }}
         </button>
-        <button type="button" class="btn btn-secondary ml-3" @click="onSave" :disabled="! changed">
-            {{ $t('Save')}}
+        <button
+          type="button"
+          class="btn btn-secondary ml-3"
+          :disabled="! changed"
+          @click="onSave"
+        >
+          {{ $t('Save') }}
         </button>
       </div>
     </b-modal>
@@ -52,55 +118,71 @@ import settingMixin from "../mixins/setting";
 
 export default {
   mixins: [settingMixin],
-  props: ['value', 'setting'],
+  props: {
+    value: {
+      type: [String, Number],
+      default: null,
+    },
+    setting: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
   data() {
     return {
       input: null,
       showModal: false,
       transformed: null,
-      type: 'password'
+      type: "password",
     };
   },
   computed: {
     variant() {
       if (this.disabled) {
-        return 'secondary';
-      } else {
-        return 'success';
+        return "secondary";
       }
+      return "success";
     },
     changed() {
       return JSON.stringify(this.input) !== JSON.stringify(this.transformed);
     },
     icon() {
-      if (this.type == 'password') {
-        return 'fa-eye';
-      } else {
-        return 'fa-eye-slash';
+      if (this.type === "password") {
+        return "fa-eye";
       }
+      return "fa-eye-slash";
     },
     hidden() {
-      return '•'.repeat(this.input.length);
+      return "•".repeat(this.input.length);
     },
     state() {
       if (this.setting?.ui?.isNotEmpty) {
-        return this.transformed !== '' && this.transformed !== null;
+        return this.transformed !== "" && this.transformed !== null;
       }
 
       return true;
     },
     invalidFeedback() {
-      if (this.setting?.ui?.isNotEmpty && (this.transformed === '' || this.transformed === null)) {
+      if (this.setting?.ui?.isNotEmpty && (this.transformed === "" || this.transformed === null)) {
         return this.$t("The current value is empty but a value is required. Please provide a valid value.");
       }
-    }
+      return "";
+    },
   },
   watch: {
     value: {
-      handler: function(value) {
+      handler(value) {
         this.input = value;
       },
+    },
+  },
+  mounted() {
+    if (this.value === null) {
+      this.input = "";
+    } else {
+      this.input = this.value;
     }
+    this.transformed = this.copy(this.input);
   },
   methods: {
     onCancel() {
@@ -110,14 +192,14 @@ export default {
       this.showModal = true;
     },
     onModalHidden() {
-      this.type = 'password';
+      this.type = "password";
       this.transformed = this.copy(this.input);
     },
     onModalShown() {
       this.$refs.input.focus();
     },
     onSave() {
-      if (this.setting.ui?.isNotEmpty && (this.transformed === '' || this.transformed === null)) {
+      if (this.setting.ui?.isNotEmpty && (this.transformed === "" || this.transformed === null)) {
         return;
       }
       this.input = this.copy(this.transformed);
@@ -125,34 +207,26 @@ export default {
       this.emitSaved(this.input);
     },
     togglePassword() {
-      if (this.type == 'text') {
-        this.type = 'password';
+      if (this.type === "text") {
+        this.type = "password";
       } else {
-        this.type = 'text';
+        this.type = "text";
       }
       this.$refs.input.focus();
-    }
+    },
   },
-  mounted() {
-    if (this.value === null) {
-      this.input = '';
-    } else {
-      this.input = this.value;
-    }
-    this.transformed = this.copy(this.input);
-  }
 };
 </script>
 
 <style lang="scss" scoped>
-  @import '../../../../sass/colors';
+@import '../../../../sass/colors';
 
-  $disabledBackground: lighten($secondary, 20%);
+$disabledBackground: lighten($secondary, 20%);
 
-  .btn:disabled,
-  .btn.disabled {
-    background: $disabledBackground;
-    border-color: $disabledBackground;
-    opacity: 1 !important;
-  }
+.btn:disabled,
+.btn.disabled {
+  background: $disabledBackground;
+  border-color: $disabledBackground;
+  opacity: 1 !important;
+}
 </style>

--- a/resources/js/admin/settings/mixins/setting.js
+++ b/resources/js/admin/settings/mixins/setting.js
@@ -1,5 +1,9 @@
 export default {
   methods: {
+    updateInputAndTransformed(value) {
+      this.input = value === null ? "" : value;
+      this.transformed = this.copy(this.input);
+    },
     emitSaved(value) {
       const setting = this.copy(this.setting);
       setting.config = value;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR is part of https://github.com/ProcessMaker/package-rpa/pull/17

When clicking the button to delete a setting and then reopening the modal, the previous value is still visible.

## Solution
- The proposed solution is to update the “transformed” value used in the v-model when the “value” prop changes.
- The remaining changes are eslint formatting adjustments.

## How to Test
1.	Go to settings and enter a value in a text input or select.
2.	Delete the value by clicking the trashcan button.
3.	Reopen the modal.
4.	There should be no value in the input or select.


## Related Tickets & Packages
- [FOUR-17133](https://processmaker.atlassian.net/browse/FOUR-17133)
- [RPA PR](https://github.com/ProcessMaker/package-rpa/pull/17)

ci:next

[FOUR-17133]: https://processmaker.atlassian.net/browse/FOUR-17133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ