### PR TITLE
observation/FOUR-17391 print of a completed form not found

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -773,10 +773,12 @@ class ProcessRequestController extends Controller
                         $dataManager = new DataManager();
                         $screen->data = $dataManager->getData($token, true);
                         $screen->screen_id = $screen->id;
+                        $screen->id = $token->id;
 
                         return $screen;
                     }
                 }
+
                 return null;
             })
             ->reject(fn ($item) => $item === null)


### PR DESCRIPTION
## Issue & Reproduction Steps
It shows us the Oops! screen when clicking on the print of a completed form

## Solution
fix the process request token id for the screenRequested

## How to Test
Log in 
Complete any process
Open the process
Click on Forms
Click on Print 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17391

ci:next