### PR TITLE
FOUR-18303 | Write Tests for Screen Templates Section

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -488,6 +488,7 @@ export default {
             variant: "link",
             icon: "fas fa-palette",
             action: "openTemplatesPanel()",
+            dataCy: "button-templates",
           },
           {
             id: "button_calcs",
@@ -732,6 +733,14 @@ export default {
     this.setEllipsisMenu();
     ProcessMaker.EventBus.$on("show-create-template-modal", () => {
       this.$refs["create-template-modal"].show();
+    });
+
+    ProcessMaker.EventBus.$on("open-templates-panel", () => {
+      this.openMyTemplates();
+    });
+
+    ProcessMaker.EventBus.$on("close-templates-panel", () => {
+      this.closeTemplatesPanel();
     });
   },
   methods: {


### PR DESCRIPTION
# Issue
Ticket: [FOUR-18303](https://processmaker.atlassian.net/browse/FOUR-18303)

This PR introduces comprehensive Cypress tests for the Screen Templates Panel in screen-builder and enhances Screen Templates Panel visibility.

The tests check that:
- The Screen Templates Panel opens when the 'Templates' button is clicked
- The Screen Templates Panel closes when the 'X' button in the Panel is clicked
- The Screen Templates Panel is hidden when a control is clicked and an Inspector Panel should open

This PR also Ensures the 'Templates' button is always visible, even without `package-versions` or `processmaker` integration.

# How to Test
1. Go to branch `task/FOUR-18303` in `screen-builder` and `processmaker`.
2. Go to Designer → Screens. Create a Screen.
3. The 'Templates' button should display in `screen-builder`.
	- If you have `package-versions` installed, uninstall it and ensure that the 'Templates' button is still visible.
4. Run `npx open cypress` and `npm run dev` in your `screen-builder` terminal.
5. Run tests for `ScreenTemplateSection.js` in Cypress.
	- All tests should pass.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.