### PR TITLE
FOUR-19287: Incorrect model_id assignment during Import in ProcessExporter importEmbed

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/EmbedExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/EmbedExporter.php
@@ -3,14 +3,9 @@
 namespace ProcessMaker\ImportExport\Exporters;
 
 use ProcessMaker\ImportExport\DependentType;
-use ProcessMaker\Models\Embed;
 
 class EmbedExporter extends ExporterBase
 {
-    public $handleDuplicatesByIncrementing = ['uuid'];
-
-    public $incrementStringSeparator = null;
-
     public function export(): void
     {
         $embed = $this->model;

--- a/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessExporter.php
@@ -495,6 +495,7 @@ class ProcessExporter extends ExporterBase
     {
         foreach ($this->getDependents(DependentType::EMBED) as $embed) {
             $embed->model->setAttribute('model_id', $this->model->id);
+            $embed->model->saveOrFail();
         }
     }
 

--- a/database/factories/ProcessMaker/Models/EmbedFactory.php
+++ b/database/factories/ProcessMaker/Models/EmbedFactory.php
@@ -11,20 +11,20 @@ use ProcessMaker\Models\Process;
  */
 class EmbedFactory extends Factory
 {
+    protected $model = Embed::class;
+
     /**
      * Define the model's default state.
-     *
-     * @return array
      */
-    public function definition()
+    public function definition(): array
     {
+        $process = Process::factory()->create();
+
         return [
-            'model_id' => function () {
-                return Process::factory()->create()->getKey();
-            },
-            'model_type' => $this->faker->randomElement(['ProcessMaker\Models\Process']),
+            'model_id' => $process->id,
+            'model_type' => Process::class,
             'mime_type' => $this->faker->randomElement(['text/url']),
-            'custom_properties' => [],
+            'custom_properties' => json_encode([]),
             'order_column' => 1,
         ];
     }

--- a/tests/Feature/ImportExport/Exporters/ProcessLaunchpadExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessLaunchpadExporterTest.php
@@ -85,6 +85,7 @@ class ProcessLaunchpadExporterTest extends TestCase
         $this->addGlobalSignalProcess();
         [
             'process' => $process,
+            'launchpad' => $launchpad,
             'savedSearch1' => $savedSearch1,
             'savedSearch2' => $savedSearch2,
         ] = $this->fixtures();
@@ -96,8 +97,9 @@ class ProcessLaunchpadExporterTest extends TestCase
         $originalSavedSearch1Id = $savedSearch1->id;
         $savedSearch1->delete();
 
-        $optionsArray[$process->uuid] = ['mode' => 'copy'];
-        $optionsArray[$savedSearch2->uuid] = ['mode' => 'copy'];
+        $optionsArray[$process->uuid] = ['mode' => 'copy', 'saveAssetsMode' => 'saveAllAssets', 'discardedByParent' => false];
+        $optionsArray[$savedSearch2->uuid] = ['mode' => 'copy', 'saveAssetsMode' => 'saveAllAssets', 'discardedByParent' => false];
+        $optionsArray[$launchpad->uuid] = ['mode' => 'copy', 'saveAssetsMode' => 'saveAllAssets', 'discardedByParent' => false];
 
         $options = new Options($optionsArray);
         $importer = new Importer($payload, $options);
@@ -118,5 +120,12 @@ class ProcessLaunchpadExporterTest extends TestCase
         $this->assertNotEquals($originalSavedSearch1Id, $savedSearch1->id);
         $this->assertEquals($savedSearch1->id, $newSavedSearch1Id);
         $this->assertEquals($savedSearch2->id, $newSavedSearch2Id);
+
+        // Re-import the same process.
+        $importer = new Importer($payload, $options);
+        $importer->doImport();
+
+        $newProcess = Process::where('name', 'Process 3')->first();
+        $this->assertNotNull($newProcess->launchpad);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
When importing a Process as a Template it appears that it does not include the LaunchPad embedded links.

## Solution
- Update code to save embed models associated with the process.
  - In `ProcessExporter.php`, added code to save the `model_id` attribute of embed models associated with the process.
  - In `ProcessExporterTest.php`, added tests to verify the saving and deletion of embed models associated with the process.


## How to Test
- Import the attached template process. (see JIRA)
- Go to processes
- The new imported process should have embed YouTube link.

## Related Tickets & Packages
- [FOUR-19287](https://processmaker.atlassian.net/browse/FOUR-19287)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19287]: https://processmaker.atlassian.net/browse/FOUR-19287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ