### PR TITLE
FOUR-17270: RPA type tasks do not have target information in overview

### DIFF
--- a/resources/js/processes/modeler/components/ProcessMap.vue
+++ b/resources/js/processes/modeler/components/ProcessMap.vue
@@ -41,6 +41,10 @@ import ProcessMapTooltip from "./ProcessMapTooltip.vue";
 
 export default {
   name: "ProcessMap",
+  components: {
+    Modeler,
+    ProcessMapTooltip,
+  },
   props: {
     forDocumenting: {
       type: Boolean,
@@ -50,10 +54,6 @@ export default {
       type: Boolean,
       default: true,
     },
-  },
-  components: {
-    Modeler,
-    ProcessMapTooltip,
   },
   data() {
     return {
@@ -74,6 +74,7 @@ export default {
           "bpmn:SequenceFlow",
           "bpmn:ScriptTask",
           "bpmn:CallActivity",
+          "bpmn:ServiceTask",
         ],
         coordinates: { x: 0, y: 0 },
         newX: 0,


### PR DESCRIPTION
## Issue & Reproduction Steps
RPA type tasks do not have target information in overview

1. Create a process with RPA 
2. Start a case  
3. Complete the process
4. Open in overview
5. Click on the RPA type task

## Solution
- The tool-tip has been enabled for Service Task nodes, such as an RPA task. This allows the information to be viewed in the process map.

https://github.com/user-attachments/assets/186b5325-fd05-4850-8de5-f0e17e8932a4

## How to Test
Follow the reproduction steps of above.

## Related Tickets & Packages
- [FOUR-17270](https://processmaker.atlassian.net/browse/FOUR-17270)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-17270]: https://processmaker.atlassian.net/browse/FOUR-17270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ