### PR TITLE
FOUR-18716, FOUR-18715: Apply translations to screen

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -17,6 +17,7 @@ use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenCategory;
 use ProcessMaker\Models\ScreenTemplates;
 use ProcessMaker\Models\ScreenType;
+use ProcessMaker\ProcessTranslations\ProcessTranslation;
 use ProcessMaker\Query\SyntaxError;
 use ProcessMaker\Traits\ProjectAssetTrait;
 
@@ -630,6 +631,53 @@ class ScreenController extends Controller
         $screen->custom_css = $request->post('custom_css');
 
         return new ScreenResource($screen);
+    }
+
+    /**
+     * Translates the controls inside a screen
+     *
+     * @param Screen $screen, the id of the screen that will be translated
+     * @param String $language, language to translate. If the translation does not exist
+     * english is applied by default
+     *
+     * @return ResponseFactory|Response
+     *
+     * @OA\Get(
+     *     path="/screens/{screen_id}/translate/{language}",
+     *     summary="Translates the screen to the desired language",
+     *     operationId="translateScreen",
+     *     tags={"Screens"},
+     *     @OA\Parameter(
+     *         description="ID of the screen",
+     *         in="path",
+     *         name="screen_id",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\Parameter(
+     *         description="Language used for the translation of the string",
+     *         in="path",
+     *         name="language",
+     *         required=true,
+     *         @OA\Schema(
+     *           type="string",
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successfully found the screen",
+     *         @OA\JsonContent(ref="#/components/schemas/screens")
+     *     ),
+     * )
+     */
+    public function translate(Screen $screen, $language)
+    {
+        $draft = $screen->versions()->draft()->first();
+        $processTranslation = new ProcessTranslation(null);
+        $transConfig = $processTranslation->translateScreen($draft, $language);
+        return $transConfig;
     }
 
     public function updateDefaultTemplate(string $screenType, int $isPublic)

--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -269,6 +269,29 @@ class ProcessTranslation
         return $config;
     }
 
+    public function translateScreen($screen, $language)
+    {
+        if (!$screen) {
+            return;
+        }
+
+        $config = $screen['config'];
+        $translations = $screen['translations'];
+        $targetLanguage = $language;
+
+        if (!$translations) {
+            return $config;
+        }
+
+        if (array_key_exists($targetLanguage, $translations)) {
+            foreach ($translations[$targetLanguage]['strings'] as $translation) {
+                $this->applyTranslationsToScreen($translation['key'], $translation['string'], $config);
+            }
+        }
+
+        return $config;
+    }
+
     public function applyTranslationsToScreen($key, $translatedString, &$config)
     {
         if ($config) {

--- a/resources/js/components/Menu.vue
+++ b/resources/js/components/Menu.vue
@@ -21,6 +21,14 @@
               <i :class="button.icon" />
               {{ button.name }}
             </b-button>
+            <select v-if="index === 1" v-model="selectedLanguage">
+              <option value="es">Spanish</option>
+              <option value="fr">French</option>
+              <option value="de">German</option>
+            </select>
+            <b-button v-if="index === 1" @click="translateScreen">
+              Translate
+            </b-button>
           </b-button-group>
 
           <b-button
@@ -125,6 +133,7 @@ export default {
       newItems: this.initialNewItems,
       sectionRight: true,
       items: [],
+      selectedLanguage: "es",
     };
   },
   computed: {
@@ -161,6 +170,9 @@ export default {
     },
   },
   methods: {
+    translateScreen() {
+      this.$emit("translate", this.selectedLanguage);
+    },
     handleNavigate(action) {
       switch (action?.value) {
         case "discard-draft":

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -10,6 +10,7 @@
         ref="menuScreen"
         :options="optionsMenu"
         :environment="self"
+        @translate="translateScreen"
       />
 
       <!-- Card Body -->
@@ -695,6 +696,14 @@ export default {
     },
   },
   mounted() {
+    // TODO -- traducciones si se desea haciendo postabcks
+    // const queryString = window.location.search;
+    // const urlParams = new URLSearchParams(queryString);
+    //
+    // if (urlParams.get("lang")) {
+    //   this.changeMode("preview");
+    // }
+
     // To include another language in the Validator with variable processmaker
     this.user = window.ProcessMaker?.user;
     if (this.user?.lang) {
@@ -719,6 +728,12 @@ export default {
   },
   methods: {
     ...mapMutations("globalErrorsModule", { setStoreMode: "setMode" }),
+    translateScreen(language) {
+      ProcessMaker.apiClient.get(`screens/${this.screen.id}/translate/${language}`)
+        .then((response) => {
+          this.preview.config = response.data;
+        });
+    },
     // eslint-disable-next-line func-names
     updateDataInput: debounce(function () {
       if (this.previewInputValid) {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -696,14 +696,6 @@ export default {
     },
   },
   mounted() {
-    // TODO -- traducciones si se desea haciendo postabcks
-    // const queryString = window.location.search;
-    // const urlParams = new URLSearchParams(queryString);
-    //
-    // if (urlParams.get("lang")) {
-    //   this.changeMode("preview");
-    // }
-
     // To include another language in the Validator with variable processmaker
     this.user = window.ProcessMaker?.user;
     if (this.user?.lang) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -100,6 +100,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::delete('screens/{screen}', [ScreenController::class, 'destroy'])->name('screens.destroy')->middleware('can:delete-screens,screen');
     Route::post('screens/{screen}/export', [ScreenController::class, 'export'])->name('screens.export')->middleware('can:export-screens,screen');
     Route::post('screens/import', [ScreenController::class, 'import'])->name('screens.import')->middleware('can:import-screens');
+    Route::get('screens/{screen}/translate/{language}', [ScreenController::class, 'translate'])->name('screen.translate')->middleware('can:edit-screens,screen');
 
     // Screen Categories
     Route::get('screen_categories', [ScreenCategoryController::class, 'index'])->name('screen_categories.index')->middleware('can:view-screen-categories');
@@ -333,6 +334,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('templates/{type}/import/validation', [TemplateController::class, 'preImportValidation'])->name('template.preImportValidation')->middleware('template-authorization');
     Route::post('template/{type}/{id}/publish', [TemplateController::class, 'publishTemplate'])->name('template.publishTemplate')->middleware('can:publish-screen-templates');
     Route::get('screen-builder/{type}/{id}', [TemplateController::class, 'show'])->name('screenBuilder.template.show')->middleware('template-authorization');
+
 
     // Wizard Templates
     Route::get('wizard-templates', [WizardTemplateController::class, 'index'])->name('wizard-templates.index');


### PR DESCRIPTION
## Issue & Reproduction Steps
Apply translations to a screen

![Peek 2024-10-01 09-18](https://github.com/user-attachments/assets/aa4e503c-f0e1-48ed-817f-6fbd74745c1c)



## Solution
- A new endpoint that translate a screen config has been created.
- In this PR the UI uses a simple "translate" button that will be replaced with the flag in tickets FOUR-18709

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- This PR resolves:
https://processmaker.atlassian.net/browse/FOUR-18715
https://processmaker.atlassian.net/browse/FOUR-18716

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next