### PR TITLE
FOUR-17680: [39200] AutoSave feature does not save correctly for New Line

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskDraftController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskDraftController.php
@@ -8,6 +8,7 @@ use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\SanitizeHelper;
 use ProcessMaker\Models\TaskDraft;
 
 class TaskDraftController extends Controller
@@ -31,7 +32,8 @@ class TaskDraftController extends Controller
         $draft = TaskDraft::firstOrNew($search, ['data' => []]);
         // Do not overwrite __deleted_files
         $deletedFiles = Arr::get($draft->data, '__deleted_files');
-        $data = $request->all();
+        $data = json_decode($request->getContent(), true);
+        $data = SanitizeHelper::sanitizeData( $data, null, $task->processRequest->do_not_sanitize ?? []);
         if ($deletedFiles) {
             $data['__deleted_files'] = $deletedFiles;
         }


### PR DESCRIPTION
FOUR-17680: [39200] AutoSave feature does not save correctly for New Line

##STEPS TO REPRODUCE
1. Create a new screen
2. add a text area
3. set textarea configuration to rich text
4. add line input
5. publish (Screenshot attached ) 
6. Run a request and fill the text area with multiple lines.
7. Make sure the autosave saves the form and then reload the page.
8. Notice that the content in the text area is not the same.

## Solution
- Into the  ProcessMaker/Http/Controllers/Api/TaskDraftController.php in the update method , we added a validation to sanitize the data

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-17680

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy