### PR TITLE
FOUR-16868: Inflight view process: when the lane is selected the user can not select any task

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -732,11 +732,25 @@ class ProcessRequestController extends Controller
             ->where([
                 'element_id' => $httpRequest->element_id,
                 'process_request_id' => $request->id,
-            ])->count();
+            ])
+            ->count();
         $token->count = $countFlag ? $tokensCount - 1 : $tokensCount;
         if ($token->count === 0) {
             throw new ModelNotFoundException();
         }
+        $repeatMessage = trans_choice(
+            '{1} The path was repeated one time|[2,*] The path was repeated :count times',
+            $token->count,
+            ['count' => $token->count]
+        );
+        $token->setAttribute('repeat_message', $repeatMessage);
+
+        // Format dates.
+        $token->setAttribute('created_at_formatted', $token->created_at->format('m/d/y H:i'));
+        $token->setAttribute(
+            'completed_at_formatted',
+            $token->completed_at ? $token->completed_at->format('m/d/y H:i') : '-'
+        );
 
         return new ApiResource($token);
     }
@@ -777,6 +791,7 @@ class ProcessRequestController extends Controller
                         return $screen;
                     }
                 }
+
                 return null;
             })
             ->reject(fn ($item) => $item === null)

--- a/resources/js/processes/modeler/components/ProcessMap.vue
+++ b/resources/js/processes/modeler/components/ProcessMap.vue
@@ -16,7 +16,7 @@
             left: `${tooltip.newX}px`,
             top: `${tooltip.newY}px`
           }"
-          @is-loading="getIsLoading"
+          @is-loading="isTooltipLoading"
         />
         <Modeler
           ref="modeler"
@@ -152,7 +152,7 @@ export default {
         this.tooltip.newX = window.innerWidth - this.rectTooltip.width;
       }
     },
-    getIsLoading(value) {
+    isTooltipLoading(value) {
       this.tooltip.isLoading = value;
     },
   },

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -864,9 +864,12 @@ class ProcessRequestsTest extends TestCase
         $expectedResponse = [
             'advanceStatus',
             'completed_at',
+            'completed_at_formatted',
             'completed_by',
             'count',
             'created_at',
+            'created_at_formatted',
+            'repeat_message',
             'element_id',
             'element_name',
             'is_sequence_flow',
@@ -893,7 +896,7 @@ class ProcessRequestsTest extends TestCase
         ]);
 
         // Validate the status is correct
-        $response = $this->apiCall('GET', self::API_TEST_URL . '/' . $request->id . '/tokens?element_id=' . $token->element_id);
+        $response = $this->apiCall('GET', route('api.requests.getRequestToken', ['request' => $request->id, 'element_id' => $token->element_id]));
         $response->assertStatus(200);
 
         // Verify structure
@@ -902,20 +905,20 @@ class ProcessRequestsTest extends TestCase
         // Validate non existing process element
         $nonExistentElementId = 999;
 
-        $response = $this->apiCall('GET', self::API_TEST_URL . '/' . $request->id . '/tokens?element_id=' . $nonExistentElementId);
+        $response = $this->apiCall('GET', route('api.requests.getRequestToken', ['request' => $request->id, 'element_id' => $nonExistentElementId]));
         $response->assertStatus(404);
 
         // Verify with other user without permissions
         $this->user = $otherUser;
 
-        $response = $this->apiCall('GET', self::API_TEST_URL . '/' . $request->id . '/tokens?element_id=' . $token->element_id);
+        $response = $this->apiCall('GET', route('api.requests.getRequestToken', ['request' => $request->id, 'element_id' => $token->element_id]));
         $response->assertStatus(403);
 
         $this->user->giveDirectPermission('view-all_requests');
         $this->user->refresh();
 
         // Verify with other user with permissions
-        $response = $this->apiCall('GET', self::API_TEST_URL . '/' . $request->id . '/tokens?element_id=' . $token->element_id);
+        $response = $this->apiCall('GET', route('api.requests.getRequestToken', ['request' => $request->id, 'element_id' => $token->element_id]));
         $response->assertStatus(200);
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Go to the Overview tab of a process.
2. Select a sequence flow or a task and mark it as highlighted (try dragging it).
3. Click on another task.

You will notice that the tooltip of the last task does not open and you have to double-click to display it. This behavior is unusual.

**Expected behavior:**
- You should be able to click between tasks and sequence flows without any issues and view the tooltip without bugs.

## Solution
- The solution was to add a next tick in the modeler to ensure that the correct highlighted node is emitted.
- The changes in the core are just a small refactor to improve the readability and maintainability of the component.

https://github.com/user-attachments/assets/77c9e11d-020e-4951-9f05-06b39be94163

## How to Test
- Perform the reproduction steps of above.

## Related Tickets & Packages
- [FOUR-16868](https://processmaker.atlassian.net/browse/FOUR-16868)
- [Modeler's PR](https://github.com/ProcessMaker/modeler/pull/1868)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-16868]: https://processmaker.atlassian.net/browse/FOUR-16868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:next
ci:deploy
ci:modeler:observation/FOUR-16868