### PR TITLE
QA Observation bugfix/FOUR-17413: Ellipsis inside a project is too far from the edge of the screen

### DIFF
--- a/resources/js/processes/designer/ProjectsLastModifiedListing.vue
+++ b/resources/js/processes/designer/ProjectsLastModifiedListing.vue
@@ -41,6 +41,7 @@
       data-cy="processes-table"
     >
       <vuetable
+        id="core-custom-project-table"
         :data-manager="dataManager"
         :sort-order="sortOrder"
         :css="css"
@@ -281,5 +282,11 @@ export default {
   justify-content: center;
   width: 100%;
   display: flex;
+}
+</style>
+<style>
+
+#core-custom-project-table tr td.vuetable-slot:last-child {
+    text-align: right;
 }
 </style>


### PR DESCRIPTION
Actual behavior: Ellipsis inside a project is too far from the edge of the screen

## Solution
- Ellipsis was adjusted to fit correctly in Projects Section

## How to Test
NOTE: This fix is related with package-projects changes
- Login PM as Admin
- Go to Designer
- Review ellipsis My Projects section
- Click on some project abd review ellipsis

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17413

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next