### PR TITLE
Add all_tasks property to tasks endpoint

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -74,6 +74,15 @@ class TaskController extends Controller
      *           type="integer",
      *         )
      *     ),
+     *     @OA\Parameter(
+     *         description="Return all task types. Not just user tasks.",
+     *         in="query",
+     *         name="all_tasks",
+     *         required=false,
+     *         @OA\Schema(
+     *           type="boolean",
+     *         )
+     *     ),
      *     @OA\Parameter(ref="#/components/parameters/filter"),
      *     @OA\Parameter(ref="#/components/parameters/order_by"),
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -114,7 +114,8 @@ trait TaskControllerIndexMethods
     private function excludeNonVisibleTasks($query, $request)
     {
         $nonSystem = filter_var($request->input('non_system'), FILTER_VALIDATE_BOOLEAN);
-        $query->where(function ($query) {
+        $allTasks = filter_var($request->input('all_tasks'), FILTER_VALIDATE_BOOLEAN);
+        $query->when(!$allTasks, function ($query) {
             $query->where('element_type', '=', 'task');
             $query->orWhere('element_type', '=', 'serviceTask');
             $query->where('element_name', '=', 'AI Assistant');

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -4536,6 +4536,15 @@
                         }
                     },
                     {
+                        "name": "all_tasks",
+                        "in": "query",
+                        "description": "Return all task types. Not just user tasks.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "$ref": "#/components/parameters/filter"
                     },
                     {


### PR DESCRIPTION
See https://processmaker.atlassian.net/browse/FOUR-18842

Return all tasks types by adding all_tasks=true, for example

`/api/1.0/tasks?pmql=process_request_id%20%3D%202&all_tasks=true`

ci:next