### PR TITLE
FOUR-17313: When a user is removed from the database, the migration that created the "updated_by" column fails

### DIFF
--- a/database/migrations/2024_07_19_152418_add_updated_by_column_to_processes.php
+++ b/database/migrations/2024_07_19_152418_add_updated_by_column_to_processes.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use ProcessMaker\Models\User;
 use ProcessMaker\Models\Process;
 
 return new class extends Migration
@@ -14,18 +15,39 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('processes', function (Blueprint $table) {
-            $table->unsignedInteger('updated_by')->nullable()->after('updated_at');
-            //Foreign keys
-            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');
+            if (! Schema::hasColumn('processes', 'updated_by')) {
+                $table->unsignedInteger('updated_by')->nullable()->after('updated_at');
+
+                $table->foreign('updated_by')
+                    ->references('id')
+                    ->on('users')
+                    ->onDelete('set null');
+            }
         });
 
         Schema::table('process_versions', function (Blueprint $table) {
-            $table->unsignedInteger('updated_by')->nullable()->after('updated_at');
-            //Foreign keys
-            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');
+            if (! Schema::hasColumn('process_versions', 'updated_by')) {
+                $table->unsignedInteger('updated_by')->nullable()->after('updated_at');
+
+                $table->foreign('updated_by')
+                    ->references('id')
+                    ->on('users')
+                    ->onDelete('set null');
+            }
         });
 
-        $this->updateUpdatedBy();
+        foreach (Process::all() as $process) {
+            $updatedBy = User::find($process->user_id);
+
+            if ($updatedBy) {
+                DB::table('processes')->where('id', $process->id)->update([
+                    'updated_by' => $updatedBy->id,
+                ]);
+
+                $this->updateVersionForAlternative($process, 'A', $updatedBy);
+                $this->updateVersionForAlternative($process, 'B', $updatedBy);
+            }
+        }
     }
 
     /**
@@ -44,32 +66,20 @@ return new class extends Migration
         });
     }
 
-    private function updateUpdatedBy(): void
-    {
-        foreach (Process::all() as $process) {
-            DB::table('processes')->where('id', $process->id)->update([
-                'updated_by' => $process->user_id,
-            ]);
-
-            $this->updateVersionForAlternative($process, 'A');
-            $this->updateVersionForAlternative($process, 'B');
-        }
-    }
-
-    private function updateVersionForAlternative($process, $alternative)
+    private function updateVersionForAlternative($process, $alternative, $updatedBy)
     {
         $latestPublished = $process->getLatestVersion($alternative);
         $latestDraftOrPublished = $process->getDraftOrPublishedLatestVersion($alternative);
 
         if ($latestPublished) {
             $latestPublished->update([
-                'updated_by' => $process->user_id,
+                'updated_by' => $updatedBy->id,
             ]);
         }
 
         if ($latestDraftOrPublished && $latestPublished && $latestPublished->id !== $latestDraftOrPublished->id) {
             $latestDraftOrPublished->update([
-                'updated_by' => $process->user_id,
+                'updated_by' => $updatedBy->id,
             ]);
         }
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a user (userA)
2. Create a Process with userA
3. Delete userA 
4. Run the ProcessMaker migration

## Solution
- Now we check if the user exists, if not, the udpated_by column is set to null.


## Related Tickets & Packages
[- Link to any related FOUR tickets, PRDs, or packages](https://processmaker.atlassian.net/browse/FOUR-17313)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next