### PR TITLE
Add Screen Templates Section in Screen Builder

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -476,6 +476,15 @@ export default {
             action: "redoAction()",
           },
           {
+            id: "button_templates",
+            type: "button",
+            title: this.$t("Screen Templates"),
+            name: this.$t("Templates"),
+            variant: "link",
+            icon: "fas fa-palette",
+            action: "openTemplatesPanel()",
+          },
+          {
             id: "button_calcs",
             type: "button",
             title: this.$t("Calculated Properties"),
@@ -1016,6 +1025,9 @@ export default {
     },
     redoAction() {
       this.$refs.builder.redo();
+    },
+    openTemplatesPanel() {
+      console.log('HIT OPEN TEMPLATE PANEL');
     },
     openComputedProperties() {
       this.$refs.computedProperties.show();

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -29,7 +29,9 @@
           :screen="screen"
           :render-controls="displayBuilder"
           :process-id="processId"
+          :show-templates-panel="showTemplatesPanel"
           @change="updateConfig"
+          @close-templates-panel="closeTemplatesPanel"
         >
           <data-loading-basic :is-loaded="false" />
         </vue-form-builder>
@@ -603,6 +605,7 @@ export default {
         ],
       },
       iframeHeight: "600px",
+      showTemplatesPanel: false,
     };
   },
   computed: {
@@ -1028,6 +1031,11 @@ export default {
     },
     openTemplatesPanel() {
       console.log('HIT OPEN TEMPLATE PANEL');
+      this.showTemplatesPanel = true;
+    },
+    closeTemplatesPanel() {
+      console.log('HIT CLOSE TEMPLATE PANEL');
+      this.showTemplatesPanel = false;
     },
     openComputedProperties() {
       this.$refs.computedProperties.show();

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -1037,11 +1037,9 @@ export default {
     openTemplatesPanel() {
       //Filter to retrieve my templates. When select shared templates, refetch.
       this.fetchMyTemplates();
-      console.log('HIT OPEN TEMPLATE PANEL');
       this.showTemplatesPanel = true;
     },
     closeTemplatesPanel() {
-      console.log('HIT CLOSE TEMPLATE PANEL');
       this.showTemplatesPanel = false;
     },
     fetchMyTemplates() {
@@ -1051,7 +1049,6 @@ export default {
         )
         .then((response) => {
           this.myTemplatesData = response.data.data;
-          console.log('myTemplatesData RETRIEVED', this.myTemplatesData);
         })
         .catch((error) => {
           console.error(error);
@@ -1064,7 +1061,6 @@ export default {
         )
         .then((response) => {
           this.sharedTemplatesData = response.data.data;
-          console.log('sharedTemplatesData RETRIEVED', this.sharedTemplatesData);
           this.$emit('shared-templates-loaded');
         })
         .catch((error) => {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -30,8 +30,11 @@
           :render-controls="displayBuilder"
           :process-id="processId"
           :show-templates-panel="showTemplatesPanel"
+          :my-templates-data="myTemplatesData"
+          :shared-templates-data="sharedTemplatesData"
           @change="updateConfig"
           @close-templates-panel="closeTemplatesPanel"
+          @show-shared-templates="fetchSharedTemplates"
         >
           <data-loading-basic :is-loaded="false" />
         </vue-form-builder>
@@ -606,6 +609,8 @@ export default {
       },
       iframeHeight: "600px",
       showTemplatesPanel: false,
+      myTemplatesData: null,
+      sharedTemplatesData: null,
     };
   },
   computed: {
@@ -1030,12 +1035,41 @@ export default {
       this.$refs.builder.redo();
     },
     openTemplatesPanel() {
+      //Filter to retrieve my templates. When select shared templates, refetch.
+      this.fetchMyTemplates();
       console.log('HIT OPEN TEMPLATE PANEL');
       this.showTemplatesPanel = true;
     },
     closeTemplatesPanel() {
       console.log('HIT CLOSE TEMPLATE PANEL');
       this.showTemplatesPanel = false;
+    },
+    fetchMyTemplates() {
+      ProcessMaker.apiClient
+        .get(
+          "templates/screen?is_public=0",
+        )
+        .then((response) => {
+          this.myTemplatesData = response.data.data;
+          console.log('myTemplatesData RETRIEVED', this.myTemplatesData);
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    },
+    fetchSharedTemplates() {
+      ProcessMaker.apiClient
+        .get(
+          "templates/screen?is_public=1",
+        )
+        .then((response) => {
+          this.sharedTemplatesData = response.data.data;
+          console.log('sharedTemplatesData RETRIEVED', this.sharedTemplatesData);
+          this.$emit('shared-templates-loaded');
+        })
+        .catch((error) => {
+          console.error(error);
+        });
     },
     openComputedProperties() {
       this.$refs.computedProperties.show();


### PR DESCRIPTION
This PR adds a new section in the screen builder that dynamically populates with templates when the 'Templates' button is selected. It fetches both user-specific and shared templates via API calls and displays the results in the right panel of the screen builder.

## Changes
- Implemented API calls to retrieve both "My Templates" and "Shared Templates" data from the backend.
- Added a new section in the right panel of the screen builder to display the retrieved templates when the 'Templates' button is clicked.

## How to Test
1. Navigate to the screen builder interface.
2. In the screen builder navigation menu, click the 'Templates' button to trigger the template loading process.
3. Ensure that API calls are made to fetch "My Templates" and "Shared Templates" correctly.
4. Once the templates are retrieved, confirm they are displayed in the right panel under appropriate categories (e.g., "My Templates" and "Shared Templates").


## Related Tickets & Packages
[FOUR-18286](https://processmaker.atlassian.net/browse/FOUR-18286)
[Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1690)


ci:next
ci:screen-builder:subtask/FOUR-18286

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-18286]: https://processmaker.atlassian.net/browse/FOUR-18286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ