### PR TITLE
FOUR-17867: Fix issue with the Sidebar not showing the proper color within the icons and text

### DIFF
--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -32,7 +32,6 @@ div.main {
   max-height: 100%;
 }
 a {
-  color: #0872C2 !important;
   text-decoration: none;
   background-color: transparent;
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The Sidebar icons and text are not displaying with the correct color when navigating to the Designer/Modeler, causing them to be invisible.

## Steps to Reproduce:
- Navigate to the Designer.
- Open any Process.
- Click on "Expand Sidebar."
- ![Screenshot 2024-08-14 at 2 46 54 PM](https://github.com/user-attachments/assets/149b3462-2d44-45e3-b545-4e8ed0e13ef6)

## Expected Behavior:
The Sidebar icons and text should be properly displayed and visible when accessed from the Modeler.

## Solution
- Remove the !important of the links within the modeler file

## How to Test
Please follow the reproduction steps and make sure that the Expected behavior is met.
![Screenshot 2024-08-14 at 2 49 02 PM](https://github.com/user-attachments/assets/e4dcbf44-0aa9-4ac1-947c-4070e55f57d4)


## Related Tickets & Packages
- Ticket: [FOUR-17867](https://processmaker.atlassian.net/browse/FOUR-17867)
- ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-17867]: https://processmaker.atlassian.net/browse/FOUR-17867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ