### PR TITLE
FOUR-19482 | Placeholder Text for All Templates Search Is Not Correct in LaunchPad

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -122,12 +122,6 @@ export default {
       await this.$nextTick();
       this.loadCard();
     },
-    processSelected(newValue) {
-      this.$emit('processSelectedChanged', newValue);
-    },
-    templateSelected(newValue) {
-      this.$emit('templateSelectedChanged', newValue);
-    },
   },
   mounted() {
     this.loadCard(()=>{

--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -3,6 +3,8 @@
     <SearchCards
       v-if="processList.length > 0 || showEmpty"
       :filter-pmql="onFilter"
+      :process-selected="processSelected"
+      :template-selected="templateSelected"
     />
     <div
       id="infinite-list-card"
@@ -95,6 +97,8 @@ export default {
       sumHeight: 0,
       isCardProcess: true,
       sizeChange: false,
+      processSelected: false,
+      templateSelected: false,
     };
   },
   computed: {
@@ -118,6 +122,12 @@ export default {
       await this.$nextTick();
       this.loadCard();
     },
+    processSelected(newValue) {
+      this.$emit('processSelectedChanged', newValue);
+    },
+    templateSelected(newValue) {
+      this.$emit('templateSelectedChanged', newValue);
+    },
   },
   mounted() {
     this.loadCard(()=>{
@@ -128,6 +138,16 @@ export default {
     }, null);
     this.$root.$on("sizeChanged", (val) => {
       this.handleSizeChange(val);
+    });
+
+    ProcessMaker.EventBus.$on("process-item-selected", () => {
+      this.processSelected = true;
+      this.templateSelected = false;
+    });
+
+    ProcessMaker.EventBus.$on("template-item-selected", () => {
+      this.templateSelected = true;
+      this.processSelected = false;
     });
   },
   beforeDestroy() {

--- a/resources/js/processes-catalogue/components/menuCatologue.vue
+++ b/resources/js/processes-catalogue/components/menuCatologue.vue
@@ -167,6 +167,14 @@ export default {
     if (!this.selectedProcessItem && !this.selectedTemplateItem) {
       this.selectDefault();
     }
+
+    if (this.selectedProcessItem && !this.selectedTemplateItem) {
+      window.ProcessMaker.EventBus.$emit("process-item-selected");
+    }
+
+    if (this.selectedTemplateItem && !this.selectedProcessItem) {
+      window.ProcessMaker.EventBus.$emit("template-item-selected");
+    }
   },
   watch: {
     $route(r) {

--- a/resources/js/processes-catalogue/components/utils/SearchCards.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCards.vue
@@ -16,7 +16,7 @@
       <b-form-input
         class="search-box"
         v-model="filter"
-        :placeholder="$t('Search Templates')"
+        :placeholder="placeholder"
         @keyup.enter="fetch()"
       />
 
@@ -52,7 +52,7 @@
 
 <script>
 export default {
-  props: ["filterPmql"],
+  props: ["filterPmql", "processSelected", "templateSelected"],
   data() {
     return {
       filter: "",
@@ -65,6 +65,13 @@ export default {
         'search-wide': true,
       };
       return classes;
+    },
+    placeholder() {
+      if (this.templateSelected) {
+        return this.$t("Search Templates");
+      }
+
+      return this.$t("Search Categories and Processes");
     },
   },
   mounted() {

--- a/resources/js/processes-catalogue/components/utils/SearchCards.vue
+++ b/resources/js/processes-catalogue/components/utils/SearchCards.vue
@@ -16,7 +16,7 @@
       <b-form-input
         class="search-box"
         v-model="filter"
-        :placeholder="$t('Search categories and processes')"
+        :placeholder="$t('Search Templates')"
         @keyup.enter="fetch()"
       />
 


### PR DESCRIPTION
# Issue
Ticket: [FOUR-19482](https://processmaker.atlassian.net/browse/FOUR-19482)

In the Process LaunchPad, the placeholder text in the templates search bar should read "Search Templates" instead of "Search Categories and Processes". 

# Solution
- Pass `processSelected` and `templateSelected` props to `SearchCards.vue`. 
- Update `b-form-input` placeholder in `SearchCards.vue` based on whether or not a Process or Template has been selected.

# How to Test
1. Go to branch `FOUR-19482` in `processmaker`.
2. Go to Processes.
3. Select 'All Templates' from the 'Add From Templates' dropdown.
     - The search bar text should read 'Search Templates'.
4. Select a Process Category under 'Available Processes'.
     - The search bar text should read 'Search Categories and Processes'.


ci:next
ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-19482]: https://processmaker.atlassian.net/browse/FOUR-19482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ