### PR TITLE
bugfix/FOUR-17453-4.10 Issue with Reassigning Tasks Without Claiming First in Self Service

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -197,6 +197,7 @@
                                       v-if="task.advanceStatus === 'open' || task.advanceStatus === 'overdue'"
                                       type="button"
                                       class="btn btn-block button-actions"
+                                      :disabled="isSelfService"
                                       @click="show"
                                     >
                                       <i class="fas fa-user-friends"></i> {{__('Reassign')}}

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -194,7 +194,7 @@
                                 <div class="col-6">
                                   <template v-if="isAllowReassignment || userIsAdmin || userIsProcessManager">
                                     <button
-                                      v-if="task.advanceStatus === 'open' || task.advanceStatus === 'overdue'"
+                                      v-if="!isSelfService && (task.advanceStatus === 'open' || task.advanceStatus === 'overdue')"
                                       type="button"
                                       class="btn btn-block button-actions"
                                       :disabled="isSelfService"

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -197,7 +197,6 @@
                                       v-if="!isSelfService && (task.advanceStatus === 'open' || task.advanceStatus === 'overdue')"
                                       type="button"
                                       class="btn btn-block button-actions"
-                                      :disabled="isSelfService"
                                       @click="show"
                                     >
                                       <i class="fas fa-user-friends"></i> {{__('Reassign')}}


### PR DESCRIPTION
## Issue & Reproduction Steps
Issue with Reassigning Tasks Without Claiming First in Self Service

## Solution
Disable reassign until the task is claimed

## How to Test
Create a test process with the following elements:
   A start event assigned to user0.
   A task assigned to a group (user1, user2) with the following assignment options: Allow reassignment and self service.
   An end event.
Start the process with user0.
Attempt to reassign the task from user1 to another user without claiming the task first.
Attempt to have user2 claim the reassigned task.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17453

ci:develop