### PR TITLE
FOUR-17348 Users endpoint being called in Requests/Cases and Tasks tr…

### DIFF
--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -14,9 +14,7 @@ const PMColumnFilterCommonMixin = {
   data() {
     return {
       advancedFilter: {},
-      userId: window.Processmaker.userId,
-      viewAssignee: [],
-      viewParticipants: [],
+      userId: window.Processmaker.userId
     };
   },
   watch: {

--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -260,26 +260,6 @@ const PMColumnFilterCommonMixin = {
 
       return operators;
     },
-    getAssignee(filter) {
-      ProcessMaker.apiClient.get(this.getUrlUsers(filter)).then(response => {
-        for (let i in response.data.data) {
-          this.viewAssignee.push({
-            text: response.data.data[i].username,
-            value: response.data.data[i].id
-          });
-        }
-      });
-    },
-    getParticipants(filter) {
-      ProcessMaker.apiClient.get(this.getUrlUsers(filter)).then(response => {
-        for (let i in response.data.data) {
-          this.viewParticipants.push({
-            text: response.data.data[i].username,
-            value: response.data.data[i].id
-          });
-        }
-      });
-    },
     advancedFilterInit() {
       for (let i in this.tableHeaders) {
         if (!(this.tableHeaders[i].field in this.advancedFilter)) {

--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -215,7 +215,6 @@ export default {
     },
   },
   mounted() {
-    this.getParticipants("");
     this.setupColumns();
     this.getFilterConfiguration();
   },

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -455,7 +455,6 @@ export default {
     },
   },
   mounted: function mounted() {
-    this.getAssignee("");
     this.setupColumns();
     this.getFilterConfiguration();
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Open Chrome Dev Tools (or any other tool to catch XHRs in browsers)
Go to Cases/Requests or Tasks
Filter calls in dev tools for “users” criteria
Click on the users endpoint
Click the Preview Tab
You will see all the information for users including phones, emails, addresses, etc.
GET /users endpoint is being called from Requests/Cases and Tasks trays exposing user information unnecessarily

## Solution
The functions `this.getParticipants("");` and `this.getAssignee("");` have become obsolete, and their usage has been deprecated. Therefore, they have been removed.

## How to Test
When Requests/Cases are called, the GET /users endpoint must not be called.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17348
- ci:next
