### PR TITLE
FOUR-17363: It's not possible to upload files on guided template helpers (develop)

### DIFF
--- a/resources/views/processes-catalogue/index.blade.php
+++ b/resources/views/processes-catalogue/index.blade.php
@@ -8,6 +8,10 @@
     @include('layouts.sidebar', ['sidebar' => Menu::get('sidebar_processes_catalogue')])
 @endsection
 
+@section('meta')
+  <meta name="request-id" content="">
+@endsection
+
 @section('content')
   <div class="px-3 page-content mb-0" id="processes-catalogue">
     <processes-catalogue


### PR DESCRIPTION
## Issue & Reproduction Steps
ProcessMaker tries to send a POST request to https://next-qa.processmaker.net/process-browser/null which causes an error

1. Select the Non-PO Invoice Approval Helper
2. Click on Get Started
3. Try to upload a file using the temporarily added File Upload control

## Solution
- It is necessary to add the meta tag in the views so that its value can be set correctly and the file upload control can obtain the correct target URL.​

![Screenshot 2024-07-25 at 15-19-11 Processes Catalogue - ProcessMaker](https://github.com/user-attachments/assets/54c8192f-f85e-4709-8b7d-cb9052f70b70)

## How to Test
- Follow the steps of above.

## Related Tickets & Packages
- [FOUR-17363](https://processmaker.atlassian.net/browse/FOUR-17363)


[FOUR-17363]: https://processmaker.atlassian.net/browse/FOUR-17363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ