### PR TITLE
FOUR-17543:PM Blocks are not visible in slide show preview mode

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -220,7 +220,7 @@ class ModelerController extends Controller
     /**
      * Load PMBlock list
      */
-    private function getPmBlockList()
+    public function getPmBlockList()
     {
         $pmBlockList = null;
         if (hasPackage('package-pm-blocks')) {


### PR DESCRIPTION
## Issue & Reproduction Steps
PM Blocks are not visible in slide show preview mode

## Related Tickets & Packages
- [FOUR-17543](https://processmaker.atlassian.net/browse/FOUR-17543)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
ci:package-slideshow:bugfix/FOUR-17543

[FOUR-17543]: https://processmaker.atlassian.net/browse/FOUR-17543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ