### PR TITLE
FOUR-18903: The Auto save date is updated without making any changes

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -92,7 +92,7 @@ class TaskController extends Controller
         $task->allow_interstitial = $interstitial['allow_interstitial'];
         $task->definition = $task->getDefinition();
         $task->requestor = $task->processRequest->user;
-        $task->draft = $task->draft();
+        $task->draft = TaskDraft::where('task_id', $task->id)->get();
         $element = $task->getDefinition(true);
         $screenFields = $screenVersion ? $screenVersion->screenFilteredFields() : [];
         $taskDraftsEnabled = TaskDraft::draftsEnabled();

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -92,7 +92,7 @@ class TaskController extends Controller
         $task->allow_interstitial = $interstitial['allow_interstitial'];
         $task->definition = $task->getDefinition();
         $task->requestor = $task->processRequest->user;
-        $task->draft = TaskDraft::where('task_id', $task->id)->get();
+        $task->draft = $task->draft;
         $element = $task->getDefinition(true);
         $screenFields = $screenVersion ? $screenVersion->screenFilteredFields() : [];
         $taskDraftsEnabled = TaskDraft::draftsEnabled();

--- a/ProcessMaker/Models/TaskDraft.php
+++ b/ProcessMaker/Models/TaskDraft.php
@@ -22,6 +22,7 @@ class TaskDraft extends ProcessMakerModel implements HasMedia
     protected $fillable = [
         'task_id',
         'data',
+        'updated_at',
     ];
 
     protected $casts = [
@@ -111,5 +112,9 @@ class TaskDraft extends ProcessMakerModel implements HasMedia
     public static function draftsEnabled()
     {
         return config('app.task_drafts_enabled');
+    }
+    protected static function getDraft()
+    {
+        return $this->belongsTo(ProcessRequestToken::class, 'task_id');
     }
 }

--- a/ProcessMaker/Models/TaskDraft.php
+++ b/ProcessMaker/Models/TaskDraft.php
@@ -22,7 +22,6 @@ class TaskDraft extends ProcessMakerModel implements HasMedia
     protected $fillable = [
         'task_id',
         'data',
-        'updated_at',
     ];
 
     protected $casts = [
@@ -112,9 +111,5 @@ class TaskDraft extends ProcessMakerModel implements HasMedia
     public static function draftsEnabled()
     {
         return config('app.task_drafts_enabled');
-    }
-    protected static function getDraft()
-    {
-        return $this->belongsTo(ProcessRequestToken::class, 'task_id');
     }
 }

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -146,7 +146,10 @@
                         <div class="card collapse-content">
                           <ul class="list-group list-group-flush w-100">
                             <li class="list-group-item">
-                            <div class="row justify-content-start pb-1">
+                            <div
+                              v-if="taskDraftsEnabled"
+                              class="row justify-content-start pb-1"
+                            >
                               <task-save-notification
                                 :options="options"
                                 :task="task"
@@ -395,6 +398,7 @@
     );
 
     const task = @json($task);
+    let draftTask = task.draft[0];
     const userHasAccessToTask = {{ Auth::user()->can('update', $task) ? "true": "false" }};
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
     const userIsProcessManager = {{ Auth::user()->id === $task->process?->manager_id ? "true": "false" }};
@@ -428,6 +432,7 @@
           filter: "",
           showReassignment: false,
           task,
+          draftTask,
           userHasAccessToTask,
           selectedUser: [],
           hasErrors: false,
@@ -456,13 +461,15 @@
           task: {
             deep: true,
             handler(task, oldTask) {
+              console.log('fas');
+              
               window.ProcessMaker.breadcrumbs.taskTitle = task.element_name;
               if (task && oldTask && task.id !== oldTask.id) {
                 history.replaceState(null, null, `/tasks/${task.id}/edit`);
               }
               if (task.draft) {
-                this.lastAutosave = moment(task.draft.updated_at).format("DD MMMM YYYY | HH:mm");
-                this.lastAutosaveNav = moment(task.draft.updated_at).format("MMM DD, YYYY / HH:mm");
+                this.lastAutosave = moment(this.draftTask.updated_at).format("DD MMMM YYYY | HH:mm");
+                this.lastAutosaveNav = moment(this.draftTask.updated_at).format("MMM DD, YYYY / HH:mm");
               } else {
                 this.lastAutosave = "-";
                 this.lastAutosaveNav = "-"
@@ -720,6 +727,7 @@
                   this.task.draft,
                   response.data
                 );
+                this.draftTask = structuredClone(response.data);
               })
               .catch(() => {
                 this.errorAutosave = true;

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -461,8 +461,6 @@
           task: {
             deep: true,
             handler(task, oldTask) {
-              console.log('fas');
-              
               window.ProcessMaker.breadcrumbs.taskTitle = task.element_name;
               if (task && oldTask && task.id !== oldTask.id) {
                 history.replaceState(null, null, `/tasks/${task.id}/edit`);

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -398,7 +398,7 @@
     );
 
     const task = @json($task);
-    let draftTask = task.draft[0];
+    let draftTask = task.draft;
     const userHasAccessToTask = {{ Auth::user()->can('update', $task) ? "true": "false" }};
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
     const userIsProcessManager = {{ Auth::user()->id === $task->process?->manager_id ? "true": "false" }};


### PR DESCRIPTION
## Issue & Reproduction Steps
The Auto save date is updated without making any changes

## Solution
- Send the updated_at field to view, by default this field it was empty

## Related Tickets & Packages
- [FOUR-18903](https://processmaker.atlassian.net/browse/FOUR-18903)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-18903]: https://processmaker.atlassian.net/browse/FOUR-18903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ