### PR TITLE
FOUR-17034: Dashboard in element destination redirects to the server from which the process was exported.

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -521,14 +521,14 @@ class ProcessExporter extends ExporterBase
                     && $data['type'] === 'customDashboard') {
                     // Create a new JSON string with updated values
                     $newElementDestination = json_encode([
-                        'type' => 'summaryScreen',
+                        'type' => 'customDashboard',
                         'value' => null,
-                    ]);
+                    ], JSON_HEX_QUOT);
 
                     // Set the new attribute value at the specified XPath
                     Utils::setAttributeAtXPath(
                         $this->model, $path, 'pm:elementDestination',
-                        htmlspecialchars($newElementDestination, ENT_QUOTES)
+                        $newElementDestination
                     );
                 }
             }


### PR DESCRIPTION

## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- only dashboard field will be cleaned after  import a process

## How to Test
Describe how to test that this solution works.

1. Login in https://ci-3b4fd7711c.engk8s.processmaker.net/
2. Import attached process
3. Create a case of process
4. Click on New submit button

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17034

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
