### PR TITLE
FOUR-17354:The Home My Cases - The ellipisis is not showed

### DIFF
--- a/resources/js/components/shared/FilterTable.vue
+++ b/resources/js/components/shared/FilterTable.vue
@@ -500,4 +500,9 @@ export default {
   background-color: #E8F0F9;
   color: #1572C2;
 }
+.custom-wrap {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
The Home My Cases - The ellipisis is not showed.

## Related Tickets & Packages
- [FOUR-17354](https://processmaker.atlassian.net/browse/FOUR-17354)
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:screen-builder:bugfix/FOUR-17354

[FOUR-17354]: https://processmaker.atlassian.net/browse/FOUR-17354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ