### PR TITLE
FOUR-18004 Add a env variable SWAGGER_AUTH_REQUIRED to enable the auth for swagger routes

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,5 +1,16 @@
 <?php
 
+// Middlewares required to use swagger with authentication
+$authMiddleware = [
+    \ProcessMaker\Http\Middleware\EncryptCookies::class,
+    \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+    \Illuminate\Session\Middleware\StartSession::class,
+    \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+    \Illuminate\Routing\Middleware\SubstituteBindings::class,
+    \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
+    'auth',
+];
+
 return [
     'default' => 'default',
     'documentations' => [
@@ -64,18 +75,9 @@ return [
              * Middleware allows to prevent unexpected access to API documentation
             */
             'middleware' => [
-                'api' => [
-                    // \App\Http\Middleware\EncryptCookies::class,
-                    // \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-                    // \Illuminate\Session\Middleware\StartSession::class,
-                    // \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-                    // \App\Http\Middleware\VerifyCsrfToken::class,
-                    // \Illuminate\Routing\Middleware\SubstituteBindings::class,
-                    // \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
-                    // 'auth',
-                ],
+                'api' => env('SWAGGER_AUTH_REQUIRED') ? $authMiddleware : [],
                 'asset' => [],
-                'docs' => [],
+                'docs' => env('SWAGGER_AUTH_REQUIRED') ? $authMiddleware : [],
                 'oauth2_callback' => [],
             ],
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently by default swaggers is accessible without a valid session.

## Solution
- Add an environment variable to require a valid login to use and access swagger routes (docs and api) assets and oauth_callback must be public.

https://github.com/user-attachments/assets/5be84705-9e27-45a1-8be9-c035ca545c04


## How to Test
Configure the env variable:
```
SWAGGER_AUTH_REQUIRED=true
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18004

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
