### PR TITLE
FOUR-17003 Fix position of buttons CANCEL and SAVE

### DIFF
--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -338,16 +338,17 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                        <div class="d-flex justify-content-end mt-2">
-                            {!! Form::button(__('Cancel'),
-                                ['class'=>'btn btn-outline-secondary button-custom',
-                                '@click' => 'onClose'])
-                            !!}
-                            {!! Form::button(__('Save'),
-                                ['class'=>'btn btn-secondary ml-3 button-custom',
-                                '@click' => 'onUpdate'])
-                            !!}
+
+                            <div class="d-flex justify-content-end mt-2">
+                                {!! Form::button(__('Cancel'),
+                                    ['class'=>'btn btn-outline-secondary button-custom',
+                                    '@click' => 'onClose'])
+                                !!}
+                                {!! Form::button(__('Save'),
+                                    ['class'=>'btn btn-secondary ml-3 button-custom',
+                                    '@click' => 'onUpdate'])
+                                !!}
+                            </div>
                         </div>
 
                         {{-- Translations --}}
@@ -573,7 +574,7 @@
                             </div>
                             <div class="d-flex justify-content-end mt-2">
                                 {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
-                                {!! Form::button(__('Save and publish'), [
+                                {!! Form::button(__('Save'), [
                                     'class' => 'btn btn-secondary ml-2',
                                     '@click' => 'onUpdate'
                                 ]) !!}

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -55,7 +55,7 @@
                         {{-- Configuration --}}
                         <div
                             class="tab-pane fade show"
-                            :class="{'active': activeTab === ''}"
+                            :class="{'active': activeTab === '' || activeTab === 'nav-config'}"
                             id="nav-config"
                             role="tabpanel"
                             aria-labelledby="nav-config-tab"


### PR DESCRIPTION
## Issue & Reproduction Steps
The buttons were placed outside a </div> close.
Also there is a problem when activating the configuration tab when the page is refreshed.
 
## Solution
- Fix the position of buttons.
- Fix the activation rule of the Config tab.

## How to Test
- Open a process configuration
- Go to any tab, before the fix you will see a CANCEL and SAVE button in every tab
- With the fix the buttons are placed properly in the bottom of the config and not in every tab.
- Go to the Configuration tab
- Refresh the page 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17003

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
