### PR TITLE
FOUR-19110: [40531] changes on screen are not reflected in ongoing cases

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/TaskController.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace ProcessMaker\Http\Controllers\Api\V1_1;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\V1_1\TaskInterstitialResource;
 use ProcessMaker\Http\Resources\V1_1\TaskResource;
@@ -62,70 +59,6 @@ class TaskController extends Controller
         ];
     }
 
-    public function show(ProcessRequestToken $task)
-    {
-        $resource = TaskResource::preprocessInclude(request(), ProcessRequestToken::where('id', $task->id));
-
-        return $resource->toArray(request());
-    }
-
-    /**
-     * Display the screen for a given task.
-     *
-     * @throws ModelNotFoundException If the task is not found.
-     */
-    public function showScreen(Request $request, int $taskId): Response
-    {
-        // Fetch the task data.
-        $task = ProcessRequestToken::select(
-            array_merge($this->defaultFields, ['process_request_id', 'process_id'])
-        )->findOrFail($taskId);
-
-        // Prepare the response.
-        $response = new TaskScreen($task);
-        $screen = $response->toArray($request)['screen'];
-        $now = isset($screen['updated_at'])
-            ? Carbon::parse($screen['updated_at'])->timestamp
-            : time();
-
-        // Create the response object.
-        $response = response($screen, 200);
-
-        // Set Cache-Control headers.
-        $cacheTime = config('screen_task_cache_time', 86400);
-        $response->headers->set('Cache-Control', 'no-cache, must-revalidate, public');
-        $response->headers->set('Expires', gmdate('D, d M Y H:i:s', $now + $cacheTime) . ' GMT');
-
-        // Set Last-Modified header.
-        $response->headers->set('Last-Modified', gmdate('D, d M Y H:i:s', $now) . ' GMT');
-
-        // Return 304 if the resource has not been modified since the provided date.
-        if ($request->headers->has('If-Modified-Since')) {
-            $ifModifiedSince = strtotime($request->headers->get('If-Modified-Since'));
-            if ($ifModifiedSince >= $now) {
-                return response()->noContent(304);
-            }
-        }
-
-        return $response;
-    }
-
-    public function showInterstitial($taskId)
-    {
-        $task = ProcessRequestToken::select(
-            array_merge($this->defaultFields, ['process_request_id', 'process_id'])
-        )->findOrFail($taskId);
-        $response = new TaskInterstitialResource($task);
-        $response = response($response->toArray(request())['screen'], 200);
-        $now = time();
-        // screen cache time
-        $cacheTime = config('screen_task_cache_time', 86400);
-        $response->headers->set('Cache-Control', 'max-age=' . $cacheTime . ', must-revalidate, public');
-        $response->headers->set('Expires', gmdate('D, d M Y H:i:s', $now + $cacheTime) . ' GMT');
-
-        return $response;
-    }
-
     private function processFilters(Request $request, Builder $query)
     {
         if (request()->has('user_id')) {
@@ -152,5 +85,44 @@ class TaskController extends Controller
                     ->where('parent_request_id', $request->input('process_request_id'))
             );
         }
+    }
+
+    public function show(ProcessRequestToken $task)
+    {
+        $resource = TaskResource::preprocessInclude(request(), ProcessRequestToken::where('id', $task->id));
+
+        return $resource->toArray(request());
+    }
+
+    public function showScreen($taskId)
+    {
+        $task = ProcessRequestToken::select(
+            array_merge($this->defaultFields, ['process_request_id', 'process_id'])
+        )->findOrFail($taskId);
+        $response = new TaskScreen($task);
+        $response = response($response->toArray(request())['screen'], 200);
+        $now = time();
+        // screen cache time
+        $cacheTime = config('screen_task_cache_time', 86400);
+        $response->headers->set('Cache-Control', 'max-age=' . $cacheTime . ', must-revalidate, public');
+        $response->headers->set('Expires', gmdate('D, d M Y H:i:s', $now + $cacheTime) . ' GMT');
+
+        return $response;
+    }
+
+    public function showInterstitial($taskId)
+    {
+        $task = ProcessRequestToken::select(
+            array_merge($this->defaultFields, ['process_request_id', 'process_id'])
+        )->findOrFail($taskId);
+        $response = new TaskInterstitialResource($task);
+        $response = response($response->toArray(request())['screen'], 200);
+        $now = time();
+        // screen cache time
+        $cacheTime = config('screen_task_cache_time', 86400);
+        $response->headers->set('Cache-Control', 'max-age=' . $cacheTime . ', must-revalidate, public');
+        $response->headers->set('Expires', gmdate('D, d M Y H:i:s', $now + $cacheTime) . ' GMT');
+
+        return $response;
     }
 }

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -55,6 +55,7 @@
                               v-model="formData"
                               :initial-task-id="{{ $task->id }}"
                               :initial-request-id="{{ $task->process_request_id }}"
+                              :screen-version="{{ $task->screen['id'] ?? null }}"
                               :user-id="{{ Auth::user()->id }}"
                               csrf-token="{{ csrf_token() }}"
                               initial-loop-context="{{ $task->getLoopContext() }}"


### PR DESCRIPTION
## Issue & Reproduction Steps

- Have cases running in a process.
- edit one of the screens that is used in those cases' process.
- save and publish the changes on the screen.
- Changes are reflected only in new cases.

**Current behavior**
- Changes applied on a screen and published are only reflected in new cases. in 4.10 the changes were reflected in new and also ongoing cases

**Expected behavior**
- Change should be reflected in ongoing cases.

## Solution
- Added a version parameter (screen_version) to screen URLs, generated based on the latest published id of the screen.
- This approach forces the browser to treat each updated published screen as a new resource, preventing the use of outdated cached versions.

## How to Test
- Verify that screen updates generate new URLs with different version parameters, ensuring that changes are correctly fetched.
- Test across different browsers to confirm that old cached versions are not used.

## Related Tickets & Packages
- [FOUR-19110](https://processmaker.atlassian.net/browse/FOUR-19110)
- [Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1716)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:screen-builder:bugfix/FOUR-19110

[FOUR-19110]: https://processmaker.atlassian.net/browse/FOUR-19110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ