### PR TITLE
FOUR-19373: Incorrect validation - Error uploading PDF file: Dangerous content of PDF file

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -431,7 +431,7 @@ class ProcessRequestFileController extends Controller
     {
         $text = $file->get();
 
-        $jsKeywords = ['/JavaScript', '/JS', '<< /S /JavaScript'];
+        $jsKeywords = ['/JavaScript', '<< /S /JavaScript'];
 
         foreach ($jsKeywords as $keyword) {
             if (strpos($text, $keyword) !== false) {


### PR DESCRIPTION
## Issue & Reproduction Steps
    Create a screen with a file upload feature.

    Integrate the screen into a process.

    Upload the next PDF
[student.pdf](https://github.com/user-attachments/files/17138471/student.pdf)

Current behavior:
The PDF is blocked

Expected behavior
 PDFs that don't have Javascript should be uploaded to ProcessMaker

## Solution
- Modified the conditions to validate a PDF


## Related Tickets & Packages
[- Link to any related FOUR tickets, PRDs, or packages](https://processmaker.atlassian.net/browse/FOUR-19373)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy