### PR TITLE
Remove and prevent duplicate default interstitials

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -419,7 +419,7 @@ class ScreenController extends Controller
         $request->validate(Screen::rules());
         $newScreen = new Screen();
 
-        $exclude = ['id', 'uuid', 'created_at', 'updated_at'];
+        $exclude = ['id', 'uuid', 'created_at', 'updated_at', 'key'];
         foreach ($screen->getAttributes() as $attribute => $value) {
             if (!in_array($attribute, $exclude)) {
                 $newScreen->{$attribute} = $screen->{$attribute};

--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -66,6 +66,11 @@ class ScreenExporter extends ExporterBase
         $this->associateCategories(ScreenCategory::class, 'screen_category_id');
         $screen->watchers = $watchers;
 
+        // There should only be one default interstitial screen
+        if ($screen->key === 'interstitial') {
+            $screen->key = null;
+        }
+
         $success = $screen->saveOrFail();
 
         return $success;

--- a/ProcessMaker/Jobs/SyncGuidedTemplates.php
+++ b/ProcessMaker/Jobs/SyncGuidedTemplates.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Log;
@@ -207,6 +208,10 @@ class SyncGuidedTemplates implements ShouldQueue
             if (in_array($asset['type'], ['Process', 'Screen', 'Script',
                 'Collections', 'DataConnector', 'ProcessTemplates'])) {
                 $payload['export'][$key]['attributes']['asset_type'] = $assetType;
+            }
+
+            if (Arr::get($asset, 'type') === 'Screen' && Arr::get($asset, 'attributes.key') === 'interstitial') {
+                $payload['export'][$key]['attributes']['key'] = null;
             }
         }
 

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -183,7 +183,11 @@ export default {
       }
 
       ProcessMaker.apiClient
-        .get("screens", { params: { key: this.defaultKey } })
+        .get("screens", { params: { 
+          key: this.defaultKey,
+          order_by: "id",
+          order_direction: "ASC"
+        }})
         .then(({ data }) => {
           this.content = data.data[0];
         });

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -186,7 +186,8 @@ export default {
         .get("screens", { params: { 
           key: this.defaultKey,
           order_by: "id",
-          order_direction: "ASC"
+          order_direction: "ASC",
+          per_page: 1,
         }})
         .then(({ data }) => {
           this.content = data.data[0];

--- a/upgrades/2024_08_26_205409_remove_interstitial_keys.php
+++ b/upgrades/2024_08_26_205409_remove_interstitial_keys.php
@@ -1,0 +1,52 @@
+<?php
+
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class RemoveInterstitialKeys extends Upgrade
+{
+    /**
+     * Run any validations/pre-run checks to ensure the environment, settings,
+     * packages installed, etc. are right correct to run this upgrade.
+     *
+     * Throw a \RuntimeException if the conditions are *NOT* correct for this
+     * upgrade migration to run. If this is not a required upgrade, then it
+     * will be skipped. Otherwise the exception thrown will be caught, noted,
+     * and will prevent the remaining migrations from continuing to run.
+     *
+     * Returning void or null denotes the checks were successful.
+     *
+     * @return void
+     *
+     * @throws RuntimeException
+     */
+    public function preflightChecks()
+    {
+        //
+    }
+
+    /**
+     * Run the upgrade migration.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $firstInterstitial = Screen::where('key', 'interstitial')->orderBy('id', 'ASC')->first();
+        if (!$firstInterstitial) {
+            return;
+        }
+        Screen::where('key', 'interstitial')
+            ->whereNot('id', $firstInterstitial->id)
+            ->update(['key' => null]);
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/upgrades/2024_08_26_205409_remove_interstitial_keys.php
+++ b/upgrades/2024_08_26_205409_remove_interstitial_keys.php
@@ -41,6 +41,10 @@ class RemoveInterstitialKeys extends Upgrade
         Screen::where('key', 'interstitial')
             ->whereNot('id', $firstInterstitial->id)
             ->update(['key' => null]);
+
+        $firstInterstitial->title = 'Screen Interstitial';
+        $firstInterstitial->asset_type = null;
+        $firstInterstitial->save();
     }
 
     /**

--- a/upgrades/2024_08_26_205409_remove_interstitial_keys.php
+++ b/upgrades/2024_08_26_205409_remove_interstitial_keys.php
@@ -32,7 +32,9 @@ class RemoveInterstitialKeys extends Upgrade
      */
     public function up()
     {
-        $firstInterstitial = Screen::where('key', 'interstitial')->orderBy('id', 'ASC')->first();
+        $firstInterstitial = Screen::where('key', 'interstitial')
+            ->where('description', 'Screen for the interstitial')
+            ->orderBy('id', 'ASC')->first();
         if (!$firstInterstitial) {
             return;
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
See issue https://processmaker.atlassian.net/browse/FOUR-18820

## Solution
- Remove 'interstitial' key when importing and cloning
- Add an upgrade script to clear all other 'interstitial' keys

## How to Test
See issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18820

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next