### PR TITLE
FOUR-18860 Fix User completes a task and is assigned the next one is not redirected to form the next task

### DIFF
--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -31,6 +31,7 @@ class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
                 'payloadUrl' => $payloadUrl,
                 'tokenId' => $event->getProcessRequestToken()->id,
                 'nodeId' => $event->getProcessRequestToken()->element_id,
+                'userId' => $event->getProcessRequestToken()->user_id,
                 'allowInterstitial' => $event->getProcessRequestToken()->getInterstitial()['allow_interstitial'],
             ]
         );


### PR DESCRIPTION
## Issue & Reproduction Steps

The redirect to next task was working only with interstitial enabled
This PR is required by: https://github.com/ProcessMaker/screen-builder/pull/1678

## Solution
- Enable redirect to next task when the next assigned user is the same of the current task as defined in the PRD

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18860

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
