### PR TITLE
FOUR-18994 Load screen performance improvements [SUMMER]

### DIFF
--- a/ProcessMaker/Facades/ScreenCompiledManager.php
+++ b/ProcessMaker/Facades/ScreenCompiledManager.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void clearCompiledAssets()
  * @method static string createKey(string $processId, string $processVersionId, string $language, string $screenId, string $screenVersionId)
  * @method static int getLastScreenVersionId()
+ * @method static void clearProcessScreensCache(string $processId)
  *
  * @see \ProcessMaker\Managers\ScreenCompiledManager
  */

--- a/ProcessMaker/Facades/ScreenCompiledManager.php
+++ b/ProcessMaker/Facades/ScreenCompiledManager.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ProcessMaker\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static void storeCompiledContent(string $screenKey, mixed $compiledContent)
+ * @method static mixed|null getCompiledContent(string $screenKey)
+ * @method static void clearCompiledAssets()
+ * @method static string createKey(string $processId, string $processVersionId, string $language, string $screenId, string $screenVersionId)
+ * @method static int getLastScreenVersionId()
+ *
+ * @see \ProcessMaker\Managers\ScreenCompiledManager
+ */
+class ScreenCompiledManager extends Facade
+{
+    /**
+     * Get the registered name of the component in the service container.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'compiledscreen';
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/ProcessTranslationController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessTranslationController.php
@@ -4,6 +4,8 @@ namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Bus;
+use ProcessMaker\Facades\ScreenCompiledManager;
+
 use function PHPUnit\Framework\isEmpty;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Models\Process;
@@ -184,6 +186,9 @@ class ProcessTranslationController extends Controller
         $processVersion = Process::find($processId)->getDraftOrPublishedLatestVersion();
         $processTranslation = new ProcessTranslation($processVersion);
         $processTranslation->updateTranslations($screensTranslations, $language);
+
+        // Clear the screens cache for the process
+        ScreenCompiledManager::clearProcessScreensCache($processId);
     }
 
     public function export(Request $request, $processId, $languageCode)

--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use ProcessMaker\Events\ScreenCreated;
 use ProcessMaker\Events\ScreenDeleted;
 use ProcessMaker\Events\ScreenUpdated;
+use ProcessMaker\Facades\ScreenCompiledManager;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
@@ -299,6 +300,10 @@ class ScreenController extends Controller
         $changes['tmp_screen_category_id'] = $request->input('screen_category_id');
         ScreenUpdated::dispatch($screen, $changes, $original);
         $this->updateScreenTemplate($screen);
+
+        // Clear the screens cache when a screen is updated. All cache is cleared
+        // because we don't know which nested screens affect to other screens
+        ScreenCompiledManager::clearCompiledAssets();
 
         return response([], 204);
     }

--- a/ProcessMaker/Http/Controllers/Api/V1_1/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/TaskController.php
@@ -6,6 +6,8 @@ namespace ProcessMaker\Http\Controllers\Api\V1_1;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Facades\ScreenCompiledManager;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\V1_1\TaskInterstitialResource;
 use ProcessMaker\Http\Resources\V1_1\TaskResource;
@@ -98,9 +100,31 @@ class TaskController extends Controller
     {
         $task = ProcessRequestToken::select(
             array_merge($this->defaultFields, ['process_request_id', 'process_id'])
-        )->findOrFail($taskId);
-        $response = new TaskScreen($task);
-        $response = response($response->toArray(request())['screen'], 200);
+        )
+        // eager loading process_request.process_version_id
+        ->with([
+            'processRequest'=> function ($query) {
+                $query->select('id', 'process_version_id');
+            },
+        ])->findOrFail($taskId);
+
+        // Prepare the key for the screen cache
+        $processId = $task->process_id;
+        $processVersionId = $task->processRequest->process_version_id;
+        $user = Auth::user();
+        $language = $user?->language ?: 'en';
+        $screenVersion = $task->getScreenVersion();
+        $key = ScreenCompiledManager::createKey($processId, $processVersionId, $language, $screenVersion->screen_id, $screenVersion->id);
+
+        // Get the screen content from the cache or compile it
+        $translatedScreen = ScreenCompiledManager::getCompiledContent($key);
+        if (!isset($translatedScreen)) {
+            $response = new TaskScreen($task);
+            $translatedScreen = $response->toArray(request())['screen'];
+            ScreenCompiledManager::storeCompiledContent($key, $translatedScreen);
+        }
+
+        $response = response($translatedScreen, 200);
         $now = time();
         // screen cache time
         $cacheTime = config('screen_task_cache_time', 86400);

--- a/ProcessMaker/Managers/ScreenCompiledManager.php
+++ b/ProcessMaker/Managers/ScreenCompiledManager.php
@@ -78,7 +78,7 @@ class ScreenCompiledManager
         $files = Storage::disk($this->storageDisk)->files($this->storagePath);
 
         foreach ($files as $file) {
-            if (strpos($file, "pid_{$processId}_") === 0) {
+            if (strpos($file, "pid_{$processId}_") !== false) {
                 Storage::disk($this->storageDisk)->delete($file);
             }
         }

--- a/ProcessMaker/Managers/ScreenCompiledManager.php
+++ b/ProcessMaker/Managers/ScreenCompiledManager.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace ProcessMaker\Managers;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class ScreenCompiledManager
+{
+    /**
+     * The storage disk to use.
+     *
+     * @var string
+     */
+    protected $storageDisk = 'local';
+
+    /**
+     * The directory where compiled screens are stored.
+     *
+     * @var string
+     */
+    protected $storagePath = 'compiled_screens/';
+
+    /**
+     * Store compiled content for a given screen ID.
+     *
+     * @param  string  $screenKey
+     * @param  mixed   $compiledContent
+     * @return void
+     */
+    public function storeCompiledContent(string $screenKey, $compiledContent)
+    {
+        $filename = $this->getFilename($screenKey);
+        $serializedContent = serialize($compiledContent);
+
+        Storage::disk($this->storageDisk)->put(
+            $this->storagePath . $filename,
+            $serializedContent
+        );
+    }
+
+    /**
+     * Retrieve compiled content by screen ID.
+     *
+     * @param  string  $screenKey
+     * @return mixed|null
+     */
+    public function getCompiledContent(string $screenKey)
+    {
+        $filename = $this->getFilename($screenKey);
+
+        if (Storage::disk($this->storageDisk)->exists($this->storagePath . $filename)) {
+            $serializedContent = Storage::disk($this->storageDisk)->get(
+                $this->storagePath . $filename
+            );
+
+            return unserialize($serializedContent);
+        }
+
+        return null;
+    }
+
+    /**
+     * Clear all compiled assets from storage.
+     *
+     * @return void
+     */
+    public function clearCompiledAssets()
+    {
+        Storage::disk($this->storageDisk)->deleteDirectory($this->storagePath);
+
+        // Recreate the directory to ensure it exists after deletion
+        Storage::disk($this->storageDisk)->makeDirectory($this->storagePath);
+    }
+
+    public function clearProcessScreensCache(string $processId)
+    {
+        $files = Storage::disk($this->storageDisk)->files($this->storagePath);
+
+        foreach ($files as $file) {
+            if (strpos($file, "pid_{$processId}_") === 0) {
+                Storage::disk($this->storageDisk)->delete($file);
+            }
+        }
+    }
+
+    public function createKey(string $processId, string $processVersionId, string $language, string $screenId, string $screenVersionId): string
+    {
+        return "pid_{$processId}_{$processVersionId}_{$language}_sid_{$screenId}_{$screenVersionId}";
+    }
+
+    public function getLastScreenVersionId()
+    {
+        $row = DB::select('SELECT id FROM screen_versions ORDER BY id DESC LIMIT 1;');
+        return $row[0]->id;
+    }
+
+    /**
+     * Generate a filename based on the screen ID.
+     *
+     * @param  string  $screenKey
+     * @return string
+     */
+    protected function getFilename(string $screenKey)
+    {
+        return 'screen_' . $screenKey . '.bin';
+    }
+}

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -25,6 +25,7 @@ use ProcessMaker\Jobs\SmartInbox;
 use ProcessMaker\LicensedPackageManifest;
 use ProcessMaker\Managers;
 use ProcessMaker\Managers\MenuManager;
+use ProcessMaker\Managers\ScreenCompiledManager;
 use ProcessMaker\Models;
 use ProcessMaker\Observers;
 use ProcessMaker\PolicyExtension;
@@ -157,6 +158,11 @@ class ProcessMakerServiceProvider extends ServiceProvider
                 app('migrator'),
                 app('events')
             );
+        });
+
+        // Register the compiled screen service
+        $this->app->singleton('compiledscreen', function ($app) {
+            return new ScreenCompiledManager();
         });
     }
 

--- a/ProcessMaker/SanitizeHelper.php
+++ b/ProcessMaker/SanitizeHelper.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker;
 
 use Illuminate\Support\Facades\Validator;
+use ProcessMaker\Facades\ScreenCompiledManager;
 use ProcessMaker\Managers\ExportManager;
 use ProcessMaker\Models\Screen;
 
@@ -107,26 +108,36 @@ class SanitizeHelper
         if ($task) {
             // Get current and nested screens IDs ..
             $currentScreenExceptions = [];
-            $currentScreenAndNestedIds = $task->getScreenAndNestedIds();
-            foreach ($currentScreenAndNestedIds as $id) {
-                // Find the screen version ..
-                $screen = Screen::findOrFail($id);
-                $screen = $screen->versionFor($task->processRequest)->toArray();
-                // Get exceptions ..
-                $exceptions = self::getExceptions((object) $screen);
-                if (count($exceptions)) {
-                    $currentScreenExceptions = array_unique(array_merge($exceptions, $currentScreenExceptions));
+            $lastVersionId = ScreenCompiledManager::getLastScreenVersionId();
+            $screenVersionId = $task->getScreenVersion()->id;
+            // Get exceptions for the current screen and nested screens from screen cache if exists ..
+            $key = 'sid_' . $screenVersionId . '_last_' . $lastVersionId;
+            $exceptTask = ScreenCompiledManager::getCompiledContent($key);
+            if (!isset($exceptTask)) {
+                $currentScreenAndNestedIds = $task->getScreenAndNestedIds();
+                foreach ($currentScreenAndNestedIds as $id) {
+                    // Find the screen version ..
+                    $screen = Screen::findOrFail($id);
+                    $screen = $screen->versionFor($task->processRequest)->toArray();
+                    // Get exceptions ..
+                    $exceptions = self::getExceptions((object) $screen);
+                    if (count($exceptions)) {
+                        $currentScreenExceptions = array_unique(array_merge($exceptions, $currentScreenExceptions));
+                    }
                 }
+
+                // Get process request exceptions stored in do_not_sanitize column ..
+                $processRequestExceptions = $task->processRequest->do_not_sanitize;
+                if (!$processRequestExceptions) {
+                    $processRequestExceptions = [];
+                }
+
+                // Merge (nestedSreensExceptions and currentScreenExceptions) with processRequestExceptions ..
+                $exceptTask = array_unique(array_merge($processRequestExceptions, $currentScreenExceptions));
+
+                ScreenCompiledManager::storeCompiledContent($key, $exceptTask);
             }
 
-            // Get process request exceptions stored in do_not_sanitize column ..
-            $processRequestExceptions = $task->processRequest->do_not_sanitize;
-            if (!$processRequestExceptions) {
-                $processRequestExceptions = [];
-            }
-
-            // Merge (nestedSreensExceptions and currentScreenExceptions) with processRequestExceptions ..
-            $exceptTask = array_unique(array_merge($processRequestExceptions, $currentScreenExceptions));
             $except = array_unique(array_merge($except, $exceptTask));
         }
 

--- a/tests/Feature/Screens/ScreenCompiledManagerTest.php
+++ b/tests/Feature/Screens/ScreenCompiledManagerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use ProcessMaker\Managers\ScreenCompiledManager;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\DB;
+
+class ScreenCompiledManagerTest extends TestCase
+{
+
+    protected $storageDisk = 'local';
+    protected $storagePath = 'compiled_screens/';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Fake the storage disk using the known default value
+        Storage::fake($this->storageDisk);
+    }
+
+    /**
+     * Validate a screen can be stored into the screens cache
+     *
+     * @test
+     */
+    public function it_stores_compiled_content()
+    {
+        // Arrange
+        $manager = new ScreenCompiledManager();
+        $screenKey = 'test_screen_key';
+        $compiledContent = ['key' => 'value'];
+
+        // Act
+        $manager->storeCompiledContent($screenKey, $compiledContent);
+
+        // Assert
+        $filename = 'screen_' . $screenKey . '.bin';
+        $storagePath = $this->storagePath . $filename;
+
+        Storage::disk($this->storageDisk)->assertExists($storagePath);
+        $storedContent = Storage::disk($this->storageDisk)->get($storagePath);
+        $this->assertEquals(serialize($compiledContent), $storedContent);
+    }
+
+    /**
+     * Validate a screen can be retrieved from screens cache
+     *
+     * @test
+     */
+    public function it_retrieves_compiled_content()
+    {
+        // Arrange content
+        $manager = new ScreenCompiledManager();
+        $screenKey = 'test_screen_key';
+        $compiledContent = ['key' => 'value'];
+        $filename = 'screen_' . $screenKey . '.bin';
+        $storagePath = $this->storagePath . $filename;
+
+        Storage::disk($this->storageDisk)->put($storagePath, serialize($compiledContent));
+
+        // Get the compiled content
+        $retrievedContent = $manager->getCompiledContent($screenKey);
+
+        // Assert the content is the same
+        $this->assertEquals($compiledContent, $retrievedContent);
+    }
+
+    /**
+     * Validate a null value is returned when compiled content does not exist
+     *
+     * @test
+     */
+    public function it_returns_null_when_compiled_content_does_not_exist()
+    {
+        // Arrange
+        $manager = new ScreenCompiledManager();
+        $screenKey = 'non_existent_key';
+
+        // Act
+        $retrievedContent = $manager->getCompiledContent($screenKey);
+
+        // Assert
+        $this->assertNull($retrievedContent);
+    }
+
+    /**
+     * Validate all compiled assets can be cleared
+     *
+     * @test
+     */
+    public function it_clears_all_compiled_assets()
+    {
+        // Arrange content
+        $manager = new ScreenCompiledManager();
+        $screenKey = 'test_screen_key';
+        $compiledContent = ['key' => 'value'];
+        $filename = 'screen_' . $screenKey . '.bin';
+        $storagePath = $this->storagePath . $filename;
+
+        Storage::disk($this->storageDisk)->put($storagePath, serialize($compiledContent));
+
+        // Clear all compiled assets
+        $manager->clearCompiledAssets();
+
+        // Assert the file has been removed
+        Storage::disk($this->storageDisk)->assertMissing($storagePath);
+        // Ensure the directory has been recreated
+        Storage::disk($this->storageDisk)->assertExists($this->storagePath);
+    }
+
+    /**
+     * Validate a screen key can be created and can be used to store and retrieve compiled content
+     * Also validate if screens cache can be cleared for a specific process
+     *
+     * @test
+     */
+    public function it_clears_process_screens_cache()
+    {
+        // Arrange
+        $manager = new ScreenCompiledManager();
+        $processId = '123';
+        $compiledContent = ['key' => 'value'];
+
+        // Files related to the process
+        $screenKeys = [
+            "pid_{$processId}_v1_en_sid_1_v1",
+            "pid_{$processId}_v1_en_sid_2_v1",
+        ];
+
+        // Files unrelated to the process
+        $otherScreenKey = "pid_999_v1_en_sid_3_v1";
+
+        foreach ($screenKeys as $screenKey) {
+            $filename = 'screen_' . $screenKey . '.bin';
+            $storagePath = $this->storagePath . $filename;
+            Storage::disk($this->storageDisk)->put($storagePath, serialize($compiledContent));
+        }
+
+        $otherFilename = 'screen_' . $otherScreenKey . '.bin';
+        $otherStoragePath = $this->storagePath . $otherFilename;
+        Storage::disk($this->storageDisk)->put($otherStoragePath, serialize($compiledContent));
+
+        // Clear the screens cache for the process
+        $manager->clearProcessScreensCache($processId);
+
+        // Assert that the files related to the process have been removed
+        foreach ($screenKeys as $screenKey) {
+            $filename = 'screen_' . $screenKey . '.bin';
+            $storagePath = $this->storagePath . $filename;
+            Storage::disk($this->storageDisk)->assertMissing($storagePath);
+        }
+        // The other file should still exist
+        Storage::disk($this->storageDisk)->assertExists($otherStoragePath);
+    }
+
+    /**
+     * Validate a screen key can be created
+     *
+     * @test
+     */
+    public function it_creates_a_screen_key()
+    {
+        // Arrange
+        $manager = new ScreenCompiledManager();
+        $processId = '123';
+        $processVersionId = '1';
+        $language = 'en';
+        $screenId = '456';
+        $screenVersionId = '1';
+
+        $expectedKey = "pid_123_1_en_sid_456_1";
+
+        // Create the screen key
+        $screenKey = $manager->createKey($processId, $processVersionId, $language, $screenId, $screenVersionId);
+
+        // Assert
+        $this->assertEquals($expectedKey, $screenKey);
+    }
+
+    /**
+     * Validate the last screen version ID can be retrieved
+     *
+     * @test
+     */
+    public function it_gets_the_last_screen_version_id()
+    {
+        // Create the manager
+        $manager = new ScreenCompiledManager();
+        $expectedId = 999;
+
+        // Mock the DB facade
+        DB::shouldReceive('select')
+            ->once()
+            ->with('SELECT id FROM screen_versions ORDER BY id DESC LIMIT 1;')
+            ->andReturn([(object)['id' => $expectedId]]);
+
+        // Get the last screen version ID
+        $lastId = $manager->getLastScreenVersionId();
+
+        // Assert the ID is the expected one
+        $this->assertEquals($expectedId, $lastId);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
WebEntry endpoints are slow.
This was caused by two features:
- Sanitize data when a webentry (task) is submited
- Get screen with nested screens

## Solution
- Implement a Screen Cache for screens and nested screens.
- This cache stores a screen by process, by language and by version
- The cache is cleared when a process translation is updated or the screen is modified.

## How to Test
- Run a web entry like Expenses process
- You will see a cache was created for the web entry task screens
- Any time the screen is updated the cache is cleared

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18994

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
