### PR TITLE
FOUR-19115 Fix when the Redirect must be triggered

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -247,7 +247,6 @@ class TaskController extends Controller
             $instance = $task->processRequest;
             TaskDraft::moveDraftFiles($task);
             WorkflowManager::completeTask($process, $instance, $task, $data);
-            HandleRedirectListener::sendRedirectToEvent();
 
             return new Resource($task->refresh());
         } elseif (!empty($request->input('user_id'))) {

--- a/ProcessMaker/Jobs/BpmnAction.php
+++ b/ProcessMaker/Jobs/BpmnAction.php
@@ -44,6 +44,8 @@ abstract class BpmnAction implements ShouldQueue
 
     protected $data;
 
+    protected $processId;
+
     /**
      * @var ProcessRequestLock
      */
@@ -67,8 +69,12 @@ abstract class BpmnAction implements ShouldQueue
 
             // Run engine to the next state
             $this->engine->runToNextState();
-            // call to redirect when user task is assigned
-            HandleRedirectListener::sendRedirectToEvent();
+            // call to redirect after all events are completed
+            // (e.g. completed, assigned, process completed, etc)
+            // excluding system process (non_persistent_process)
+            if ($this->processId !== 'non_persistent_process') {
+                HandleRedirectListener::sendRedirectToEvent();
+            }
         } catch (HttpABTestingException $exception) {
             Log::error($exception->getMessage());
             throw $exception;


### PR DESCRIPTION
## Fix when the Redirect must be triggered
- Redirect event were sent twisse in next-qa
- package-advanced-manager-user were affecting the redirect to when assignment event is triggered

## Solution
- Fix when the Redirect must be triggered.

## How to Test
Run the process described in the ticket.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19115

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:connector-idp:bugfix/FOUR-19124
