### PR TITLE
observation/FOUR-17364 added  template id and guided_template params to the url

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
+++ b/ProcessMaker/Http/Controllers/ProcessesCatalogueController.php
@@ -26,6 +26,12 @@ class ProcessesCatalogueController extends Controller
 
     public function index(Request $request, Process $process = null)
     {
+        if ($request->has('guided_templates')) {
+            return redirect()->route('process.browser.index', [
+                'categoryId' => 'guided_templates',
+                'template' => $request->input('template'),
+            ]);
+        }
         $manager = app(ScreenBuilderManager::class);
         event(new ScreenBuilderStarting($manager, 'DISPLAY'));
         $launchpad = null;

--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -152,7 +152,7 @@ export default {
   },
   computed: {
     hasGuidedTemplateParams() {
-      return window.location.search.includes('?guided_templates=true&template=');
+      return window.location.search.includes('?categoryId=guided_templates');
     }
   },
   watch: {
@@ -234,7 +234,8 @@ export default {
       } else if ($event && $event.type === "wizard") {  // Handle different scenarios based on $event type 
         // Add template parameter to the URL if guided templates are selected
         let url = new URL(window.location.href);
-        if (url.search.includes('?guided_templates=true')) {
+        if (url.search.includes('?categoryId=guided_templates')) {
+          url.searchParams.append('guided_templates', true);
           url.searchParams.append('template', $event.template.unique_template_id);
           history.pushState(null, '', url); // Update the URL without triggering a page reload
         }

--- a/resources/js/components/templates/WizardTemplateDetails.vue
+++ b/resources/js/components/templates/WizardTemplateDetails.vue
@@ -100,8 +100,9 @@ export default {
       
       // Remove template parameter from the URL
       let url = new URL(window.location.href);
-      if (url.search.includes('?guided_templates=true&template=')) {
+      if (url.search.includes('?categoryId=guided_templates')) {
         url.searchParams.delete('template');
+        url.searchParams.delete('guided_templates');
         history.pushState(null, '', url); // Update the URL without triggering a page reload
       }
       


### PR DESCRIPTION
## Issue & Reproduction Steps
Guided template direct links not working

## Solution
added  template id and guided_template params to the new guided templates URL

## How to Test
copy the link /process-browser/?categoryId=guided_templates&guided_templates=true&template=nonpo_invoice_approval

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17364

ci:next
ci:deploy