### PR TITLE
Add missing user attributes

### DIFF
--- a/ProcessMaker/Http/Resources/V1_1/TaskResource.php
+++ b/ProcessMaker/Http/Resources/V1_1/TaskResource.php
@@ -47,7 +47,7 @@ class TaskResource extends ApiResource
         'status',
         'due_at',
         'process_request_id',
-        'is_self_service'
+        'is_self_service',
     ];
 
     protected static $defaultIncludes = [
@@ -56,7 +56,39 @@ class TaskResource extends ApiResource
     ];
 
     protected static $defaultFieldsFor = [
-        'user' => ['id', 'firstname', 'lastname', 'email', 'username', 'avatar'],
+        'user' => [
+            'id',
+            'uuid',
+            'email',
+            'firstname',
+            'lastname',
+            'username',
+            'status',
+            'address',
+            'city',
+            'state',
+            'postal',
+            'country',
+            'phone',
+            'fax',
+            'cell',
+            'title',
+            'birthdate',
+            'timezone',
+            'datetime_format',
+            'language',
+            'meta',
+            'is_administrator',
+            'expires_at',
+            'loggedin_at',
+            'active_at',
+            'created_at',
+            'updated_at',
+            'delegation_user_id',
+            'manager_id',
+            'schedule',
+            'avatar',
+        ],
         'requestor' => ['id', 'first_name', 'last_name', 'email'],
         'processRequest' => [
             'id',


### PR DESCRIPTION
## Issue & Reproduction Steps
The new task resource only had some user attributes returned with the magic `_user` variable.


## Solution
- Add most user attributes back to the task resource to match the previous resource

## How to Test
See jira issues


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19027

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
