### PR TITLE
FOUR-17624 form data using watchers is displayed empty when printing in forms

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -771,6 +771,7 @@ class ProcessRequestController extends Controller
                     $screen = $token->getScreenVersion();
                     if ($screen) {
                         $dataManager = new DataManager();
+                        $screen->token_id = $token->id;
                         $screen->data = $dataManager->getData($token, true);
                         $screen->screen_id = $screen->id;
 

--- a/resources/js/requests/components/RequestScreens.vue
+++ b/resources/js/requests/components/RequestScreens.vue
@@ -118,14 +118,7 @@ export default {
   },
   methods: {
     preview(data) {
-      window.open(
-        "/requests/" +
-          this.id +
-          "/task/" +
-          data.id +
-          "/screen/" +
-          data.screen_id
-      );
+      window.open(`/requests/${this.id}/task/${data.token_id}/screen/${data.screen_id}`);
     },
     previewScreen(data) {
       data.view = !data.view;


### PR DESCRIPTION
## Issue & Reproduction Steps
Form data using watchers is displayed empty when printing in forms

### Current behavior
As we can see, the form is shown as empty at the time of printing.

### Expected behavior
The form should not be displayed empty when trying to print.

## Solution
- Associate the token ID to the screen on the Request summary

https://github.com/user-attachments/assets/65f4cd99-9c46-438d-9de0-4ebd5a2d0e96

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-17624](https://processmaker.atlassian.net/browse/FOUR-17624)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-17624]: https://processmaker.atlassian.net/browse/FOUR-17624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ