### PR TITLE
FOUR-19081 Fix default paths for nayra docker container

### DIFF
--- a/ProcessMaker/Console/Commands/BuildScriptExecutors.php
+++ b/ProcessMaker/Console/Commands/BuildScriptExecutors.php
@@ -147,7 +147,8 @@ class BuildScriptExecutors extends Command
             $this->info("SDK is at {$sdkDir}");
         }
 
-        $dockerfile = ScriptExecutor::initDockerfile($lang) . "\n" . $scriptExecutor->config;
+        // add the first lines for the Docker file, then the script executor config and then the rest last part of the Dockerfile
+        $dockerfile = $this->getDockerfileContent($scriptExecutor);
 
         $this->info("Dockerfile:\n  " . implode("\n  ", explode("\n", $dockerfile)));
         file_put_contents($packagePath . '/Dockerfile.custom', $dockerfile);
@@ -164,6 +165,15 @@ class BuildScriptExecutors extends Command
         if ($isNayra) {
             Base::bringUpNayraExecutor($this, $image);
         }
+    }
+
+    public function getDockerfileContent(ScriptExecutor $scriptExecutor): string
+    {
+        $lang = $scriptExecutor->language;
+
+        return ScriptExecutor::initDockerfile($lang) . "\n"
+            . $scriptExecutor->config . "\n"
+            . ScriptExecutor::finalInstructions($lang);
     }
 
     public function execCommand(string $command)

--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -115,6 +115,13 @@ class ScriptExecutor extends ProcessMakerModel
         return $dockerfile;
     }
 
+    public static function finalInstructions($language)
+    {
+        $finalInstruction = self::config($language)['final_instructions'] ?? '';
+
+        return is_array($finalInstruction) ? implode("\n", $finalInstruction) : $finalInstruction;
+    }
+
     public static function packagePath($language)
     {
         return self::config($language)['package_path'];

--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -184,7 +184,11 @@ abstract class Base
         });
 
         // Add the url to the host
-        $variablesParameter[] = 'HOST_URL=' . escapeshellarg(config('app.docker_host_url'));
+        if ($useEscape) {
+            $variablesParameter[] = 'HOST_URL=' . escapeshellarg(config('app.docker_host_url'));
+        } else {
+            $variablesParameter[] = 'HOST_URL=' . config('app.docker_host_url');
+        }
 
         return $variablesParameter;
     }

--- a/config/script-runners.php
+++ b/config/script-runners.php
@@ -17,9 +17,13 @@ return [
         'runner' => 'PhpRunner',
         'mime_type' => 'application/x-php',
         'options' => ['invokerPackage' => 'ProcessMaker\\Client'],
-        'init_dockerfile' => [
-        ],
         'package_path' => base_path('/docker-services/nayra'),
+        'init_dockerfile' => [
+            'WORKDIR /opt/executor/src',
+        ],
+        'final_instructions' => [
+            'WORKDIR /app',
+        ],
         'package_version' => '1.0.0',
         'sdk' => '',
     ],

--- a/tests/ScriptExecutors/BuildScriptExecutorsTest.php
+++ b/tests/ScriptExecutors/BuildScriptExecutorsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Model;
+
+use ProcessMaker\Console\Commands\BuildScriptExecutors;
+use ProcessMaker\Models\ScriptExecutor;
+use Tests\TestCase;
+
+class BuildScriptExecutorsTest extends TestCase
+{
+
+    public function testBuildScriptExecutorsDockerfile()
+    {
+        $scriptExecutor = ScriptExecutor::factory()->create([
+            'language' => 'php-nayra',
+            'config' => 'RUN apt-get update && apt-get install -y libxml2-dev',
+        ]);
+        $builder = new BuildScriptExecutors();
+        $code = $builder->getDockerfileContent($scriptExecutor);
+
+        // Check the $code contains 'WORKDIR /opt/executor/src'
+        $expectedCode = <<<EOF
+        WORKDIR /opt/executor/src
+        RUN apt-get update && apt-get install -y libxml2-dev
+        WORKDIR /app
+        EOF;
+        $this->assertStringContainsString($expectedCode, $code);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
The executor builder were installing the composer librearies to the app folder instead to the executor folder.

## Solution
- Configure properly the paths when building the executor.

## How to Test
- Add some composer libraries like:
```
RUN composer require clegginabox/pdf-merger:dev-master
RUN composer require setasign/fpdf
RUN composer require setasign/fpdi
RUN composer require setasign/fpdi-fpdf &&\
apt-get update && \
     apt-get install -y \
         libzip-dev \
         && docker-php-ext-install zip
```
- Rebuild the nayra executor.


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19081

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
