### PR TITLE
Fix 500 Error When Applying Templates to Unsaved Screen Pages

### DIFF
--- a/ProcessMaker/Exception/MissingScreenPageException.php
+++ b/ProcessMaker/Exception/MissingScreenPageException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ProcessMaker\Exception;
+
+use Exception;
+
+class MissingScreenPageException extends Exception
+{
+    protected $message = 'The specified screen page does not exist in the configuration. Please try saving the screen or check the configuration.';
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses the 500 error encountered when attempting to apply a template to a screen page that has not been stored in the database. The root cause was the absence of the newly created screen page in the screens table during the query for the screen configuration.

## Solution
- Implemented a query using the `screens_versions` table, which retains the 'draft' version of the screen.
- Added a fallback mechanism to handle cases where the `screens_versions` table is unavailable. When this occurs, an error message prompts the user to save the screen.

## How to Test

### Without Versions Package
1. Ensure screen templates are created and available.
2. Open or create a new screen in Screen Builder.
3. Add a new page within the screen.
4. Go to the newly created page.
5. Select 'Templates' in the navigation bar.
6. Choose a template and apply all settings.
7. Ensure an error message prompts you to save the screen.
8. Save the screen as instructed by the error message.
9. Try to apply the template again.
10. Ensure the template is successfully applied to the selected page.

### With Versions Package
1. Ensure the versions package is installed using branch `observation/FOUR-19320`
2. Ensure screen templates are created and available.
3. Open or create a new screen in Screen Builder.
4. Add a new page within the screen.
5. Go to the newly created page.
6. Select 'Templates' in the navigation bar.
7. Choose a template and apply all settings.
8. Ensure the template is successfully applied to the selected page.


## Related Tickets & Packages
- [FOUR-19320](https://processmaker.atlassian.net/browse/FOUR-19320)
- [Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1736)
- [Versions Package PR](https://github.com/ProcessMaker/package-versions/pull/98)

ci:screen-builder:observation/FOUR-19320
ci:package-versions:observation/FOUR-19320



## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19320]: https://processmaker.atlassian.net/browse/FOUR-19320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ