### PR TITLE
The Block duplicate session in IP Restriction option only works the first time

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -242,10 +242,6 @@ class LoginController extends Controller
     public function beforeLogout(Request $request)
     {
         if (Auth::check()) {
-            // Remove the Laravel cookie
-            $request->session()->invalidate();
-            Cookie::queue(Cookie::forget(Passport::cookie()));
-
             //Clear the user permissions
             $request->session()->forget('permissions');
 
@@ -263,6 +259,10 @@ class LoginController extends Controller
             session()->remove(TwoFactorAuthController::TFA_VALIDATED);
             session()->remove(TwoFactorAuthController::TFA_MESSAGE);
             session()->remove(TwoFactorAuthController::TFA_ERROR);
+
+            // Remove the Laravel cookie
+            $request->session()->invalidate();
+            Cookie::queue(Cookie::forget(Passport::cookie()));
         }
 
         return $this->logout($request);


### PR DESCRIPTION
## Issue & Reproduction Steps
When the option to block double session is set for ProcessMaker, the session is locked and the state is not allowed to change.

## Solution
- Change order to disable sessions

## How to Test
Steps in the ticket

review ticket FOUR-16704, as well.

## Related Tickets & Packages
- [FOUR-19466](https://processmaker.atlassian.net/browse/FOUR-19466)
- [FOUR-16704](https://processmaker.atlassian.net/browse/FOUR-16704)
ci:next
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19466]: https://processmaker.atlassian.net/browse/FOUR-19466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-16704]: https://processmaker.atlassian.net/browse/FOUR-16704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ