### PR TITLE
FOUR-17021-A Verify that truncated text is displayed

### DIFF
--- a/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
@@ -34,7 +34,7 @@
           <button class="btn button-start-event">
             <i class="fas fa-link pr-1" />
           </button>
-          {{ event.name }}
+          {{ formatEventName(event.name) }}
           <div class="start-event-label">
             {{ $t('Copy link') }}  
           </div>
@@ -45,7 +45,7 @@
           <button class="btn button-start-event">
             <i class="fas fa-play-circle pr-1" />  
           </button>
-          {{ event.name }}
+          {{ formatEventName(event.name) }}
           <div class="start-event-label">
             {{ $t('Start') }}
           </div>
@@ -121,6 +121,12 @@ export default {
       } else {
         ProcessMaker.alert(this.$t("Link copied"), "success");
       }
+    },
+    formatEventName(string) {
+      if (string.length > 25) {
+        string = string.slice(0, 25) + "...";
+      }
+      return string;
     },
   },
 };

--- a/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ButtonsStart.vue
@@ -30,7 +30,9 @@
       >
         <div v-if="event.webEntry" 
              class="start-event"
-             @click="copyLink(event)">
+             @click="copyLink(event)"
+             v-b-tooltip.hover.top.options="{ boundary: 'viewport' }" 
+             :title=" sizeEventName(event.name) ? event.name : '' ">
           <button class="btn button-start-event">
             <i class="fas fa-link pr-1" />
           </button>
@@ -41,7 +43,9 @@
         </div>
         <div v-else
              class="start-event"
-             @click="goToNewRequest(event.id)">
+             @click="goToNewRequest(event.id)"
+             v-b-tooltip.hover.top.options="{ boundary: 'viewport' }" 
+             :title=" sizeEventName(event.name) ? event.name: '' ">
           <button class="btn button-start-event">
             <i class="fas fa-play-circle pr-1" />  
           </button>
@@ -122,8 +126,11 @@ export default {
         ProcessMaker.alert(this.$t("Link copied"), "success");
       }
     },
+    sizeEventName(string){
+      return string.length > 25;
+    },
     formatEventName(string) {
-      if (string.length > 25) {
+      if (this.sizeEventName(string)) {
         string = string.slice(0, 25) + "...";
       }
       return string;


### PR DESCRIPTION
## Issue & Reproduction Steps
Verify that truncated text is displayed

## Solution
25 characters limit, only one line of text for starting event, after that, is truncated with three dots (...)
show the complete text in a tooltip

## How to Test
25 characters limit, only one line of text for starting event, after that, is truncated with three dots (...)
show the complete text in a tooltip

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17021

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
