### PR TITLE
Allow admin users to reassign any user task

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -7,6 +7,7 @@ use DB;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Scout\Searchable;
 use Log;
@@ -494,25 +495,6 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         }
 
         return $result;
-    }
-
-    /**
-     * Check if the user has access to reassign this task
-     *
-     * @param User $user
-     */
-    public function authorizeReassignment(User $user)
-    {
-        if ($user->can('update', $this)) {
-            $definitions = $this->getDefinition();
-            if (empty($definitions['allowReassignment']) || $definitions['allowReassignment'] === 'false') {
-                throw new AuthorizationException('Not authorized to reassign this task');
-            }
-
-            return true;
-        } else {
-            throw new AuthorizationException('Not authorized to view this task');
-        }
     }
 
     /**
@@ -1168,7 +1150,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
             $reassingAction = true;
         } else {
             // Validate if user can reassign
-            $this->authorizeReassignment($requestingUser);
+            Gate::forUser($requestingUser)->authorize('reassign', $this);
             // Reassign user
             $this->reassignTo($toUserId);
             $this->persistUserData($toUserId);

--- a/database/factories/ProcessMaker/Models/UserFactory.php
+++ b/database/factories/ProcessMaker/Models/UserFactory.php
@@ -20,10 +20,10 @@ class UserFactory extends Factory
         }
 
         return [
-            'username' => $this->faker->unique()->userName().'.'.$this->faker->word(),
+            'username' => $this->faker->unique()->userName() . '.' . $this->faker->word(),
             'email' => $this->faker->unique()->email(),
             'password' => $GLOBALS['testPassword'],
-            'status' => $this->faker->randomElement(['ACTIVE', 'INACTIVE']),
+            'status' => 'ACTIVE',
             'firstname' => $this->faker->firstName(),
             'lastname' => $this->faker->lastName(),
             'address' => $this->faker->streetAddress(),


### PR DESCRIPTION
## Issue & Reproduction Steps
Admin users should always be allowed to reassign tasks

## Solution
- Move reassign permission check to policy

## How to Test
Attempt to reassign a usertask using the API as an admin user

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19002

ci:next
ci:deploy
.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
