### PR TITLE
Bugfix/FOUR-16548: Drafts being lost after renaming the screen

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -272,9 +272,11 @@ class ScreenController extends Controller
      */
     public function update(Screen $screen, Request $request)
     {
+        $lastVersion = $screen->getDraftOrPublishedLatestVersion();
         $request->validate(Screen::rules($screen));
         $screen->fill($request->input());
         $original = $screen->getOriginal();
+        $screen->config = $lastVersion->config;
         $screen->saveOrFail();
         $screen->syncProjectAsset($request, Screen::class);
 

--- a/ProcessMaker/Http/Controllers/Process/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScreenController.php
@@ -83,8 +83,21 @@ class ScreenController extends Controller
     {
         $addons = $this->getPluginAddons('edit', compact(['screen']));
         $assignedProjects = json_decode($screen->projects, true);
+        
+        $lastDraftOrPublishedVersion = $screen->getDraftOrPublishedLatestVersion();
 
-        return view('processes.screens.edit', compact('screen', 'addons', 'assignedProjects'));
+        $isDraft = 0;
+        if ($lastDraftOrPublishedVersion) {
+            $isDraft = $lastDraftOrPublishedVersion->draft;
+        }
+
+        return view('processes.screens.edit', compact(
+                'screen',
+                'addons',
+                'assignedProjects',
+                'isDraft'
+            )
+        );
     }
 
     /**

--- a/resources/views/processes/screens/edit.blade.php
+++ b/resources/views/processes/screens/edit.blade.php
@@ -64,8 +64,14 @@
                             </project-select>
                             <br>
                             <div class="text-right">
-                                {!! Form::button(__('Cancel'), ['class'=>'btn btn-outline-secondary', '@click' => 'onClose']) !!}
-                                {!! Form::button(__('Save'), ['class'=>'btn btn-secondary ml-2', '@click' => 'onUpdate']) !!}
+                                {!! Form::button(__('Cancel'), [
+                                    'class'=>'btn btn-outline-secondary',
+                                    '@click' => 'onClose'
+                                ]) !!}
+                                {!! Form::button(__('Save and publish'), [
+                                    'class'=>'btn btn-secondary ml-2',
+                                    '@click' => 'onUpdate'
+                                ]) !!}
                             </div>
                         </div>
                         @isset($addons)
@@ -92,6 +98,7 @@
                 return {
                     formData: @json($screen),
                     assignedProjects: @json($assignedProjects),
+                    isDraft: @json($isDraft),
                     selectedProjects: '',
                     errors: {
                         'title': null,
@@ -123,6 +130,20 @@
                   window.location.href = projectId ? `/designer/projects/${projectId}`: '/designer/screens';
                 },
                 onUpdate() {
+                    if (this.isDraft) {
+                        ProcessMaker.confirmModal(
+                            this.$t("Caution!"),
+                            this.$t("You are about to publish a draft version. Are you sure you want to proceed?"),
+                            "",
+                            () => {
+                                this.handleUpdate();
+                            }
+                        );
+                    } else {
+                        this.handleUpdate();
+                    }
+                },
+                handleUpdate() {
                     this.resetErrors();
                     ProcessMaker.apiClient.put('screens/' + this.formData.id, this.formData)
                         .then(response => {


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a new screen.
- Add some elements to the screen 
- You can refresh your screen to validate that your changes are still there.
- Go to the screen configuration and change the name of the screen.

**Current Behavior:**
All the changes will be lost

**Expected Behavior:**
The draft with the recent changes should still be there after renaming.

**Notes for QA:**
The information lost only occurs on unpublished versions. However, these changes exist in the version history as drafts before renaming the screen.

## Solution
- When saving in configuration, now we get the last version of the screen and we update the BPMN.
- The button in configuration changed from **Save** to **Save and publish**
- If a draft exist for the screen, when clicking in Save and publish, we show a confirmation modal to let the user decide if must continue.

## How to Test
- Create a screen.
- Go to screen builder and do some changes (add elements), wait the autosave
- Go to the screen configuration and change the screen name and save

Ensure the confirmation modal shows in the configuration when saving if the screen is draft

## Related Tickets & Packages
- [FOUR-16548](https://processmaker.atlassian.net/browse/FOUR-16548)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-16548]: https://processmaker.atlassian.net/browse/FOUR-16548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ