### PR TITLE
QA Observation Bugfix/FOUR-16952-b: Mobile launchpad > Categories are not listed in Processes page

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -94,7 +94,7 @@ export default {
       category: null,
       selectedProcess: null,
       guidedTemplates: false,
-      numCategories: 20,
+      numCategories: 100,
       page: 1,
       key: 0,
       totalPages: 1,

--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -156,12 +156,6 @@ export default {
     },
   },
   mounted() {
-    const listElm = document.querySelector("#infinite-list");
-    listElm.addEventListener("scroll", () => {
-      if (listElm.scrollTop + listElm.clientHeight + 2 >= listElm.scrollHeight) {
-        this.loadMore();
-      }
-    });
     this.comeFromProcess = this.fromProcessList;
     this.checkPackageAiInstalled();
   },
@@ -303,7 +297,7 @@ i {
 }
 @media (max-width: 650px) {
   #category-menu > .list-group {
-    max-height: 60vh;
+    max-height: 75vh;
   }
 }
 .list-group-item {


### PR DESCRIPTION
## Solution
- Categories list was modified to load all categories (max 100)

## How to Test
- Login to PM
- Go to Processes
- Check on left sidebar all Categories must be displayed

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16952

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next