### PR TITLE
FOUR-16695: "Updated" does not show the correct update in the documentation

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -178,6 +178,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         'user_id',
         'created_at',
         'updated_at',
+        'updated_by',
         'has_timer_start_events',
         'warnings',
     ];
@@ -240,6 +241,21 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         'conditional_events' => 'array',
         'properties' => 'array',
     ];
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            $user = Auth::user();
+            $model->updated_by = $user?->id;
+        });
+
+        static::updating(function ($model) {
+            $user = Auth::user();
+            $model->updated_by = $user?->id;
+        });
+    }
 
     /**
      * Category of the process.
@@ -415,6 +431,14 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * Get the last user that updated the process
+     */
+    public function updatedByUser()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
     }
 
     /**

--- a/database/migrations/2024_07_19_152418_add_updated_by_column_to_processes.php
+++ b/database/migrations/2024_07_19_152418_add_updated_by_column_to_processes.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use ProcessMaker\Models\Process;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('processes', function (Blueprint $table) {
+            $table->unsignedInteger('updated_by')->nullable()->after('updated_at');
+            //Foreign keys
+            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');;
+        });
+
+        Schema::table('process_versions', function (Blueprint $table) {
+            $table->unsignedInteger('updated_by')->nullable()->after('updated_at');
+            //Foreign keys
+            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');;
+        });
+
+        $this->updateUpdatedBy();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('processes', function (Blueprint $table) {
+            $table->dropForeign(['updated_by']);
+            $table->dropColumn('updated_by');
+        });
+
+        Schema::table('process_versions', function (Blueprint $table) {
+            $table->dropForeign(['updated_by']);
+            $table->dropColumn('updated_by');
+        });
+    }
+
+    private function updateUpdatedBy(): void
+    {
+        foreach (Process::all() as $process) {
+            DB::table('processes')->where('id', $process->id)->update([
+                'updated_by' => $process->user_id,
+            ]);
+
+            $this->updateVersionForAlternative($process, 'A');
+            $this->updateVersionForAlternative($process, 'B');
+        }
+    }
+
+    private function updateVersionForAlternative($process, $alternative)
+    {
+        $latestPublished = $process->getLatestVersion($alternative);
+        $latestDraftOrPublished = $process->getDraftOrPublishedLatestVersion($alternative);
+
+        if ($latestPublished) {
+            $latestPublished->update([
+                'updated_by' => $process->user_id,
+            ]);
+        }
+
+        if ($latestDraftOrPublished && $latestPublished && $latestPublished->id !== $latestDraftOrPublished->id) {
+            $latestDraftOrPublished->update([
+                'updated_by' => $process->user_id,
+            ]);
+        }
+    }
+};

--- a/database/migrations/2024_07_19_152418_add_updated_by_column_to_processes.php
+++ b/database/migrations/2024_07_19_152418_add_updated_by_column_to_processes.php
@@ -16,13 +16,13 @@ return new class extends Migration
         Schema::table('processes', function (Blueprint $table) {
             $table->unsignedInteger('updated_by')->nullable()->after('updated_at');
             //Foreign keys
-            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');;
+            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');
         });
 
         Schema::table('process_versions', function (Blueprint $table) {
             $table->unsignedInteger('updated_by')->nullable()->after('updated_at');
             //Foreign keys
-            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');;
+            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');
         });
 
         $this->updateUpdatedBy();


### PR DESCRIPTION
## Issue & Reproduction Steps
To Implement FOUR-16695 it is necessary to track the last user that updated a process.

## Solution
- Added a new column "updated_by" to the processes table

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16695

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next