### PR TITLE
Add 'Templates' Button to Screen Builder Navigation Menu

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -476,6 +476,15 @@ export default {
             action: "redoAction()",
           },
           {
+            id: "button_templates",
+            type: "button",
+            title: this.$t("Screen Templates"),
+            name: this.$t("Templates"),
+            variant: "link",
+            icon: "fas fa-palette",
+            action: "openTemplatesPanel()",
+          },
+          {
             id: "button_calcs",
             type: "button",
             title: this.$t("Calculated Properties"),
@@ -1016,6 +1025,9 @@ export default {
     },
     redoAction() {
       this.$refs.builder.redo();
+    },
+    openTemplatesPanel() {
+      console.log('HIT OPEN TEMPLATE PANEL');
     },
     openComputedProperties() {
       this.$refs.computedProperties.show();


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR adds a 'Templates' button to the navigation menu within the screen builder. It updates the existing options array in screen.vue to accommodate the new button.

## Changes:
- Updated the `options` array in `screen.vue` to include a new 'Templates' button in the screen builder navigation menu.

## How to Test
1. Navigate to the screen builder in the application.
2. Ensure the 'Templates' button is now present in the screen builder navigation menu.

## Related Tickets & Packages
[FOUR-18284](https://processmaker.atlassian.net/browse/FOUR-18284)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-18284]: https://processmaker.atlassian.net/browse/FOUR-18284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ