### PR TITLE
observation/FOUR-15427 Optimize initial Launchpad generation time

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/WizardTemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/WizardTemplateController.php
@@ -21,7 +21,7 @@ class WizardTemplateController extends Controller
 
         $direction = $request->input('order_direction', 'asc');
 
-        $query = WizardTemplate::with('process', 'process_template')->filter($filter)
+        $query = WizardTemplate::with('process')->filter($filter)
             ->orderBy($column, $direction);
 
         $data = $query->paginate($perPage);

--- a/resources/js/processes-catalogue/components/WizardTemplates.vue
+++ b/resources/js/processes-catalogue/components/WizardTemplates.vue
@@ -6,6 +6,7 @@
       package-ai="false"
       :component="currentComponent"
       :show-template-options-action-bar="false"
+      :fetch-on-created="false"
       @show-details="showDetails($event)"
     />
   </div>


### PR DESCRIPTION
## Issue & Reproduction Steps
Optimize initial Launchpad generation time

## Solution
removed double api call and unnecessary join

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15427

ci:next

