### PR TITLE
FOUR-17626: block duplicate session does not work with saml user

### DIFF
--- a/ProcessMaker/Http/Middleware/SessionControlBlock.php
+++ b/ProcessMaker/Http/Middleware/SessionControlBlock.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Jenssegers\Agent\Agent;
+use ProcessMaker\Managers\SessionControlManager;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,17 +26,13 @@ class SessionControlBlock
     public function handle(Request $request, Closure $next): Response
     {
         $user = $this->getUser($request);
+        $ip = $request->getClientIp() ?? $request->ip();
         $hasUserSession = $request->session()->has('user_session');
 
-        if ($user && !$hasUserSession) {
-            // Check if the user's session should be blocked based on IP restriction
-            if ($this->blockedByIp($user, $request)) {
-                return $this->redirectToLogin();
-            }
-            // Check if the user's session should be blocked based on device restriction
-            if ($this->blockedByDevice($user, $request)) {
-                return $this->redirectToLogin();
-            }
+        $sessionManager = new SessionControlManager($user, $ip);
+
+        if ($user && !$hasUserSession && $sessionManager->isSessionBlocked()) {
+            return $sessionManager->redirectToLogin();
         }
 
         return $next($request);
@@ -50,86 +47,5 @@ class SessionControlBlock
                 $query->where('is_active', true);
             })->where('username', $request->input('username'))
             ->first();
-    }
-
-    private function blockedByIp(User $user, Request $request): bool
-    {
-        return Setting::configByKey(self::IP_RESTRICTION_KEY) === '1' && $this->blockSessionByIp($user, $request);
-    }
-
-    private function blockedByDevice(User $user, Request $request): bool
-    {
-        return Setting::configByKey(self::DEVICE_RESTRICTION_KEY) === '1'
-            && $this->blockSessionByDevice($user, $request);
-    }
-
-    /**
-     * Checks if a user's session is a duplicate based on their IP address.
-     *
-     * @param User user
-     * @param Request request
-     *
-     * @return bool
-     */
-    private function blockSessionByIp(User $user, Request $request): bool
-    {
-        // Get the user's most recent session
-        $session = $user->sessions->sortByDesc('created_at')->first();
-        // Get the user's current IP address
-        $ip = $request->getClientIp() ?? $request->ip();
-
-        return $session->ip_address === $ip;
-    }
-
-    /**
-     * Checks if the user's current session device matches the device used in the request
-     *
-     * @param User user
-     * @param Request request
-     *
-     * @return bool
-     */
-    private function blockSessionByDevice(User $user, Request $request): bool
-    {
-        $agent = new Agent();
-        // Get the device details from the request
-        $agentDevice = $agent->device() ? $agent->device() : 'Unknown';
-        $requestDevice = $this->formatDeviceInfo($agentDevice, $agent->deviceType(), $agent->platform());
-        // Get the user's current IP address
-        $ip = $request->getClientIp() ?? $request->ip();
-        // Get the active user sessions
-        $sessions = $user->sessions()
-            ->where([
-                ['is_active', true],
-                ['expired_date', null],
-            ])
-            ->orderBy('created_at', 'desc')
-            ->get();
-
-        $openSessions = $sessions->reduce(function ($carry, $session) use ($requestDevice, $ip) {
-            $sessionDevice = $this->formatDeviceInfo(
-                $session->device_name, $session->device_type, $session->device_platform
-            );
-
-            if ($requestDevice !== $sessionDevice || $session->ip_address !== $ip) {
-                return $carry + 1;
-            } else {
-                return $carry - 1;
-            }
-        }, 0);
-
-        return $openSessions > 0;
-    }
-
-    private function formatDeviceInfo(string $deviceName, string $deviceType, string $devicePlatform): string
-    {
-        return Str::slug($deviceName . '-' . $deviceType . '-' . $devicePlatform);
-    }
-
-    private function redirectToLogin(): Response
-    {
-        return redirect()
-            ->route('login')
-            ->with('login-error', __('You are already logged in'));
     }
 }

--- a/ProcessMaker/Listeners/UserSession.php
+++ b/ProcessMaker/Listeners/UserSession.php
@@ -30,7 +30,8 @@ class UserSession
         $configDevice = Setting::configByKey('session-control.device_restriction');
 
         // Get the IP address and device information
-        $ip = request()->getClientIp() ?? request()->ip();
+        $ip = request()->header('X-Forwarded-For') ?? request()->getClientIp() ?? request()->ip();
+
         $agentDevice = $agent->device() ? $agent->device() : 'Unknown';
         $agentDeviceType = $agent->deviceType();
         $agentPlatform = $agent->platform();

--- a/ProcessMaker/Managers/SessionControlManager.php
+++ b/ProcessMaker/Managers/SessionControlManager.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Jenssegers\Agent\Agent;
+use ProcessMaker\Models\Setting;
+use ProcessMaker\Models\User;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Helpers that control if a user session is blocked by some session policy
+ */
+class SessionControlManager
+{
+    const IP_RESTRICTION_KEY = 'session-control.ip_restriction';
+    const DEVICE_RESTRICTION_KEY = 'session-control.device_restriction';
+
+    private ?User $user;
+    private string $clientIp;
+
+    public function __construct(?User $user, string $clientIp)
+    {
+        $this->user = $user;
+        $this->clientIp = $clientIp;
+    }
+
+    /**
+     *
+     * If the session is blocked by some of the ProcessMaker policies, returns true, false otherwise
+     *
+     * @return bool
+     */
+    public function isSessionBlocked()
+    {
+        // Check if the user's session should be blocked based on IP restriction
+        if ($this->blockedByIp()) {
+            return true;
+        }
+        // Check if the user's session should be blocked based on device restriction
+        if ($this->blockedByDevice()) {
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Checks if a user's session is a duplicate based on their IP address.
+     *
+     * @return bool
+     */
+    public function blockSessionByIp(): bool
+    {
+        // Get the user's most recent session
+        $session = $this->user->sessions->sortByDesc('created_at')->first();
+        // Get the user's current IP address
+        return $session->ip_address === $this->clientIp;
+    }
+
+    /**
+     * Checks if the user's current session device matches the device used in the request
+     *
+     * @return bool
+     */
+    public function blockSessionByDevice(): bool
+    {
+        $agent = new Agent();
+        // Get the device details from the request
+        $agentDevice = $agent->device() ? $agent->device() : 'Unknown';
+        $requestDevice = $this->formatDeviceInfo($agentDevice, $agent->deviceType(), $agent->platform());
+        // Get the active user sessions
+        $sessions = $this->user->sessions()
+            ->where([
+                ['is_active', true],
+                ['expired_date', null],
+            ])
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $openSessions = $sessions->reduce(function ($carry, $session) use ($requestDevice) {
+            $sessionDevice = $this->formatDeviceInfo(
+                $session->device_name, $session->device_type, $session->device_platform
+            );
+
+            if ($requestDevice !== $sessionDevice || $session->ip_address !== $this->clientIp) {
+                return $carry + 1;
+            } else {
+                return $carry - 1;
+            }
+        }, 0);
+
+        return $openSessions > 0;
+    }
+
+    public function blockedByIp(): bool
+    {
+        return Setting::configByKey(self::IP_RESTRICTION_KEY) === '1' && $this->blockSessionByIp();
+    }
+
+    public function blockedByDevice(): bool
+    {
+        return Setting::configByKey(self::DEVICE_RESTRICTION_KEY) === '1'
+            && $this->blockSessionByDevice();
+    }
+
+    public function redirectToLogin(): Response
+    {
+        return redirect()
+            ->route('login')
+            ->with('login-error', __('You are already logged in'));
+    }
+
+    private function formatDeviceInfo(string $deviceName, string $deviceType, string $devicePlatform): string
+    {
+        return Str::slug($deviceName . '-' . $deviceType . '-' . $devicePlatform);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
When users SAML to log-in they and PM has configured the setting "Device Restriction", this setting is not working. Users can log-in from multiple devices.

Steps to Reproduce:
    Log in
    Configure  Sesiin control with Bock duplciate session
    Login with other borwser with  saml user

## Solution
- Added to Package-Auth the logic to control session by devices
- Refactored in PM core the code that controls the session policies so that the same logic can be used in package-auth.

## How to Test
Steps to Reproduce:

    Log in

    Configure  Sesiin control with Bock duplciate session

    Login with other borwser with  saml user

## Related Tickets & Packages
[- Link to any related FOUR tickets, PRDs, or packages](https://processmaker.atlassian.net/browse/FOUR-17626)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-auth:observation/FOUR-17626
ci:next

