### PR TITLE
FOUR-17868 launchpad > Start this process does not display the list w…

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessHeaderStart.vue
+++ b/resources/js/processes-catalogue/components/ProcessHeaderStart.vue
@@ -93,8 +93,10 @@ export default {
           if (this.processEvents.length === 0) {
             ProcessMaker.alert(this.$t("The current user does not have permission to start this process"), "danger");
           }
-          const nonWebEntryStartEvents = this.processEvents.filter(e => !("webEntry" in e) || !e.webEntry);
-          if (nonWebEntryStartEvents.length === 1) {
+          const nonWebEntryStartEvents = this.processEvents.filter(
+            (e) => !("webEntry" in e) || !e.webEntry
+          );
+          if (nonWebEntryStartEvents.length === 1 && this.processEvents.length === 1) {
             this.singleStartEvent = nonWebEntryStartEvents[0].id;
           }
         })


### PR DESCRIPTION
…hen a Process has one or two web entries

## Issue & Reproduction Steps
When a process has: 
- One start events and two web entries
- One start events and one web entry
- One start event and one web entry
The list is not displayed.

## Solution
Start This Process button should display correctly the list according to Start Events and Web entries configured in the process

## How to Test
Create two web entrie events and single event

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17868

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next