### PR TITLE
FOUR-16704: Session Token Not Invalidated on Logout

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Validation\ValidationException;
+use Laravel\Passport\HasApiTokens;
+use Laravel\Passport\Passport;
 use ProcessMaker\Events\Logout;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Managers\LoginManager;
@@ -19,6 +21,7 @@ use ProcessMaker\Traits\HasControllerAddons;
 
 class LoginController extends Controller
 {
+    use HasApiTokens;
     use HasControllerAddons;
     /*
     |--------------------------------------------------------------------------
@@ -239,6 +242,10 @@ class LoginController extends Controller
     public function beforeLogout(Request $request)
     {
         if (Auth::check()) {
+            // Remove the Laravel cookie
+            $request->session()->invalidate();
+            Cookie::queue(Cookie::forget(Passport::cookie()));
+
             //Clear the user permissions
             $request->session()->forget('permissions');
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The problem is described in the next video:

https://github.com/user-attachments/assets/20dc1a61-79fa-45df-ada4-7afabc8c3b8c


https://drive.google.com/file/d/1ZrFNuWyK-gioGwM9XXtV9dixT398KWks/view

## Solution
- As part of the logout, the Laravel cookie is removed, so it can't be used again.

## Related Tickets & Packages
- [Link to any related FOUR tickets, PRDs, or packages](https://processmaker.atlassian.net/browse/FOUR-16704)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next