### PR TITLE
FOUR-18059 Implement Clipboard Tab

### DIFF
--- a/resources/js/components/Menu.vue
+++ b/resources/js/components/Menu.vue
@@ -62,6 +62,7 @@
               class="text-capitalize screen-toolbar-button"
               :title="button.title"
               :data-cy="`toolbar-${button.id}`"
+              :disabled="toolbarDisabled"
               @click="executeFunction(button.action)"
             >
               <i :class="button.icon" />
@@ -117,6 +118,10 @@ export default {
     initialNewItems: {
       type: Array,
       default: () => [],
+    },
+    toolbarDisabled: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -10,6 +10,7 @@
         ref="menuScreen"
         :options="optionsMenu"
         :environment="self"
+        :toolbar-disabled="$refs.builder?.isCurrentPageClipboard"
       />
 
       <!-- Card Body -->


### PR DESCRIPTION
## Implement Clipboard Tab in screen builder
- Disable screen toolbar when Clipboard Tab is active

## How to Test
- Open an screen
- Add some elements to clipboard
- Open the clipboard from the pages dropdown
- You can add or remove elements from the clipboard
- Note the toolbar is disabled

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18059

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:screen-builder:FOUR-18059
ci:deploy
