### PR TITLE
FOUR-16901 Advanced filters on saved search columns are case-sensitive

### DIFF
--- a/ProcessMaker/Filters/Filter.php
+++ b/ProcessMaker/Filters/Filter.php
@@ -153,7 +153,14 @@ class Filter
             $value = DB::connection()->getPdo()->quote($value);
         }
 
-        $query->whereRaw("json_unquote(json_extract(`data`, '$.\"{$selector}\"')) {$operator} {$value}");
+        if ($operator === 'like') {
+            // For JSON data is required to do a CAST in order to make insensitive the comparison
+            $query->whereRaw(
+                "cast(json_unquote(json_extract(`data`, '$.\"{$selector}\"')) as CHAR) {$operator} {$value}"
+            );
+        } else {
+            $query->whereRaw("json_unquote(json_extract(`data`, '$.\"{$selector}\"')) {$operator} {$value}");
+        }
     }
 
     private function operator()


### PR DESCRIPTION
## Issue & Reproduction Steps
The advance filter is case-sensitive even when the operator is “contains“

## Solution
When the "where" section is builded forJSON data, for "like" operator we're casting the value to CHAR in order to make the comparison insensitive.

## How to Test
Create a Saved Search and include a custom column that uses a process request variable set a filter by using the three “dots” button with “contains” as the operator.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16901

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

