### PR TITLE
FOUR-18920 Fix environment variable encoding for nayra executor

### DIFF
--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -184,7 +184,11 @@ abstract class Base
         });
 
         // Add the url to the host
-        $variablesParameter[] = 'HOST_URL=' . escapeshellarg(config('app.docker_host_url'));
+        if ($useEscape) {
+            $variablesParameter[] = 'HOST_URL=' . escapeshellarg(config('app.docker_host_url'));
+        } else {
+            $variablesParameter[] = 'HOST_URL=' . config('app.docker_host_url');
+        }
 
         return $variablesParameter;
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
$_SERVER['HOST_URL'] in being encoded incorrectly for nayara executor.

## Solution
- Fix the encoding of the variable

## How to Test
Run a Script Task (php-nayra)
```
<?php

return [
  'host' => $_SERVER['HOST_URL'], 
];
```
This must return
```
{
  "output": {
    "host": "https://server.location.without.single.quotes"
  }
}
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18920

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
