### PR TITLE
FOUR-17328 Patch generated SDK code to fix error

### DIFF
--- a/ProcessMaker/BuildSdk.php
+++ b/ProcessMaker/BuildSdk.php
@@ -58,7 +58,7 @@ class BuildSdk
     public function setUserId($userId)
     {
         if (!is_numeric($userId)) {
-            throw new \Exception('User id must be a number');
+            throw new Exception('User id must be a number');
         }
         $this->userId = $userId;
     }
@@ -235,6 +235,22 @@ class BuildSdk
                 "find {$folder} -name '*.py' -exec " .
                 "sed -i -E 's/ProcessMaker\\\Models\\\/ProcessMaker\\\\\\\Models\\\\\\\/g' {} \;"
             );
+        }
+
+        if ($this->lang === 'php') {
+            $content = file_get_contents("{$folder}/lib/ObjectSerializer.php");
+            $line = 'if (in_array($class, [\'DateTime';
+            $insertAbove = '
+                if ($class === "mixed") {
+                    $jsonObj = json_decode($data, true);
+                    if ($jsonObj === null && json_last_error() !== JSON_ERROR_NONE) {
+                        return $data;
+                    }
+                    return $jsonObj;
+                }
+            ';
+            $content = str_replace($line, $insertAbove . "\n\n" . $line, $content);
+            file_put_contents("{$folder}/lib/ObjectSerializer.php", $content);
         }
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This is a bug in OpenAPI Generator https://github.com/OpenAPITools/openapi-generator/issues/8943

It was apparently fixed in v6 but we are locked into 5.1.1 because, as far as I remember, in more recent versions the CSharp SDK was broken.

Even with 5.1.1 we are patching some code and this fix patches more code.

The OpenAPI Generator project has continued to have problems and we should consider depreciating its usage. We could just replace it with a pre-built guzzle client.

## Solution
- Patch the generated code.

## How to Test
- Verify you can see the problem in the jira ticket using the script editor
- Checkout this branch and rebuild the executor `php artisan processmaker:build-script-executor php --rebuild`
- Try it again and it should work

ci:next

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17328

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
