### PR TITLE
observation/FOUR-17168 Duplicated name when a Task is opened

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -256,7 +256,7 @@
                             </li>
                             <li class="list-group-item">
                               <p class="section-title">{{__('Case')}}</p>
-                              {{ $task->process->name }}
+                              @{{ caseTitle }}
                               <p class="launchpad-link">
                                 <a href="{{route('process.browser.index', [$task->process->id])}}">
                                   {{ __('Open Process Launchpad') }}
@@ -435,6 +435,7 @@
           showInfo: true,
           isPriority: false,
           userHasInteracted: false,
+          caseTitle: "",
         },
         watch: {
           task: {
@@ -764,9 +765,13 @@
           },
           collapseTabs() {
 
+          },
+          caseTitleField(task) {
+            this.caseTitle = task.process_request.case_title;
           }
         },
         mounted() {
+          this.caseTitleField(this.task);
           this.prepareData();
           window.ProcessMaker.isSelfService = this.isSelfService;
           this.isPriority = task.is_priority;


### PR DESCRIPTION
## Issue & Reproduction Steps
The Case and Request section are displaying the process name twice

## Solution
Show case title in the edit task case section

## How to Test
Create a process
Run a Case
Open the Task

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17168

ci:next