### PR TITLE
FOUR-17398 Date filter is shown in ISO 8601 format and in UTC confusi…

### DIFF
--- a/resources/js/common/advancedFilterStatusMixin.js
+++ b/resources/js/common/advancedFilterStatusMixin.js
@@ -26,7 +26,8 @@ export default {
   },
   methods: {
     setAdvancedFilter() {
-      this.advancedFilter = get(this.advancedFilterProp, 'filters') || get(window, 'ProcessMaker.advanced_filter.filters', []);
+      this.advancedFilter = get(this.advancedFilterProp, 'filters') || 
+              get(window, 'ProcessMaker.advanced_filter.filters', []);
       this.$refs.pmqlInputFilters?.buildPmql();
     },
     formatForBadge(filters, result) {
@@ -36,7 +37,13 @@ export default {
         }
         result.push([
           this.formatBadgeSubject(filter),
-          [{name: this.formatBadgeValue(filter), operator: filter.operator, advanced_filter: true}]
+          [
+            {
+              name: this.formatBadgeValue(filter),
+              operator: filter.operator,
+              advanced_filter: true
+            }
+          ]
         ]);
 
         if (filter.or && filter.or.length > 0) {
@@ -51,7 +58,29 @@ export default {
       if ('_display_value' in filter) {
         return filter._display_value;
       }
-      return filter.value
+      if (this.isDatetime(filter.value)) {
+        return this.formatDatetime(filter.value);
+      }
+      if (Array.isArray(filter.value)) {
+        let copyArray = [...filter.value];
+        for (let i = 0; i < copyArray.length; i++) {
+          let cell = copyArray[i];
+          if (this.isDatetime(cell)) {
+            copyArray[i] = this.formatDatetime(cell);
+          }
+        }
+        return copyArray;
+      }
+      return filter.value;
+    },
+    isDatetime(value) {
+      let date = new Date(value);
+      return date instanceof Date && !isNaN(date);
+    },
+    formatDatetime(value) {
+      return moment(value)
+              .tz(window.ProcessMaker.user.timezone)
+              .format(window.ProcessMaker.user.datetime_format);
     }
   },
   computed: {

--- a/resources/js/components/PMColumnFilterPopover/PMColumnFilterOpDatetime.vue
+++ b/resources/js/components/PMColumnFilterPopover/PMColumnFilterOpDatetime.vue
@@ -1,131 +1,43 @@
 <template>
-  <div class="pm-column-filter-op-datetime">
-    <b-form-input v-model="input"
-                  type="text"
-                  placeholder="YYYY-MM-DD"
-                  autocomplete="off"
-                  readonly
-                  size="sm">
-    </b-form-input>
-    <b-form-datepicker v-model="selectedDate"
-                       button-only
-                       right
-                       size="sm"
-                       label-help=""
-                       boundary="window"
-                       :hide-header="true"
-                       button-variant="outline-secondary"
-                       class="pm-column-filter-op-button">
-    </b-form-datepicker>
-    <b-form-timepicker v-model="selectedTime"
-                       button-only
-                       show-seconds
-                       right
-                       size="sm"
-                       boundary="window"
-                       button-variant="outline-secondary"
-                       class="pm-column-filter-op-button">
-    </b-form-timepicker>
-  </div>
+  <PMDatetimePicker v-model="input"
+                    :placeholder="format"
+                    :format="format"
+                    :withTime="true"
+                    :size="'sm'"
+                    :timeZone="timeZone"
+                    :guestTimeZone="timeZone">
+  </PMDatetimePicker>
 </template>
 
 <script>
+  import PMDatetimePicker from "../../components/PMDatetimePicker.vue";
   export default {
-    props: [
-      "value"
-    ],
+    components: {
+      PMDatetimePicker
+    },
+    props: {
+      value: {
+        type: null,
+        default: ""
+      }
+    },
     data() {
       return {
-        input: "",
-        selectedDate: "",
-        selectedTime: ""
+        input: this.value,
+        format: window.ProcessMaker.user.datetime_format,
+        timeZone: window.ProcessMaker.user.timezone
       };
     },
     watch: {
       value: {
         handler(newValue) {
-          this.input = this.convertFromISOString(newValue);
+          this.input = newValue;
         },
         immediate: true
       },
       input() {
-        this.emitInput();
-      },
-      selectedDate() {
-        this.setInput();
-      },
-      selectedTime() {
-        this.setInput();
-      }
-    },
-    mounted() {
-      this.selectedDate = this.getCurrentDate(this.input);
-      this.selectedTime = this.getCurrentTime(this.input);
-    },
-    methods: {
-      convertToISOString(dateString) {
-        let inUTCTimeZone = "";
-        if (dateString) {
-          inUTCTimeZone = moment(dateString).tz('UTC').toISOString();
-        }
-        return inUTCTimeZone;
-      },
-      convertFromISOString(dateString) {
-        let inLocalTimeZone = dateString;
-        if (dateString) {
-          inLocalTimeZone = moment(dateString).tz(window.ProcessMaker.user.timezone).format("YYYY-MM-DD HH:mm:ss");
-        }
-        return inLocalTimeZone;
-      },
-      emitInput() {
-        this.$emit("input", this.convertToISOString(this.input));
-      },
-      setInput() {
-        this.input = this.selectedDate + " " + this.selectedTime;
-      },
-      currentDate() {
-        let date = new Date();
-        return date.toISOString().split("T")[0];
-      },
-      isDatetime(string) {
-        const date = new Date(string);
-        return !isNaN(date.getTime()) && /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(string);
-      },
-      getCurrentDate(newValue) {
-        if (this.isDatetime(newValue)) {
-          let s = newValue.trim().split(" ");
-          return s[0];
-        } else {
-          return this.currentDate();
-        }
-      },
-      getCurrentTime(newValue) {
-        if (this.isDatetime(newValue)) {
-          let s = newValue.trim().split(" ");
-          return s.length > 1 ? s[1] : "00:00:00";
-        } else {
-          return "00:00:00";
-        }
+        this.$emit("input", this.input);
       }
     }
   };
 </script>
-
-<style>
-  .pm-column-filter-op-button > button{
-    border-color: #ced4da;
-    border-left: 0px;
-    border-top-left-radius: 0px;
-    border-bottom-left-radius: 0px;
-    padding: 2px;
-  }
-</style>
-<style scoped>
-  .pm-column-filter-op-datetime{
-    display: inline-flex;
-  }
-  .pm-column-filter-op-datetime > input{
-    border-top-right-radius: 0px;
-    border-bottom-right-radius: 0px;
-  }
-</style>


### PR DESCRIPTION
## Issue & Reproduction Steps
Date filters are shown in ISO 8601 format and UTC time
In the screenshot above, note that even though the date and time selected in the filter was 2024-07-26 00:00:00, the filter is showing 2024-07-26T04:00:00.000Z
This causes confusion in end users since they believe the time used are incorrect.

## Solution
Date filters should be shown in user’s date and time format and user’s timezone.
The control has been changed; it now uses the PMDatetimePicker component, which is an improved version that supports date and time formatting. Please perform a quick test of its functionality.

## Related Tickets & Packages
[- Link to any related FOUR tickets, PRDs, or packages
](https://processmaker.atlassian.net/browse/FOUR-17398)

ci:next

