### PR TITLE
observation/FOUR-17475 The option menu, rises to the top when we edit the lounchpad§

### DIFF
--- a/resources/js/processes-catalogue/components/Process.vue
+++ b/resources/js/processes-catalogue/components/Process.vue
@@ -117,7 +117,6 @@ export default {
 <style lang="scss" scoped>
 @import '~styles/variables';
 .process-info-main {
-  overflow-y: auto;
   position: relative;
 }
 .mobile-process-nav {


### PR DESCRIPTION
## Issue & Reproduction Steps
The option menu, rises to the top when we edit the lounchpad

## Solution
fixed dropdown menu

## How to Test
Log in
Have a process created
Click on Processes menu 
Search the process 
Open whit  lounchpad 
Click on Options
Click on Edit  Lounchpad 
Edit the  screen lounch pad 
Save 
Clik on Porcesses  again
Click on options menu by process

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17475

ci:next