### PR TITLE
FOUR-19530: The application logs out the second time, when using a SAML user

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 use Laravel\Passport\HasApiTokens;
 use Laravel\Passport\Passport;
@@ -253,8 +254,12 @@ class LoginController extends Controller
             // Clear the user session
             $this->forgetUserSession();
 
-            event(new Logout(Auth::user()));
-
+            try {
+                $eventResult = event(new Logout(Auth::user()));
+            } catch (\Throwable $e) {
+                Log::error('Error when in logout event: ' . $e->getMessage());
+                report($e);
+            }
             // Always destroy 2fa flag
             session()->remove(TwoFactorAuthController::TFA_VALIDATED);
             session()->remove(TwoFactorAuthController::TFA_MESSAGE);

--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -257,7 +257,7 @@ class LoginController extends Controller
             try {
                 $eventResult = event(new Logout(Auth::user()));
             } catch (\Throwable $e) {
-                Log::error('Error when in logout event: ' . $e->getMessage());
+                Log::error('Error in logout event: ' . $e->getMessage());
                 report($e);
             }
             // Always destroy 2fa flag


### PR DESCRIPTION
## Issue & Reproduction Steps
    Log in 
    Configure suer  SAML 
    log in with SAML
    log out 

Current Behavior:
It is necessary to logout twice.


## Solution
- https://processmaker.atlassian.net/browse/FOUR-19492


## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
