### PR TITLE
FOUR-18599 populate cases_started, cases_participated tables (main flow)

### DIFF
--- a/ProcessMaker/Contracts/CaseRepositoryInterface.php
+++ b/ProcessMaker/Contracts/CaseRepositoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ProcessMaker\Contracts;
+
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+interface CaseRepositoryInterface
+{
+    /**
+     * Store a new case started.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @return void
+     */
+    public function create(ExecutionInstanceInterface $instance): void;
+    /**
+     * Update the case started.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @param TokenInterface $token
+     * @return void
+     */
+    public function update(ExecutionInstanceInterface $instance, TokenInterface $token): void;
+    /**
+     * Update the status of a case started.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @return void
+     */
+    public function updateStatus(ExecutionInstanceInterface $instance): void;
+}

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -19,6 +19,7 @@ use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\Task as Resource;
 use ProcessMaker\Http\Resources\TaskCollection;
+use ProcessMaker\Jobs\CaseUpdate;
 use ProcessMaker\Listeners\HandleRedirectListener;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
@@ -253,7 +254,11 @@ class TaskController extends Controller
             $userToAssign = $request->input('user_id');
             $task->reassign($userToAssign, $request->user());
 
-            return new Resource($task->refresh());
+            $taskRefreshed = $task->refresh();
+
+            CaseUpdate::dispatch($task->processRequest, $taskRefreshed);
+
+            return new Resource($taskRefreshed);
         } else {
             return abort(422);
         }

--- a/ProcessMaker/Jobs/CaseStore.php
+++ b/ProcessMaker/Jobs/CaseStore.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+use ProcessMaker\Repositories\CaseRepository;
+
+class CaseStore implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(protected ExecutionInstanceInterface $instance)
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(CaseRepository $caseRepository): void
+    {
+        $caseRepository->create($this->instance);
+    }
+}

--- a/ProcessMaker/Jobs/CaseUpdate.php
+++ b/ProcessMaker/Jobs/CaseUpdate.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+use ProcessMaker\Repositories\CaseRepository;
+
+class CaseUpdate implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(protected ExecutionInstanceInterface $instance, protected TokenInterface $token)
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(CaseRepository $caseRepository): void
+    {
+        $caseRepository->update($this->instance, $this->token);
+    }
+}

--- a/ProcessMaker/Jobs/CaseUpdateStatus.php
+++ b/ProcessMaker/Jobs/CaseUpdateStatus.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+use ProcessMaker\Repositories\CaseRepository;
+
+class CaseUpdateStatus implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(protected ExecutionInstanceInterface $instance)
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(CaseRepository $caseRepository): void
+    {
+        $caseRepository->updateStatus($this->instance);
+    }
+}

--- a/ProcessMaker/Models/CaseParticipated.php
+++ b/ProcessMaker/Models/CaseParticipated.php
@@ -3,7 +3,7 @@
 namespace ProcessMaker\Models;
 
 use Database\Factories\CaseParticipatedFactory;
-use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use ProcessMaker\Models\ProcessMakerModel;
@@ -31,13 +31,20 @@ class CaseParticipated extends ProcessMakerModel
     ];
 
     protected $casts = [
-        'processes' => AsArrayObject::class,
-        'requests' => AsArrayObject::class,
-        'request_tokens' => AsArrayObject::class,
-        'tasks' => AsArrayObject::class,
-        'participants' => AsArrayObject::class,
-        'initiated_at' => 'datetime',
-        'completed_at' => 'datetime',
+        'processes' => AsCollection::class,
+        'requests' => AsCollection::class,
+        'request_tokens' => AsCollection::class,
+        'tasks' => AsCollection::class,
+        'participants' => AsCollection::class,
+    ];
+
+    protected $dates = [
+        'initiated_at',
+        'completed_at',
+    ];
+
+    protected $attributes = [
+        'keywords' => '',
     ];
 
     protected static function newFactory(): Factory

--- a/ProcessMaker/Models/CaseStarted.php
+++ b/ProcessMaker/Models/CaseStarted.php
@@ -14,8 +14,6 @@ class CaseStarted extends ProcessMakerModel
 
     protected $table = 'cases_started';
 
-    protected $primaryKey = 'case_number';
-
     protected $fillable = [
         'case_number',
         'user_id',

--- a/ProcessMaker/Models/CaseStarted.php
+++ b/ProcessMaker/Models/CaseStarted.php
@@ -4,7 +4,7 @@ namespace ProcessMaker\Models;
 
 use Database\Factories\CaseStartedFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use ProcessMaker\Models\ProcessMakerModel;
 
@@ -13,6 +13,8 @@ class CaseStarted extends ProcessMakerModel
     use HasFactory;
 
     protected $table = 'cases_started';
+
+    protected $primaryKey = 'case_number';
 
     protected $fillable = [
         'case_number',
@@ -31,13 +33,20 @@ class CaseStarted extends ProcessMakerModel
     ];
 
     protected $casts = [
-        'processes' => AsArrayObject::class,
-        'requests' => AsArrayObject::class,
-        'request_tokens' => AsArrayObject::class,
-        'tasks' => AsArrayObject::class,
-        'participants' => AsArrayObject::class,
-        'initiated_at' => 'datetime',
-        'completed_at' => 'datetime',
+        'processes' => AsCollection::class,
+        'requests' => AsCollection::class,
+        'request_tokens' => AsCollection::class,
+        'tasks' => AsCollection::class,
+        'participants' => AsCollection::class,
+    ];
+
+    protected $dates = [
+        'initiated_at',
+        'completed_at',
+    ];
+
+    protected $attributes = [
+        'keywords' => '',
     ];
 
     protected static function newFactory(): Factory

--- a/ProcessMaker/Repositories/CaseParticipatedRepository.php
+++ b/ProcessMaker/Repositories/CaseParticipatedRepository.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace ProcessMaker\Repositories;
+
+use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Models\CaseStarted;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+
+class CaseParticipatedRepository
+{
+    /**
+     * Store a new case participated.
+     *
+     * @param CaseStarted $case
+     * @param TokenInterface $token
+     * @return void
+     */
+    public function create(CaseStarted $case, TokenInterface $token): void
+    {
+        try {
+            CaseParticipated::create([
+                'user_id' => $token->user->id,
+                'case_number' => $case->case_number,
+                'case_title' => $case->case_title,
+                'case_title_formatted' => $case->case_title_formatted,
+                'case_status' => $case->case_status,
+                'processes' => $case->processes,
+                'requests' => $case->requests,
+                'request_tokens' => [$token->getKey()],
+                'tasks' => [
+                    [
+                        'id' => $token->getKey(),
+                        'element_id' => $token->element_id,
+                        'name' => $token->element_name,
+                        'process_id' => $token->process_id,
+                    ],
+                ],
+                'participants' => $case->participants,
+                'initiated_at' => $case->initiated_at,
+                'completed_at' => null,
+            ]);
+        } catch (\Exception $e) {
+            \Log::error($e->getMessage());
+        }
+    }
+
+    /**
+     * Update the case participated.
+     *
+     * @param CaseStarted $case
+     * @param TokenInterface $token
+     * @return void
+     */
+    public function update(CaseStarted $case, TokenInterface $token)
+    {
+        try {
+            $caseParticipated = CaseParticipated::where('user_id', $token->user->id)
+                ->where('case_number', $case->case_number)
+                ->first();
+
+            // Add the token data to the request_tokens
+            $requestTokens = $caseParticipated->request_tokens->push($token->getKey())
+                ->unique()
+                ->values();
+            // Add the task data to the tasks
+            $tasks = $caseParticipated->tasks->push([
+                'id' => $token->getKey(),
+                'element_id' => $token->element_id,
+                'name' => $token->element_name,
+                'process_id' => $token->process_id,
+            ])
+            ->unique('id')
+            ->values();
+
+            $caseParticipated->update([
+                'case_title' => $case->case_title,
+                'case_title_formatted' => $case->case_title_formatted,
+                'case_status' => $case->case_status,
+                'processes' => $case->processes,
+                'requests' => $case->requests,
+                'request_tokens' => $requestTokens,
+                'tasks' => $tasks,
+                'participants' => $case->participants,
+            ]);
+        } catch (\Exception $e) {
+            \Log::error($e->getMessage());
+        }
+    }
+
+    /**
+     * Update the status of a case participated.
+     *
+     * @param int $caseNumber
+     * @param array $statusData
+     * @return void
+     */
+    public function updateStatus(int $caseNumber, array $statusData)
+    {
+        try {
+            CaseParticipated::where('case_number', $caseNumber)
+                ->update($statusData);
+        } catch (\Exception $e) {
+            \Log::error($e->getMessage());
+        }
+    }
+}

--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace ProcessMaker\Repositories;
+
+use Carbon\Carbon;
+use ProcessMaker\Contracts\CaseRepositoryInterface;
+use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Models\CaseStarted;
+use ProcessMaker\Models\User;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+class CaseRepository implements CaseRepositoryInterface
+{
+    public function create(ExecutionInstanceInterface $instance): void
+    {
+        if ($this->checkIfCaseStartedExist($instance->case_number)) {
+            return;
+        }
+
+        try {
+            $process = [
+                'id' => $instance->process->id,
+                'name' => $instance->process->name,
+            ];
+
+            $request = [
+                'id' => $instance->id,
+                'name' => $instance->name,
+                'parent_request_id' => $instance->parentRequest->id ?? 0,
+            ];
+
+            CaseStarted::create([
+                'case_number' => $instance->case_number,
+                'user_id' => $instance->user_id,
+                'case_title' => $instance->case_title,
+                'case_title_formatted' => $instance->case_title_formatted,
+                'case_status' => 'IN_PROGRESS',
+                'processes' => [$process],
+                'requests' => [$request],
+                'request_tokens' => [],
+                'tasks' => [],
+                'participants' => [],
+                'initiated_at' => $instance->initiated_at,
+                'completed_at' => null,
+            ]);
+        } catch (\Exception $e) {
+            \Log::error($e->getMessage());
+        }
+    }
+
+    public function update(ExecutionInstanceInterface $instance, TokenInterface $token): void
+    {
+        try {
+            $case = CaseStarted::where('case_number', $instance->case_number)->first();
+            $user = $token->user;
+
+            $this->updateRequestTokens($case, $token);
+            $this->updateTasks($case, $token);
+            $this->updateParticipants($case, $user);
+
+            $case->saveOrFail();
+        } catch (\Exception $e) {
+            \Log::error($e->getMessage());
+            dd($e->getMessage());
+        }
+    }
+
+    public function updateStatus(ExecutionInstanceInterface $instance): void
+    {
+        try {
+            $data = [
+                'case_status' => $instance->status,
+            ];
+
+            if ($instance->status === 'COMPLETED') {
+                $data['completed_at'] = Carbon::now();
+            }
+
+            CaseStarted::where('case_number', $instance->case_number)->update($data);
+        } catch (\Exception $e) {
+            \Log::error($e->getMessage());
+            dd($e->getMessage());
+        }
+    }
+
+    private function updateRequestTokens(CaseStarted $case, TokenInterface $token)
+    {
+        $requestTokenExists = $case->request_tokens->contains($token->getKey());
+
+        if (!$requestTokenExists) {
+            $case->request_tokens->push($token->getKey());
+        }
+    }
+
+    private function updateTasks(CaseStarted $case, TokenInterface $token)
+    {
+        $taskExists = $case->tasks->contains(function ($task) use ($token) {
+            return $task['id'] === $token->element_id;
+        });
+
+        if (!$taskExists) {
+            $case->tasks->push([
+                'id' => $token->element_id,
+                'name' => $token->element_name,
+            ]);
+        }
+    }
+
+    private function updateParticipants(CaseStarted $case, User | null $user)
+    {
+        if (!$user) {
+            return;
+        }
+
+        $participantExists = $case->participants->contains(function ($participant) use ($user) {
+            return $participant['id'] === $user->id;
+        });
+
+        if (!$participantExists) {
+            $case->participants->push([
+                'id' => $user->id,
+                'name' => $user->getFullName(),
+            ]);
+
+            CaseParticipated::create([
+                'user_id' => $user->id,
+                'case_number' => $case->case_number,
+                'case_title' => $case->case_title,
+                'case_title_formatted' => $case->case_title_formatted,
+                'case_status' => $case->case_status,
+                'processes' => $case->processes,
+                'requests' => $case->requests,
+                'request_tokens' => $case->request_tokens,
+                'tasks' => $case->tasks,
+                'participants' => $case->participants,
+                'initiated_at' => $case->initiated_at,
+                'completed_at' => $case->completed_at,
+            ]);
+        }
+    }
+
+    private function checkIfCaseStartedExist(int $caseNumber): bool
+    {
+        return CaseStarted::where('case_number', $caseNumber)->count() > 0;
+    }
+}

--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -4,14 +4,21 @@ namespace ProcessMaker\Repositories;
 
 use Carbon\Carbon;
 use ProcessMaker\Contracts\CaseRepositoryInterface;
-use ProcessMaker\Models\CaseParticipated;
 use ProcessMaker\Models\CaseStarted;
-use ProcessMaker\Models\User;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
 class CaseRepository implements CaseRepositoryInterface
 {
+    public function __construct(protected CaseParticipatedRepository $caseParticipatedRepository)
+    {
+    }
+    /**
+     * Store a new case started.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @return void
+     */
     public function create(ExecutionInstanceInterface $instance): void
     {
         if ($this->checkIfCaseStartedExist($instance->case_number)) {
@@ -19,15 +26,19 @@ class CaseRepository implements CaseRepositoryInterface
         }
 
         try {
-            $process = [
-                'id' => $instance->process->id,
-                'name' => $instance->process->name,
+            $processes = [
+                [
+                    'id' => $instance->process->id,
+                    'name' => $instance->process->name,
+                ],
             ];
 
-            $request = [
-                'id' => $instance->id,
-                'name' => $instance->name,
-                'parent_request_id' => $instance->parentRequest->id ?? 0,
+            $requests = [
+                [
+                    'id' => $instance->id,
+                    'name' => $instance->name,
+                    'parent_request_id' => $instance->parentRequest->id ?? 0,
+                ],
             ];
 
             CaseStarted::create([
@@ -36,8 +47,8 @@ class CaseRepository implements CaseRepositoryInterface
                 'case_title' => $instance->case_title,
                 'case_title_formatted' => $instance->case_title_formatted,
                 'case_status' => 'IN_PROGRESS',
-                'processes' => [$process],
-                'requests' => [$request],
+                'processes' => $processes,
+                'requests' => $requests,
                 'request_tokens' => [],
                 'tasks' => [],
                 'participants' => [],
@@ -49,23 +60,50 @@ class CaseRepository implements CaseRepositoryInterface
         }
     }
 
+    /**
+     * Update the case started.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @param TokenInterface $token
+     * @return void
+     */
     public function update(ExecutionInstanceInterface $instance, TokenInterface $token): void
     {
         try {
             $case = CaseStarted::where('case_number', $instance->case_number)->first();
-            $user = $token->user;
 
-            $this->updateRequestTokens($case, $token);
-            $this->updateTasks($case, $token);
-            $this->updateParticipants($case, $user);
+            $case->case_title = $instance->case_title;
+            $case->case_status = $instance->status === 'ACTIVE' ? 'IN_PROGRESS' : $instance->status;
+
+            $case->request_tokens->push($token->getKey())
+                ->unique()
+                ->values();
+
+            if (!in_array($token->element_type, ['scriptTask'])) {
+                $case->tasks->push([
+                    'id' => $token->getKey(),
+                    'element_id' => $token->element_id,
+                    'name' => $token->element_name,
+                    'process_id' => $token->process_id,
+                ])
+                ->unique('id')
+                ->values();
+            }
+
+            $this->updateParticipants($case, $token);
 
             $case->saveOrFail();
         } catch (\Exception $e) {
             \Log::error($e->getMessage());
-            dd($e->getMessage());
         }
     }
 
+    /**
+     * Update the status of a case started.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @return void
+     */
     public function updateStatus(ExecutionInstanceInterface $instance): void
     {
         try {
@@ -77,38 +115,25 @@ class CaseRepository implements CaseRepositoryInterface
                 $data['completed_at'] = Carbon::now();
             }
 
+            // Update the case started and case participated
             CaseStarted::where('case_number', $instance->case_number)->update($data);
+            $this->caseParticipatedRepository->updateStatus($instance->case_number, $data);
         } catch (\Exception $e) {
             \Log::error($e->getMessage());
-            dd($e->getMessage());
         }
     }
 
-    private function updateRequestTokens(CaseStarted $case, TokenInterface $token)
+    /**
+     * Update the participants of the case started.
+     *
+     * @param CaseStarted $case
+     * @param TokenInterface $token
+     * @return void
+     */
+    private function updateParticipants(CaseStarted $case, TokenInterface $token): void
     {
-        $requestTokenExists = $case->request_tokens->contains($token->getKey());
+        $user = $token->user;
 
-        if (!$requestTokenExists) {
-            $case->request_tokens->push($token->getKey());
-        }
-    }
-
-    private function updateTasks(CaseStarted $case, TokenInterface $token)
-    {
-        $taskExists = $case->tasks->contains(function ($task) use ($token) {
-            return $task['id'] === $token->element_id;
-        });
-
-        if (!$taskExists) {
-            $case->tasks->push([
-                'id' => $token->element_id,
-                'name' => $token->element_name,
-            ]);
-        }
-    }
-
-    private function updateParticipants(CaseStarted $case, User | null $user)
-    {
         if (!$user) {
             return;
         }
@@ -121,25 +146,22 @@ class CaseRepository implements CaseRepositoryInterface
             $case->participants->push([
                 'id' => $user->id,
                 'name' => $user->getFullName(),
+                'title' => $user->title,
+                'avatar' => $user->avatar,
             ]);
 
-            CaseParticipated::create([
-                'user_id' => $user->id,
-                'case_number' => $case->case_number,
-                'case_title' => $case->case_title,
-                'case_title_formatted' => $case->case_title_formatted,
-                'case_status' => $case->case_status,
-                'processes' => $case->processes,
-                'requests' => $case->requests,
-                'request_tokens' => $case->request_tokens,
-                'tasks' => $case->tasks,
-                'participants' => $case->participants,
-                'initiated_at' => $case->initiated_at,
-                'completed_at' => $case->completed_at,
-            ]);
+            $this->caseParticipatedRepository->create($case, $token);
         }
+
+        $this->caseParticipatedRepository->update($case, $token);
     }
 
+    /**
+     * Check if the case started exist.
+     *
+     * @param int $caseNumber
+     * @return bool
+     */
     private function checkIfCaseStartedExist(int $caseNumber): bool
     {
         return CaseStarted::where('case_number', $caseNumber)->count() > 0;

--- a/ProcessMaker/Repositories/ExecutionInstanceRepository.php
+++ b/ProcessMaker/Repositories/ExecutionInstanceRepository.php
@@ -3,6 +3,8 @@
 namespace ProcessMaker\Repositories;
 
 use Carbon\Carbon;
+use ProcessMaker\Jobs\CaseStore;
+use ProcessMaker\Jobs\CaseUpdateStatus;
 use ProcessMaker\Models\ProcessCollaboration;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Nayra\Contracts\Bpmn\ParticipantInterface;
@@ -184,6 +186,8 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         // Set id
         $instance->setId($instance->getKey());
 
+        CaseStore::dispatch($instance);
+
         // Persists collaboration
         $this->persistCollaboration($instance);
     }
@@ -208,6 +212,8 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         $instance->status = 'ERROR';
         $instance->mergeLatestStoredData();
         $instance->saveOrFail();
+
+        CaseUpdateStatus::dispatch($instance);
     }
 
     /**
@@ -255,6 +261,8 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         $instance->completed_at = Carbon::now();
         $instance->mergeLatestStoredData();
         $instance->saveOrFail();
+
+        CaseUpdateStatus::dispatch($instance);
     }
 
     /**

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Mustache_Engine;
+use ProcessMaker\Jobs\CaseUpdate;
 use ProcessMaker\Mail\TaskActionByEmail;
 use ProcessMaker\Models\ProcessAbeRequestToken;
 use ProcessMaker\Models\ProcessCollaboration;
@@ -158,6 +159,9 @@ class TokenRepository implements TokenRepositoryInterface
         $token->setId($token->getKey());
         $request = $token->getInstance();
         $request->notifyProcessUpdated('ACTIVITY_ACTIVATED', $token);
+
+        CaseUpdate::dispatch($request, $token);
+
         if (!is_null($user)) {
             $this->validateAndSendActionByEmail($activity, $token, $user->email);
         }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "jenssegers/agent": "^2.6",
         "laravel/framework": "^10.19",
         "laravel/horizon": "^5.12",
+        "laravel/pail": "*",
         "laravel/passport": "^11.5",
         "laravel/scout": "^9.8",
         "laravel/telescope": "^4.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfd04a0f3ee33c659f5333738092adeb",
+    "content-hash": "2e3ed0dbb125cedadc0fa04b8380026d",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3483,6 +3483,84 @@
                 "source": "https://github.com/laravel/horizon/tree/v5.21.4"
             },
             "time": "2023-11-23T15:47:58+00:00"
+        },
+        {
+            "name": "laravel/pail",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pail.git",
+                "reference": "c22fe771277971eb9cd224955996bcf39c1a710d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/c22fe771277971eb9cd224955996bcf39c1a710d",
+                "reference": "c22fe771277971eb9cd224955996bcf39c1a710d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-pcntl": "*",
+                "illuminate/console": "^10.24|^11.0",
+                "illuminate/contracts": "^10.24|^11.0",
+                "illuminate/log": "^10.24|^11.0",
+                "illuminate/process": "^10.24|^11.0",
+                "illuminate/support": "^10.24|^11.0",
+                "nunomaduro/termwind": "^1.15|^2.0",
+                "php": "^8.2",
+                "symfony/console": "^6.0|^7.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13",
+                "orchestra/testbench": "^8.12|^9.0",
+                "pestphp/pest": "^2.20",
+                "pestphp/pest-plugin-type-coverage": "^2.3",
+                "phpstan/phpstan": "^1.10",
+                "symfony/var-dumper": "^6.3|^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Pail\\PailServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Pail\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Easily delve into your Laravel application's log files directly from the command line.",
+            "homepage": "https://github.com/laravel/pail",
+            "keywords": [
+                "laravel",
+                "logs",
+                "php",
+                "tail"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pail/issues",
+                "source": "https://github.com/laravel/pail"
+            },
+            "time": "2024-05-08T18:19:39+00:00"
         },
         {
             "name": "laravel/passport",

--- a/database/migrations/2024_09_09_181717_create_cases_started_table.php
+++ b/database/migrations/2024_09_09_181717_create_cases_started_table.php
@@ -12,7 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('cases_started', function (Blueprint $table) {
-            $table->unsignedInteger('case_number')->primary();
+            $table->id();
+            $table->unsignedInteger('case_number')->unique();
             $table->unsignedInteger('user_id');
             $table->string('case_title', 255);
             $table->text('case_title_formatted');
@@ -29,6 +30,7 @@ return new class extends Migration
 
             $table->foreign('user_id')->references('id')->on('users');
 
+            $table->index(['case_number']);
             $table->index(['user_id', 'case_status', 'created_at']);
             $table->index(['user_id', 'case_status', 'updated_at']);
 

--- a/database/migrations/2024_09_12_172734_create_cases_participated_table.php
+++ b/database/migrations/2024_09_12_172734_create_cases_participated_table.php
@@ -12,6 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('cases_participated', function (Blueprint $table) {
+            $table->id();
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('case_number');
             $table->string('case_title', 255);
@@ -27,9 +28,9 @@ return new class extends Migration
             $table->timestamps();
             $table->text('keywords');
 
-            $table->primary(['user_id', 'case_number']);
             $table->foreign('user_id')->references('id')->on('users');
 
+            $table->index(['user_id', 'case_number']);
             $table->index(['user_id', 'case_status', 'created_at']);
             $table->index(['user_id', 'case_status', 'completed_at']);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Every time a new request without a case is started create a new started case and participated case

## Solution
- Add Case and CaseParticipated repositories
- Add CaseStore, CaseUpdate and CaseUpdateStatus queues
- Add the laravel/pail library

## Related Tickets & Packages
[FOUR-18599](https://processmaker.atlassian.net/browse/FOUR-18599)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-18599]: https://processmaker.atlassian.net/browse/FOUR-18599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ