### PR TITLE
Fix PM blocks launchpad import issue

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -549,7 +549,7 @@ abstract class ExporterBase implements ExporterInterface
                 $foundCategory = $categoryClass::find($this->model->process_category_id);
 
                 if (!$foundCategory instanceof $categoryClass) {
-                    Log::warning('Import/Export: Unable to find ' . $categoryClass::class .
+                    \Log::warning('Import/Export: Unable to find ' . $categoryClass .
                         " with id {$this->model->process_category_id}, updated to 'Uncategorized'.");
                 }
 

--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -213,6 +213,10 @@ abstract class ExporterBase implements ExporterInterface
 
     public function runImport($existingAssetInDatabase = null, $importingFromTemplate = false)
     {
+        // Ensure we have the latest version of the model because some attributes
+        // may have changed with updateDuplicateAttributes()
+        $this->model->refresh();
+
         $extensions = app()->make(Extension::class);
         $extensions->runExtensions($this, 'preImport', $this->logger);
         $this->logger->log('Running Import ' . static::class);
@@ -249,7 +253,7 @@ abstract class ExporterBase implements ExporterInterface
         } elseif ($this->getClassName() === 'LaunchpadSetting') {
             $name = 'Setting';
         }
-       
+
         return $name;
     }
 

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -459,6 +459,7 @@ class ProcessExporter extends ExporterBase
     {
         foreach ($this->getDependents(DependentType::MEDIA) as $media) {
             $media->model->setAttribute('model_id', $this->model->id);
+            $media->model->saveOrFail();
         }
     }
 
@@ -484,6 +485,7 @@ class ProcessExporter extends ExporterBase
     {
         foreach ($this->getDependents('process_launchpad') as $launchpad) {
             $launchpad->model->setAttribute('process_id', $this->model->id);
+            $launchpad->model->saveOrFail();
         }
     }
 

--- a/ProcessMaker/ImportExport/Psudomodels/Psudomodel.php
+++ b/ProcessMaker/ImportExport/Psudomodels/Psudomodel.php
@@ -7,4 +7,8 @@ abstract class Psudomodel
     public function preventSavingDiscardedModel()
     {
     }
+
+    public function refresh()
+    {
+    }
 }

--- a/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessExporterTest.php
@@ -155,6 +155,7 @@ class ProcessExporterTest extends TestCase
         $media = $process->media()->first();
         $fakeFilePath = $media->id . '/' . $media->file_name;
         $this->assertFileExists(Storage::disk('public')->path($fakeFilePath));
+        $this->assertEquals('a value', $media->getCustomProperty('a_custom_property'));
     }
 
     public function testSignals()
@@ -468,6 +469,7 @@ class ProcessExporterTest extends TestCase
             'collection_name' => 'images_carousel',
             'name' => 'image',
             'file_name' => 'image.png',
+            'custom_properties' => ['a_custom_property' => 'a value'],
         ]);
 
         // Create a fake image and save it directly to the fake storage.


### PR DESCRIPTION
## Issue & Reproduction Steps
The importer automatically increments the process_id of ProcessLaunchpad because it must be unique. But the new ID was not seen by the import logic that happens later so it was attempting to save using the old (non-unique) id.

## Solution
- Run refresh() on the model before running the import logic.

## How to Test
See steps in jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16751

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
.