### PR TITLE
When I import an exported project that contains flow genie, the flow genies are not imported

### DIFF
--- a/ProcessMaker/Enums/ExporterMap.php
+++ b/ProcessMaker/Enums/ExporterMap.php
@@ -11,7 +11,10 @@ enum ExporterMap
         'process_templates' => [\ProcessMaker\Models\ProcessTemplates::class, \ProcessMaker\ImportExport\Exporters\TemplateExporter::class],
         'data_source' => [\ProcessMaker\Packages\Connectors\DataSources\Models\DataSource::class, \ProcessMaker\Packages\Connectors\DataSources\ImportExport\DataSourceExporter::class],
         'decision_table' => [\ProcessMaker\Package\PackageDecisionEngine\Models\DecisionTable::class, \ProcessMaker\Package\PackageDecisionEngine\ImportExport\DecisionTableExporter::class],
-        'flow_genie' => [\ProcessMaker\Package\PackageAi\Models\FlowGenie::class, \ProcessMaker\Package\PackageAi\ImportExport\FlowGenieExporter::class],
+        'flow_genie' => [
+            \ProcessMaker\Package\PackageAi\Models\FlowGenie::class,
+            \ProcessMaker\Package\PackageAi\ImportExport\FlowGenieExporter::class,
+        ],
         'screen-template' => [
             \ProcessMaker\Models\ScreenTemplates::class,
             \ProcessMaker\ImportExport\Exporters\ScreenTemplatesExporter::class,

--- a/ProcessMaker/Enums/ExporterMap.php
+++ b/ProcessMaker/Enums/ExporterMap.php
@@ -11,6 +11,7 @@ enum ExporterMap
         'process_templates' => [\ProcessMaker\Models\ProcessTemplates::class, \ProcessMaker\ImportExport\Exporters\TemplateExporter::class],
         'data_source' => [\ProcessMaker\Packages\Connectors\DataSources\Models\DataSource::class, \ProcessMaker\Packages\Connectors\DataSources\ImportExport\DataSourceExporter::class],
         'decision_table' => [\ProcessMaker\Package\PackageDecisionEngine\Models\DecisionTable::class, \ProcessMaker\Package\PackageDecisionEngine\ImportExport\DecisionTableExporter::class],
+        'flow_genie' => [\ProcessMaker\Package\PackageAi\Models\FlowGenie::class, \ProcessMaker\Package\PackageAi\ImportExport\FlowGenieExporter::class],
         'screen-template' => [
             \ProcessMaker\Models\ScreenTemplates::class,
             \ProcessMaker\ImportExport\Exporters\ScreenTemplatesExporter::class,


### PR DESCRIPTION
## Issue & Reproduction Steps
FlowGenie is not exported from the project

## Solution
- add asset flowGenie

## How to Test
Export/import Project with asset FlowGenie

## Related Tickets & Packages
- [FOUR-17426](https://processmaker.atlassian.net/browse/FOUR-17426)

Related PR
- https://github.com/ProcessMaker/package-projects/pull/133
- https://github.com/ProcessMaker/package-ai/pull/275

ci:next
ci:package-project:bugfix/FOUR-17426
ci:package-ai:bugfix/FOUR-17426

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-17426]: https://processmaker.atlassian.net/browse/FOUR-17426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ