### PR TITLE
FOUR-18984 Parallel Task is not redirected according element destination configuration once completed

### DIFF
--- a/ProcessMaker/Listeners/HandleActivityCompletedRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityCompletedRedirect.php
@@ -12,11 +12,16 @@ class HandleActivityCompletedRedirect extends HandleRedirectListener
      */
     public function handle(ActivityCompleted $event): void
     {
-        $request = $event->getProcessRequestToken()->getInstance();
+        $token = $event->getProcessRequestToken();
+        $request = $token->getInstance();
+
         if (empty($request)) {
             return;
         }
 
-        $this->setRedirectTo($request, 'processUpdated', $event);
+        $this->setRedirectTo($request, 'processUpdated', [
+            'tokenId' => $token->id,
+            'requestStatus' => $request->status,
+        ]);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

Redirect to Summary Screen from End Event with Multiple Tasks Parallel Assigned

Expected behavior: 
Task TCP4-4247-A completed should redirect to Task List
Task TCP4-4247-B completed should redirect to Welcome Screen
Task TCP4-4247-C completed should redirect to Summary Screen

Actual behavior: 
Task TCP4-4247-A completed is not redirected according to the Element Destination configuration
Task TCP4-4247-B completed is not redirected according to the Element Destination configuration 

## Solution
- Verify if the request is active once the parallel task is completed

https://github.com/user-attachments/assets/38663ece-3443-42d6-b47f-20e777153329

## How to Test
see the ticket

## Related Tickets & Packages
[FOUR-18984](https://processmaker.atlassian.net/browse/FOUR-18984)
https://github.com/ProcessMaker/screen-builder/pull/1689

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:screen-builder:bugfix/FOUR-18984
ci:deploy


[FOUR-18984]: https://processmaker.atlassian.net/browse/FOUR-18984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ