### PR TITLE
FOUR-16119 it is not possible to import pmblock

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/GroupExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/GroupExporter.php
@@ -30,7 +30,7 @@ class GroupExporter extends ExporterBase
             $dependent->model->groups()->syncWithoutDetaching($group->id);
         }
 
-        $permissions = $this->getReference('permissions');
+        $permissions = $this->getReference('permissions') ?? [];
         $permissionIds = Permission::whereIn('name', $permissions)->pluck('id')->toArray();
         $group->permissions()->sync($permissionIds);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
### Current behavior:
It is not possible to import a pm block

### Expected behavior
It should be possible to import a pm block 

## Solution
- Add a validation for non-group permissions on import

https://github.com/user-attachments/assets/277e864a-ba2d-46eb-8b8d-67c59885f934

## How to Test
1. Create a pm block 
2. Export the pmblock 
3. Try to import the pmblock

## Related Tickets & Packages
[FOUR-16119](https://processmaker.atlassian.net/browse/FOUR-16119)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-16119]: https://processmaker.atlassian.net/browse/FOUR-16119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ