### PR TITLE
FOUR-17334: 400 Error  in Upload image in slide show configuration

### DIFF
--- a/ProcessMaker/Models/Media.php
+++ b/ProcessMaker/Models/Media.php
@@ -129,6 +129,7 @@ class Media extends MediaLibraryModel
         } elseif ($name === 'slideshow') {
             return self::COLLECTION_SLIDESHOW;
         }
+
         return null;
     }
 
@@ -229,10 +230,14 @@ class Media extends MediaLibraryModel
                 $customProperties['alternative'] = $properties['alternative'] ?? '';
             }
             // Store the images related move to MEDIA
-            $process->addMediaFromBase64($properties['url'])
-                ->usingFileName($properties['file_name'])
-                ->withCustomProperties($customProperties)
-                ->toMediaCollection($collectionName);
+            $media = $process->addMediaFromBase64($properties['url'])
+                ->withCustomProperties($customProperties);
+            // Only if the file_name exist this will save
+            if (isset($properties['file_name']) && !empty($properties['file_name'])) {
+                $media->usingFileName($properties['file_name']);
+            }
+            // Add the media
+            $media->toMediaCollection($collectionName);
         }
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
3. Add a task form
5. Open the task configurations
7. Upload an image in the task form 
9. Open console developer
## Current Behavior
13. It is not possible to upload image to slide show configuration in the modeler

## Solution
- The file_name can not defined from FE

## How to Test
like steps

## Related Tickets & Packages
- [FOUR-17334](https://processmaker.atlassian.net/browse/FOUR-17334)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next

[FOUR-17334]: https://processmaker.atlassian.net/browse/FOUR-17334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ