### PR TITLE
FOUR-18163 the element destination configuration with custom dashboard is not imported

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -564,7 +564,7 @@ class ProcessExporter extends ExporterBase
                     // Set the new attribute value at the specified XPath
                     Utils::setAttributeAtXPath(
                         $this->model, $path, self::PM_ELEMENT_DESTINATION,
-                        htmlspecialchars($newElementDestination, ENT_QUOTES)
+                        $newElementDestination
                     );
                 }
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
The element destination configuration with a custom dashboard is not imported

### Current behavior
Element destination field contains `Task Source(Default)`

### Expected behavior
Element destination field should contain `Custom Dashboard`

## Solution
- Remove the htmlspecialchars fn from the elementDestination data due to the DB encoding

https://github.com/user-attachments/assets/99a8481f-5daf-403f-a509-75e0a7cbd8f9

## How to Test
see the ticket

## Related Tickets & Packages
[FOUR-18163](https://processmaker.atlassian.net/browse/FOUR-18163)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-18163]: https://processmaker.atlassian.net/browse/FOUR-18163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ