### PR TITLE
FOUR-18601 populate cases_started table - sub processes

### DIFF
--- a/ProcessMaker/Repositories/CaseUtils.php
+++ b/ProcessMaker/Repositories/CaseUtils.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace ProcessMaker\Repositories;
+
+use Illuminate\Support\Collection;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+
+class CaseUtils
+{
+    const ALLOWED_ELEMENT_TYPES = ['task'];
+
+    /**
+     * Store processes.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @param Collection $processes
+     * @return Collection
+     */
+    public static function storeProcesses(ExecutionInstanceInterface $instance, Collection $processes)
+    {
+        return $processes->push([
+            'id' => $instance->process->id,
+            'name' => $instance->process->name,
+        ])
+        ->unique('id')
+        ->values();
+    }
+
+    /**
+     * Store requests.
+     *
+     * @param ExecutionInstanceInterface $instance
+     * @param Collection $requests
+     * @return Collection
+     */
+    public static function storeRequests(ExecutionInstanceInterface $instance, Collection $requests)
+    {
+        return $requests->push([
+            'id' => $instance->id,
+            'name' => $instance->name,
+            'parent_request_id' => $instance?->parentRequest?->id,
+        ])
+        ->unique('id')
+        ->values();
+    }
+
+    /**
+     * Store request tokens.
+     *
+     * @param int $tokenId
+     * @param Collection $requestTokens
+     * @return Collection
+     */
+    public static function storeRequestTokens(int $tokenId, Collection $requestTokens)
+    {
+        return $requestTokens->push($tokenId)
+            ->unique()
+            ->values();
+    }
+
+    /**
+     * Store tasks.
+     *
+     * @param TokenInterface $token
+     * @param Collection $tasks
+     * @return Collection
+     */
+    public static function storeTasks(TokenInterface $token, Collection $tasks)
+    {
+        if (in_array($token->element_type, self::ALLOWED_ELEMENT_TYPES)) {
+            return $tasks->push([
+                'id' => $token->getKey(),
+                'element_id' => $token->element_id,
+                'name' => $token->element_name,
+                'process_id' => $token->process_id,
+            ])
+            ->unique('id')
+            ->values();
+        }
+
+        return $tasks;
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
### Populate cases_started table - Sub processes
- The User starts a process that has been assigned.
- The cases_started table is populated with the cases started by the User.
- The process starts a new subprocess request (this does not create a new case, it updates the existing one)
- The system updates the related fields: processes_ids, processes_titles, process_requests_ids. These values must be UNIQUE not duplicated.
- The participants of the sub processes are also updated in the case_started row.
- The user completes all the started requests of the case
- The system updates the status field to COMPLETED, and compleated_at for the created row at cases_started

### Considerations:
- In the column processes: Consider the first process must be always the main process (parent process)
- In the column requests: Consider the first request must be always the main request (parent process)

## Related Tickets & Packages
[FOUR-18601](https://processmaker.atlassian.net/browse/FOUR-18601)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
