### PR TITLE
FOUR-18876 Fix Wrong german label for Elementziel

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -307,7 +307,7 @@
   "Element is missing label/name": "Dem Element fehlt eine Bezeichnung oder ein Name",
   "Element is not connected": "Das Element ist nicht verbunden",
   "Element": "Element",
-  "Element Destination": "„Elementziel",
+  "Element Destination": "Elementziel",
   "Email Address": "E-Mail-Adresse",
   "Email": "E-Mail",
   "Enable": "Aktivieren",


### PR DESCRIPTION
## Issue & Reproduction Steps
Wrong german label for Elementziel

## Solution
- Fix the label.

## How to Test

1. With a user with German language
2. Open a process in modeler
3. Select a Task or End Event
4. Note the Elementziel has a sign „
5. 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18876

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
