### PR TITLE
Use the first admin user if user_id is not set

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -82,6 +82,14 @@ class ProcessExporter extends ExporterBase
             $process->user_id = $dependent->model->id;
         }
 
+        // The process must have a user ID. If it does not, use the first admin
+        // user. Note that this could also be another fallbackMatchColumn in the
+        // user exporter however we're doing it here to maintain backwards
+        // compatibility with old exports.
+        if (!$process->user_id) {
+            $process->user_id = User::where('is_administrator', true)->firstOrFail()->id;
+        }
+
         foreach ($this->getDependents('manager') as $dependent) {
             $process->manager_id = $dependent->model->id;
         }


### PR DESCRIPTION
## Issue & Reproduction Steps

Some instances do have a user with the username 'admin'. The importer is looking for that user when importing some PM Blocks.

## Solution
- If no user_id is set, use the first admin user.

## How to Test
1. For your 'admin' user, change both their username and their email address
2. Sync pm blocks

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18160

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
