### PR TITLE
FOUR-17233 Nayra Executor can not connect in next-qa deployment

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -241,7 +241,7 @@ return [
 
     'force_https' => env('FORCE_HTTPS', true),
 
-    'nayra_docker_network' => env('NAYRA_DOCKER_NETWORK', ''),
+    'nayra_docker_network' => env('NAYRA_DOCKER_NETWORK', 'host'),
 
     // Process Request security log rate limit: 1 per day (86400 seconds)
     'process_request_errors_rate_limit' => env('PROCESS_REQUEST_ERRORS_RATE_LIMIT', 1),


### PR DESCRIPTION
## Issue & Reproduction Steps
When the executor is deployed the first time it can not connect to queue jobs.

## Solution
- By default the value for "nayra_docker_network" is now "host".
- When try to get the IPs from the docker the command to use is different for "host" value

## How to Test
Create a script using executor "php-nayra"

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17233

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
