### PR TITLE
FOUR-17298 Artisan command to unlock Executor Builder

### DIFF
--- a/ProcessMaker/Console/Commands/UnlockExecutorBuilder.php
+++ b/ProcessMaker/Console/Commands/UnlockExecutorBuilder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use ProcessMaker\Jobs\BuildScriptExecutor;
+
+class UnlockExecutorBuilder extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'processmaker:unlock-executor-builder';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command to unlock the executor builder';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $job = new BuildScriptExecutor('', '');
+        $keyLock = $job->middleware()[0]->getLockKey($job);
+
+        // release lock from cache
+        $cache = Container::getInstance()->make(Cache::class);
+        $cache->forget($keyLock);
+
+        return 0;
+    }
+}

--- a/ProcessMaker/Jobs/BuildScriptExecutor.php
+++ b/ProcessMaker/Jobs/BuildScriptExecutor.php
@@ -47,7 +47,7 @@ class BuildScriptExecutor implements ShouldQueue
 
     /**
      * Prevent job overlaps
-     * 
+     *
      * @return WithoutOverlapping[]
      */
     public function middleware(): array

--- a/ProcessMaker/Jobs/BuildScriptExecutor.php
+++ b/ProcessMaker/Jobs/BuildScriptExecutor.php
@@ -19,7 +19,7 @@ class BuildScriptExecutor implements ShouldQueue
     protected $userId;
 
     // Do not retry this job if it fails
-    public $tries = 20;
+    public $tries = 10;
 
     // Building can take some time
     public $timeout = 600;
@@ -47,9 +47,11 @@ class BuildScriptExecutor implements ShouldQueue
 
     /**
      * Prevent job overlaps
+     * 
+     * @return WithoutOverlapping[]
      */
     public function middleware(): array
     {
-        return [(new WithoutOverlapping())->releaseAfter(10)];
+        return [(new WithoutOverlapping())->releaseAfter(30)->expireAfter(630)];
     }
 }


### PR DESCRIPTION
## Executor Buyilder get locked when a builder fails or takes more than 5 minutes

## Solution
- Set an expire timeout for the job lock.
- Improve the lock logic of the job
- Add an artisan command to manually unlock the executor builder

## How to Test
If there is a lock of the Executor builder you can run the command:
```
php artisan processmaker:unlock-executor-builder
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17298

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

.