### PR TITLE
FOUR-18107 - feature/FOUR-18103:  Support for drafts (hidden variable in screen data)

### DIFF
--- a/ProcessMaker/Traits/HasScreenFields.php
+++ b/ProcessMaker/Traits/HasScreenFields.php
@@ -1,20 +1,15 @@
 <?php
-
 namespace ProcessMaker\Traits;
-
 use Illuminate\Support\Arr;
 use Log;
 use ProcessMaker\Models\Column;
 use ProcessMaker\Models\Screen;
-
 trait HasScreenFields
 {
     private $parsedFields;
-
     private $restrictedComponents = [
         'FormImage',
     ];
-
     public function getFieldsAttribute()
     {
         if (empty($this->parsedFields)) {
@@ -35,10 +30,8 @@ trait HasScreenFields
                 ]);
             }
         }
-
         return $this->parsedFields->unique('field');
     }
-
     public function parseNestedScreen($node)
     {
         $nested = Screen::find($node['config']['screen']);
@@ -46,16 +39,24 @@ trait HasScreenFields
             $this->parsedFields->push($field);
         }
     }
-
+    public function parseCollectionRecordControl($node)
+    {
+        $collection = Screen::find($node['config']['collection']['screen']);
+        foreach ($collection->fields as $field) {
+            $this->parsedFields->push($field);
+        }
+    }
     public function walkArray($array, $key = null)
     {
         if (!is_array($array)) {
             $array = json_decode($array);
         }
-
         foreach ($array as $subkey => $value) {
+
             if (isset($value['component']) && $value['component'] === 'FormNestedScreen') {
                 $this->parseNestedScreen($value);
+            } elseif (isset($value['component']) && $value['component'] === 'FormCollectionRecordControl') {
+                $this->parseCollectionRecordControl($value);
             } elseif ($key !== 'inspector' && is_array($value) && isset($value['config']['name'])) {
                 $this->parseItem($value);
             }
@@ -64,7 +65,6 @@ trait HasScreenFields
             }
         }
     }
-
     public function parseItem($item)
     {
         if (isset($item['component']) && !in_array($item['component'], $this->restrictedComponents)) {
@@ -79,12 +79,10 @@ trait HasScreenFields
             ]));
         }
     }
-
     public function parseItemName($item)
     {
         return $item['config']['name'];
     }
-
     public function parseItemLabel($item)
     {
         if (isset($item['config']['label'])) {
@@ -93,15 +91,12 @@ trait HasScreenFields
             return null;
         }
     }
-
     public function parseItemFormat($item)
     {
         $format = 'string';
-
         if (isset($item['config']['dataFormat'])) {
             $format = $item['config']['dataFormat'];
         }
-
         if (isset($item['component'])) {
             switch ($item['component']) {
                 case 'FileUpload':
@@ -128,22 +123,18 @@ trait HasScreenFields
                     break;
             }
         }
-
         return $format;
     }
-
     public function parseItemMask($item)
     {
         return $item['config']['dataMask'] ?? null;
         if (isset($item['config']['dataMask'])) {
         }
     }
-
     public function parseIsSubmitButton($item)
     {
         return Arr::get($item, 'config.event') === 'submit';
     }
-
     /**
      * Return an array of fields that can be included when
      * saving a draft or doing a quick fill, so as not to

--- a/ProcessMaker/Traits/HasScreenFields.php
+++ b/ProcessMaker/Traits/HasScreenFields.php
@@ -1,5 +1,6 @@
 <?php
 namespace ProcessMaker\Traits;
+
 use Illuminate\Support\Arr;
 use Log;
 use ProcessMaker\Models\Column;
@@ -32,6 +33,7 @@ trait HasScreenFields
         }
         return $this->parsedFields->unique('field');
     }
+
     public function parseNestedScreen($node)
     {
         $nested = Screen::find($node['config']['screen']);
@@ -39,6 +41,7 @@ trait HasScreenFields
             $this->parsedFields->push($field);
         }
     }
+
     public function parseCollectionRecordControl($node)
     {
         $collection = Screen::find($node['config']['collection']['screen']);
@@ -46,6 +49,7 @@ trait HasScreenFields
             $this->parsedFields->push($field);
         }
     }
+
     public function walkArray($array, $key = null)
     {
         if (!is_array($array)) {
@@ -65,6 +69,7 @@ trait HasScreenFields
             }
         }
     }
+
     public function parseItem($item)
     {
         if (isset($item['component']) && !in_array($item['component'], $this->restrictedComponents)) {
@@ -79,10 +84,12 @@ trait HasScreenFields
             ]));
         }
     }
+
     public function parseItemName($item)
     {
         return $item['config']['name'];
     }
+
     public function parseItemLabel($item)
     {
         if (isset($item['config']['label'])) {
@@ -91,6 +98,7 @@ trait HasScreenFields
             return null;
         }
     }
+
     public function parseItemFormat($item)
     {
         $format = 'string';
@@ -125,16 +133,19 @@ trait HasScreenFields
         }
         return $format;
     }
+
     public function parseItemMask($item)
     {
         return $item['config']['dataMask'] ?? null;
         if (isset($item['config']['dataMask'])) {
         }
     }
+
     public function parseIsSubmitButton($item)
     {
         return Arr::get($item, 'config.event') === 'submit';
     }
+
     /**
      * Return an array of fields that can be included when
      * saving a draft or doing a quick fill, so as not to
@@ -142,6 +153,7 @@ trait HasScreenFields
      *
      * @return array
      */
+
     public function screenFilteredFields()
     {
         return $this->fields->pluck('field');


### PR DESCRIPTION
## Solution
- HasScreenFields trait was modified to show fields from new component CollectionRecordControl

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-18353

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next