### PR TITLE
FOUR-17911 loop created between two tasks with self service

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -577,6 +577,9 @@
                 is_self_service: 0,
               })
               .then(response => {
+                // Save the current URL to redirect after the task is claimed
+                sessionStorage.setItem('sessionUrlSelfService', document.referrer);
+
                 window.location.reload();
               });
           },


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
When Task Source (default) is selected, the Task should be opened and displayed on the screen with the Claim message

Actual behavior: 
The next task is not displayed and a loop displays the completed task message 

## Solution
- Add a session variable to identify when a Task has been claimed

https://github.com/user-attachments/assets/96ae4684-0308-4f8d-baf7-77814deb1a5f

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-17911](https://processmaker.atlassian.net/browse/FOUR-17911)
https://github.com/ProcessMaker/screen-builder/pull/1671

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:screen-builder:bugfix/FOUR-17911


[FOUR-17911]: https://processmaker.atlassian.net/browse/FOUR-17911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ