### PR TITLE
FOUR-17581 Fix Processes that are started with another thread do not display the screen

### DIFF
--- a/ProcessMaker/Events/RedirectToEvent.php
+++ b/ProcessMaker/Events/RedirectToEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Models\ProcessRequest;
+
+class RedirectToEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        private ProcessRequest $processRequest,
+        public string $method,
+        public array $params,
+    ) {
+        //
+    }
+
+    /**
+     * Get the Event name with the syntax ‘[Past-test Action] [Object]’
+     *
+     * @return string
+     */
+    public function getEventName(): string
+    {
+        return 'RedirectTo';
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('ProcessMaker.Models.ProcessRequest.' . $this->processRequest->getKey()),
+        ];
+    }
+}

--- a/ProcessMaker/Events/RedirectToEvent.php
+++ b/ProcessMaker/Events/RedirectToEvent.php
@@ -4,13 +4,18 @@ namespace ProcessMaker\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use ProcessMaker\Models\ProcessRequest;
 
-class RedirectToEvent
+class RedirectToEvent implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $payloadUrl;
+
+    private $processRequestToken;
 
     /**
      * Create a new event instance.
@@ -18,17 +23,17 @@ class RedirectToEvent
     public function __construct(
         private ProcessRequest $processRequest,
         public string $method,
-        public array $params,
+        public array $params
     ) {
         //
     }
 
     /**
-     * Get the Event name with the syntax ‘[Past-test Action] [Object]’
+     * Set the event name
      *
      * @return string
      */
-    public function getEventName(): string
+    public function broadcastAs()
     {
         return 'RedirectTo';
     }

--- a/ProcessMaker/Events/RedirectToEvent.php
+++ b/ProcessMaker/Events/RedirectToEvent.php
@@ -15,8 +15,6 @@ class RedirectToEvent implements ShouldBroadcastNow
 
     public $payloadUrl;
 
-    private $processRequestToken;
-
     /**
      * Create a new event instance.
      */

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -19,6 +19,7 @@ use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\Task as Resource;
 use ProcessMaker\Http\Resources\TaskCollection;
+use ProcessMaker\Listeners\HandleRedirectListener;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -245,6 +246,7 @@ class TaskController extends Controller
             $instance = $task->processRequest;
             TaskDraft::moveDraftFiles($task);
             WorkflowManager::completeTask($process, $instance, $task, $data);
+            HandleRedirectListener::sendRedirectToEvent();
 
             return new Resource($task->refresh());
         } elseif (!empty($request->input('user_id'))) {

--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use ProcessMaker\BpmnEngine;
 use ProcessMaker\Exception\HttpABTestingException;
+use ProcessMaker\Listeners\HandleRedirectListener;
 use ProcessMaker\Models\Process as Definitions;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestLock;
@@ -66,6 +67,8 @@ abstract class BpmnAction implements ShouldQueue
 
             // Run engine to the next state
             $this->engine->runToNextState();
+            // call to redirect when user task is assigned
+            HandleRedirectListener::sendRedirectToEvent();
         } catch (HttpABTestingException $exception) {
             Log::error($exception->getMessage());
             throw $exception;

--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -20,6 +20,10 @@ class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
     public function handle(ActivityAssigned $event): void
     {
         $request = $event->getProcessRequestToken()->getInstance();
+        if (empty($request)) {
+            return;
+        }
+
         $allowInterstitial = $event->getProcessRequestToken()->getInterstitial()['allow_interstitial'];
         if ($allowInterstitial) {
             $payloadUrl = route('tasks.edit', ['task' => $event->getProcessRequestToken()->id]);

--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -20,6 +20,19 @@ class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
     public function handle(ActivityAssigned $event): void
     {
         $request = $event->getProcessRequestToken()->getInstance();
-        $this->setRedirectTo($request, 'javascript:redirectToTask', $event->getProcessRequestToken()->id);
+        $allowInterstitial = $event->getProcessRequestToken()->getInterstitial()['allow_interstitial'];
+        if ($allowInterstitial) {
+            $payloadUrl = route('tasks.edit', ['task' => $event->getProcessRequestToken()->id]);
+        } else {
+            $payloadUrl = route('requests.show', ['request' => $event->getProcessRequestToken()->getAttribute('process_request_id')]);
+        }
+        $this->setRedirectTo($request,
+            'javascript:redirectToTask',
+            [
+                'payloadUrl' => $payloadUrl,
+                'tokenId' => $event->getProcessRequestToken()->id,
+                'allowInterstitial' => $event->getProcessRequestToken()->getInterstitial()['allow_interstitial'],
+            ]
+        );
     }
 }

--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -34,7 +34,7 @@ class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
             ]);
         }
         $this->setRedirectTo($request,
-            'javascript:redirectToTask',
+            'redirectToTask',
             [
                 'payloadUrl' => $payloadUrl,
                 'tokenId' => $event->getProcessRequestToken()->id,

--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ProcessMaker\Listeners;
+
+use ProcessMaker\Events\ActivityAssigned;
+
+class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(ActivityAssigned $event): void
+    {
+        $request = $event->getProcessRequestToken()->getInstance();
+        $this->setRedirectTo($request, 'javascript:redirectToTask', $event->getProcessRequestToken()->id);
+    }
+}

--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -28,7 +28,10 @@ class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
         if ($allowInterstitial) {
             $payloadUrl = route('tasks.edit', ['task' => $event->getProcessRequestToken()->id]);
         } else {
-            $payloadUrl = route('requests.show', ['request' => $event->getProcessRequestToken()->getAttribute('process_request_id')]);
+            $payloadUrl = route('requests.show', [
+                'request' => $event->getProcessRequestToken()
+                    ->getAttribute('process_request_id')
+            ]);
         }
         $this->setRedirectTo($request,
             'javascript:redirectToTask',

--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -6,13 +6,6 @@ use ProcessMaker\Events\ActivityAssigned;
 
 class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
 {
-    /**
-     * Create the event listener.
-     */
-    public function __construct()
-    {
-        //
-    }
 
     /**
      * Handle the event.

--- a/ProcessMaker/Listeners/HandleActivityCompletedRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityCompletedRedirect.php
@@ -17,6 +17,6 @@ class HandleActivityCompletedRedirect extends HandleRedirectListener
             return;
         }
 
-        $this->setRedirectTo($request, 'javascript:processUpdated', $event);
+        $this->setRedirectTo($request, 'processUpdated', $event);
     }
 }

--- a/ProcessMaker/Listeners/HandleActivityCompletedRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityCompletedRedirect.php
@@ -13,6 +13,10 @@ class HandleActivityCompletedRedirect extends HandleRedirectListener
     public function handle(ActivityCompleted $event): void
     {
         $request = $event->getProcessRequestToken()->getInstance();
+        if (empty($request)) {
+            return;
+        }
+
         $this->setRedirectTo($request, 'javascript:processUpdated', $event);
     }
 }

--- a/ProcessMaker/Listeners/HandleActivityCompletedRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityCompletedRedirect.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ProcessMaker\Listeners;
+
+use ProcessMaker\Events\ActivityCompleted;
+
+class HandleActivityCompletedRedirect extends HandleRedirectListener
+{
+
+    /**
+     * Handle the event.
+     */
+    public function handle(ActivityCompleted $event): void
+    {
+        $request = $event->getProcessRequestToken()->getInstance();
+        $this->setRedirectTo($request, 'javascript:processUpdated', $event);
+    }
+}

--- a/ProcessMaker/Listeners/HandleEndEventRedirect.php
+++ b/ProcessMaker/Listeners/HandleEndEventRedirect.php
@@ -7,13 +7,6 @@ use ProcessMaker\Events\ProcessCompleted;
 
 class HandleEndEventRedirect extends HandleRedirectListener
 {
-    /**
-     * Create the event listener.
-     */
-    public function __construct()
-    {
-        //
-    }
 
     /**
      * Handle the event.

--- a/ProcessMaker/Listeners/HandleEndEventRedirect.php
+++ b/ProcessMaker/Listeners/HandleEndEventRedirect.php
@@ -27,6 +27,6 @@ class HandleEndEventRedirect extends HandleRedirectListener
 
         $userId = Auth::id();
         $requestId = $event->getProcessRequest()->id;
-        $this->setRedirectTo($request, 'javascript:processCompletedRedirect', $event, $userId, $requestId);
+        $this->setRedirectTo($request, 'processCompletedRedirect', $event, $userId, $requestId);
     }
 }

--- a/ProcessMaker/Listeners/HandleEndEventRedirect.php
+++ b/ProcessMaker/Listeners/HandleEndEventRedirect.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ProcessMaker\Listeners;
+
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Events\ProcessCompleted;
+
+class HandleEndEventRedirect extends HandleRedirectListener
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(ProcessCompleted $event): void
+    {
+        $request = $event->getProcessRequest();
+        $userId = Auth::id();
+        $requestId = $event->getProcessRequest()->id;
+        $this->setRedirectTo($request, 'javascript:processCompletedRedirect', $event, $userId, $requestId);
+    }
+}

--- a/ProcessMaker/Listeners/HandleEndEventRedirect.php
+++ b/ProcessMaker/Listeners/HandleEndEventRedirect.php
@@ -21,6 +21,10 @@ class HandleEndEventRedirect extends HandleRedirectListener
     public function handle(ProcessCompleted $event): void
     {
         $request = $event->getProcessRequest();
+        if (empty($request)) {
+            return;
+        }
+
         $userId = Auth::id();
         $requestId = $event->getProcessRequest()->id;
         $this->setRedirectTo($request, 'javascript:processCompletedRedirect', $event, $userId, $requestId);

--- a/ProcessMaker/Listeners/HandleRedirectListener.php
+++ b/ProcessMaker/Listeners/HandleRedirectListener.php
@@ -7,8 +7,10 @@ use ProcessMaker\Models\ProcessRequest;
 
 class HandleRedirectListener
 {
-    private static $processRequest;
+    private static $processRequest = null;
+
     private static $redirectionMethod = '';
+
     private static $redirectionParams = [];
 
     protected function setRedirectTo(ProcessRequest $processRequest, string $method, ...$params): void
@@ -23,7 +25,14 @@ class HandleRedirectListener
         $method = self::$redirectionMethod;
         $params = self::$redirectionParams;
         $processRequest = self::$processRequest;
-        $event = new RedirectToEvent($processRequest, $method, $params);
-        event($event);
+
+        if ($processRequest !== null) {
+            $event = new RedirectToEvent($processRequest, $method, $params);
+            event($event);
+            // clean params to prevent send the same redirect multiple times
+            self::$redirectionParams = [];
+            self::$redirectionMethod = '';
+            self::$processRequest = null;
+        }
     }
 }

--- a/ProcessMaker/Listeners/HandleRedirectListener.php
+++ b/ProcessMaker/Listeners/HandleRedirectListener.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ProcessMaker\Listeners;
+
+use ProcessMaker\Events\RedirectToEvent;
+use ProcessMaker\Models\ProcessRequest;
+
+class HandleRedirectListener
+{
+    private static $processRequest;
+    private static $redirectionMethod = '';
+    private static $redirectionParams = [];
+
+    protected function setRedirectTo(ProcessRequest $processRequest, string $method, ...$params): void
+    {
+        self::$processRequest = $processRequest;
+        self::$redirectionMethod = $method;
+        self::$redirectionParams = $params;
+    }
+
+    public static function sendRedirectToEvent()
+    {
+        $method = self::$redirectionMethod;
+        $params = self::$redirectionParams;
+        $processRequest = self::$processRequest;
+        $event = new RedirectToEvent($processRequest, $method, $params);
+        event($event);
+    }
+}

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -3,6 +3,8 @@
 namespace ProcessMaker\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use ProcessMaker\Events\ActivityAssigned;
+use ProcessMaker\Events\ActivityCompleted;
 use ProcessMaker\Events\ActivityReassignment;
 use ProcessMaker\Events\AuthClientCreated;
 use ProcessMaker\Events\AuthClientDeleted;
@@ -25,6 +27,7 @@ use ProcessMaker\Events\GroupUpdated;
 use ProcessMaker\Events\GroupUsersUpdated;
 use ProcessMaker\Events\PermissionUpdated;
 use ProcessMaker\Events\ProcessArchived;
+use ProcessMaker\Events\ProcessCompleted;
 use ProcessMaker\Events\ProcessCreated;
 use ProcessMaker\Events\ProcessPublished;
 use ProcessMaker\Events\ProcessRestored;
@@ -58,6 +61,9 @@ use ProcessMaker\Events\UserDeleted;
 use ProcessMaker\Events\UserGroupMembershipUpdated;
 use ProcessMaker\Events\UserRestored;
 use ProcessMaker\Events\UserUpdated;
+use ProcessMaker\Listeners\HandleActivityAssignedInterstitialRedirect;
+use ProcessMaker\Listeners\HandleActivityCompletedRedirect;
+use ProcessMaker\Listeners\HandleEndEventRedirect;
 use ProcessMaker\Listeners\SecurityLogger;
 use ProcessMaker\Listeners\SessionControlSettingsUpdated;
 
@@ -90,6 +96,15 @@ class EventServiceProvider extends ServiceProvider
         ],
         SettingsUpdated::class => [
             SessionControlSettingsUpdated::class,
+        ],
+        ProcessCompleted::class => [
+            HandleEndEventRedirect::class,
+        ],
+        ActivityCompleted::class => [
+            HandleActivityCompletedRedirect::class,
+        ],
+        ActivityAssigned::class => [
+            HandleActivityAssignedInterstitialRedirect::class,
         ],
     ];
 

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -543,13 +543,6 @@
             if (this.task.component && this.task.component === 'AdvancedScreenFrame') {
               return;
             }
-
-            //if (endEventDestination) {
-            //  this.redirect(endEventDestination);
-            //  return;
-            //}
-//
-            // this.redirect(`/requests/${processRequestId}`);
           },
           error(processRequestId) {
             this.$refs.task.showSimpleErrorMessage();
@@ -563,12 +556,6 @@
             if (this.task.component && this.task.component === 'AdvancedScreenFrame') {
               return;
             }
-
-            if (elementDestination) {
-              this.redirect(elementDestination);
-              return;
-            }
-            console.log('closed');
             this.redirect("/tasks");
           },
           claimTask() {

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -544,12 +544,12 @@
               return;
             }
 
-            if (endEventDestination) {
-              this.redirect(endEventDestination);
-              return;
-            }
-
-            this.redirect(`/requests/${processRequestId}`);
+            //if (endEventDestination) {
+            //  this.redirect(endEventDestination);
+            //  return;
+            //}
+//
+            // this.redirect(`/requests/${processRequestId}`);
           },
           error(processRequestId) {
             this.$refs.task.showSimpleErrorMessage();

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -555,7 +555,8 @@
             this.$refs.task.showSimpleErrorMessage();
           },
           redirectToTask(task, force = false) {
-            this.redirect(`/tasks/${task}/edit`, force);
+            console.log('redirectToTask');
+            this.redirect(`/tasks/${task} /edit`, force);
           },
           closed(taskId, elementDestination = null) {
             // avoid redirection if using a customized renderer
@@ -567,7 +568,7 @@
               this.redirect(elementDestination);
               return;
             }
-
+            console.log('closed');
             this.redirect("/tasks");
           },
           claimTask() {

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -548,7 +548,7 @@
             this.$refs.task.showSimpleErrorMessage();
           },
           redirectToTask(task, force = false) {
-            this.redirect(`/tasks/${task} /edit`, force);
+            this.redirect(`/tasks/${task}/edit`, force);
           },
           closed(taskId, elementDestination = null) {
             // avoid redirection if using a customized renderer

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -548,7 +548,6 @@
             this.$refs.task.showSimpleErrorMessage();
           },
           redirectToTask(task, force = false) {
-            console.log('redirectToTask');
             this.redirect(`/tasks/${task} /edit`, force);
           },
           closed(taskId, elementDestination = null) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Fix Processes that are started with another thread do not display the screen

## Solution
- Use an specific event to handle the redirection.

## How to Test
Review the steps in ticket: https://processmaker.atlassian.net/browse/FOUR-17581

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17581

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:screen-builder:bugfix/FOUR-17581b
