### PR TITLE
FOUR-18600 populate cases_started table automated tasks

### DIFF
--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -75,12 +75,12 @@ class CaseRepository implements CaseRepositoryInterface
             $case->case_title = $instance->case_title;
             $case->case_status = $instance->status === 'ACTIVE' ? 'IN_PROGRESS' : $instance->status;
 
-            $case->request_tokens->push($token->getKey())
+            $case->request_tokens = $case->request_tokens->push($token->getKey())
                 ->unique()
                 ->values();
 
             if (!in_array($token->element_type, ['scriptTask'])) {
-                $case->tasks->push([
+                $case->tasks = $case->tasks->push([
                     'id' => $token->getKey(),
                     'element_id' => $token->element_id,
                     'name' => $token->element_name,

--- a/tests/Feature/Cases/CaseParticipatedTest.php
+++ b/tests/Feature/Cases/CaseParticipatedTest.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace Tests\Feature\Cases;
+
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use ProcessMaker\Repositories\CaseParticipatedRepository;
+use ProcessMaker\Repositories\CaseRepository;
+use Tests\TestCase;
+
+class CaseParticipatedTest extends TestCase
+{
+    public function test_create_case_participated()
+    {
+        $user = User::factory()->create();
+        $process = Process::factory()->create();
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseHas('cases_started', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $this->assertDatabaseCount('cases_participated', 0);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+
+        $this->assertDatabaseCount('cases_participated', 1);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+            'processes->[0]->id' => $process->id,
+            'processes->[0]->name' => $process->name,
+            'requests->[0]->id' => $instance->id,
+            'requests->[0]->name' => $instance->name,
+            'requests->[0]->parent_request_id' => $instance->parent_request_id ?? 0,
+            'request_tokens->[0]' => $token->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+    }
+
+    public function test_create_multiple_case_participated()
+    {
+        $user = User::factory()->create();
+        $process = Process::factory()->create();
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseHas('cases_started', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+
+        $this->assertDatabaseCount('cases_participated', 1);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+
+        $token2 = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token2);
+
+        $this->assertDatabaseCount('cases_participated', 1);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token->id,
+            'request_tokens->[1]' => $token2->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+            'tasks->[1]->id' => $token2->id,
+            'tasks->[1]->element_id' => $token2->element_id,
+            'tasks->[1]->name' => $token2->element_name,
+            'tasks->[1]->process_id' => $token2->process_id,
+        ]);
+    }
+
+    public function test_update_case_participated_users()
+    {
+        $user = User::factory()->create();
+        $user2 = User::factory()->create();
+        $process = Process::factory()->create();
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseHas('cases_started', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+
+        $this->assertDatabaseCount('cases_participated', 1);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+
+        $token2 = ProcessRequestToken::factory()->create([
+            'user_id' => $user2->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token2);
+
+        $this->assertDatabaseCount('cases_participated', 2);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user2->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token2->id,
+            'tasks->[0]->id' => $token2->id,
+            'tasks->[0]->element_id' => $token2->element_id,
+            'tasks->[0]->name' => $token2->element_name,
+            'tasks->[0]->process_id' => $token2->process_id,
+        ]);
+    }
+
+    public function test_update_case_participated_user_tasks()
+    {
+        $user = User::factory()->create();
+        $user2 = User::factory()->create();
+        $process = Process::factory()->create();
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+
+        $this->assertDatabaseCount('cases_participated', 1);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'request_tokens->[0]' => $token->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+
+        $token2 = ProcessRequestToken::factory()->create([
+            'user_id' => $user2->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token2);
+
+        $this->assertDatabaseCount('cases_participated', 2);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user2->id,
+            'case_number' => $instance->case_number,
+            'request_tokens->[0]' => $token2->id,
+            'tasks->[0]->id' => $token2->id,
+            'tasks->[0]->element_id' => $token2->element_id,
+            'tasks->[0]->name' => $token2->element_name,
+            'tasks->[0]->process_id' => $token2->process_id,
+        ]);
+
+        $token3 = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token3);
+
+        $this->assertDatabaseCount('cases_participated', 2);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'request_tokens->[0]' => $token->id,
+            'request_tokens->[1]' => $token3->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+            'tasks->[1]->id' => $token3->id,
+            'tasks->[1]->element_id' => $token3->element_id,
+            'tasks->[1]->name' => $token3->element_name,
+            'tasks->[1]->process_id' => $token3->process_id,
+        ]);
+    }
+
+    public function test_update_case_participated_completed()
+    {
+        $user = User::factory()->create();
+        $user2 = User::factory()->create();
+        $process = Process::factory()->create();
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+
+        $this->assertDatabaseCount('cases_participated', 1);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+
+        $token2 = ProcessRequestToken::factory()->create([
+            'user_id' => $user2->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token2);
+
+        $this->assertDatabaseCount('cases_participated', 2);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user2->id,
+            'case_number' => $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token2->id,
+            'tasks->[0]->id' => $token2->id,
+            'tasks->[0]->element_id' => $token2->element_id,
+            'tasks->[0]->name' => $token2->element_name,
+            'tasks->[0]->process_id' => $token2->process_id,
+        ]);
+
+        $token3 = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token3);
+
+        $this->assertDatabaseCount('cases_participated', 2);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token->id,
+            'request_tokens->[1]' => $token3->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+            'tasks->[1]->id' => $token3->id,
+            'tasks->[1]->element_id' => $token3->element_id,
+            'tasks->[1]->name' => $token3->element_name,
+            'tasks->[1]->process_id' => $token3->process_id,
+        ]);
+
+        $instance->status = 'COMPLETED';
+        $repo->updateStatus($instance);
+
+        $this->assertDatabaseCount('cases_participated', 2);
+        $this->assertDatabaseHas('cases_participated', [
+            'case_number' => $instance->case_number,
+            'case_status' => 'COMPLETED',
+            'completed_at' => now(),
+        ]);
+    }
+}

--- a/tests/Feature/Cases/CaseStartedTest.php
+++ b/tests/Feature/Cases/CaseStartedTest.php
@@ -1,0 +1,393 @@
+<?php
+
+namespace Tests\Feature\Cases;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Mockery;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use ProcessMaker\Repositories\CaseParticipatedRepository;
+use ProcessMaker\Repositories\CaseRepository;
+
+class CaseStartedTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_create_case()
+    {
+        $user = User::factory()->create();
+        $repoParticipant = Mockery::mock(CaseParticipatedRepository::class);
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+    }
+
+    public function test_create_multiple_cases()
+    {
+        $user = User::factory()->create();
+        $repoParticipant = Mockery::mock(CaseParticipatedRepository::class);
+        $instance1 = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $instance2 = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance1);
+        $repo->create($instance2);
+
+        $this->assertDatabaseCount('cases_started', 2);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance1->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance1->case_number,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance2->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance2->case_number,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+    }
+
+    public function test_create_case_started_processes()
+    {
+        $process = Process::factory()->create();
+
+        $user = User::factory()->create();
+        $repoParticipant = Mockery::mock(CaseParticipatedRepository::class);
+
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'processes->[0]->id' => $process->id,
+            'processes->[0]->name' => $process->name,
+        ]);
+    }
+
+    public function test_create_case_started_requests()
+    {
+        $process = Process::factory()->create();
+
+        $user = User::factory()->create();
+        $repoParticipant = Mockery::mock(CaseParticipatedRepository::class);
+
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'requests->[0]->id' => $instance->id,
+            'requests->[0]->name' => $instance->name,
+            'requests->[0]->parent_request_id' => $instance->parent_request_id ?? 0,
+        ]);
+    }
+
+    public function test_update_case_started_request_tokens()
+    {
+        $process = Process::factory()->create();
+
+        $user = User::factory()->create();
+
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token->id,
+        ]);
+    }
+
+    public function test_update_case_started_tasks()
+    {
+        $process = Process::factory()->create();
+
+        $user = User::factory()->create();
+
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+
+        $token2 = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token2);
+
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'tasks->[1]->id' => $token2->id,
+            'tasks->[1]->element_id' => $token2->element_id,
+            'tasks->[1]->name' => $token2->element_name,
+            'tasks->[1]->process_id' => $token2->process_id,
+        ]);
+    }
+
+    public function test_update_case_started_script_tasks()
+    {
+        $process = Process::factory()->create();
+
+        $user = User::factory()->create();
+
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+
+        $token2 = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+            'element_type' => 'scriptTask',
+        ]);
+
+        $repo->update($instance, $token2);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'tasks->[1]->id' => null,
+            'tasks->[1]->element_id' => null,
+            'tasks->[1]->name' => null,
+            'tasks->[1]->process_id' => null,
+        ]);
+    }
+
+    public function test_update_case_started_participants()
+    {
+        $process = Process::factory()->create();
+
+        $user = User::factory()->create();
+
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'participants->[0]->id' => $user->id,
+            'participants->[0]->name' => $user->fullName,
+            'participants->[0]->title' => $user->title,
+            'participants->[0]->avatar' => $user->avatar,
+        ]);
+
+        $user2 = User::factory()->create();
+        $token2 = ProcessRequestToken::factory()->create([
+            'user_id' => $user2->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token2);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'participants->[1]->id' => $user2->id,
+            'participants->[1]->name' => $user2->fullName,
+            'participants->[1]->title' => $user2->title,
+            'participants->[1]->avatar' => $user2->avatar,
+        ]);
+    }
+
+    public function test_update_case_started_status()
+    {
+        $process = Process::factory()->create();
+        $user = User::factory()->create();
+
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repoParticipant = new CaseParticipatedRepository();
+
+        $repo = new CaseRepository($repoParticipant);
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 1);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+        ]);
+
+        $repo->update($instance, $token);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'IN_PROGRESS',
+            'completed_at' => null,
+            'request_tokens->[0]' => $token->id,
+        ]);
+
+        $instance->status = 'COMPLETED';
+        $repo->updateStatus($instance, $token);
+        $this->assertDatabaseHas('cases_started', [
+            'case_number' => $instance->case_number,
+            'user_id' => $user->id,
+            'case_title' => 'Case #' . $instance->case_number,
+            'case_status' => 'COMPLETED',
+            'completed_at' => now(),
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+    }
+}

--- a/tests/Feature/Cases/CasesJobTest.php
+++ b/tests/Feature/Cases/CasesJobTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use Illuminate\Support\Facades\Queue;
+use ProcessMaker\Jobs\CaseStore;
+use ProcessMaker\Jobs\CaseUpdate;
+use ProcessMaker\Jobs\CaseUpdateStatus;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class CasesJobTest extends TestCase
+{
+    use RequestHelper;
+
+    public function test_handle_case_store_job()
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        CaseStore::dispatch($instance);
+
+        Queue::assertPushed(CaseStore::class, 1);
+    }
+
+    public function test_handle_case_update_job()
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_request_id' => $instance->id,
+        ]);
+
+        CaseUpdate::dispatch($instance, $token);
+
+        Queue::assertPushed(CaseUpdate::class, 1);
+    }
+
+    public function test_handle_case_update_status_job()
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_request_id' => $instance->id,
+        ]);
+
+        CaseUpdateStatus::dispatch($instance, $token);
+
+        Queue::assertPushed(CaseUpdateStatus::class, 1);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
When a process runs an automated task (Script Task, Service Task) it must update the following fields:

- The User starts a process that has assigned.
- The cases_started table is populated with the cases started by the User.
- The process goes into automated tasks (like script tasks, data-connectos,…)
- The system updates all cases_started fields that changed except: tasks_ids, tasks_titles, since this columns stores only User and Manual Tasks

## Related Tickets & Packages
[FOUR-18600](https://processmaker.atlassian.net/browse/FOUR-18600)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-18600]: https://processmaker.atlassian.net/browse/FOUR-18600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ