### PR TITLE
FOUR-17648 Launchpad > Added Saved Search is not working correctly

### DIFF
--- a/resources/js/processes-catalogue/components/CreateSavedSearchTab.vue
+++ b/resources/js/processes-catalogue/components/CreateSavedSearchTab.vue
@@ -16,7 +16,7 @@
       <PMDropdownSuggest v-model="idSavedSearch"
                          :options="options"
                          @onInput="onInput"
-                         @onSelectedOption="$emit('onSelectedOption',$event)"
+                         @onSelectedOption="onSelectedOption"
                          :state="stateIdSavedSearch"
                          :placeholder="$t('Type here to search')">
       </PMDropdownSuggest>
@@ -73,6 +73,7 @@
         tabName: "",
         filter: "",
         pmql: "",
+        advanced_filter: null,
         columns: [],
         idSavedSearch: null,
         seeTabOnMobile: false,
@@ -117,6 +118,7 @@
           name: this.tabName,
           filter: this.filter,
           pmql: this.pmql,
+          advanced_filter: this.advanced_filter,
           columns: this.columns,
           idSavedSearch: this.idSavedSearch,
           seeTabOnMobile: this.seeTabOnMobile
@@ -144,7 +146,8 @@
                   response?.data?.data?.forEach(item => {
                     this.options.push({
                       text: item.title,
-                      value: item.id
+                      value: item.id,
+                      advanced_filter: item.advanced_filter
                     });
                   });
                 });
@@ -155,6 +158,7 @@
         this.tabName = tab.name;
         this.filter = tab.filter;
         this.pmql = tab.pmql;
+        this.advanced_filter = tab.advanced_filter;
         this.columns = tab.columns;
         this.hideSelectSavedSearch = tab.type === "myCases" || tab.type === "myTasks";
         if (!this.hideSelectSavedSearch) {
@@ -162,6 +166,10 @@
           this.idSavedSearch = tab.idSavedSearch;
         }
         this.seeTabOnMobile = tab.seeTabOnMobile === true;
+      },
+      onSelectedOption(option) {
+        this.advanced_filter = option.advanced_filter;
+        this.$emit('onSelectedOption', option);
       }
     }
   }

--- a/resources/js/processes-catalogue/components/ProcessTab.vue
+++ b/resources/js/processes-catalogue/components/ProcessTab.vue
@@ -86,6 +86,7 @@
                       :fetch-on-created="false"
                       :saved-search="item.idSavedSearch"
                       no-results-message="launchpad"
+                      :advancedFilterProp="item.advanced_filter"
                       @in-overdue="setInOverdueMessage">
           </tasks-list>
         </template>
@@ -175,6 +176,7 @@
             name: this.$t("My Cases"),
             filter: "",
             pmql: `(user_id = ${ProcessMaker.user.id}) AND (process_id = ${this.process.id})`,
+            advanced_filter: null,
             columns: [
               {
                 label: "Case #",
@@ -222,6 +224,7 @@
             name: this.$t("My Tasks"),
             filter: "",
             pmql: `(user_id = ${ProcessMaker.user.id}) AND (process_id = ${this.process.id})`,
+            advanced_filter: null,
             columns: window.Processmaker.defaultColumns || [],
             seeTabOnMobile: true
           }


### PR DESCRIPTION
## Issue & Reproduction Steps
Launchpad > Added Saved Search is not working correctly.


## Solution
- The rows in the new tab should be displayed according to filters.

## How to Test
Please, it is important to edit or add new saved searches in the tabs of the Launchpad to see the effects.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17648

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next