### PR TITLE
observation/FOUR-17495 Tasks and Cases are not the same between mobile and desktop views

### DIFF
--- a/resources/js/Mobile/Card.vue
+++ b/resources/js/Mobile/Card.vue
@@ -136,6 +136,24 @@ export default {
       return null;
     },
   },
+  watch: {
+    item() {
+      this.formatItem = cloneDeep(this.item);
+      if (this.type === "requests") {
+        this.splitText(this.sanitize(this.item.case_title_formatted));
+      } else if (this.type === "tasks") {
+        this.splitText(this.sanitize(this.item.process_request.case_title_formatted));
+      }
+      this.fields.forEach((row) => {
+        if (row.field === "tasks") {
+          this.formatItem[row.field] = this.formatActiveTasks(this.formatItem.active_tasks);
+        }
+        if (row.format && row.format === "dateTime") {
+          this.formatItem[row.field] = this.formatDate(this.formatItem[row.field]);
+        }
+      });
+    },
+  },
   mounted() {
     this.formatItem = cloneDeep(this.item);
     this.callbackResize = () => {
@@ -171,7 +189,7 @@ export default {
       const statusMap = {
         "DRAFT": { color: "#F9E8C3", label: this.$t("Draft") },
         "CANCELED": { color: "#FFC7C7", label: this.$t("Canceled") },
-        "COMPLETED": { color: "#B8DCF7", label: this.$t("Completed") },
+        "CLOSED": { color: "#B8DCF7", label: this.$t("Completed") },
         "ERROR": { color: "#FFC7C7", label: this.$t("Error") },
         "ACTIVE": {
           "overdue": { color: "#FFC7C7", label: this.$t("Overdue") },

--- a/resources/js/requests/components/MobileRequests.vue
+++ b/resources/js/requests/components/MobileRequests.vue
@@ -80,7 +80,8 @@ export default {
     };
   },
   mounted() {
-    this.pmql = `(status = "In Progress") AND (requester = "${Processmaker.user.username}") AND (process_id = ${this.process.id})`;
+    const filter = this.process ? ` AND (process_id = ${this.process.id})` : "";
+    this.pmql = `(status = "In Progress") AND (requester = "${Processmaker.user.username}")${filter}`;
   },
   methods: {
     updatePmql(value, status) {

--- a/resources/js/tasks/components/MobileTasks.vue
+++ b/resources/js/tasks/components/MobileTasks.vue
@@ -76,7 +76,8 @@ export default {
     };
   },
   mounted() {
-    this.pmql = `(user_id = ${ProcessMaker.user.id}) AND (status = "In Progress") AND (process_id = ${this.process.id})`;
+    const filter = this.process ? ` AND (process_id = ${this.process.id})` : "";
+    this.pmql = `(user_id = ${ProcessMaker.user.id}) AND (status = "In Progress")${filter}`;
   },
   methods: {
     updatePmql(value) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Tasks and Cases are not the same between mobile and desktop views

## Solution
ix the tasks and cases data format after applying a filter in the mobile view

## How to Test
Log in
Create a USER_A
Create a simple process (start event - task -task - end event)
Assign all Tasks to USER_A
Start some Cases  from ADMIN USER
logout
login with USER_A from mobile view
Open some cases and sent to next task
Go to Tasks tab
Go to Cases tab

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17495

ci:next