### PR TITLE
Temporary Fix for Redirecting After Completion of Guided Helper Processes

### DIFF
--- a/ProcessMaker/Events/ProcessCompleted.php
+++ b/ProcessMaker/Events/ProcessCompleted.php
@@ -28,7 +28,10 @@ class ProcessCompleted implements ShouldBroadcastNow
     {
         $this->payloadUrl = route('api.requests.show', ['request' => $processRequest->getKey()]);
         $this->processRequest = $processRequest;
-        $this->endEventDestination = $processRequest->getElementDestination();
+
+        if ($processRequest->asset_type !== 'GUIDED_HELPER_PROCESS') {
+            $this->endEventDestination = $processRequest->getElementDestination();
+        }
     }
 
     /**

--- a/ProcessMaker/Events/ProcessCompleted.php
+++ b/ProcessMaker/Events/ProcessCompleted.php
@@ -29,7 +29,7 @@ class ProcessCompleted implements ShouldBroadcastNow
         $this->payloadUrl = route('api.requests.show', ['request' => $processRequest->getKey()]);
         $this->processRequest = $processRequest;
 
-        if ($processRequest->asset_type !== 'GUIDED_HELPER_PROCESS') {
+        if ($processRequest->process->asset_type !== 'GUIDED_HELPER_PROCESS') {
             $this->endEventDestination = $processRequest->getElementDestination();
         }
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
 This PR introduces a temporary solution to address the redirect issue when a guided helper process is completed. The issue arises from the Element Destination configuration, which incorrectly redirects the user to the Summary page instead of the desired launchpad location. The solution involves differentiating the behavior for guided helper processes and redirecting the user to the Launchpad of the newly created process.

## Solution
- Temporary Redirect Fix
   - Implement a conditional check for `processRequest->process->asset_type` to determine if the `asset_type` is `GUIDED_HELPER_PROCESS`
   - If the `asset_type` is not `GUIDED_HELPER_PROCESS` , the existing endEvent destination logic is executed.
   - If the `asset_type` is `GUIDED_HELPER_PROCESS` ,  the logic to import the process template and redirect to the launchpad of the process is executed.

ci:next
..

## How to Test
1. Run the Expense Report guided template
2. Ensure you are redirected to either the 'Asset management' page or the 'Launchpad' of the newly created process.

## Related Tickets & Packages
- [FOUR-18840](https://processmaker.atlassian.net/browse/FOUR-18840)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-18840]: https://processmaker.atlassian.net/browse/FOUR-18840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ