### PR TITLE
observation/FOUR-16192: Alternatives filter fixed with a different input

### DIFF
--- a/.github/workflows/deploy-pm4.yml
+++ b/.github/workflows/deploy-pm4.yml
@@ -264,9 +264,9 @@ jobs:
         run: |          
           cd pm4-k8s-distribution/images/pm4-tools
           docker pull $IMAGE
-          docker-compose down -v
-          docker-compose build phpunit
-          docker-compose run phpunit
+          docker compose down -v
+          docker compose build phpunit
+          docker compose run phpunit
           CONTAINER_ID=$(docker ps -a --filter ancestor=pm4-eks-phpunit:latest --format "{{.ID}}" | head -n 1)
           docker cp $CONTAINER_ID:/opt/processmaker/coverage.xml coverage.xml
       - name: Archive code coverage

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -164,10 +164,15 @@ class ProcessRequestController extends Controller
             } elseif ($request->input('total') == 'true') {
                 return ['meta' => ['total' => $query->count()]];
             } else {
-                $response = $query->orderBy(
-                    str_ireplace('.', '->', $request->input('order_by', 'name')),
-                    $request->input('order_direction', 'ASC')
-                )
+                if ($request->input('order_by') == 'process.alternative') {
+                    $query->orderByRaw('process_version_alternative '. $request->input('order_direction'));
+                } else {
+                    $query->orderBy(
+                        str_ireplace('.', '->', $request->input('order_by', 'name')),
+                        $request->input('order_direction', 'ASC')
+                    );
+                }
+                $response = $query
                     ->select('process_requests.*')
                     ->withAggregate('processVersion', 'alternative')
                     ->paginate($request->input('per_page', 10));

--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -176,7 +176,8 @@ const PMColumnFilterCommonMixin = {
     onUpdate(object, index) {
       if (object.$refs.pmColumnFilterForm &&
               index in this.advancedFilter &&
-              this.advancedFilter[index].length > 0) {
+              this.advancedFilter[index].length > 0) 
+      {
         object.$refs.pmColumnFilterForm.setValues(this.advancedFilter[index]);
       }
     },
@@ -220,15 +221,19 @@ const PMColumnFilterCommonMixin = {
           format = "string";
         }
       }
-      if (column.field === "status") {
+      if (column.field === "status" || column.field === "process_version_alternative") {
         format = "stringSelect";
       }
+      
       return format;
     },
     getFormatRange(column) {
       let formatRange = [];
       if (column.field === "status") {
         formatRange = this.getStatus();
+      }
+      if (column.field === "process_version_alternative") {
+        formatRange = this.getAlternatives();
       }
       return formatRange;
     },
@@ -239,6 +244,9 @@ const PMColumnFilterCommonMixin = {
       }
       if (column.field === "status") {
         operators = ["=", "in"];
+      }
+      if (column.field === "process_version_alternative") {
+        operators = ["="];
       }
       if (column.field === "initiated_at" || column.field === "completed_at" || column.field === "due_at") {
         operators = ["<", "<=", ">", ">=", "between"];

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -558,6 +558,12 @@ export default {
     },
     handleRowClick(row) {
     },
+    getAlternatives() {
+      return [
+        {value: "A", text: this.$t("Alternative A")},
+        {value: "B", text: this.$t("Alternative B")}
+      ]
+    },
     /**
      * This method is used in PMColumnFilterPopoverCommonMixin.js
      * @returns {Array}

--- a/tests/unit/ProcessMaker/FilterTest.php
+++ b/tests/unit/ProcessMaker/FilterTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use ProcessMaker\Models\Process;
+use Database\Factories\ProcessMaker\Models\ProcessFactory;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Filters\Filter;
 use ProcessMaker\Models\ProcessRequest;
@@ -285,6 +287,27 @@ class FilterTest extends TestCase
         $query = ProcessRequestToken::query();
         Filter::filter($query, json_encode($filter));
         $this->assertEquals($query->first()->id, $task->id);
+    }
+    
+    public function testAlternative()
+    {
+        $process = Process::factory()->create(['alternative' => 'B']);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'process_version_id' => $process->getLatestVersion('B')
+        ]);
+
+        $filter = [
+            [
+                'subject' => ['type' => 'Relationship', 'value' => 'process.alternative'],
+                'operator' => '=',
+                'value' => 'B',
+            ],
+        ];
+
+        $query = ProcessRequest::query();
+        Filter::filter($query, json_encode($filter));
+        $this->assertEquals($query->first()->id, $request->id);
     }
 
     public function testTaskCaseNumber()


### PR DESCRIPTION
## Ticket solved by this PR
- [FOUR-16192](https://processmaker.atlassian.net/browse/FOUR-16192)

## Solution
- Added `process_version_alternative` to the list of controls that use a dropdown or selectbox
- Added A and B as options to choose for filtering
- Added an ordering for the alternatives filter
- Added test for the Alternative filter

## PRs Related:
- https://github.com/ProcessMaker/package-savedsearch/pull/464

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next

[FOUR-16192]: https://processmaker.atlassian.net/browse/FOUR-16192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ