### PR TITLE
Process variable assignment not working when target user is set as out of office with delegation user configured

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -760,6 +760,16 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         // We need to remove inactive users.
         $users = User::whereIn('id', array_unique($assignedUsers))->where('status', 'ACTIVE')->pluck('id')->toArray();
 
+        // user in OUT_OF_OFFICE
+        $outOfOffice = User::whereIn('id', array_unique($assignedUsers))->where('status', 'OUT_OF_OFFICE')->get();
+
+        foreach ($outOfOffice as $user) {
+            $delegation = $user->delegationUser()->pluck('id')->toArray();
+            if ($delegation) {
+                $users[] = $delegation[0];
+            }
+        }
+
         foreach ($assignedGroups as $groupId) {
             // getConsolidatedUsers already removes inactive users
             $this->getConsolidatedUsers($groupId, $users);

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1034,7 +1034,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
                 $query->where('group_id', $groupOrGroups);
             })
             ->leftjoin('users', 'users.id', '=', 'group_members.member_id')
-            ->whereNotIn('users.status', Process::NOT_ASSIGNABLE_USER_STATUS)
+            ->whereNotIn('users.status', self::NOT_ASSIGNABLE_USER_STATUS)
             ->chunk(1000, function ($members) use (&$users) {
                 $userIds = $members->pluck('member_id')->toArray();
                 $users = array_unique(array_merge($users, $userIds));


### PR DESCRIPTION
## Issue & Reproduction Steps
Assignment is only allowed to users with ACTIVE status when an assignment is a process variable.

## Solution
- It is now allowed to assign users with the out_of_office status and assign them to the user that is available for delegation.

## How to Test
Steps in ticket.

## Related Tickets & Packages
- [FOUR-15164](https://processmaker.atlassian.net/browse/FOUR-15164)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next

[FOUR-15164]: https://processmaker.atlassian.net/browse/FOUR-15164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ