### PR TITLE
FOUR-17836 Fix error executing script with env variables with spaces

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/EnvironmentVariableExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/EnvironmentVariableExporter.php
@@ -12,6 +12,8 @@ class EnvironmentVariableExporter extends ExporterBase
 
     public $handleDuplicatesByIncrementing = ['name'];
 
+    public $incrementStringSeparator = '_';
+
     public function export() : void
     {
         $this->addReference(DependentType::ENVIRONMENT_VARIABLE_VALUE, $this->model->value);

--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -197,6 +197,7 @@ trait ScriptDockerNayraTrait
                     $output,
                     $status
                 );
+                $ip = explode(' ', trim($ip))[0];
             } else {
                 $ip = exec(
                     $docker . ' inspect --format '
@@ -296,9 +297,9 @@ trait ScriptDockerNayraTrait
             . $image
         );
         $builder->info('Get IP address of the nayra container');
-        $ip = self::findNayraAddresses($docker, $instanceName, 30);
-        if ($ip) {
-            $builder->info('Nayra container IP: ' . $ip);
+        $found = self::findNayraAddresses($docker, $instanceName, 30);
+        if ($found) {
+            $builder->info('Nayra container IP: ' . self::getNayraAddresses()[0]);
             $builder->sendEvent(0, 'done');
         } else {
             throw new UnexpectedValueException('Could not get IP address of the nayra container');

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -687,6 +687,8 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
         $environmentVariables = [];
         EnvironmentVariable::chunk(50, function ($variables) use (&$environmentVariables) {
             foreach ($variables as $variable) {
+                // Fix variables that have spaces
+                $variable['name'] = str_replace(' ', '_', $variable['name']);
                 $environmentVariables[$variable['name']] = $variable['value'];
             }
         });

--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -173,6 +173,8 @@ abstract class Base
         $variablesParameter = [];
         EnvironmentVariable::chunk(50, function ($variables) use (&$variablesParameter, $useEscape) {
             foreach ($variables as $variable) {
+                // Fix variables that have spaces
+                $variable['name'] = str_replace(' ', '_', $variable['name']);
                 if ($useEscape) {
                     $variablesParameter[] = escapeshellarg($variable['name']) . '=' . escapeshellarg($variable['value']);
                 } else {

--- a/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ScriptExporterTest.php
@@ -4,14 +4,12 @@ namespace Tests\Feature\ImportExport\Exporters;
 
 use Database\Seeders\CategorySystemSeeder;
 use Illuminate\Support\Facades\DB;
-use PHPUnit\Framework\ExpectationFailedException;
 use ProcessMaker\ImportExport\Exporters\ScriptExporter;
 use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Models\EnvironmentVariable;
 use ProcessMaker\Models\Script;
 use ProcessMaker\Models\ScriptCategory;
 use ProcessMaker\Models\User;
-use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use Tests\Feature\ImportExport\HelperTrait;
 use Tests\TestCase;
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The nayra executor fails to run when exists env variables with spaces.

## Solution
- Replace space by undescore before to send the env variables to the executor
- Fix the ImportExport class for EnvVariables to use "_" instead of " "
- Add a test to validate the solution

## How to Test
- Export a process with a script task that use environment variables
- Import it to the same server
- Choose the option as a copy

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17836

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
