### PR TITLE
task/FOUR-18687: Added function to delete language file from packages

### DIFF
--- a/ProcessMaker/Managers/PackageManager.php
+++ b/ProcessMaker/Managers/PackageManager.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Managers;
 
+use File;
+
 class PackageManager
 {
     private $packages;
@@ -82,6 +84,25 @@ class PackageManager
                     // Create file in package
                     file_put_contents("{$package}/{$code}.json", $baseFile);
                 }
+            }
+        }
+    }
+
+    /**
+     * Delete a language file form all currently installed packages
+     * 
+     * @param $code The language code of which to delete the language file 
+     */
+    public function deleteLanguageFile($code)
+    {
+         // Get current packages
+         $packages = app()->translator->getLoader()->jsonPaths();
+
+         foreach ($packages as $package) {
+            // Check if file exists in package
+            if (File::exists("{$package}/{$code}.json")) {
+                // Delete file
+                File::delete("{$package}/{$code}.json");
             }
         }
     }


### PR DESCRIPTION
## Tickets solved by this PR:
- https://processmaker.atlassian.net/browse/FOUR-18687

## Solution
- Added `deleteLanguageFile` function to delete a language file from all currently installed packages

## Related PRs
- https://github.com/ProcessMaker/package-translations/pull/97

## Notes for testing:
Use this URL on Postman to test: (depending on your pm4 installation)
- Make sure you already have a language installed (`it`, `ar`, `ca`, etc.)
`http://processmaker.test/api/1.0/languages/ar/uninstall`

ci:next