### PR TITLE
FOUR-19102 Fix Redirect when the process ends before load the request

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -818,4 +818,25 @@ class ProcessRequestController extends Controller
 
         return $affectedRows > 0;
     }
+
+    /**
+     * This endpoint returns the destination of the last end event of a process request
+     *
+     * @param ProcessRequest $request
+     */
+    public function endEventDestination(ProcessRequest $request)
+    {
+        $lastEndEvent = $request->tokens()
+            ->where('element_type', 'end_event')
+            ->orderBy('id', 'desc')
+            ->first();
+        if (!$lastEndEvent) {
+            return response()->json(['message' => __('No end event found'), 'data' => null]);
+        }
+        $data = [
+            'endEventDestination' => $lastEndEvent->element_destination,
+        ];
+
+        return response()->json(['message' => __('End event found'), 'data' => $data]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -225,6 +225,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('requests/{request}/tokens', [ProcessRequestController::class, 'getRequestToken'])->name('requests.getRequestToken')->middleware('can:view,request');
     Route::post('requests/{request}/events/{event}', [ProcessRequestController::class, 'activateIntermediateEvent'])->name('requests.update,request');
     Route::get('requests/{request}/details-screen-request', [ProcessRequestController::class, 'screenRequested'])->name('requests.detail.screen')->middleware('can:view,request');
+    Route::get('requests/{request}/end-event-destination', [ProcessRequestController::class, 'endEventDestination'])->name('requests.end_event_destination')->middleware('can:view,request');
 
     // Request Files
     Route::get('requests/{request}/files', [ProcessRequestFileController::class, 'index'])->name('requests.files.index')->middleware('can:view,request');


### PR DESCRIPTION
## Issue & Reproduction Steps

- When the process run, it ends before the request page is loaded
- The page missed all the redirection events so it stays in white

## Solution
- Catch when the process ends during the Task component mounting and execute the end event redirection.
- Requires: Screen Builder: https://github.com/ProcessMaker/screen-builder/pull/1699

## How to Test
- Run the processes described in the ticket
- The script could something like:
```
<?php
return [];
```
- Usa nayra executor (runs a bit faster that php executor)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19102

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:connector-idp:bugfix/FOUR-19124
