### PR TITLE
feature/FOUR-18629: BE: The API needs to consider save the collapse pero user and feature

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Http\Controllers\Api;
 
+use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Http\Controllers\Controller;
@@ -63,7 +64,7 @@ class UserConfigurationController extends Controller
             ], [
                 'ui_configuration' => $uiConfiguration,
             ]);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return response()->json(['error' => $e->getMessage()], 400);
         }
 

--- a/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Api;
+
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Http\Resources\ApiResource;
+use ProcessMaker\Models\User;
+use ProcessMaker\Models\UserConfiguration;
+
+class UserConfigurationController extends Controller
+{
+    const DEFAULT_USER_CONFIGURATION = [
+        "launchpad" => [
+           "isMenuCollapse" => true
+        ],
+        "cases" => [
+           "isMenuCollapse" => true
+        ],
+        "requests" => [
+           "isMenuCollapse" => true
+        ],
+        "tasks" => [
+           "isMenuCollapse" => true
+        ]
+    ];
+
+    public function index()
+    {
+        $user = Auth::user();
+        $query = UserConfiguration::select('user_id', 'ui_configuration');
+        $query->userConfiguration($user->id);
+        $response = $query->first();
+
+        if (empty($response)) {
+            $response = [
+                'user_id' => $user->id, 
+                'ui_configuration' =>
+                json_encode(self::DEFAULT_USER_CONFIGURATION)
+            ]; // return default
+        }
+        
+        return new ApiResource($response);
+    }
+
+    public function store(Request $request)
+    {
+        $user = Auth::user();
+        $userConf = new UserConfiguration();
+        $request->validate([
+            'ui_configuration' => 'required|array',
+            'ui_configuration.launchpad' => 'required|array',
+            'ui_configuration.cases' => 'required|array',
+            'ui_configuration.requests' => 'required|array',
+            'ui_configuration.tasks' => 'required|array',
+        ]);
+        $uiConfiguration = json_encode($request->input('ui_configuration')); 
+
+        try {
+            // Store the user configuration
+            $userConf->updateOrCreate([
+                'user_id' => $user->id,
+            ], [
+                'ui_configuration' => $uiConfiguration,
+            ]);
+
+        } catch (\Exception $e) {
+            return response()->json(['error' => $e->getMessage()], 400);
+        }
+
+        return new ApiResource($userConf->refresh());
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
@@ -2,7 +2,6 @@
 
 namespace ProcessMaker\Http\Controllers\Api;
 
-
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Http\Controllers\Controller;
@@ -13,18 +12,18 @@ use ProcessMaker\Models\UserConfiguration;
 class UserConfigurationController extends Controller
 {
     const DEFAULT_USER_CONFIGURATION = [
-        "launchpad" => [
-           "isMenuCollapse" => true
+        'launchpad' => [
+            'isMenuCollapse' => true,
         ],
-        "cases" => [
-           "isMenuCollapse" => true
+        'cases' => [
+            'isMenuCollapse' => true,
         ],
-        "requests" => [
-           "isMenuCollapse" => true
+        'requests' => [
+            'isMenuCollapse' => true,
         ],
-        "tasks" => [
-           "isMenuCollapse" => true
-        ]
+        'tasks' => [
+            'isMenuCollapse' => true,
+        ],
     ];
 
     public function index()
@@ -36,12 +35,11 @@ class UserConfigurationController extends Controller
 
         if (empty($response)) {
             $response = [
-                'user_id' => $user->id, 
-                'ui_configuration' =>
-                json_encode(self::DEFAULT_USER_CONFIGURATION)
+                'user_id' => $user->id,
+                'ui_configuration' => json_encode(self::DEFAULT_USER_CONFIGURATION),
             ]; // return default
         }
-        
+
         return new ApiResource($response);
     }
 
@@ -56,7 +54,7 @@ class UserConfigurationController extends Controller
             'ui_configuration.requests' => 'required|array',
             'ui_configuration.tasks' => 'required|array',
         ]);
-        $uiConfiguration = json_encode($request->input('ui_configuration')); 
+        $uiConfiguration = json_encode($request->input('ui_configuration'));
 
         try {
             // Store the user configuration
@@ -65,7 +63,6 @@ class UserConfigurationController extends Controller
             ], [
                 'ui_configuration' => $uiConfiguration,
             ]);
-
         } catch (\Exception $e) {
             return response()->json(['error' => $e->getMessage()], 400);
         }

--- a/ProcessMaker/Models/UserConfiguration.php
+++ b/ProcessMaker/Models/UserConfiguration.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use ProcessMaker\Traits\HasUuids;
+use ProcessMaker\Traits\Exportable;
+
+class UserConfiguration extends ProcessMakerModel
+{
+    use HasFactory;
+
+    protected $connection = 'processmaker';
+
+    protected $table = 'user_configuration';
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'id',
+        'created_at',
+        'updated_at',
+    ];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'user_id',
+        'ui_configuration',
+    ];
+
+    public static function rules(): array
+    {
+        return [
+            'user_id' => 'required',
+        ];
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * Get the launchpad related
+     */
+    public function scopeUserConfiguration($query, $userId)
+    {
+        return $query->where('user_id', $userId);
+    }
+}

--- a/ProcessMaker/Models/UserConfiguration.php
+++ b/ProcessMaker/Models/UserConfiguration.php
@@ -3,8 +3,8 @@
 namespace ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use ProcessMaker\Traits\HasUuids;
 use ProcessMaker\Traits\Exportable;
+use ProcessMaker\Traits\HasUuids;
 
 class UserConfiguration extends ProcessMakerModel
 {

--- a/database/migrations/2024_09_26_131232_create_user_configuration.php
+++ b/database/migrations/2024_09_26_131232_create_user_configuration.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2024_09_26_131232_create_user_configuration.php
+++ b/database/migrations/2024_09_26_131232_create_user_configuration.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_configuration', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id');
+            $table->json('ui_configuration');
+            $table->timestamps();
+
+            // Indexes
+            $table->index('user_id');
+
+            // Foreign keys
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_configuration');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,6 +35,7 @@ use ProcessMaker\Http\Controllers\Api\TaskAssignmentController;
 use ProcessMaker\Http\Controllers\Api\TaskController;
 use ProcessMaker\Http\Controllers\Api\TaskDraftController;
 use ProcessMaker\Http\Controllers\Api\TemplateController;
+use ProcessMaker\Http\Controllers\Api\UserConfigurationController;
 use ProcessMaker\Http\Controllers\Api\UserController;
 use ProcessMaker\Http\Controllers\Api\UserTokenController;
 use ProcessMaker\Http\Controllers\Api\WizardTemplateController;
@@ -62,6 +63,9 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('users/{user}/tokens/{tokenId}', [UserTokenController::class, 'show'])->name('users.tokens.show'); // Permissions handled in the controller
     Route::post('users/{user}/tokens', [UserTokenController::class, 'store'])->name('users.tokens.store'); // Permissions handled in the controller
     Route::delete('users/{user}/tokens/{tokenId}', [UserTokenController::class, 'destroy'])->name('users.tokens.destroy'); // Permissions handled in the controller
+    // User Configuration
+    Route::get('users/configuration', [UserConfigurationController::class, 'index'])->name('users.configuration.show');
+    Route::put('users/configuration', [UserConfigurationController::class, 'store'])->name('users.configuration.update');
 
     // Groups//Permissions policy
     Route::get('groups', [GroupController::class, 'index'])->name('groups.index'); // Permissions handled in the controller

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,8 +64,8 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('users/{user}/tokens', [UserTokenController::class, 'store'])->name('users.tokens.store'); // Permissions handled in the controller
     Route::delete('users/{user}/tokens/{tokenId}', [UserTokenController::class, 'destroy'])->name('users.tokens.destroy'); // Permissions handled in the controller
     // User Configuration
-    Route::get('users/configuration', [UserConfigurationController::class, 'index'])->name('users.configuration.show');
-    Route::put('users/configuration', [UserConfigurationController::class, 'store'])->name('users.configuration.update');
+    Route::get('users/configuration', [UserConfigurationController::class, 'index'])->name('users.configuration.index');
+    Route::put('users/configuration', [UserConfigurationController::class, 'store'])->name('users.configuration.store');
 
     // Groups//Permissions policy
     Route::get('groups', [GroupController::class, 'index'])->name('groups.index'); // Permissions handled in the controller

--- a/tests/Feature/Api/UserConfigurationTest.php
+++ b/tests/Feature/Api/UserConfigurationTest.php
@@ -16,7 +16,7 @@ class UserConfigurationTest extends TestCase
 
     const STRUCTURE = [
         'user_id',
-        'ui_configuration'
+        'ui_configuration',
     ];
 
     /**
@@ -43,18 +43,18 @@ class UserConfigurationTest extends TestCase
     {
         // Call the api PUT
         $values = [
-            "launchpad" => [
-               "isMenuCollapse" => false
+            'launchpad' => [
+                'isMenuCollapse' => false,
             ],
-            "cases" => [
-               "isMenuCollapse" => false
+            'cases' => [
+                'isMenuCollapse' => false,
             ],
-            "requests" => [
-               "isMenuCollapse" => false
+            'requests' => [
+                'isMenuCollapse' => false,
             ],
-            "tasks" => [
-               "isMenuCollapse" => false
-            ]
+            'tasks' => [
+                'isMenuCollapse' => false,
+            ],
         ];
 
         $response = $this->apiCall('PUT', self::API_TEST_URL, ['ui_configuration' => $values]);
@@ -90,15 +90,15 @@ class UserConfigurationTest extends TestCase
 
         // An incomplete ui_configuration
         $values = [
-            "cases" => [
-               "isMenuCollapse" => false
+            'cases' => [
+                'isMenuCollapse' => false,
             ],
-            "requests" => [
-               "isMenuCollapse" => false
+            'requests' => [
+                'isMenuCollapse' => false,
             ],
-            "tasks" => [
-               "isMenuCollapse" => false
-            ]
+            'tasks' => [
+                'isMenuCollapse' => false,
+            ],
         ];
         $response = $this->apiCall('PUT', self::API_TEST_URL, ['ui_configuration' => $values]);
         // Validate the header status code

--- a/tests/Feature/Api/UserConfigurationTest.php
+++ b/tests/Feature/Api/UserConfigurationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use ProcessMaker\Http\Controllers\Api\UserConfigurationController;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessLaunchpad;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class UserConfigurationTest extends TestCase
+{
+    use RequestHelper;
+
+    const API_TEST_URL = '/users/configuration';
+
+    const STRUCTURE = [
+        'user_id',
+        'ui_configuration'
+    ];
+
+    /**
+     * Test get deafult user configuration
+     */
+    public function testGetDefaultUserConfiguration()
+    {
+        // Call the api GET
+        $response = $this->apiCall('GET', self::API_TEST_URL);
+        // Validate the header status code
+        $response->assertStatus(200);
+        $this->assertNotEmpty($response);
+        // Verify structure
+        $response->assertJsonStructure(self::STRUCTURE);
+        // Verify default values
+        $defaultValues = json_encode(UserConfigurationController::DEFAULT_USER_CONFIGURATION);
+        $this->assertEquals($response->json()['ui_configuration'], $defaultValues);
+    }
+
+    /**
+     * Test store user configuration and get the new values
+     */
+    public function testStoreUserConfigurationAndGetNewValues()
+    {
+        // Call the api PUT
+        $values = [
+            "launchpad" => [
+               "isMenuCollapse" => false
+            ],
+            "cases" => [
+               "isMenuCollapse" => false
+            ],
+            "requests" => [
+               "isMenuCollapse" => false
+            ],
+            "tasks" => [
+               "isMenuCollapse" => false
+            ]
+        ];
+
+        $response = $this->apiCall('PUT', self::API_TEST_URL, ['ui_configuration' => $values]);
+        // Validate the header status code
+        $response->assertStatus(200);
+
+        // Call the api GET
+        $response = $this->apiCall('GET', self::API_TEST_URL);
+        // Validate the header status code
+        $response->assertStatus(200);
+        $this->assertNotEmpty($response);
+        // Verify structure
+        $response->assertJsonStructure(self::STRUCTURE);
+        // Verify default values
+        $uiConfig = json_decode($response->json()['ui_configuration']);
+        $this->assertEquals($uiConfig->launchpad->isMenuCollapse, $values['launchpad']['isMenuCollapse']);
+        $this->assertEquals($uiConfig->cases->isMenuCollapse, $values['cases']['isMenuCollapse']);
+        $this->assertEquals($uiConfig->requests->isMenuCollapse, $values['requests']['isMenuCollapse']);
+        $this->assertEquals($uiConfig->tasks->isMenuCollapse, $values['tasks']['isMenuCollapse']);
+    }
+
+    /**
+     * Test store user configuration with invalid values
+     */
+    public function testStoreUserConfigurationWithInvalidValues()
+    {
+        // With no values
+        $response = $this->apiCall('PUT', self::API_TEST_URL);
+
+        // Validate the header status code
+        $response->assertStatus(422);
+        $this->assertEquals('The Ui configuration field is required. (and 4 more errors)', $response->json()['message']);
+
+        // An incomplete ui_configuration
+        $values = [
+            "cases" => [
+               "isMenuCollapse" => false
+            ],
+            "requests" => [
+               "isMenuCollapse" => false
+            ],
+            "tasks" => [
+               "isMenuCollapse" => false
+            ]
+        ];
+        $response = $this->apiCall('PUT', self::API_TEST_URL, ['ui_configuration' => $values]);
+        // Validate the header status code
+        $response->assertStatus(422);
+        $this->assertEquals('The Ui configuration.launchpad field is required.', $response->json()['message']);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Create the new table user_configuration to save the configuration, review the ticket related https://processmaker.atlassian.net/browse/FOUR-18560

Create a new API’s to save the information in this table

```
Route::get('users/configuration', [UserConfigurationController::class, 'index'])->name('users.configuration.show');
Route::put('users/configuration', [UserConfigurationController::class, 'store'])->name('users.configuration.update'); 
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18629

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next