### PR TITLE
observation/FOUR-17341 Mobile Launchpad > A space is covering the card list

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -452,7 +452,6 @@ export default {
 .processes-info {
   width: 100%;
   margin-right: 0px;
-  height: calc(100vh - 145px);
   overflow-x: hidden;
   @media (max-width: $lp-breakpoint) {
     padding-left: 0;


### PR DESCRIPTION
## Issue & Reproduction Steps
Mobile Launchpad > A space is covering the card list

## Solution
Fixed the processes info style in the mobile view

## How to Test
Login mobile version
Press processes tab
Search and open a process
Press My Cases or My tasks tab
Scroll down

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17341

ci:next