### PR TITLE
feature/FOUR-18241: Change permissions of ellipsis documentation option

### DIFF
--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -78,7 +78,7 @@ export default {
           content: "View Documentation",
           link: true,
           href: ProcessMaker.packages.includes('package-ai') ? "/modeler/{{id}}/documentation" : "/modeler/{{id}}/print",
-          permission: ["view-processes", "view-additional-asset-actions"],
+          permission: ["view-documentation", "view-additional-asset-actions"],
           icon: "fas fa-sign",
           conditional: "isDocumenterInstalled",
         },

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -78,7 +78,7 @@ export default {
           content: "View Documentation",
           link: true,
           href: ProcessMaker.packages.includes('package-ai') ? "/modeler/{{id}}/documentation" : "/modeler/{{id}}/print",
-          permission: ["view-documentation", "view-additional-asset-actions"],
+          permission: ["view-documentation", "edit-documentation", "view-additional-asset-actions"],
           icon: "fas fa-sign",
           conditional: "isDocumenterInstalled",
         },


### PR DESCRIPTION
## Issue & Reproduction Steps
FOUR-18152 Change permissions of ellipsis documentation option (considering the permissions in case of ai documentation)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18241

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next