### PR TITLE
FOUR-17380:The links are not blue color in Processmaker

### DIFF
--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -31,6 +31,11 @@ div.main {
   height: 100%;
   max-height: 100%;
 }
+a {
+  color: #0872C2 !important;
+  text-decoration: none;
+  background-color: transparent;
+}
 </style>
 @yield('extra_css')
 @endsection


### PR DESCRIPTION
## Issue & Reproduction Steps
The links are not blue color in Processmaker
![Screenshot 2024-07-26 at 08 29 14](https://github.com/user-attachments/assets/5915db69-58c4-40c5-90db-31d76755a3de)

## Related Tickets & Packages
- [FOUR-17380](https://processmaker.atlassian.net/browse/FOUR-17380)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next

[FOUR-17380]: https://processmaker.atlassian.net/browse/FOUR-17380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ