### PR TITLE
FOUR-16179 server error when saving a screen with too many watchers and too many resources in data connectors

### DIFF
--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -517,6 +517,7 @@ class ImportProcess implements ShouldQueue
 
             return $new;
         } catch (\Exception $e) {
+            Log::info('*** Error: ' . $e->getMessage());
             return false;
         }
     }

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -517,7 +517,7 @@ class ImportProcess implements ShouldQueue
 
             return $new;
         } catch (\Exception $e) {
-            Log::info('*** Error: ' . $e->getMessage());
+            Log::error('Import Screen: ' . $e->getMessage());
             return false;
         }
     }

--- a/ProcessMaker/Jobs/ImportScreen.php
+++ b/ProcessMaker/Jobs/ImportScreen.php
@@ -2,7 +2,6 @@
 
 namespace ProcessMaker\Jobs;
 
-use Exception;
 use ProcessMaker\Managers\ExportManager;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\Script;
@@ -49,6 +48,7 @@ class ImportScreen extends ImportProcess
         $this->prepareStatus('screens', count($this->file->screens));
         foreach ($this->file->screens as $screen) {
             $newScreen = $this->saveScreen($screen);
+
             $this->status['screens']['id'] = $newScreen->id;
 
             $new[Screen::class][$screen->id] = $newScreen;

--- a/database/migrations/2024_07_30_120225_modify_watchers_column_in_screens_table.php
+++ b/database/migrations/2024_07_30_120225_modify_watchers_column_in_screens_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('screens', function (Blueprint $table) {
+            $table->mediumText('watchers')->nullable()->change();
+        });
+
+        Schema::table('screen_versions', function (Blueprint $table) {
+            $table->mediumText('watchers')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // It is not possible to revert this change because of Error code: 1406
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
Server error when saving a screen with too many watchers and too many resources in data connectors

## Solution
- Add a migration to change the `watchers` column type in `screens` and `screen_versions` tables
- Handle exceptions in the import screen

## How to Test
1. Have/Create a Data Connector that has many endpoints
2. Create a screen 
3. Add many watchers to the screen using the Data Connector 
4. At the moment we continue adding watchers, at some point, we receive a Server error

## Related Tickets & Packages
[FOUR-16179](https://processmaker.atlassian.net/browse/FOUR-16179)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-16179]: https://processmaker.atlassian.net/browse/FOUR-16179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ