### PR TITLE
Observation/FOUR-17565: "Show me My templates" button does not work in process-browser for a user without permissions

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -52,7 +52,6 @@
     <CatalogueEmpty
       v-if="!loading && processList.length === 0"
       :show-empty="showEmpty"
-      @wizardLinkSelect="wizardLinkSelected"
     />
   </div>
 </template>
@@ -165,12 +164,6 @@ export default {
             });
           } 
         });
-    },
-    /**
-     * Go to wizard templates section
-     */
-    wizardLinkSelected() {
-      this.$emit("wizardLinkSelect");
     },
     /**
      * Build URL for Process Cards

--- a/resources/js/processes-catalogue/components/CatalogueEmpty.vue
+++ b/resources/js/processes-catalogue/components/CatalogueEmpty.vue
@@ -40,7 +40,14 @@ export default {
      * go to wizard templates section
      */
     wizardLinkSelected() {
-      this.$emit("wizardLinkSelect");
+      window.ProcessMaker.EventBus.$emit(
+        "wizard-templates-selected",
+        {
+          label: this.$t("Guided Templates"),
+          selected: false,
+          id: "guided_templates",
+        },
+      );
     },
   },
 };

--- a/resources/js/processes-catalogue/components/ProcessListing.vue
+++ b/resources/js/processes-catalogue/components/ProcessListing.vue
@@ -37,7 +37,7 @@ export default {
     isTemplateCategory() {
       return ['guided_templates'].includes(this.categoryId)
     },
-  }
+  },
 };
 </script>
 

--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -146,6 +146,10 @@ export default {
     EventBus.$on('templates-selected', (obj) => {
       this.openTemplate(obj);
     });
+
+    window.ProcessMaker.EventBus.$on("wizard-templates-selected", (obj) => {
+      this.selectTemplateItem(obj);
+    });
   },
   computed: {
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduced:**

- Create a userA without permissions
- Log In with userA
- Click on processes
- Click on My bookmarks
- Click on "Show me My templates"

## Solution
- Added a emit to trigger the correct redirect

**Working video**

https://github.com/user-attachments/assets/1a834d66-555b-4d3e-afa7-4a30e638c5d9


## How to Test
Follow steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17565

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next