### PR TITLE
FOUR-17533: File Preview is not visible in Form completed details

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -773,10 +773,13 @@ class ProcessRequestController extends Controller
                         $dataManager = new DataManager();
                         $screen->data = $dataManager->getData($token, true);
                         $screen->screen_id = $screen->id;
+                        // Assign the task_id from the token object to the screen object
+                        $screen->task_id = $token->id;
 
                         return $screen;
                     }
                 }
+
                 return null;
             })
             ->reject(fn ($item) => $item === null)

--- a/resources/js/requests/components/RequestScreens.vue
+++ b/resources/js/requests/components/RequestScreens.vue
@@ -122,7 +122,7 @@ export default {
         "/requests/" +
           this.id +
           "/task/" +
-          data.id +
+          data.task_id +
           "/screen/" +
           data.screen_id
       );


### PR DESCRIPTION
## Issue & Reproduction Steps
The preview file is not working in a cases completed 
## Solution
- add  a new parameter to screen object response (task_id) using the existing token id
- based on ProcessMaker/Models/ProcessRequest.php line 380


https://github.com/user-attachments/assets/e081e034-775b-4a6b-8eb5-c39ea3abd873


## How to Test
Describe how to test that this solution works.

1. Create a process with the following configuration 
2. Start Event → Task Form → Manual task → End Event
3. In the task form configure file upload
4. In the manual task configure preview file
5. Create cases
6. In the task form upload files
7. Complete the manual task
8. Go to Form 
9. Click on details
10. Click on print

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17533

ci:next 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
