### PR TITLE
observation/FOUR-16890-2 Launchpad change to mobile view when browser's screen is 640px

### DIFF
--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -142,4 +142,4 @@ $dangerlight: #FFEBE9;
 $successlight: #E6FFEB;
 
 // Launchpad Mobile Breakpoint
-$lp-breakpoint: 640px;
+$lp-breakpoint: 639px;


### PR DESCRIPTION
## Issue & Reproduction Steps
Launchpad change to mobile view when browser's screen is 640px

## Solution
changed the mobile breakpoint to 640px

## How to Test
Go to processes page
change the browser’s screen size to 640px

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16890

ci:next