### PR TITLE
observation/FOUR-17985 Launchpad > Metrics are having different values when process info is collapsed

### DIFF
--- a/resources/js/processes-catalogue/components/optionsMenu/ProcessCounter.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ProcessCounter.vue
@@ -28,13 +28,13 @@
     <span class="text-summary">{{ count }} {{ $t('Cases started') }}</span>
     <div class="charts">
       <mini-pie-chart
-        :count="process.counts.completed"
+        :count="process.counts.in_progress"
         :total="process.counts.total"
         :name="$t('In Progress')"
         color="#4EA075"
       />
       <mini-pie-chart
-        :count="process.counts.in_progress"
+        :count="process.counts.completed"
         :total="process.counts.total"
         :name="$t('Completed')"
         color="#478FCC"


### PR DESCRIPTION
## Issue & Reproduction Steps
Launchpad > Metrics are having different values when process info is collapsed

## Solution
Fix the collapse process info values

## How to Test
Go to server
login with a user
Go to process-browser page
Search and open a process
Check the metrics
Collapse process info

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17985

ci:next