### PR TITLE
FOUR-16620: Adjust permissions of export-processes within the  Ellipsis menu

### DIFF
--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -108,7 +108,7 @@ export default {
         {
           value: "download-bpmn",
           content: "Download BPMN",
-          permission: ["view-processes", "view-additional-asset-actions"],
+          permission: ["export-processes"],
           icon: "fas fa-file-download",
         },
       ],


### PR DESCRIPTION
## Issue & Reproduction Steps
A process can be exported as XML even when only view permissions are set.

- Go to the **Admin** tab.
- Create a Test User.
- Navigate to **Groups**.
- Create a new group.
- Set up the group with only View permissions.
- Add the Test User to the new group
- Log in as the Test User.
- Go to the **Designer** tab.
- Navigate to **Processes**.
- Select any process.
- Click on the Ellipsis menu **Options**.
- Select **Download BPMN**.
- ![Screenshot 2024-08-02 at 3 41 51 PM](https://github.com/user-attachments/assets/08c4e1d4-fe13-4b7a-9edf-1cf9e67d4dd2)


### Current Behavior

- The BPMN file can be downloaded even though the user’s group has only View permissions.
- The Export BPMN button is accessible within the Ellipsis Menu.

### Expected Behavior
- The BPMN button should not be visible if the user or group is not configured with the export-processes or admin permissions.

## Solution
-  Adjust permissions of the Download BPMN button within the  Ellipsis menu

## How to Test
Please follow the reproduction steps and make sure that the Expected Behavior is met.

## Related Tickets & Packages
- Ticket: [FOUR-16620](https://processmaker.atlassian.net/browse/FOUR-16620)
- ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-16620]: https://processmaker.atlassian.net/browse/FOUR-16620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ