### PR TITLE
FOUR-19276: [FALL] Add parameter in the login

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -70,12 +70,14 @@ class LoginController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function showLoginForm()
+    public function showLoginForm(Request $request)
     {
         $manager = App::make(LoginManager::class);
         $addons = $manager->list();
+        // Cheche if the user can by pass
+        $showForceLogin = $request->has('showLogin') && $request->get('showLogin') === 'true';
         // Review if we need to redirect the default SSO
-        if (config('app.enable_default_sso')) {
+        if (config('app.enable_default_sso') && !$showForceLogin) {
             $arrayAddons = $addons->toArray();
             $driver = $this->getDefaultSSO($arrayAddons);
             // If a default SSO was defined we will to redirect


### PR DESCRIPTION
## Issue & Reproduction Steps
Add a parameter for URL to login without force SAML

## Solution
- List the changes you've introduced to solve the issue.

## How to Test

1. Configure other type of login
2. Force to login using this config
3. Add in the login the new parameter to avoid the login config
`?showLogin=true`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19276

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next