### PR TITLE
observation/FOUR-16890-3 Launchpad change to mobile view when browser's screen is 640px

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessInfo.vue
@@ -10,6 +10,7 @@
       v-show="hideLaunchpad"
       :current-user="currentUser"
       :process="process"
+      class="process-tab-container"
     />
 
     <div w-100 h-100 v-show="!hideLaunchpad">
@@ -80,3 +81,12 @@ export default {
   },
 };
 </script>
+<style lang="scss" scoped>
+@import '~styles/variables';
+.process-tab-container {
+  @media (min-width: $lp-breakpoint) {
+    margin-top: 16px;
+    margin-right: 20px;
+  }
+}
+</style>


### PR DESCRIPTION
## Issue & Reproduction Steps
Launchpad change to mobile view when browser's screen is 640px

## Solution
changed the mobile breakpoint to 640px

## How to Test
Go to processes page
change the browser’s screen size to 640px

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16890

ci:next