### PR TITLE
Feature/FOUR-18107: STORY Collection Record Control in Form Screens

### DIFF
--- a/resources/js/processes/screen-builder/typeDisplay.js
+++ b/resources/js/processes/screen-builder/typeDisplay.js
@@ -15,6 +15,7 @@ const FormNestedScreen = FormBuilderControls.find((control) => control.rendererB
 const FileDownloadControl = FormBuilderControls.find((control) => control.builderBinding === "FileDownload");
 const FormListTable = FormBuilderControls.find((control) => control.rendererBinding === "FormListTable");
 const FormAnalyticsChart = FormBuilderControls.find((control) => control.rendererBinding === "FormAnalyticsChart");
+const FormCollectionRecordControl = FormBuilderControls.find((control) => control.rendererBinding === "FormCollectionRecordControl");
 // Remove editable inspector props
 FormRecordList.control.inspector = FormRecordList.control.inspector.filter((prop) => prop.field !== "editable" && prop.field !== "form");
 
@@ -32,6 +33,7 @@ const controlsDisplay = [
   FileDownloadControl,
   FormListTable,
   FormAnalyticsChart,
+  FormCollectionRecordControl,
 ];
 
 ProcessMaker.EventBus.$on("screen-builder-init", (manager) => {


### PR DESCRIPTION
## Information
-This PR is related with other Screen-Builder Pull
 
## Solution
- A new control Collection Record Control was added to Screen Builder

## How to Test
- Login PM4
- Create a new Screen
- In Screen Builder got to Content fields section
- Drag Collection Record Control
- Select a collection from dropdown
- Enter an existing Record ID
- Choose Mode "Edit" by default or "View"

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-18107

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next