### PR TITLE
QA Observation bugfix/FOUR-17282: Invalid message when saved search is created as a tab

### DIFF
--- a/resources/js/processes-catalogue/components/CreateSavedSearchTab.vue
+++ b/resources/js/processes-catalogue/components/CreateSavedSearchTab.vue
@@ -94,7 +94,7 @@
         this.stateTabName = null;
         this.stateIdSavedSearch = null;
         if (!this.tabName) {
-          this.stateMessageTabName = this.$t('Please enter Tab Name');
+          this.stateMessageTabName = this.$t('Type a valid name');
           this.stateTabName = false;
           return;
         }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1935,6 +1935,7 @@
   "Type to search task": "Type to search task",
   "Type to search": "Type to search",
   "Type": "Type",
+  "Type a valid name": "Type a valid name",
   "Unable to import the process.": "Unable to import the process.",
   "Unable to import": "Unable to import",
   "Unable to save. Verify your internet connection.": "Unable to save. Verify your internet connection.",


### PR DESCRIPTION
## Solution
- Correct name was assigned to Saved Search when name is invalid

## How to Test
- Go to processes
- Select any process
- Try to add a new saved search and sabe without a name (empty field)

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17282

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next