### PR TITLE
FOUR-19397 populate the participants column with user data

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/CaseController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/CaseController.php
@@ -163,7 +163,11 @@ class CaseController extends Controller
     private function paginateResponse(Builder $query): JsonResponse
     {
         $pageSize = $this->request->get('pageSize', self::DEFAULT_PAGE_SIZE);
-        $pagination = CaseResource::collection($query->paginate($pageSize));
+        $data = $query->paginate($pageSize);
+        // Get all the participants ids from the data
+        $users = $this->caseRepository->getUsers($data);
+
+        $pagination = CaseResource::customCollection($data, $users);
 
         return response()->json([
             'data' => $pagination->items(),

--- a/ProcessMaker/Http/Resources/V1_1/CaseResource.php
+++ b/ProcessMaker/Http/Resources/V1_1/CaseResource.php
@@ -2,12 +2,17 @@
 
 namespace ProcessMaker\Http\Resources\V1_1;
 
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Collection;
 use ProcessMaker\Http\Resources\ApiResource;
-use ProcessMaker\Models\User;
 
 class CaseResource extends ApiResource
 {
+    /**
+     * The users collection.
+     */
+    private static Collection $users;
+
     /**
      * Default fields that will be included in the response.
      */
@@ -30,22 +35,10 @@ class CaseResource extends ApiResource
     {
         $data = [];
 
-        $users = User::select('id', 'firstname', 'lastname', 'title', 'avatar')
-            ->get()
-            ->map(function ($user) {
-                return [
-                    'id' => $user->id,
-                    'name' => $user->fullname,
-                    'title' => $user->title,
-                    'avatar' => $user->avatar,
-                ];
-            })
-            ->keyBy('id');
-
         foreach (static::$defaultFields as $field) {
             if ($field === 'participants') {
                 $participants = $this->$field->toArray();
-                $data[$field] = $this->getParticipanData($participants, $users);
+                $data[$field] = $this->getParticipantData($participants);
 
                 continue;
             }
@@ -60,11 +53,24 @@ class CaseResource extends ApiResource
      * Transform participants using the users collection.
      *
      * @param array $participants The participants array.
-     * @param Collection $users The users collection.
      * @return array The transformed participants.
      */
-    private function getParticipanData(array $participants, Collection $users): array
+    private function getParticipantData(array $participants): array
     {
-        return array_map(fn($participant) => $users->get($participant), $participants);
+        return array_map(fn($participant) => self::$users->get($participant), $participants);
+    }
+
+    /**
+     * New resource collection method that accepts a users collection.
+     *
+     * @param mixed $resource The resource.
+     * @param Collection $users The users collection.
+     * @return AnonymousResourceCollection The anonymous resource collection.
+     */
+    public static function customCollection($resource, $users): AnonymousResourceCollection
+    {
+        self::$users = $users;
+
+        return parent::collection($resource);
     }
 }

--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -142,17 +142,10 @@ class CaseRepository implements CaseRepositoryInterface
             return;
         }
 
-        $participantExists = $this->case->participants->contains(function ($participant) use ($user) {
-            return $participant['id'] === $user->id;
-        });
+        $participantExists = $this->case->participants->contains($user->id);
 
         if (!$participantExists) {
-            $this->case->participants->push([
-                'id' => $user->id,
-                'name' => $user->getFullName(),
-                'title' => $user->title,
-                'avatar' => $user->avatar,
-            ]);
+            $this->case->participants->push($user->id);
 
             $this->caseParticipatedRepository->create($this->case, $token);
         }

--- a/database/factories/CaseParticipatedFactory.php
+++ b/database/factories/CaseParticipatedFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Models\User;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\ProcessMaker\Models\CaseParticipated>
@@ -19,8 +20,10 @@ class CaseParticipatedFactory extends Factory
      */
     public function definition(): array
     {
+        $users = User::get();
+
         return [
-            'user_id' => fake()->randomElement([1, 3]),
+            'user_id' => $users->random()->id,
             'case_number' => fake()->unique()->randomNumber(),
             'case_title' => fake()->words(3, true),
             'case_title_formatted' => fake()->words(3, true),
@@ -43,7 +46,11 @@ class CaseParticipatedFactory extends Factory
                     'parent_request' => fake()->randomNumber(),
                 ],
             ],
-            'request_tokens' => fake()->randomElement([fake()->randomNumber(), fake()->randomNumber(), fake()->randomNumber()]),
+            'request_tokens' => array_map(fn() => fake()->randomElement([
+                fake()->randomNumber(),
+                fake()->randomNumber(),
+                fake()->randomNumber(),
+            ]), range(1, 3)),
             'tasks' => [
                 [
                     'id' => fake()->numerify('node_####'),
@@ -58,20 +65,7 @@ class CaseParticipatedFactory extends Factory
                     'name' => fake()->words(2, true),
                 ],
             ],
-            'participants' => [
-                [
-                    'id' => fake()->randomNumber(),
-                    'name' => fake()->name(),
-                ],
-                [
-                    'id' => fake()->randomNumber(),
-                    'name' => fake()->name(),
-                ],
-                [
-                    'id' => fake()->randomNumber(),
-                    'name' => fake()->name(),
-                ],
-            ],
+            'participants' => array_map(fn() => fake()->randomElement($users->pluck('id')->toArray()), range(1, 3)),
             'initiated_at' => fake()->dateTime(),
             'completed_at' => fake()->dateTime(),
             'keywords' => '',

--- a/database/factories/CaseStartedFactory.php
+++ b/database/factories/CaseStartedFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use ProcessMaker\Models\CaseStarted;
+use ProcessMaker\Models\User;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\ProcessMaker\Models\CaseStarted>
@@ -19,9 +20,11 @@ class CaseStartedFactory extends Factory
      */
     public function definition(): array
     {
+        $users = User::get();
+
         return [
             'case_number' => fake()->unique()->randomNumber(),
-            'user_id' => fake()->randomElement([1, 3]),
+            'user_id' => $users->random()->id,
             'case_title' => fake()->words(3, true),
             'case_title_formatted' => fake()->words(3, true),
             'case_status' => fake()->randomElement(['IN_PROGRESS', 'COMPLETED']),
@@ -43,7 +46,11 @@ class CaseStartedFactory extends Factory
                     'parent_request' => fake()->randomNumber(),
                 ],
             ],
-            'request_tokens' => fake()->randomElement([fake()->randomNumber(), fake()->randomNumber(), fake()->randomNumber()]),
+            'request_tokens' => array_map(fn() => fake()->randomElement([
+                fake()->randomNumber(),
+                fake()->randomNumber(),
+                fake()->randomNumber(),
+            ]), range(1, 3)),
             'tasks' => [
                 [
                     'id' => fake()->numerify('node_####'),
@@ -58,20 +65,7 @@ class CaseStartedFactory extends Factory
                     'name' => fake()->words(2, true),
                 ],
             ],
-            'participants' => [
-                [
-                    'id' => fake()->randomNumber(),
-                    'name' => fake()->name(),
-                ],
-                [
-                    'id' => fake()->randomNumber(),
-                    'name' => fake()->name(),
-                ],
-                [
-                    'id' => fake()->randomNumber(),
-                    'name' => fake()->name(),
-                ],
-            ],
+            'participants' => array_map(fn() => fake()->randomElement($users->pluck('id')->toArray()), range(1, 3)),
             'initiated_at' => fake()->dateTime(),
             'completed_at' => fake()->dateTime(),
             'keywords' => '',

--- a/tests/Feature/Cases/CaseStartedTest.php
+++ b/tests/Feature/Cases/CaseStartedTest.php
@@ -308,10 +308,7 @@ class CaseStartedTest extends TestCase
             'user_id' => $user->id,
             'case_title' => 'Case #' . $instance->case_number,
             'case_status' => 'IN_PROGRESS',
-            'participants->[0]->id' => $user->id,
-            'participants->[0]->name' => $user->fullName,
-            'participants->[0]->title' => $user->title,
-            'participants->[0]->avatar' => $user->avatar,
+            'participants->[0]' => $user->id,
         ]);
 
         $user2 = User::factory()->create();
@@ -326,10 +323,7 @@ class CaseStartedTest extends TestCase
             'user_id' => $user->id,
             'case_title' => 'Case #' . $instance->case_number,
             'case_status' => 'IN_PROGRESS',
-            'participants->[1]->id' => $user2->id,
-            'participants->[1]->name' => $user2->fullName,
-            'participants->[1]->title' => $user2->title,
-            'participants->[1]->avatar' => $user2->avatar,
+            'participants->[1]' => $user2->id,
         ]);
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Instead of populating this field in the cases tables (started and participated), store only the IDs and do a post-processing to complete the required information

## Related Tickets & Packages
[FOUR-19397](https://processmaker.atlassian.net/browse/FOUR-19397)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-19397]: https://processmaker.atlassian.net/browse/FOUR-19397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ