### PR TITLE
FOUR-17278 Remove temporal files from failing script tasks

### DIFF
--- a/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
@@ -2,7 +2,7 @@
 
 namespace ProcessMaker\Models;
 
-use Log;
+use Illuminate\Support\Facades\Log;
 use ProcessMaker\Exception\ScriptException;
 use ProcessMaker\Exception\ScriptTimeoutException;
 use ProcessMaker\Facades\Docker;
@@ -75,6 +75,7 @@ trait ScriptDockerBindingFilesTrait
         if ($returnCode) {
             if ($returnCode == 137 || $returnCode == 9) {
                 Log::error('Script timed out');
+                $this->removeTemporalFiles();
                 throw new ScriptTimeoutException(
                     __('Script took too long to complete. Consider increasing the timeout.')
                   . "\n"
@@ -88,6 +89,7 @@ trait ScriptDockerBindingFilesTrait
             $message = implode("\n", $output);
             $message .= "\n\nProcessMaker Stack:\n";
             $message .= (new \Exception)->getTraceAsString();
+            $this->removeTemporalFiles();
             throw new ScriptException($message);
         }
         $outputs = $this->getOutputFilesContent();

--- a/upgrades/2024_08_26_220829_remove_old_script_files.php
+++ b/upgrades/2024_08_26_220829_remove_old_script_files.php
@@ -1,0 +1,46 @@
+<?php
+
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class RemoveOldScriptFiles extends Upgrade
+{
+    /**
+     * Run the upgrade migration.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Remove old script input files (with prefix `put`)
+        $path = config('app.processmaker_scripts_home');
+        $files = glob($path . '/put*');
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        // Remove old script files with prefix `get`
+        $path = config('app.processmaker_scripts_home');
+        $files = glob($path . '/get*');
+        $timeNow = time();
+
+        foreach ($files as $file) {
+            // Verify if the file was created 1 hour ago or more
+            if (filemtime($file) <= ($timeNow - 3600)) {
+                unlink($file);
+            }
+        }
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}
+


### PR DESCRIPTION
## When a script task fails it keeps the data it uses to run
This cause the disk get filled during the time and when there are lots of scripts failing.

## Solution
- Remove the temporal fails even if script task fails, since the log and data is available in the DB
- Remove old temporal files

## How to Test
- Update the environment (php artisan upgrade).
- Check that the `config('app.processmaker_scripts_home')` folder is empty unless it have pending script for a window of 1 hour.
- Run an script with an exception. e.g.
```
<?php 
sleep(5);
throw new Exception("!!");

return [];
```
- Check that the `config('app.processmaker_scripts_home')` folder is empty

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17278

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
