### PR TITLE
FOUR-19402 Fix self_service_groups variable types

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -135,6 +135,10 @@ class TokenRepository implements TokenRepositoryInterface
                     $evaluatedUsers = is_array($evaluatedUsers) ? $evaluatedUsers : [$evaluatedUsers];
                     $evaluatedGroups = is_array($evaluatedGroups) ? $evaluatedGroups : [$evaluatedGroups];
 
+                    // convert to array of strings
+                    $evaluatedUsers = array_map('strval', $evaluatedUsers);
+                    $evaluatedGroups = array_map('strval', $evaluatedGroups);
+
                     $token->self_service_groups = ['users' => $evaluatedUsers, 'groups' => $evaluatedGroups];
                     break;
                 case 'rule_expression':


### PR DESCRIPTION
## Issue & Reproduction Steps
- When the variable used in self_service_groups is a list of integer IDs it cause the webentry could not find the tasks self service assigned to the logged user.

## Solution
- Cast the self_service_groups variable types to array of strings.

## How to Test
- Import the process described in the ticket
- Run the webentry with a logged user
- Check that the second task does not show the self service task
- Try to do a refresh and the problem persists

With the fix
- Import the process described in the ticket
- Run the webentry with a logged user
- Check that the second task now shows a self service task
- Try to do a refresh and self service remains

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19402

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
