### PR TITLE
FOUR-17524 server error when i want to filter by alternative column

### DIFF
--- a/ProcessMaker/Filters/Filter.php
+++ b/ProcessMaker/Filters/Filter.php
@@ -21,6 +21,8 @@ class Filter
 
     public const TYPE_STATUS = 'Status';
 
+    public const TYPE_ALTERNATIVE = 'Alternative';
+
     public const TYPE_FIELD = 'Field';
 
     public const TYPE_PROCESS = 'Process';
@@ -262,6 +264,9 @@ class Filter
                 break;
             case self::TYPE_STATUS:
                 $method = 'valueAliasStatus';
+                break;
+            case self::TYPE_ALTERNATIVE:
+                $method = 'valueAliasAlternative';
                 break;
         }
 

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -30,6 +30,7 @@ use ProcessMaker\Traits\SerializeToIso8601;
 use ProcessMaker\Traits\SqlsrvSupportTrait;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use stdClass;
 use Throwable;
 
 /**
@@ -766,11 +767,11 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
      * PMQL value alias for the alternative field in the process version
      *
      * @param string value
-     * @param ProcessMaker\Query\Expression expression
+     * @param ProcessMaker\Query\Expression | stdClass $expression
      *
      * @return callable
      */
-    public function valueAliasAlternative(string $value, Expression $expression): callable
+    public function valueAliasAlternative(string $value, Expression | stdClass $expression): callable
     {
         return function ($query) use ($expression, $value) {
             $query->whereHas('processVersion', function ($query) use ($expression, $value) {

--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -220,16 +220,28 @@ const PMColumnFilterCommonMixin = {
           format = "string";
         }
       }
-      if (column.field === "status") {
+
+      if (['status', 'process_version_alternative'].includes(column.field)) {
         format = "stringSelect";
       }
+
       return format;
     },
     getFormatRange(column) {
-      let formatRange = [];
-      if (column.field === "status") {
-        formatRange = this.getStatus();
+      let formatRange;
+
+      switch (column.field) {
+        case 'status':
+          formatRange = this.getStatus();
+          break;
+        case 'process_version_alternative':
+          formatRange = this.getAlternatives();
+          break;
+        default:
+          formatRange = [];
+          break;
       }
+
       return formatRange;
     },
     getOperators(column) {
@@ -237,12 +249,15 @@ const PMColumnFilterCommonMixin = {
       if (column.field === "case_title" || column.field === "name" || column.field === "process" || column.field === "task_name" || column.field === "element_name" || column.field === "participants" || column.field === "assignee") {
         operators = ["=", "in", "contains", "regex"];
       }
-      if (column.field === "status") {
+
+      if (['status', 'process_version_alternative'].includes(column.field)) {
         operators = ["=", "in"];
       }
+
       if (column.field === "initiated_at" || column.field === "completed_at" || column.field === "due_at") {
         operators = ["<", "<=", ">", ">=", "between"];
       }
+
       return operators;
     },
     getAssignee(filter) {

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -436,7 +436,7 @@ export default {
       }
 
       return `
-        <span 
+        <span
           class="badge badge-${color} status-${badge}"
         >
           ${this.$t('Alternative')} ${value}
@@ -568,6 +568,18 @@ export default {
         {value: "Completed", text: this.$t("Completed")},
         {value: "Error", text: this.$t("Error")},
         {value: "Canceled", text: this.$t("Canceled")}
+      ];
+    },
+    /**
+     * This method is used in PMColumnFilterPopoverCommonMixin.js
+     * Returns the available alternatives for the process version
+     *
+     * @returns {Array}
+     */
+    getAlternatives() {
+      return [
+        { value: 'A', text: 'A' },
+        { value: 'B', text: 'B' },
       ];
     },
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
There should be no errors when filtering by the alternative column, after creating a Saved Search

Actual behavior: 
It shows us a server error when trying to filter by the alternative column in a Saved Search

## Solution
- Add filtering support for process alternative column
- Convert the alternative filter into a select

https://github.com/user-attachments/assets/ca4b63b6-4786-4879-b402-bb6ed73113aa

## How to Test
1. Log in 
2. Create a new Saved Search 
3. The alternative column is enabled
4. Filter by the alternative column

## Related Tickets & Packages
[FOUR-17524](https://processmaker.atlassian.net/browse/FOUR-17524)
https://github.com/ProcessMaker/package-savedsearch/pull/463

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:package-savedsearch:bugfix/FOUR-17524
ci:deploy


[FOUR-17524]: https://processmaker.atlassian.net/browse/FOUR-17524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ