### PR TITLE
FOUR-8718: Render mustaches, maybe a re render

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -672,11 +672,15 @@ class ScreenController extends Controller
      *     ),
      * )
      */
-    public function translate(Screen $screen, $language)
+    public function translate(Request $request, Screen $screen, $language)
     {
         $draft = $screen->versions()->draft()->first();
         $processTranslation = new ProcessTranslation(null);
-        $transConfig = $processTranslation->translateScreen($draft, $language);
+        $transConfig = $processTranslation->translateScreen(
+            $draft,
+            $request->input('screenConfig'),
+            $request->input('inputData'),
+            $language);
         return $transConfig;
     }
 

--- a/ProcessMaker/ProcessTranslations/ProcessTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ProcessTranslation.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Cache;
 use ProcessMaker\Assets\ScreensInProcess;
 use ProcessMaker\Assets\ScreensInScreen;
 use ProcessMaker\ImportExport\Utils;
+use ProcessMaker\Models\MustacheExpressionEvaluator;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessTranslationToken;
 use ProcessMaker\Models\Screen;
@@ -269,13 +270,16 @@ class ProcessTranslation
         return $config;
     }
 
-    public function translateScreen($screen, $language)
+    public function translateScreen($screen, $screenConfig, $data, $language)
     {
         if (!$screen) {
             return;
         }
 
-        $config = $screen['config'];
+        $mustacheEngine = new MustacheExpressionEvaluator();
+        $configEvaluated = $mustacheEngine->render(json_encode($screenConfig), $data);
+
+        $config = json_decode($configEvaluated, true);
         $translations = $screen['translations'];
         $targetLanguage = $language;
 

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -721,7 +721,11 @@ export default {
   methods: {
     ...mapMutations("globalErrorsModule", { setStoreMode: "setMode" }),
     translateScreen(language) {
-      ProcessMaker.apiClient.get(`screens/${this.screen.id}/translate/${language}`)
+      const postData = {
+        inputData: this.previewData,
+        screenConfig: this.screen.config,
+      };
+      ProcessMaker.apiClient.post(`screens/${this.screen.id}/translate/${language}`, postData)
         .then((response) => {
           this.preview.config = response.data;
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -100,7 +100,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::delete('screens/{screen}', [ScreenController::class, 'destroy'])->name('screens.destroy')->middleware('can:delete-screens,screen');
     Route::post('screens/{screen}/export', [ScreenController::class, 'export'])->name('screens.export')->middleware('can:export-screens,screen');
     Route::post('screens/import', [ScreenController::class, 'import'])->name('screens.import')->middleware('can:import-screens');
-    Route::get('screens/{screen}/translate/{language}', [ScreenController::class, 'translate'])->name('screen.translate')->middleware('can:edit-screens,screen');
+    Route::post('screens/{screen}/translate/{language}', [ScreenController::class, 'translate'])->name('screen.translate')->middleware('can:edit-screens,screen');
 
     // Screen Categories
     Route::get('screen_categories', [ScreenCategoryController::class, 'index'])->name('screen_categories.index')->middleware('can:view-screen-categories');


### PR DESCRIPTION
## Issue & Reproduction Steps
Implements https://processmaker.atlassian.net/browse/FOUR-18718

## Solution
- Evaluates mustache before translating a screen


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18718

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next