### PR TITLE
bugfix/FOUR-17639: Unread tasks marked as read when preview is used

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -27,6 +27,7 @@ use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\TaskDraft;
 use ProcessMaker\Models\User;
+use ProcessMaker\Models\UserResourceView;
 use ProcessMaker\Notifications\TaskReassignmentNotification;
 use ProcessMaker\Query\SyntaxError;
 use ProcessMaker\SanitizeHelper;
@@ -282,6 +283,11 @@ class TaskController extends Controller
     {
         // Authorized in policy
         return new ApiResource($screen->versionFor($task->processRequest));
+    }
+
+    public function setViewed(Request $request, ProcessRequestToken $task)
+    {
+        return UserResourceView::setViewed(Auth::user(), $task);
     }
 
     public function eligibleRollbackTask(Request $request, ProcessRequestToken $task)

--- a/resources/js/tasks/components/PreviewMixin.js
+++ b/resources/js/tasks/components/PreviewMixin.js
@@ -79,6 +79,10 @@ const PreviewMixin = {
       if (size) {
         this.splitpaneSize = size;
       }
+
+      // Set Task as read upon preview
+      this.$emit('onSetViewed', info);
+
       let param = "";
       this.stopFrame = false;
       this.taskTitle = info.element_name;

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -219,6 +219,7 @@
       ref="preview"
       @mark-selected-row="markSelectedRow"
       :tooltip-button="tooltipFromButton"
+      @onSetViewed="setViewed"
       @onWatchShowPreview="onWatchShowPreview"
     >
       <template v-slot:header="{ close, screenFilteredTaskData, taskReady }">
@@ -647,6 +648,21 @@ export default {
       this.tooltipFromButton = fromButton;
       this.selectedRow = info.id;
       this.$refs.preview.showSideBar(info, this.data.data, true, size);
+    },
+    setViewed(task) {
+      const url = `tasks/${task.id}/setViewed`;
+      const params = {
+        id: task.id
+      };
+      ProcessMaker.apiClient
+        .post(url, params)
+        .then(
+          (response) => {
+            let taskToUpdate = this.data.data.findIndex(data => data.uuid === task.uuid);
+            this.data.data[taskToUpdate].user_viewed_at = response.data.created_at;
+          }
+        )
+        .catch((err) => {});
     },
     formatStatus(props) {
       let color = "success";

--- a/routes/api.php
+++ b/routes/api.php
@@ -194,6 +194,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('tasks/{task}/screens/{screen}', [TaskController::class, 'getScreen'])->name('tasks.get_screen')->middleware('can:viewScreen,task,screen');
     Route::get('tasks/{task}/eligibleRollbackTask', [TaskController::class, 'eligibleRollbackTask'])->name('tasks.eligible_rollback_task')->middleware('can:rollback,task');
     Route::post('tasks/{task}/rollback', [TaskController::class, 'rollbackTask'])->name('tasks.rollback_task')->middleware('can:rollback,task');
+    Route::post('tasks/{task}/setViewed', [TaskController::class, 'setViewed'])->name('tasks.set_viewed')->middleware('can:viewScreen,task,screen');
     Route::put('tasks/{task}/setPriority', [TaskController::class, 'setPriority'])->name('tasks.priority');
 
     // TaskDrafts


### PR DESCRIPTION
## Tickets solved by this PR:
- https://processmaker.atlassian.net/browse/FOUR-17639

## Solution
- Added endpoint `setViewed` to mark task as read.
- Added method on TaskList to trigger endpoint when task is previewed


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next