### PR TITLE
FOUR-17365 39399 - Fidelity Bank Performance, queries constantly running

### DIFF
--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -138,10 +138,14 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
     {
         $today = $this->today();
         try {
-            if (!Schema::hasTable('scheduled_tasks')) {
-                return;
-            }
-
+            /**
+             * This validation is removed; the database schema should exist before 
+             * any initiation of 'jobs' and 'schedule'.
+             * 
+             * if (!Schema::hasTable('scheduled_tasks')) {
+             *     return;
+             * }
+             */
             $this->removeExpiredLocks();
 
             $tasks = ScheduledTask::cursor();
@@ -202,7 +206,7 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
                 }
             }
         } catch (PDOException $e) {
-            Log::error('The connection to the database had problems');
+            Log::error('The connection to the database had problems (scheduleTasks): ' .  $e->getMessage());
         }
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
On the our analysis we found 3 queries that are constantly running in the database

- For the first 2, we searched the process and also other assets int he database and there is no place in the scripts, screens and saved searches where the criteria for the queries was explicitly set from the UI, so I assume it is internal, however, on a quick review I can tell that tue queries are poorly written

SELECT * FROM collection_96 WHERE ( LOWER ( DATA ) LIKE ? OR id LIKE ? OR created_at LIKE ? OR updated_at LIKE ? ) ORDER BY id ASC LIMIT ? OFFSET ?

SELECT COUNT ( * ) AS AGGREGATE FROM collection_96 WHERE ( LOWER ( DATA ) LIKE ? OR id LIKE ? OR created_at LIKE ? OR updated_at LIKE ? )

- For this 3rd query, we notices this runs for every customer, but it case of Fidelity it shows high peaks in coudwatch

select table_name as name, (data_length + index_length) as size, table_comment as comment, engine as engine, table_collation as collation from information_schema.tables where table_schema = 'fidelity' and table_type = 'BASE TABLE' order by table_name


## Solution
For all these we need to understand where the queries are coming from and how to improve them or stop them (the third one)

## How to Test
Check in the query execution monitor to ensure that this execution has been reduced.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17365

