### PR TITLE
FOUR-18610 combine search text and filters

### DIFF
--- a/ProcessMaker/Models/CaseStarted.php
+++ b/ProcessMaker/Models/CaseStarted.php
@@ -45,10 +45,6 @@ class CaseStarted extends ProcessMakerModel
         'completed_at',
     ];
 
-    protected $attributes = [
-        'keywords' => '',
-    ];
-
     protected static function newFactory(): Factory
     {
         return CaseStartedFactory::new();

--- a/ProcessMaker/Repositories/CaseApiRepository.php
+++ b/ProcessMaker/Repositories/CaseApiRepository.php
@@ -35,6 +35,8 @@ class CaseApiRepository implements CaseApiRepositoryInterface
 
     protected $sortableFields = [
         'case_number',
+        'case_title',
+        'status',
         'initiated_at',
         'completed_at',
     ];

--- a/ProcessMaker/Repositories/CaseApiRepository.php
+++ b/ProcessMaker/Repositories/CaseApiRepository.php
@@ -40,8 +40,7 @@ class CaseApiRepository implements CaseApiRepositoryInterface
     ];
 
     protected $searchableFields = [
-        'case_number',
-        'case_title',
+        'keywords',
     ];
 
     protected $filterableFields = [
@@ -149,15 +148,17 @@ class CaseApiRepository implements CaseApiRepositoryInterface
         if ($request->filled('search')) {
             $search = $request->get('search');
 
-            $query->where(function ($q) use ($search) {
-                foreach ($this->searchableFields as $field) {
-                    if ($field === 'case_title') {
-                        $q->orWhereFullText($field, $search . '*', ['mode' => 'boolean']);
-                    } else {
-                        $q->where($field, $search);
-                    }
-                }
-            });
+            if (is_numeric($search)) {
+                $search = CaseUtils::CASE_NUMBER_PREFIX . $search;
+            } else {
+                // Remove special characters except another languages
+                $search = preg_replace(['/[^a-zA-Z0-9\s]/', '/\s{2,}/'], [' ', ' '], $search);
+            }
+
+            // Add a plus (+) to the beginning and an asterisk (*) to the end of each word
+            $search = preg_replace('/\b(\w+)\b/', '+$1*', $search);
+
+            $query->whereFullText($this->searchableFields, $search, ['mode' => 'boolean']);
         }
     }
 

--- a/ProcessMaker/Repositories/CaseParticipatedRepository.php
+++ b/ProcessMaker/Repositories/CaseParticipatedRepository.php
@@ -43,6 +43,7 @@ class CaseParticipatedRepository
                 'participants' => $case->participants,
                 'initiated_at' => $case->initiated_at,
                 'completed_at' => null,
+                'keywords' => $case->keywords,
             ]);
         } catch (\Exception $e) {
             Log::error('CaseException: ' . $e->getMessage());
@@ -73,6 +74,7 @@ class CaseParticipatedRepository
                 'request_tokens' => CaseUtils::storeRequestTokens($token->getKey(), $this->caseParticipated->request_tokens),
                 'tasks' => CaseUtils::storeTasks($token, $this->caseParticipated->tasks),
                 'participants' => $case->participants,
+                'keywords' => $case->keywords,
             ]);
         } catch (\Exception $e) {
             Log::error('CaseException: ' . $e->getMessage());

--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -64,6 +64,7 @@ class CaseRepository implements CaseRepositoryInterface
                 'participants' => [],
                 'initiated_at' => $instance->initiated_at,
                 'completed_at' => null,
+                'keywords' => $instance->case_title,
             ]);
         } catch (\Exception $e) {
             Log::error('CaseException: ' . $e->getMessage());
@@ -91,6 +92,7 @@ class CaseRepository implements CaseRepositoryInterface
             $this->case->case_status = $instance->status === self::CASE_STATUS_ACTIVE ? 'IN_PROGRESS' : $instance->status;
             $this->case->request_tokens = CaseUtils::storeRequestTokens($token->getKey(), $this->case->request_tokens);
             $this->case->tasks = CaseUtils::storeTasks($token, $this->case->tasks);
+            $this->case->keywords = $instance->case_title;
 
             $this->updateParticipants($token);
 

--- a/ProcessMaker/Repositories/CaseSyncRepository.php
+++ b/ProcessMaker/Repositories/CaseSyncRepository.php
@@ -59,6 +59,7 @@ class CaseSyncRepository
                         'participants' => $participants,
                         'initiated_at' => $instance->initiated_at,
                         'completed_at' => $instance->completed_at,
+                        'keywords' => CaseUtils::getCaseNumberByKeywords($instance->case_number) . ' ' . $instance->case_title,
                     ],
                 );
 
@@ -95,6 +96,7 @@ class CaseSyncRepository
             'participants' => $participants,
             'initiated_at' => $instance->initiated_at,
             'completed_at' => $instance->completed_at,
+            'keywords' => CaseUtils::getCaseNumberByKeywords($instance->case_number) . ' ' . $instance->case_title,
         ];
     }
 

--- a/ProcessMaker/Repositories/CaseUtils.php
+++ b/ProcessMaker/Repositories/CaseUtils.php
@@ -12,6 +12,22 @@ class CaseUtils
 
     const ALLOWED_REQUEST_TOKENS = ['task', 'scriptTask', 'callActivity'];
 
+    const CASE_NUMBER_PREFIX = 'cn_';
+
+    /**
+     * Get the case number split into keywords.
+     */
+    public static function getCaseNumberByKeywords(int $caseNumber)
+    {
+        $caseNumber = (string) $caseNumber;
+        $keywords = array_map(
+            fn($i) => self::CASE_NUMBER_PREFIX . substr($caseNumber, 0, $i),
+            range(1, strlen($caseNumber))
+        );
+
+        return implode(' ', $keywords);
+    }
+
     /**
      * Store processes.
      *

--- a/database/factories/CaseParticipatedFactory.php
+++ b/database/factories/CaseParticipatedFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use ProcessMaker\Models\CaseParticipated;
 use ProcessMaker\Models\User;
+use ProcessMaker\Repositories\CaseUtils;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\ProcessMaker\Models\CaseParticipated>
@@ -22,10 +23,13 @@ class CaseParticipatedFactory extends Factory
     {
         $users = User::get();
 
+        $caseTitle = fake()->words(4, true);
+        $caseNumber = fake()->unique()->randomNumber();
+
         return [
             'user_id' => $users->random()->id,
-            'case_number' => fake()->unique()->randomNumber(),
-            'case_title' => fake()->words(3, true),
+            'case_number' => $caseNumber,
+            'case_title' => $caseTitle,
             'case_title_formatted' => fake()->words(3, true),
             'case_status' => fake()->randomElement(['IN_PROGRESS', 'COMPLETED']),
             'processes' => array_map(function() {
@@ -68,7 +72,7 @@ class CaseParticipatedFactory extends Factory
             'participants' => array_map(fn() => fake()->randomElement($users->pluck('id')->toArray()), range(1, 3)),
             'initiated_at' => fake()->dateTime(),
             'completed_at' => fake()->dateTime(),
-            'keywords' => '',
+            'keywords' => CaseUtils::getCaseNumberByKeywords($caseNumber) . ' ' . $caseTitle,
         ];
     }
 }

--- a/database/factories/CaseStartedFactory.php
+++ b/database/factories/CaseStartedFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use ProcessMaker\Models\CaseStarted;
 use ProcessMaker\Models\User;
+use ProcessMaker\Repositories\CaseUtils;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\ProcessMaker\Models\CaseStarted>
@@ -22,11 +23,14 @@ class CaseStartedFactory extends Factory
     {
         $users = User::get();
 
+        $caseTitle = fake()->words(4, true);
+        $caseNumber = fake()->unique()->randomNumber();
+
         return [
-            'case_number' => fake()->unique()->randomNumber(),
+            'case_number' => $caseNumber,
             'user_id' => $users->random()->id,
-            'case_title' => fake()->words(3, true),
-            'case_title_formatted' => fake()->words(3, true),
+            'case_title' => $caseTitle,
+            'case_title_formatted' => $caseTitle,
             'case_status' => fake()->randomElement(['IN_PROGRESS', 'COMPLETED']),
             'processes' => array_map(function() {
                 return [
@@ -68,7 +72,7 @@ class CaseStartedFactory extends Factory
             'participants' => array_map(fn() => fake()->randomElement($users->pluck('id')->toArray()), range(1, 3)),
             'initiated_at' => fake()->dateTime(),
             'completed_at' => fake()->dateTime(),
-            'keywords' => '',
+            'keywords' => CaseUtils::getCaseNumberByKeywords($caseNumber) . ' ' . $caseTitle,
         ];
     }
 }

--- a/tests/Feature/Api/V1_1/CaseControllerSearchTest.php
+++ b/tests/Feature/Api/V1_1/CaseControllerSearchTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Feature\Api\V1_1;
+
+use ProcessMaker\Repositories\CaseUtils;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class CaseControllerSearchTest extends TestCase
+{
+    use RequestHelper;
+
+    public function test_search_all_cases_by_case_number(): void
+    {
+        $user = CaseControllerTest::createUser('user_a');
+        CaseControllerTest::createCasesStartedForUser($user->id, 5);
+        $caseNumber = 123456;
+        CaseControllerTest::createCasesStartedForUser($user->id, 1, ['case_number' => $caseNumber, 'keywords' => CaseUtils::getCaseNumberByKeywords($caseNumber)]);
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases'));
+        $response->assertStatus(200);
+        $response->assertJsonCount(6, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['search' => $caseNumber]));
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+    }
+
+    public function test_search_in_progress_cases_by_case_number(): void
+    {
+        $user = CaseControllerTest::createUser('user_b');
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 5, ['case_status' => 'IN_PROGRESS']);
+        $caseNumber = 123456;
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 1, [
+            'case_number' => $caseNumber, 'case_status' => 'IN_PROGRESS', 'keywords' => CaseUtils::getCaseNumberByKeywords($caseNumber),
+        ]);
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.in_progress'));
+        $response->assertStatus(200);
+        $response->assertJsonCount(6, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.in_progress', ['search' => $caseNumber]));
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+    }
+
+    public function test_search_completed_cases_by_case_number(): void
+    {
+        $user = CaseControllerTest::createUser('user_c');
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 5, ['case_status' => 'COMPLETED']);
+        $caseNumber = 987654;
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 1, [
+            'case_number' => $caseNumber, 'case_status' => 'COMPLETED', 'keywords' => CaseUtils::getCaseNumberByKeywords($caseNumber),
+        ]);
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed'));
+        $response->assertStatus(200);
+        $response->assertJsonCount(6, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed', ['search' => $caseNumber]));
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+    }
+
+    public function test_search_all_cases_by_case_title(): void
+    {
+        $caseTitle1 = 'Accident Insurance Registration Process';
+        $caseTitle2 = 'ABE Spring';
+        $caseTitle3 = 'Credit Evaluation Process';
+
+        $user = CaseControllerTest::createUser('user_d');
+        CaseControllerTest::createCasesStartedForUser($user->id, 5, ['case_title' => $caseTitle1, 'keywords' => $caseTitle1]);
+        CaseControllerTest::createCasesStartedForUser($user->id, 5, ['case_title' => $caseTitle2, 'keywords' => $caseTitle2]);
+        CaseControllerTest::createCasesStartedForUser($user->id, 5, ['case_title' => $caseTitle3, 'keywords' => $caseTitle3]);
+
+        $this->assertDatabaseCount('cases_started', 21);
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases'));
+        $response->assertStatus(200);
+        $response->assertJsonCount(15, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['search' => 'insurance']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['search' => 'spri']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['search' => 'accident registration']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['search' => 'accident evaluation']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(0, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['search' => '(credit)']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+    }
+
+    public function test_search_in_progress_cases_by_case_title(): void
+    {
+        $caseTitle1 = 'Accident Insurance Registration Process';
+        $caseTitle2 = 'ABE Spring';
+        $caseTitle3 = 'Credit Evaluation Process';
+
+        $user = CaseControllerTest::createUser('user_e');
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 10, ['case_title' => $caseTitle1, 'case_status' => 'IN_PROGRESS', 'keywords' => $caseTitle1]);
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 5, ['case_title' => $caseTitle2, 'case_status' => 'IN_PROGRESS', 'keywords' => $caseTitle2]);
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 5, ['case_title' => $caseTitle3, 'case_status' => 'IN_PROGRESS', 'keywords' => $caseTitle3]);
+
+        $this->assertDatabaseCount('cases_participated', 32);
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.in_progress', ['pageSize' => 50]));
+        $response->assertStatus(200);
+        $response->assertJsonCount(26, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.in_progress', ['search' => 'accident']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(10, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.in_progress', ['search' => 'proc']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(15, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.in_progress', ['search' => 'registration       accident']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(10, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.in_progress', ['search' => 'insurance abe']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(0, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.in_progress', ['search' => '(evaluation)']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+    }
+
+    public function test_search_completed_cases_by_case_title(): void
+    {
+        $caseTitle1 = 'Accident Insurance Registration Process';
+        $caseTitle2 = 'ABE Spring';
+        $caseTitle3 = 'Credit Evaluation Process 123-abc';
+
+        $user = CaseControllerTest::createUser('user_f');
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 5, ['case_title' => $caseTitle1, 'case_status' => 'COMPLETED', 'keywords' => $caseTitle1]);
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 10, ['case_title' => $caseTitle2, 'case_status' => 'COMPLETED', 'keywords' => $caseTitle2]);
+        CaseControllerTest::createCasesParticipatedForUser($user->id, 5, ['case_title' => $caseTitle3, 'case_status' => 'COMPLETED', 'keywords' => $caseTitle3]);
+
+        $this->assertDatabaseCount('cases_participated', 52);
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed', ['pageSize' => 30]));
+        $response->assertStatus(200);
+        $response->assertJsonCount(26, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed', ['search' => 'accident']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed', ['search' => 'ab']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(15, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed', ['search' => 'credit evaluation']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed', ['search' => 'proc         spr']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(0, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed', ['search' => '(accident)']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.completed', ['search' => '(123-abc)']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+    }
+
+    public function test_search_special_all_cases_by_case_number(): void
+    {
+        $caseTitle1 = 'this is a ci 123456LP';
+
+        $user = CaseControllerTest::createUser('user_g');
+        CaseControllerTest::createCasesStartedForUser($user->id, 5, ['case_title' => $caseTitle1, 'keywords' => $caseTitle1]);
+
+        $this->assertDatabaseCount('cases_started', 26);
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases'));
+        $response->assertStatus(200);
+        $response->assertJsonCount(15, 'data');
+
+        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['search' => '123456LP']));
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+    }
+
+    protected function connectionsToTransact()
+    {
+        return [];
+    }
+}

--- a/tests/Feature/Api/V1_1/CaseControllerTest.php
+++ b/tests/Feature/Api/V1_1/CaseControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api\V1_1;
 
-use Faker\Factory as Faker;
 use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\CaseParticipated;
 use ProcessMaker\Models\CaseStarted;
@@ -16,7 +15,7 @@ class CaseControllerTest extends TestCase
 {
     use RequestHelper;
 
-    private function createUser(string $username, string $password = 'secret', string $status = 'ACTIVE'): User
+    public static function createUser(string $username, string $password = 'secret', string $status = 'ACTIVE'): User
     {
         return User::factory()->create([
             'username' => $username,
@@ -25,20 +24,20 @@ class CaseControllerTest extends TestCase
         ]);
     }
 
-    private function createCasesStartedForUser(int $userId, int $count = 1, $data = [])
+    public static function createCasesStartedForUser(int $userId, int $count = 1, $data = [])
     {
         return CaseStarted::factory()->count($count)->create(array_merge(['user_id' => $userId], $data));
     }
 
-    private function createCasesParticipatedForUser(int $userId, int $count = 1, $data = [])
+    public static function createCasesParticipatedForUser(int $userId, int $count = 1, $data = [])
     {
         return CaseParticipated::factory()->count($count)->create(array_merge(['user_id' => $userId], $data));
     }
 
     public function test_get_all_cases(): void
     {
-        $userA = $this->createUser('user_a');
-        $cases = $this->createCasesStartedForUser($userA->id, 10);
+        $userA = self::createUser('user_a');
+        $cases = self::createCasesStartedForUser($userA->id, 10);
 
         $response = $this->apiCall('GET', route('api.1.1.cases.all_cases'));
         $response->assertStatus(200);
@@ -47,8 +46,8 @@ class CaseControllerTest extends TestCase
 
     public function test_get_in_progress(): void
     {
-        $userA = $this->createUser('user_a');
-        $cases = $this->createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
+        $userA = self::createUser('user_a');
+        $cases = self::createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
 
         $response = $this->apiCall('GET', route('api.1.1.cases.in_progress'));
         $response->assertStatus(200);
@@ -63,8 +62,8 @@ class CaseControllerTest extends TestCase
 
     public function test_get_completed(): void
     {
-        $userA = $this->createUser('user_a');
-        $cases = $this->createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'COMPLETED']);
+        $userA = self::createUser('user_a');
+        $cases = self::createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'COMPLETED']);
 
         $response = $this->apiCall('GET', route('api.1.1.cases.completed'));
         $response->assertStatus(200);
@@ -79,12 +78,12 @@ class CaseControllerTest extends TestCase
 
     public function test_get_all_cases_by_users(): void
     {
-        $userA = $this->createUser('user_a');
-        $userB = $this->createUser('user_b');
+        $userA = self::createUser('user_a');
+        $userB = self::createUser('user_b');
 
-        $casesA = $this->createCasesStartedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
-        $casesB = $this->createCasesStartedForUser($userB->id, 6, ['case_status' => 'COMPLETED']);
-        $casesC = $this->createCasesStartedForUser($userA->id, 4, ['case_status' => 'IN_PROGRESS']);
+        $casesA = self::createCasesStartedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
+        $casesB = self::createCasesStartedForUser($userB->id, 6, ['case_status' => 'COMPLETED']);
+        $casesC = self::createCasesStartedForUser($userA->id, 4, ['case_status' => 'IN_PROGRESS']);
 
         $response = $this->apiCall('GET', route('api.1.1.cases.all_cases'));
 
@@ -107,12 +106,12 @@ class CaseControllerTest extends TestCase
 
     public function test_get_all_cases_by_status(): void
     {
-        $userA = $this->createUser('user_a');
-        $userB = $this->createUser('user_b');
+        $userA = self::createUser('user_a');
+        $userB = self::createUser('user_b');
 
-        $casesA = $this->createCasesStartedForUser($userA->id, 5, ['case_status' => 'COMPLETED']);
-        $casesB = $this->createCasesStartedForUser($userB->id, 6, ['case_status' => 'IN_PROGRESS']);
-        $casesC = $this->createCasesStartedForUser($userA->id, 4, ['case_status' => 'COMPLETED']);
+        $casesA = self::createCasesStartedForUser($userA->id, 5, ['case_status' => 'COMPLETED']);
+        $casesB = self::createCasesStartedForUser($userB->id, 6, ['case_status' => 'IN_PROGRESS']);
+        $casesC = self::createCasesStartedForUser($userA->id, 4, ['case_status' => 'COMPLETED']);
 
         $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['status' => 'IN_PROGRESS']));
         $response->assertStatus(200);
@@ -126,12 +125,12 @@ class CaseControllerTest extends TestCase
 
     public function test_get_in_progress_by_user(): void
     {
-        $userA = $this->createUser('user_a');
-        $userB = $this->createUser('user_b');
-        $userC = $this->createUser('user_c');
-        $casesA = $this->createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
-        $casesB = $this->createCasesParticipatedForUser($userB->id, 6, ['case_status' => 'IN_PROGRESS']);
-        $casesC = $this->createCasesParticipatedForUser($userC->id, 4, ['case_status' => 'IN_PROGRESS']);
+        $userA = self::createUser('user_a');
+        $userB = self::createUser('user_b');
+        $userC = self::createUser('user_c');
+        $casesA = self::createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
+        $casesB = self::createCasesParticipatedForUser($userB->id, 6, ['case_status' => 'IN_PROGRESS']);
+        $casesC = self::createCasesParticipatedForUser($userC->id, 4, ['case_status' => 'IN_PROGRESS']);
 
         $response = $this->apiCall('GET', route('api.1.1.cases.in_progress', ['userId' => $userA->id]));
         $response->assertStatus(200);
@@ -146,26 +145,10 @@ class CaseControllerTest extends TestCase
         $response->assertJsonCount($casesC->count(), 'data');
     }
 
-    public function test_search_all_cases_by_case_number(): void
-    {
-        $userA = $this->createUser('user_a');
-        $this->createCasesStartedForUser($userA->id, 5);
-        $caseNumber = 123456;
-        $this->createCasesStartedForUser($userA->id, 1, ['case_number' => $caseNumber]);
-
-        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases'));
-        $response->assertStatus(200);
-        $response->assertJsonCount(6, 'data');
-
-        $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['search' => $caseNumber]));
-        $response->assertStatus(200);
-        $response->assertJsonCount(1, 'data');
-    }
-
     public function test_get_all_cases_sort_by_case_number(): void
     {
-        $userA = $this->createUser('user_a');
-        $cases = $this->createCasesStartedForUser($userA->id, 10);
+        $userA = self::createUser('user_a');
+        $cases = self::createCasesStartedForUser($userA->id, 10);
 
         $casesSorted = $cases->sortBy('case_number');
 
@@ -182,8 +165,8 @@ class CaseControllerTest extends TestCase
 
     public function test_get_all_cases_sort_by_completed_at(): void
     {
-        $userA = $this->createUser('user_a');
-        $cases = $this->createCasesStartedForUser($userA->id, 10);
+        $userA = self::createUser('user_a');
+        $cases = self::createCasesStartedForUser($userA->id, 10);
         $casesSorted = $cases->sortBy('completed_at');
 
         $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['sortBy' => 'completed_at:asc']));
@@ -212,10 +195,10 @@ class CaseControllerTest extends TestCase
 
     public function test_filter_by_case_number(): void
     {
-        $userA = $this->createUser('user_a');
+        $userA = self::createUser('user_a');
         $caseNumber = 123456;
-        $this->createCasesStartedForUser($userA->id, 5);
-        $this->createCasesStartedForUser($userA->id, 1, ['case_number' => $caseNumber]);
+        self::createCasesStartedForUser($userA->id, 5);
+        self::createCasesStartedForUser($userA->id, 1, ['case_number' => $caseNumber]);
 
         $filterBy = [
             'filterBy' => json_encode([
@@ -235,10 +218,10 @@ class CaseControllerTest extends TestCase
 
     public function test_filter_by_case_status(): void
     {
-        $userA = $this->createUser('user_a');
-        $casesA = $this->createCasesStartedForUser($userA->id, 5);
+        $userA = self::createUser('user_a');
+        $casesA = self::createCasesStartedForUser($userA->id, 5);
         $caseNumber = 123456;
-        $casesB = $this->createCasesStartedForUser($userA->id, 1, [
+        $casesB = self::createCasesStartedForUser($userA->id, 1, [
             'case_number' => $caseNumber,
             'case_status' => 'IN_PROGRESS',
         ]);
@@ -265,10 +248,10 @@ class CaseControllerTest extends TestCase
 
     public function test_filter_by_user_and_case_status(): void
     {
-        $userA = $this->createUser('user_a');
-        $casesA = $this->createCasesStartedForUser($userA->id, 5);
+        $userA = self::createUser('user_a');
+        $casesA = self::createCasesStartedForUser($userA->id, 5);
         $caseNumber = 123456;
-        $casesB = $this->createCasesStartedForUser($userA->id, 1, [
+        $casesB = self::createCasesStartedForUser($userA->id, 1, [
             'case_number' => $caseNumber,
             'case_status' => 'IN_PROGRESS',
         ]);
@@ -302,10 +285,10 @@ class CaseControllerTest extends TestCase
 
     public function test_filter_by_user_case_status_and_created_at(): void
     {
-        $userA = $this->createUser('user_a');
-        $casesA = $this->createCasesStartedForUser($userA->id, 5);
+        $userA = self::createUser('user_a');
+        $casesA = self::createCasesStartedForUser($userA->id, 5);
         $caseNumber = 123456;
-        $casesB = $this->createCasesStartedForUser($userA->id, 1, [
+        $casesB = self::createCasesStartedForUser($userA->id, 1, [
             'case_number' => $caseNumber,
             'case_status' => 'IN_PROGRESS',
         ]);
@@ -346,10 +329,10 @@ class CaseControllerTest extends TestCase
 
     public function test_filter_by_user_case_status_created_at_and_completed_at(): void
     {
-        $userA = $this->createUser('user_a');
-        $casesA = $this->createCasesStartedForUser($userA->id, 5);
+        $userA = self::createUser('user_a');
+        $casesA = self::createCasesStartedForUser($userA->id, 5);
         $caseNumber = 123456;
-        $casesB = $this->createCasesStartedForUser($userA->id, 1, [
+        $casesB = self::createCasesStartedForUser($userA->id, 1, [
             'case_number' => $caseNumber,
             'case_status' => 'IN_PROGRESS',
         ]);
@@ -424,23 +407,23 @@ class CaseControllerTest extends TestCase
             'title' => 'View My Requests',
         ]);
 
-        $userA = $this->createUser('user_a');
-        $userB = $this->createUser('user_b');
+        $userA = self::createUser('user_a');
+        $userB = self::createUser('user_b');
 
         $userA->giveDirectPermission('view-all_cases');
         $userA->giveDirectPermission('view-my_requests');
         $userB->giveDirectPermission('view-all_cases');
         $userB->giveDirectPermission('view-my_requests');
 
-        $casesA = $this->createCasesStartedForUser($userA->id, 5, ['case_status' => 'COMPLETED']);
-        $casesB = $this->createCasesStartedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
-        $casesC = $this->createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'COMPLETED']);
-        $casesD = $this->createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
+        $casesA = self::createCasesStartedForUser($userA->id, 5, ['case_status' => 'COMPLETED']);
+        $casesB = self::createCasesStartedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
+        $casesC = self::createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'COMPLETED']);
+        $casesD = self::createCasesParticipatedForUser($userA->id, 5, ['case_status' => 'IN_PROGRESS']);
 
-        $casesE = $this->createCasesStartedForUser($userB->id, 5, ['case_status' => 'COMPLETED']);
-        $casesF = $this->createCasesStartedForUser($userB->id, 5, ['case_status' => 'IN_PROGRESS']);
-        $casesG = $this->createCasesParticipatedForUser($userB->id, 5, ['case_status' => 'COMPLETED']);
-        $casesH = $this->createCasesParticipatedForUser($userB->id, 5, ['case_status' => 'IN_PROGRESS']);
+        $casesE = self::createCasesStartedForUser($userB->id, 5, ['case_status' => 'COMPLETED']);
+        $casesF = self::createCasesStartedForUser($userB->id, 5, ['case_status' => 'IN_PROGRESS']);
+        $casesG = self::createCasesParticipatedForUser($userB->id, 5, ['case_status' => 'COMPLETED']);
+        $casesH = self::createCasesParticipatedForUser($userB->id, 5, ['case_status' => 'IN_PROGRESS']);
 
         $in_progress = ProcessRequest::factory(5)->create([
             'status' => 'ACTIVE',


### PR DESCRIPTION
## Issue & Reproduction Steps
Implement a Text match search and filters based on the following document: ([Improve My Cases | Full Text Search Examples with cases_started](https://processmaker.atlassian.net/wiki/spaces/ARB/pages/3597762650/Improve+My+Cases#Full-Text-Search-Examples-with-cases_started) ) 

For sorting options consider:

Sort available only for the following fields
case_number

case_title (low performance because of full scan)

status (low performance because of full scan)

initiated_at (low performance because of full scan)

completed_at (low performance because of full scan)

## Related Tickets & Packages
[FOUR-18610](https://processmaker.atlassian.net/browse/FOUR-18610)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next



[FOUR-18610]: https://processmaker.atlassian.net/browse/FOUR-18610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ