### PR TITLE
FOUR-19390 Fix call to missing method

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1077,7 +1077,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
             ->where('groups.status', 'ACTIVE')
             ->chunk(1000, function ($members) use (&$users) {
                 $groupIds = $members->pluck('member_id')->toArray();
-                $users = $this->addActiveAssignedGroupMembers($groupIds, $users);
+                $users = $this->getConsolidatedUsers($groupIds, $users);
             });
 
         return $users;

--- a/tests/unit/ProcessMaker/Models/ProcessTest.php
+++ b/tests/unit/ProcessMaker/Models/ProcessTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Models;
+
+use ProcessMaker\Models\Group;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class ProcessTest extends TestCase
+{
+    public function testGetConsolidatedUsers()
+    {
+        $process = Process::factory()->create();
+
+        $groupA = Group::factory()->create(['name' => 'Group A', 'status' => 'ACTIVE']);
+        $groupB = Group::factory()->create(['name' => 'Group B', 'status' => 'ACTIVE']);
+
+        $groupAUser = User::factory()->create(['status' => 'ACTIVE']);
+        $groupBUser = User::factory()->create(['status' => 'ACTIVE']);
+
+        $groupA->groupMembers()->create(['member_id' => $groupAUser->id, 'member_type' => User::class]);
+        $groupB->groupMembers()->create(['member_id' => $groupBUser->id, 'member_type' => User::class]);
+
+        // Add group B to group A
+        $groupA->groupMembers()->create(['member_id' => $groupB->id, 'member_type' => Group::class]);
+
+        $users = [];
+        $process->getConsolidatedUsers($groupA->id, $users);
+
+        $this->assertEquals([$groupAUser->id, $groupBUser->id], $users);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Tasks with nested groups assigned were throwing an error.

## Solution
- Fix a incorrect method call, probably happened in a refactor
- Add test

## How to Test
See reproduction steps in jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19390

ci:next
ci:deploy
.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
