### PR TITLE
QA Observation Bugfix/FOUR-15496: Add attributes to edit, copy and delete options in RPA configurations

### DIFF
--- a/resources/js/admin/settings/components/SettingsListing.vue
+++ b/resources/js/admin/settings/components/SettingsListing.vue
@@ -147,6 +147,7 @@
                     @click="onClear(row)"
                     variant="link"
                     class="settings-listing-button"
+                    :data-cy="`clear-${row.item.key}`"
                     >
                     <i class="fa-lg fas fa-trash-alt settings-listing-button"></i>
                   </b-button>


### PR DESCRIPTION
## Solution
- data-cy tag for CLEAR option was added (Edit and Copy already had)

## How to Test
- Login
- Go to Admin -> Settings -> Integrations
- Open DevTools and select some Trash Icon to confirm tag data-cy="clear-rpa.organization_name"

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15496

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next