### PR TITLE
FOUR-18184:Add the component auto save instead the notification in Web

### DIFF
--- a/resources/js/tasks/components/TaskSaveNotification.vue
+++ b/resources/js/tasks/components/TaskSaveNotification.vue
@@ -1,17 +1,27 @@
 <template>
   <div>
-    <div
-      class="btn text-black text-capitalize cursor-default"
-    >
+    <div class="btn text-black text-capitalize cursor-default">
       <div class="toolbar-item d-flex align-items-center">
-        <span>
+        <div class="save-date">
+          <span
+            v-if="size === 0"
+            class="autosave-draft-date"
+          >
+            {{ date }}
+          </span>
           <FontAwesomeIcon
             v-if="task.draft"
             :class="{ 'text-success': !error, 'text-secondary': error }"
             :icon="icon"
             :spin="isLoading"
           />
-        </span>
+          <span
+            v-if="size === 0"
+            class="autosave-draft-date"
+          >
+            {{ $t("Saved") }}
+          </span>
+        </div>
         <span
           id="saved-status"
           class="element-name truncate-text"
@@ -19,8 +29,7 @@
             maxWidth: `${size}px`
           }"
           v-html="sanitizeHtml(task.element_name)"
-        >
-        </span>
+        />
       </div>
     </div>
     <b-tooltip
@@ -32,11 +41,22 @@
         {{ task.process_request.case_title }}
       </div>
       <div class="tooltip-draft-date">
-        <FontAwesomeIcon v-if="!error" class="text-success" :icon="savedIcon" />
-        {{ $t('Last Autosave: ')+date }}
+        <FontAwesomeIcon
+          v-if="!error"
+          class="text-success"
+          :icon="savedIcon"
+        />
+        {{ $t('Last Autosave: ') + date }}
       </div>
-      <div v-if="error" class="tooltip-draft-error">
-        <FontAwesomeIcon v-if="error" class="text-secondary" :icon="errorIcon " />
+      <div
+        v-if="error"
+        class="tooltip-draft-error"
+      >
+        <FontAwesomeIcon
+          v-if="error"
+          class="text-secondary"
+          :icon="errorIcon "
+        />
         <span>{{ $t('Unable to save. Verify your internet connection.') }}
         </span>
       </div>
@@ -124,14 +144,14 @@ export default {
       return this.removeScriptsHtml(html);
     },
     removeScriptsHtml(input) {
-      const doc = new DOMParser().parseFromString(input, 'text/html');
+      const doc = new DOMParser().parseFromString(input, "text/html");
 
-      const scripts = doc.querySelectorAll('script');
+      const scripts = doc.querySelectorAll("script");
       scripts.forEach((script) => {
         script.remove();
       });
 
-      const styles = doc.querySelectorAll('style');
+      const styles = doc.querySelectorAll("style");
       styles.forEach((style) => {
         style.remove();
       });
@@ -193,5 +213,10 @@ export default {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+.save-date {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
 }
 </style>

--- a/resources/js/tasks/show.js
+++ b/resources/js/tasks/show.js
@@ -13,6 +13,7 @@ import TasksList from "./components/TasksList.vue";
 import TaskSavePanel from "./components/TaskSavePanel.vue";
 import autosaveMixins from "../modules/autosave/autosaveMixin";
 import draftFileUploadMixin from "../modules/autosave/draftFileUploadMixin";
+import TaskSaveNotification from "./components/TaskSaveNotification.vue";
 
 Vue.use(Vuex);
 Vue.use("task", Task);
@@ -25,6 +26,7 @@ Vue.component("TimelineItem", TimelineItem);
 Vue.component("QuickFillPreview", QuickFillPreview);
 Vue.component("TasksList", TasksList);
 Vue.component("TaskSavePanel", TaskSavePanel);
+Vue.component("TaskSaveNotification", TaskSaveNotification);
 
 Vue.mixin(autosaveMixins);
 Vue.mixin(draftFileUploadMixin);

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -715,7 +715,6 @@
               return ProcessMaker.apiClient
               .put("drafts/" + this.task.id, draftData)
               .then((response) => {
-                // ProcessMaker.alert(this.$t('Saved'), 'success')
                 this.task.draft = _.merge(
                   {},
                   this.task.draft,

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -146,7 +146,15 @@
                         <div class="card collapse-content">
                           <ul class="list-group list-group-flush w-100">
                             <li class="list-group-item">
-                              <!-- ADD THE OTHER BUTTONS -->
+                            <div class="row justify-content-start pb-1">
+                              <task-save-notification
+                                :options="options"
+                                :task="task"
+                                :date="lastAutosaveNav"
+                                :error="errorAutosave"
+                                :form-data="formData"
+                              />
+                            </div>
                               <div class="row button-group">
                                 <div class="col-6">
                                   <button
@@ -435,6 +443,7 @@
             is_loading: false,
           },
           lastAutosave: "-",
+          lastAutosaveNav: "-",
           errorAutosave: false,
           formDataWatcherActive: true,
           showTabs: true,
@@ -453,8 +462,10 @@
               }
               if (task.draft) {
                 this.lastAutosave = moment(task.draft.updated_at).format("DD MMMM YYYY | HH:mm");
+                this.lastAutosaveNav = moment(task.draft.updated_at).format("MMM DD, YYYY / HH:mm");
               } else {
                 this.lastAutosave = "-";
+                this.lastAutosaveNav = "-"
               }
             }
           },
@@ -704,7 +715,7 @@
               return ProcessMaker.apiClient
               .put("drafts/" + this.task.id, draftData)
               .then((response) => {
-                ProcessMaker.alert(this.$t('Saved'), 'success')
+                // ProcessMaker.alert(this.$t('Saved'), 'success')
                 this.task.draft = _.merge(
                   {},
                   this.task.draft,


### PR DESCRIPTION
## Issue & Reproduction Steps
Add the component auto save instead the notification in Web
## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18184

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next