### PR TITLE
FOUR-17338: Fix global exclude scope

### DIFF
--- a/ProcessMaker/Models/ProcessMakerModel.php
+++ b/ProcessMaker/Models/ProcessMakerModel.php
@@ -30,7 +30,7 @@ class ProcessMakerModel extends Model
 
     public function scopeExclude($query, array $columns)
     {
-        if (!empty($columns)) {
+        if (empty($columns)) {
             return $query;
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Screens API is returning the wrong IDs

## Solution
- Fix the global exclude scope

## How to Test
- Try to associate a screen to a task in modeler. When it was broken, the chosen screen would not save (because they all had ID 1).

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17338

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
