### PR TITLE
FOUR-16302: Resolve error with ProcessLaunchpadExporter

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
@@ -12,7 +12,9 @@ class ProcessLaunchpadExporter extends ExporterBase
 
     public function export(): void
     {
-        $this->addDependent('user', $this->model->user, UserExporter::class);
+        if ($this->model->user) {
+            $this->addDependent('user', $this->model->user, UserExporter::class);
+        }
 
         $properties = json_decode($this->model->properties, true);
         $screenUuid = $properties['screen_uuid'] ?? null;


### PR DESCRIPTION
## Issue & Reproduction Steps
While working on FOUR-16302, I encountered an additional issue when importing the process referred to in the ticket. This issue was related to the ProcessLaunchpadExporter.

1. Import the Process within the [ticket](https://processmaker.atlassian.net/browse/FOUR-16302?focusedCommentId=409119).
2. Create a new Project
3. Add the imported Process to the Project.
4. See the error below

## Actual behavior:
An error occurs when trying to add a Process that contains signals to a Project.
```
"ProcessMaker\\ImportExport\\Exporters\\ExporterBase::addDependent(): Argument #2 ($dependentModel) must be of type Illuminate\\Database\\Eloquent\\Model|ProcessMaker\\ImportExport\\Psudomodels\\Psudomodel, null given, called in /Users/estebangallego/www/processmaker/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php on line 15"

```

## Expected behavior:
The process should be integrated into the project without any errors, even when it includes Signals within a Task.

## Solution
- Check if the user exist within the ProcessLaunchpadExporter class.

### How to Test
Please test the steps to reproduce and make sure that the expected behavior is met.

## Related Tickets & Packages
- Ticket: [FOUR-16302](https://processmaker.atlassian.net/browse/FOUR-16302)
- ci:develop
- ci:package-projects:bugfix/FOUR-16302-develop


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-16302]: https://processmaker.atlassian.net/browse/FOUR-16302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ