### PR TITLE
Reload the window if the user closes a quick create modal

### DIFF
--- a/resources/js/processes/screens/components/CreateScreenModal.vue
+++ b/resources/js/processes/screens/components/CreateScreenModal.vue
@@ -271,6 +271,10 @@ export default {
       this.resetErrors();
       this.showTemplatePreview = false;
       this.selectedTemplate = null;
+      if (this.isQuickCreate === true) {
+        // reload without query params
+        window.location.href = window.location.pathname;
+      }
     },
     close() {
       this.$bvModal.hide("createScreen");


### PR DESCRIPTION
## Issue & Reproduction Steps
If the user cancels a quick create flow, they can re-open it and change the required asset type

## Solution
- Reload the window without any query parameters if they close a quick create modal

## How to Test
Follow steps in the issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17774
- https://processmaker.atlassian.net/browse/FOUR-17772

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
