### PR TITLE
observation/FOUR-17297 per page label has a different size

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -315,7 +315,7 @@ export default {
   color: #556271;
   text-transform: none;
   border-radius: 4px;
-  font-size: 16px;
+  font-size: 16px !important;
 }
 .ellipsis-icon-v {
   height: 16px;

--- a/resources/js/components/shared/PaginationTable.vue
+++ b/resources/js/components/shared/PaginationTable.vue
@@ -245,7 +245,7 @@ export default {
 }
 .pagination-dropup {
   font-weight: 400;
-  font-size: 15px;
+  font-size: 15px !important;
   color: #5C5C63;
   text-transform: none;
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Launchpad > `per page` label has a different size compare to other places that using the same pagination

## Solution
Changed the font-size style for pagination and ellipsis button

## How to Test
Select processes menu
Search and open a Process
Create at least one Case
Check the pagination
Go to tasks page
Check the pagination

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17297

ci:next