### PR TITLE
FOUR-19210: Error when Importing Guided Template

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1234,7 +1234,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                 ]);
                 break;
             case 'taskSource':
-                $elementDestination = $elementDestinationType;
+                $elementDestination = null;
                 break;
             default:
                 $elementDestination = null;


### PR DESCRIPTION
## Issue & Reproduction Steps
1.	Start the import process for a Guided Template (e.g., Expense Report).
2.	Complete the required steps.
3.	Observe the redirect after the import is completed.

## Solution
- Set elementDestination to null for taskSource case at ProcessMaker/Models/ProcessRequestToken.php

## How to Test
Follow the reproduction steps.

## Related Tickets & Packages
- [FOUR-19210](https://processmaker.atlassian.net/browse/FOUR-19210)

ci:next
ci:deploy

[FOUR-19210]: https://processmaker.atlassian.net/browse/FOUR-19210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ