### PR TITLE
FOUR-18323 | Implement CSS Application Logic

### DIFF
--- a/ProcessMaker/Helpers/ScreenTemplateHelper.php
+++ b/ProcessMaker/Helpers/ScreenTemplateHelper.php
@@ -256,13 +256,11 @@ class ScreenTemplateHelper
     {
         $rules = [];
         // Regex to match complex CSS selectors, allowing for any selector pattern
-        preg_match_all('/\[selector="([\w-]+)"\]\s*([^{]+)\s*{([^}]+)}/', $cssString, $matches, PREG_SET_ORDER);
+        preg_match_all('/([^{}]+)\s*\{([^}]*)\}/', $cssString, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $match) {
-            $baseSelector = $match[1];
-            $additionalSelector = trim($match[2]);
-            $fullSelector = "[selector=\"$baseSelector\"] " . $additionalSelector;
-            $propertiesString = trim($match[3]);
+            $fullSelector = trim($match[1]); // Full CSS selector
+            $propertiesString = trim($match[2]); // Properties between the brackets
 
             // Split properties into key-value pairs
             $propertiesArray = explode(';', $propertiesString);
@@ -279,6 +277,7 @@ class ScreenTemplateHelper
                 }
             }
 
+            // Add rule for the selector
             $rules[$fullSelector] = $properties;
         }
 

--- a/ProcessMaker/Helpers/ScreenTemplateHelper.php
+++ b/ProcessMaker/Helpers/ScreenTemplateHelper.php
@@ -250,4 +250,72 @@ class ScreenTemplateHelper
 
         return $flattenedItems;
     }
+
+    // Parse the CSS string into an associative array
+    public static function parseCss($cssString)
+    {
+        $rules = [];
+        // Regex to match complex CSS selectors, allowing for any selector pattern
+        preg_match_all('/\[selector="([\w-]+)"\]\s*([^{]+)\s*{([^}]+)}/', $cssString, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $baseSelector = $match[1];
+            $additionalSelector = trim($match[2]);
+            $fullSelector = "[selector=\"$baseSelector\"] " . $additionalSelector;
+            $propertiesString = trim($match[3]);
+
+            // Split properties into key-value pairs
+            $propertiesArray = explode(';', $propertiesString);
+            $properties = [];
+
+            foreach ($propertiesArray as $property) {
+                $propertyParts = explode(':', $property);
+                if (count($propertyParts) == 2) {
+                    $key = trim($propertyParts[0]);
+                    $value = trim($propertyParts[1]);
+                    if (!empty($key) && !empty($value)) {
+                        $properties[$key] = $value;
+                    }
+                }
+            }
+
+            $rules[$fullSelector] = $properties;
+        }
+
+        return $rules;
+    }
+
+    // Merge the two CSS arrays
+    public static function mergeCss($currentCss, $templateCss)
+    {
+        foreach ($templateCss as $selector => $properties) {
+            if (isset($currentCss[$selector])) {
+                // Merge properties from Template CSS into the Current Screen CSS for the same selector
+                $currentCss[$selector] = array_merge($currentCss[$selector], $properties);
+            } else {
+                // Add new selector and properties from Template CSS
+                $currentCss[$selector] = $properties;
+            }
+        }
+
+        return $currentCss;
+    }
+
+    public static function generateCss($cssArray)
+    {
+        // Convert the CSS array back into a string and output the final CSS
+        $cssString = '';
+
+        foreach ($cssArray as $selector => $properties) {
+            $cssString .= "$selector {\n";
+
+            foreach ($properties as $key => $value) {
+                $cssString .= " $key: $value;\n";
+            }
+
+            $cssString .= "}\n\n";
+        }
+
+        return $cssString;
+    }
 }

--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -242,6 +242,11 @@ class TemplateController extends Controller
         return $this->template->deleteMediaImages($type, $request);
     }
 
+    public function applyTemplate(string $type, Request $request)
+    {
+        return $this->template->applyTemplate($type, $request);
+    }
+
     private function validateImportedFile($content, $request, $type)
     {
         $decoded = null;

--- a/ProcessMaker/Models/Template.php
+++ b/ProcessMaker/Models/Template.php
@@ -101,6 +101,11 @@ class Template extends ProcessMakerModel
         return (new $this->types[$type][1])->deleteMediaImages($request);
     }
 
+    public function applyTemplate(string $type, Request $request)
+    {
+        return (new $this->types[$type][1])->applyTemplate($request);
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -677,6 +677,39 @@ class ScreenTemplate implements TemplateInterface
         }
     }
 
+    // Applies the template to an existing screen in screen builder
+    public function applyTemplate($request)
+    {
+        // Get the selected template
+        $templateId = (int) $request->id;
+        $template = ScreenTemplates::findOrFail($templateId);
+
+        // Get the selected template options
+        $templateOptions = $request->get('templateOptions');
+        // Get the current screen to apply the template
+        $screenId = $request->get('screenId');
+        $screen = Screen::where('id', $screenId)->first();
+        // Define available options and their corresponding components
+        $availableOptions = ScreenComponents::getComponents();
+
+        if (is_array($templateOptions)) {
+            // Iterate through available options to handle each one
+            foreach ($availableOptions as $option => $components) {
+                // Apply the CSS to the current screen
+                if ($option == 'CSS' && in_array($option, $templateOptions)) {
+                    $currentScreenCssArray = ScreenTemplateHelper::parseCss($screen->custom_css);
+                    $templateCssArray = ScreenTemplateHelper::parseCss($template->screen_custom_css);
+                    $mergedCss = ScreenTemplateHelper::mergeCss($currentScreenCssArray, $templateCssArray);
+
+                    $finalCss = ScreenTemplateHelper::generateCss($mergedCss);
+                    $screen->custom_css = $finalCss;
+                }
+
+                $screen->save();
+            }
+        }
+    }
+
     private function syncTemplateMedia($template, $media)
     {
         // Get the UUIDs of updated media

--- a/routes/api.php
+++ b/routes/api.php
@@ -330,6 +330,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('modeler/templates/{type}/{id}', [TemplateController::class, 'show'])->name('modeler.template.show')->middleware('template-authorization');
     Route::post('templates/{type}/import/validation', [TemplateController::class, 'preImportValidation'])->name('template.preImportValidation')->middleware('template-authorization');
     Route::post('template/{type}/{id}/publish', [TemplateController::class, 'publishTemplate'])->name('template.publishTemplate')->middleware('can:publish-screen-templates');
+    Route::post('template/{type}/{id}/apply', [TemplateController::class, 'applyTemplate'])->name('template.applyTemplate')->middleware('template-authorization');
     Route::get('screen-builder/{type}/{id}', [TemplateController::class, 'show'])->name('screenBuilder.template.show')->middleware('template-authorization');
 
     // Wizard Templates


### PR DESCRIPTION
# Feature
Ticket: [FOUR-18323](https://processmaker.atlassian.net/browse/FOUR-18323)

This PR introduces logic for Applying CSS to Screens via the Screen Templates Panel in `screen-builder`.

When a user chooses to only apply CSS from a template to their screen:

- If the template introduces CSS elements, they will be added to the existing screen CSS.

- If the template has the same CSS elements as the existing screen, it will replace them with the  CSS elements from the template.

- If both, screen and template, share CSS elements but the template adds new styles or properties, they should be added to the existing screen individually. 

# How to Test
1. Go to branch `task/FOUR-18323` in `screen-builder` and `processmaker`.
2. Ensure you have a Screen Template with Custom CSS in your environment.
3. Create a new screen in the Screen Builder.
4. Select 'Templates'. Select the template card for the Screen Template that has CSS.
5. Select 'CSS'.
    - When the page reloads, check that the CSS of your screen has been updated with the CSS from your template.
6. Update the CSS in your template and in your screen so that they have the same CSS elements with different properties. For example:
	`[selector="my-selector"]  {background-color: red;}`
	 
	`[selector="my-selector"]  {background-color: blue; }`
7. Save the Screen and the Template.
8. In your Screen, select the template again and select 'CSS'.
   - When the page reloads, check that the CSS in your screen has been replaced by the CSS from your template.
9. Update the CSS in your template and in your screen so that they have the same CSS element with different properties. For example:
	 - Screen CSS:
	 `div > p [selector="test-selector"] { border: 1px solid red; }`
	 
	 - Template CSS:
	 `div > p [selector="test-selector"] { background-color: red; font-size: 12px; }`
10. Save the Screen and the Template.
11. In your Screen, select the template again and select 'CSS'.
	- When the page reloads, check that the CSS in your screen has been updated like this:
	`div > p [selector="test-selector"] { border: 1px solid red; background-color: red; font-size: 12px; }`

ci:next
ci:screen-builder:task/FOUR-18323
ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-18323]: https://processmaker.atlassian.net/browse/FOUR-18323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ