### PR TITLE
QA Observation bugfix/FOUR-16886-b : Launchpad > pagination in the infinite scroll does not cover all screen width 

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -316,32 +316,33 @@ export default {
   }
 }
 .separator-class.width-changed {
-  @media (min-width: 641px) and (max-width:767px) {
+  @media (min-width: 641px) and (max-width:775px) {
     width: 340px;
   }
 
-  @media (min-width: 768px) and (max-width:1075px) {
+  @media (min-width: 776px) and (max-width:1083px) {
     width: 678px;
   }
 
-  @media (min-width: 1076px) and (max-width:1520px) {
-    width: 1156px;
+  @media (min-width: 1084px) and (max-width:1572px) {
+    width: 1154px;
   }
 
-  @media (min-width: 1521px) and (max-width: 1789px) {
-    width: 1156px;
+  @media (min-width: 1573px) and (max-width:1669px) {
+    width: 1544px;
+    margin-right: -95px;
   }
 
-  @media (min-width: 1790px) and (max-width: 1879px) {
-    width: 1542px;
+  @media (min-width: 1670px) and (max-width: 1931px) {
+    width: 1544px;
   }
 
-  @media (min-width: 1880px) and (max-width: 2148px){
-    width: 1859px;
+  @media (min-width: 1932px) and (max-width: 2290px){
+    width: 1932px;
   }
 
-  @media (min-width: 2149px) and (max-width: 2438px){
-    width: 1926px;
+  @media (min-width: 2291px) and (max-width: 2438px){
+    width: 2308px;
   }
 
   @media (min-width: 2439px){

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -324,7 +324,7 @@ export default {
   }
 
   @media (min-width: 3321px) and (max-width: 3440px){
-    width: 3075px;
+    width: 3087px;
     margin-right: -200px;
   }
 
@@ -380,7 +380,7 @@ export default {
   }
 
   @media (min-width: 3368px) and (max-width: 3726px){
-    width: 3464px;
+    width: 3470px;
   }
 
   @media (min-width: 3727px){

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -311,8 +311,30 @@ export default {
     width: 1926px;
   }
 
-  @media (min-width: 2439px){
-    width: 2308px;
+  @media (min-width: 2439px) and (max-width: 2602px){ //n
+    width: 1932px;
+  }
+
+  @media (min-width: 2603px) and (max-width: 2961px){
+    width: 2312px;
+  }
+
+  @media (min-width: 2962px) and (max-width: 3320px){
+    width: 2700px;
+  }
+
+  @media (min-width: 3321px) and (max-width: 3440px){
+    width: 3075px;
+    margin-right: -200px;
+  }
+
+  @media (min-width: 3441px) and (max-width: 3680px){
+    width: 3075px;
+    margin-right: -200px;
+  }
+
+  @media (min-width: 3681px){
+    width: 100%;
   }
 }
 .separator-class.width-changed {
@@ -345,8 +367,24 @@ export default {
     width: 2308px;
   }
 
-  @media (min-width: 2439px){
-    width: 2308px;
+  @media (min-width: 2439px) and (max-width: 2649px){ //n
+    width: 2318px;
+  }
+
+  @media (min-width: 2650px) and (max-width: 3008px){
+    width: 2685px;
+  }
+
+  @media (min-width: 3009px) and (max-width: 3367px){
+    width: 3076px;
+  }
+
+  @media (min-width: 3368px) and (max-width: 3726px){
+    width: 3464px;
+  }
+
+  @media (min-width: 3727px){
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## Solution
- Some media queries were added with new range of screen dimensions

## How to Test
- Login PM
- Go to Processes
- Collapse left side bar and navigate
- Separator and cards should fix correctly in the screen

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16886

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next
ci:deploy