### PR TITLE
FOUR-17531 Can not change Scripts with PHP to PHP-NAYRA

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Process/ScriptController.php
@@ -59,7 +59,7 @@ class ScriptController extends Controller
     {
         $selectedUser = $script->runAsUser;
         $assignedProjects = json_decode($script->projects, true);
-        $scriptExecutors = ScriptExecutor::list($script->scriptExecutor->language);
+        $scriptExecutors = ScriptExecutor::list($script->scriptExecutor->language, true);
         $addons = $this->getPluginAddons('edit', compact(['script']));
 
         return view('processes.scripts.edit', compact('script', 'selectedUser', 'scriptExecutors', 'addons', 'assignedProjects'));

--- a/ProcessMaker/Models/Script.php
+++ b/ProcessMaker/Models/Script.php
@@ -197,6 +197,11 @@ class Script extends ProcessMakerModel implements ScriptInterface
             $values[] = $key;
         }
 
+        // If "php" format is included also include "php-nayra"
+        if (in_array('php', $values)) {
+            $values[] = 'php-nayra';
+        }
+
         return $values;
     }
 

--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -142,7 +142,7 @@ class ScriptExecutor extends ProcessMakerModel
         ];
     }
 
-    public static function list($language = null)
+    public static function list($language = null, $forEditMode = false)
     {
         $list = [];
         $executors =
@@ -151,6 +151,16 @@ class ScriptExecutor extends ProcessMakerModel
 
         if ($language) {
             $executors->where('language', $language);
+
+            // If the list is for edition mode and "php" language is selected also include "php-nayra"
+            if ($language === 'php' && $forEditMode) {
+                $executors->orWhere('language', 'php-nayra');
+            }
+
+            // If the list is for edition mode and "php-nayra" language is selected also include "php"
+            if ($language === 'php-nayra' && $forEditMode) {
+                $executors->orWhere('language', 'php');
+            }
         }
 
         foreach ($executors->get() as $executor) {

--- a/resources/views/processes/scripts/edit.blade.php
+++ b/resources/views/processes/scripts/edit.blade.php
@@ -152,6 +152,7 @@
         data() {
           return {
             formData: @json($script),
+            scriptExecutors: @json($scriptExecutors),
             selectedUser: @json($selectedUser),
             assignedProjects: @json($assignedProjects),
             selectedProjects: '',
@@ -192,7 +193,7 @@
             this.resetErrors();
             ProcessMaker.apiClient.put('scripts/' + this.formData.id, {
               title: this.formData.title,
-              language: this.formData.language,
+              language: this.scriptExecutors[this.formData.script_executor_id].language,
               script_category_id: this.formData.script_category_id,
               description: this.formData.description,
               run_as_user_id: this.selectedUser === null ? null : this.selectedUser.id,


### PR DESCRIPTION
## Issue & Reproduction Steps
When an script task was created with php language, then it cannot be changed to use php-nayra to improve its performance. This is because the Script Configuration screen does not allow to change to other language. We need to allow change php ↔︎ php-nayra for any case.

## Solution
Added "php-nayra" in the dropdpwn when a script configuration is edited

## How to Test
Create a Scrip Task PHP Executor
Save it
Go to scripts lists
Edit the Configuration of the created script
Try to change the executor to PHP-NAYRA

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17531

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
.