### PR TITLE
QA Observation bugfix/FOUR-17507: The ellipsis options in processes are not responsive.

### DIFF
--- a/resources/js/components/shared/EllipsisMenu.vue
+++ b/resources/js/components/shared/EllipsisMenu.vue
@@ -8,6 +8,7 @@
     lazy
     no-caret
     class="ellipsis-dropdown-main static-header"
+    :popper-opts="{ placement: 'bottom-end' }"
     :dropleft="!lauchpad"
     @show="onShow"
     @hide="onHide"

--- a/resources/js/components/shared/FilterTable.vue
+++ b/resources/js/components/shared/FilterTable.vue
@@ -496,6 +496,10 @@ export default {
     white-space: nowrap;
   }
 }
+.ellipsis-dropdown-main ul.dropdown-menu.dropdown-menu.show {
+  max-height: 250px;
+  overflow-y: auto;
+}
 .pm-table-selected-row {
   background-color: #E8F0F9;
   color: #1572C2;


### PR DESCRIPTION
## Solution
- Ellipsis button fits the screen based on window size

## How to Test
-Login PM as admin
-Go to Designer->All processes
-Click on Ellipsis button and dropdown Processes list scrollbar
-Ellipsis option list should have scrollbar

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17507

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next