### PR TITLE
FOUR-17218: Fix 405 error when closing the guided template model

### DIFF
--- a/resources/js/components/templates/mixins/wizardHelperProcessModal.js
+++ b/resources/js/components/templates/mixins/wizardHelperProcessModal.js
@@ -74,7 +74,7 @@ export default {
       this.cancelHelperProcessRequest();
     },
     cancelHelperProcessRequest() {
-      const { process_request_id: processRequestId } = this.task;
+      const processRequestId = this.task.process_request.id;
       ProcessMaker.apiClient.put(`requests/${processRequestId}`, {
         status: "CANCELED",
       }).then(() => {


### PR DESCRIPTION
## Issue & Reproduction Steps

When navigating through the Guided Templates interface, closing the modal results in a 405 error.

1. Access the Process tab
2. Access the Guided Template Categorie
3. Select any Guided Template
4. Click on Start and start navigating the helper process
5. Attempt to close the Modal before ending the navigation

## Actual Result:
A 405 error is displayed when attempting to close the modal.

## Expected Result:
The modal should close without errors, and the interface should return to the previous state.

## Solution
- Set processRequestId with the correct value when closing the Modal

## How to Test
Please follow the reproduction steps and make sure that nor errors are been display.

## Related Tickets & Packages
- Ticket [FOUR-17218](https://processmaker.atlassian.net/browse/FOUR-17218)
- ci:next
- ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-17218]: https://processmaker.atlassian.net/browse/FOUR-17218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ