### PR TITLE
FOUR-17258 Fix Task Initialization in Webentries

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -80,7 +80,13 @@ class ScreenController extends Controller
 
         $query = Screen::nonSystem()
             ->leftJoin('screen_categories as category', 'screens.screen_category_id', '=', 'category.id')
-            ->exclude($exclusions);
+            ->when($request->has('exclude'), function ($query) use ($exclusions) {
+                $query->exclude($exclusions);
+            })
+            ->when(!$request->has('exclude'), function ($query)  {
+                // Return all screen columns by default
+                $query->select('screens.*');
+            });
 
         $include = $request->input('include', '');
 

--- a/ProcessMaker/Models/ProcessMakerModel.php
+++ b/ProcessMaker/Models/ProcessMakerModel.php
@@ -30,7 +30,7 @@ class ProcessMakerModel extends Model
 
     public function scopeExclude($query, array $columns)
     {
-        if (!empty($columns)) {
+        if (empty($columns)) {
             return $query;
         }
 

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -58,6 +58,7 @@
                               :user-id="{{ Auth::user()->id }}"
                               csrf-token="{{ csrf_token() }}"
                               initial-loop-context="{{ $task->getLoopContext() }}"
+                              :wait-loading-listeners="true"
                               @task-updated="taskUpdated"
                               @submit="submit"
                               @completed="completed"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,2 @@
 sonar.projectKey=ProcessMaker_processmaker_AYkzkfKexYvY_isvKt07
+sonar.tests=tests

--- a/tests/Feature/Api/ScreenTest.php
+++ b/tests/Feature/Api/ScreenTest.php
@@ -573,4 +573,64 @@ class ScreenTest extends TestCase
         $this->assertEquals('c2', $json['computed'][3]['name']);
         $this->assertEquals("bar\nfoo", $json['custom_css']);
     }
+
+    /**
+     * Test get list of screens with categories but without config field
+     */
+    public function testListScreensWithCategoriesAndWithoutConfig()
+    {
+        $category = ScreenCategory::factory()->create();
+        $screen1 = Screen::factory()->create([
+            'screen_category_id' => $category->id,
+        ]);
+        $screen2 = Screen::factory()->create([
+            'screen_category_id' => $category->id,
+        ]);
+
+        $url = self::API_TEST_SCREEN . '?exclude=config&order_by=id';
+        $response = $this->apiCall('GET', $url);
+        $response->assertStatus(200);
+
+        $json = $response->json();
+
+        // Verify the IDs of screens and categories
+        $this->assertEquals($category->id, $json['data'][0]['screen_category_id']);
+        $this->assertEquals($category->id, $json['data'][1]['screen_category_id']);
+        $this->assertEquals($screen1->id, $json['data'][0]['id']);
+        $this->assertEquals($screen2->id, $json['data'][1]['id']);
+
+        // Verify the response does not contain the confing field
+        $this->assertArrayNotHasKey('config', $json['data'][0]);
+        $this->assertArrayNotHasKey('config', $json['data'][1]);
+    }
+
+    /**
+     * Test get list of screens with categories with config field
+     */
+    public function testListScreensWithCategoriesWithoContent()
+    {
+        $category = ScreenCategory::factory()->create();
+        $screen1 = Screen::factory()->create([
+            'screen_category_id' => $category->id,
+        ]);
+        $screen2 = Screen::factory()->create([
+            'screen_category_id' => $category->id,
+        ]);
+
+        $url = self::API_TEST_SCREEN . '?order_by=id';
+        $response = $this->apiCall('GET', $url);
+        $response->assertStatus(200);
+
+        $json = $response->json();
+
+        // Verify the IDs of screens and categories
+        $this->assertEquals($category->id, $json['data'][0]['screen_category_id']);
+        $this->assertEquals($category->id, $json['data'][1]['screen_category_id']);
+        $this->assertEquals($screen1->id, $json['data'][0]['id']);
+        $this->assertEquals($screen2->id, $json['data'][1]['id']);
+
+        // Verify the response must contain the config field
+        $this->assertArrayHasKey('config', $json['data'][0]);
+        $this->assertArrayHasKey('config', $json['data'][1]);
+    }
 }


### PR DESCRIPTION
## Fix Task Initialization in Webentries

When a webentry is opened, it does not count with request or task, this caused error in the Task component new changes. Also the screen kept disabled because of that.
Also there is a problem in the screens endpoint when selecting an screen.

## Solution
- Fix the initialization of the Task considering it could not have a request
- Disable the screen at the begining only when a request is present
- Fix screen endpoint and add some tests to validate it.

https://github.com/user-attachments/assets/25661c71-5648-4dde-ba8c-9aa8e2ed7b5c

## How to Test
- Create a process with an anonnymous webentry
  - Variations: With interstitial screen
  - Variation: Without interstitial screen
- Open the web entry
- Complete the form

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17258

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
