### PR TITLE
FOUR-18255: Save filters when the user applies changes

### DIFF
--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -65,8 +65,7 @@ const PMColumnFilterCommonMixin = {
         filters: this.formattedFilter(),
         order
       };
-
-      if (!this.autosaveFilter) {
+      if (this.autosaveFilter) {
         ProcessMaker.apiClient.put(url, config);
       }
       window.ProcessMaker.advanced_filter = config;


### PR DESCRIPTION
## Issue & Reproduction Steps
Issue: Filters are not being saved on the Tasks and Case pages, leading to a frustrating user experience where applied filters are lost when the user refreshes the page or navigates away and then returns. This issue forces users to repeatedly re-apply their desired filters, disrupting their workflow and potentially leading to inefficiencies, especially for users who rely on specific filtered views to manage their tasks or cases effectively.

1. Navigate to the Cases or Tasks page.
2. Add a filter to the table.
![Screenshot 2024-08-23 at 3 12 11 PM](https://github.com/user-attachments/assets/3cfc0fe5-cc88-4e5c-918a-3f126740fbe8)

3. Refresh the page.
4. Return to the Cases or Tasks page.

**Current Behavior:**
Filters are cleared on the Tasks and Cases pages after refreshing or returning to the page.

**Expected Behavior:**
Filters should persist on the Tasks and Cases pages, ensuring that any filters applied by the user remain active even after navigating away from the page, refreshing the browser, or returning to the page later. 


## Solution
- Reverse the logic of autosaveFilter

## How to Test
Please follow the current behaivior and make sure the Expected Behavior is met.

## Related Tickets & Packages
- Ticket: [FOUR-18255](https://processmaker.atlassian.net/browse/FOUR-18255)
- ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
