### PR TITLE
QA Observation Bugfix/FOUR-17562: A `Server error` message when a criteria is added in the search field in the Security Logs tab

### DIFF
--- a/resources/js/admin/users/components/SecurityLogsListing.vue
+++ b/resources/js/admin/users/components/SecurityLogsListing.vue
@@ -181,7 +181,7 @@ export default {
       ProcessMaker.apiClient
         .get(
           `security-logs?pmql=${
-            this.pmql
+            encodeURIComponent(this.pmql)
           }&filter=${
             this.searchFilter
           }&page=${


### PR DESCRIPTION
## How to Test
- Go to Security logs tab, and search with any critera.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17562

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next