### PR TITLE
Update env var name

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -67,6 +67,6 @@ return [
         'base_url' => 'https://raw.githubusercontent.com/processmaker',
         'repo' => env('RECOMMENDATIONS_REPO', 'pm4-recommendations'),
         'branch' => env('RECOMMENDATIONS_BRANCH', 'develop'),
-        'token' => env('GITHUB_TOKEN'),
+        'token' => env('RECOMMENDATIONS_GITHUB_TOKEN'),
     ],
 ];


### PR DESCRIPTION
## Issue & Reproduction Steps
GITHUB_TOKEN is being set by docker to an empty string in QA environments. This should actually be its own variable scoped to the recommendations repository. 

## Solution
- Change the env var name

## How to Test
- Set a RECOMMENDATIONS_GITHUB_TOKEN in your .env to a working github token
- run `php artisan optimize`
- run `php artisan processmaker:sync-recommendations`
- Should complete without errors

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17236

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next