### PR TITLE
Exclude the svg field by default

### DIFF
--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -60,6 +60,7 @@ class ProcessVersion extends ProcessMakerModel implements ProcessModelInterface
      */
     protected $hidden = [
         'bpmn',
+        'svg',
     ];
 
     protected static function boot()


### PR DESCRIPTION
## Issue & Reproduction Steps
The SVG for process versions was being sent with the requests API results.

NOTE: Even after excluding the svg, [the change made here](https://github.com/ProcessMaker/processmaker/commit/ea1e35278aa923e915c4a23e0347a3074cd56c12#diff-3bee9c69cb7d9684799f1bb151bca48778a2a022d6a2f82abd8bf82e4b4a947cR171) more than doubles the payload size. I think we should only include process_versions when they are explicitly included in the `include` param.

## Solution
- Exclude it by default

## How to Test
Look for a smaller payload when getting the requests from `api/1.0/requests`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17264

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next