### PR TITLE
FOUR-16700: XSS via PDF File Upload

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -435,7 +435,7 @@ class ProcessRequestFileController extends Controller
 
         foreach ($jsKeywords as $keyword) {
             if (strpos($text, $keyword) !== false) {
-                $errors[] = __('Dangerous PDF file content.');
+                $errors[] = __('Dangerous PDF file content');
                 break;
             }
         }

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -290,6 +290,12 @@ class ProcessRequestFileController extends Controller
      */
     private function saveUploadedFile(UploadedFile $file, ProcessRequest $processRequest, Request $laravelRequest)
     {
+        $errors = [];
+        $this->validateFile($file, $errors);
+        if (count($errors) > 0) {
+            return abort(response($errors , 422));
+        }
+
         $parentId = $processRequest->parent_request_id;
         $parentRequest = $processRequest;
 
@@ -410,5 +416,30 @@ class ProcessRequestFileController extends Controller
         FilesDeleted::dispatch($fileId, $file->file_name);
 
         return response([], 204);
+    }
+
+    private function validateFile(UploadedFile $file, &$errors)
+    {
+        if (strtolower($file->getClientOriginalExtension() === 'pdf')) {
+             $this->validatePDFFile($file, $errors);
+        }
+
+        return $errors;
+    }
+
+    private function validatePDFFile(UploadedFile $file, &$errors)
+    {
+        $text = $file->get();
+
+        $jsKeywords = ['/JavaScript', '/JS', '<< /S /JavaScript'];
+
+        foreach ($jsKeywords as $keyword) {
+            if (strpos($text, $keyword) !== false) {
+                $errors[] = __('Dangerous PDF file content.');
+                break;
+            }
+        }
+
+        return $errors;
     }
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -429,6 +429,7 @@
   "Cycle": "Cycle",
   "danger": "danger",
   "Danger": "Danger",
+  "Dangerous PDF file content": "Dangerous PDF file content",
   "dark": "dark",
   "Dark": "Dark",
   "DashboardCreated": "Dashboard Created",


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Login and visit the next URL file-manager/public.
2. Upload the next PDF file
[pdfgarlito.pdf](https://github.com/user-attachments/files/16849360/pdfgarlito.pdf)
3. Open the uploaded file and press over the direct link of the file:
![image](https://github.com/user-attachments/assets/57e8e318-fb56-4bc3-85dc-d798705f6efc)

Current Behavior: 
When opening the file a JavaScript alert will be displayed

Expected Behavior:
PDF files with dangerous content should be controlled.

## Solution
- File upload endpoint (in PM Core) now validates if a PDF file has JavaScript included
- file-upload component in Screen Builder now adds file upload error handling
- When the file upload of a PDF file fails, a message is displayed.

![image](https://github.com/user-attachments/assets/9df7c3ff-bb92-4cba-bd35-3ad1e7f0d6b4)


## How to Test
Use the reproduction steps

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages
Ticket: https://processmaker.atlassian.net/browse/FOUR-16700
PRs
Screen Builder - https://github.com/ProcessMaker/screen-builder/pull/1684
Package Files - https://github.com/ProcessMaker/package-files/pull/132
PM Core https://github.com/ProcessMaker/processmaker/pull/7312

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next