### PR TITLE
observation/FOUR-17889 Launchpad Mobile Process Name is not truncated

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -53,7 +53,6 @@
       v-if="!loading && processList.length === 0"
       :show-empty="showEmpty"
       :is-bookmark-empty="categoryId === 'bookmarks'"
-      @wizardLinkSelect="wizardLinkSelected"
     />
   </div>
 </template>

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -241,12 +241,16 @@ export default {
   letter-spacing: -0.4px;
   text-transform: uppercase;
   display: -webkit-box;
-  -webkit-line-clamp: 1;
-  line-clamp: 1;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-word;
+  @media (max-width: $lp-breakpoint) {
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+  }
 }
 .b-popover-custom.popover {
   background-color: #F6F9FB;

--- a/resources/js/processes-catalogue/components/utils/Card.vue
+++ b/resources/js/processes-catalogue/components/utils/Card.vue
@@ -241,10 +241,11 @@ export default {
   letter-spacing: -0.4px;
   text-transform: uppercase;
   display: -webkit-box;
-  -webkit-line-clamp: 4;
-  line-clamp: 4;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
   word-break: break-word;
 }
 .b-popover-custom.popover {


### PR DESCRIPTION
## Issue & Reproduction Steps
Launchpad Mobile > Process Name is not truncated

## Solution
Added a text-overflow style for the process title in the mobile view

## How to Test
Go to server
Create a simple process with a long name
Login (mobile view)
Press to Processes tab
Search and open the process

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17889

ci:next