### PR TITLE
QA Observation bugfix/FOUR-17196: Mobile > Filters and search field are displayed inside Case Details

### DIFF
--- a/resources/js/requests/components/RequestDetailMobile.vue
+++ b/resources/js/requests/components/RequestDetailMobile.vue
@@ -4,6 +4,7 @@
       <card
         :key="index"
         :item="item"
+        :fields="fields"
         :show-cards="true"
         type="tasks"
       />
@@ -14,10 +15,11 @@
 <script>
 import datatableMixin from "../../components/common/mixins/datatable";
 import Card from "../../Mobile/Card.vue";
+import dataLoadingMixin from "../../components/common/mixins/apiDataLoading";
 
 export default {
   components: { Card },
-  mixins: [datatableMixin],
+  mixins: [datatableMixin,  dataLoadingMixin],
   props: ["processRequestId", "isAdmin", "isProcessManager"],
   data() {
     return {
@@ -27,6 +29,17 @@ export default {
           field: "due_at",
           sortField: "due_at",
           direction: "asc",
+        },
+      ],
+      fields: [
+        {
+          label: "Task",
+          field: "element_name",
+        },
+        {
+          label: "Due Date",
+          field: "due_at",
+          format: "dateTime",
         },
       ],
     };

--- a/resources/views/requests/showMobile.blade.php
+++ b/resources/views/requests/showMobile.blade.php
@@ -87,7 +87,6 @@
           role="tabpanel"
           aria-labelledby="tasks-tab"
         >
-          <filter-mobile type="tasks" @filterspmqlchange="onFiltersPmqlChange"></filter-mobile>
           <request-detail-mobile
             ref="pending"
             :process-request-id="request.id"


### PR DESCRIPTION
## Solution
- Removing search and filters component from view
- Sending parameters to Tasks Card

## How to Test
- Login to PM in Mobile Mode
- Go to Cases Tab
- Select some case
- Below the screen, in Tasks Tab, none Search or Filter must be displayed

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17196

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next