### PR TITLE
FOUR-19490: The store comments needs to consider populate the comments.case_number

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/CommentController.php
+++ b/ProcessMaker/Http/Controllers/Api/CommentController.php
@@ -156,6 +156,7 @@ class CommentController extends Controller
 
         $data['user_id'] = Auth::user()->id;
         // Get the case_number if was not send
+        $caseNumber = null;
         if (!$request->has('case_number')) {
             $caseNumber = $this->getCaseNumber($request);
         }
@@ -200,6 +201,7 @@ class CommentController extends Controller
         }
         $data['user_id'] = Auth::user()->id;
         // Get the case_number if was not send
+        $caseNumber = null;
         if (!$request->has('case_number')) {
             $caseNumber = $this->getCaseNumber($request);
         }

--- a/ProcessMaker/Http/Controllers/Api/CommentController.php
+++ b/ProcessMaker/Http/Controllers/Api/CommentController.php
@@ -156,8 +156,8 @@ class CommentController extends Controller
 
         $data['user_id'] = Auth::user()->id;
         // Get the case_number if was not send
-        $caseNumber = null;
-        if (!$request->has('case_number')) {
+        $caseNumber = $request->input('case_number', null);
+        if (is_null($caseNumber)) {
             $caseNumber = $this->getCaseNumber($request);
         }
         $data['case_number'] = $caseNumber;
@@ -201,8 +201,8 @@ class CommentController extends Controller
         }
         $data['user_id'] = Auth::user()->id;
         // Get the case_number if was not send
-        $caseNumber = null;
-        if (!$request->has('case_number')) {
+        $caseNumber = $request->input('case_number', null);
+        if (is_null($caseNumber)) {
             $caseNumber = $this->getCaseNumber($request);
         }
         $data['case_number'] = $caseNumber;
@@ -244,9 +244,9 @@ class CommentController extends Controller
     {
         $requestId = null;
         $commentableType = $request->input('commentable_type');
-        if ($commentableType === 'ProcessMaker\\Models\\ProcessRequestToken') {
-            $requestId = ProcessRequestToken::select('process_request_id')->find($request->input('commentable_id'));
-        } elseif ($commentableType === 'ProcessMaker\\Models\\ProcessRequest') {
+        if ($commentableType === 'ProcessMaker\Models\ProcessRequestToken') {
+            $requestId = ProcessRequestToken::where('id', $request->input('commentable_id'))->value('process_request_id');
+        } elseif ($commentableType === 'ProcessMaker\Models\ProcessRequest') {
             $requestId = $request->input('commentable_id');
         }
         if ($requestId) {

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -401,6 +401,7 @@ class ProcessRequestController extends Controller
                 'commentable_id' => $request->id,
                 'subject' => 'Data edited',
                 'body' => $user_name . ' ' . $text,
+                'case_number' => isset($request->case_number) ? $request->case_number : null,
             ]);
         } else {
             $httpRequest->validate(ProcessRequest::rules($request));
@@ -629,6 +630,7 @@ class ProcessRequestController extends Controller
             'commentable_id' => $request->id,
             'subject' => __('Process Manually Completed'),
             'body' => $user->fullname . ' ' . __('manually completed the request from an error state'),
+            'case_number' => isset($request->case_number) ? $request->case_number : null,
         ]);
     }
 

--- a/ProcessMaker/Listeners/CommentsSubscriber.php
+++ b/ProcessMaker/Listeners/CommentsSubscriber.php
@@ -34,6 +34,8 @@ class CommentsSubscriber
         if ($token->is_actionbyemail) {
             $message = $message . ' via email';
         }
+        // Get the case_number
+        $caseNumber = ProcessRequest::where('id', $token->process_request_id)->value('case_number');
 
         Comment::create([
             'type' => 'LOG',
@@ -42,6 +44,7 @@ class CommentsSubscriber
             'commentable_id' => $token->process_request_id,
             'subject' => 'Task Complete',
             'body' => __($message, ['user' => $user_name, 'task_name' => $token->element_name]),
+            'case_number' => $caseNumber,
         ]);
     }
 
@@ -59,6 +62,8 @@ class CommentsSubscriber
         if (!is_int($token->getInstance()->getId())) {
             return;
         }
+        // Get the case number
+        $caseNumber = ProcessRequest::where('id', $token->getInstance()->getId())->value('case_number');
 
         Comment::create([
             'type' => 'LOG',
@@ -67,6 +72,7 @@ class CommentsSubscriber
             'commentable_id' => $token->getInstance()->getId(),
             'subject' => 'Task Skipped',
             'body' => __('The task :task_name was skipped', ['task_name' => $taskName]),
+            'case_number' => $caseNumber,
         ]);
     }
 
@@ -112,6 +118,8 @@ class CommentsSubscriber
             if (!is_int($token->getInstance()->getId())) {
                 return;
             }
+            // Get the case number
+            $caseNumber = ProcessRequest::where('id', $token->getInstance()->getId())->value('case_number');
 
             Comment::create([
                 'type' => 'LOG',
@@ -120,6 +128,7 @@ class CommentsSubscriber
                 'commentable_id' => $token->getInstance()->getId(),
                 'subject' => 'Gateway',
                 'body' => $sourceLabel . ': ' . $flowLabel,
+                'case_number' => $caseNumber,
             ]);
         }
     }

--- a/ProcessMaker/Models/Comment.php
+++ b/ProcessMaker/Models/Comment.php
@@ -49,7 +49,17 @@ class Comment extends ProcessMakerModel
     use SoftDeletes;
 
     protected $fillable = [
-        'user_id', 'parent_id', 'group_id', 'group_name', 'commentable_id', 'commentable_type', 'subject', 'body', 'hidden', 'type',
+        'user_id',
+        'parent_id',
+        'group_id',
+        'group_name',
+        'commentable_id',
+        'commentable_type',
+        'subject',
+        'body',
+        'hidden',
+        'type',
+        'case_number',
     ];
 
     protected $casts = [

--- a/ProcessMaker/RetryProcessRequest.php
+++ b/ProcessMaker/RetryProcessRequest.php
@@ -111,7 +111,7 @@ class RetryProcessRequest
     /**
      * Clear previous ProcessRequestToken errors off of its parent ProcessRequest(s)
      *
-     * @param  \ProcessMaker\Models\ProcessRequestToken  $token
+     * @param  ProcessRequestToken  $token
      *
      * @return void
      */
@@ -153,6 +153,7 @@ class RetryProcessRequest
             'commentable_type' => ProcessRequest::class,
             'commentable_id' => $this->processRequest->id,
             'subject' => __('Request Retried'),
+            'case_number' => isset($this->processRequest->case_number) ? $this->processRequest->case_number : null,
         ]);
 
         if ($user = $this->initializingUser()) {

--- a/ProcessMaker/RollbackProcessRequest.php
+++ b/ProcessMaker/RollbackProcessRequest.php
@@ -206,6 +206,7 @@ class RollbackProcessRequest
                 'failed_task_name' => $this->currentTask->element_name,
                 'new_task_name' => $this->newTask->element_name,
             ]),
+            'case_number' => isset($this->currentTask->case_number) ? $this->currentTask->case_number : null,
         ]);
     }
 }

--- a/tests/Feature/Api/CommentTest.php
+++ b/tests/Feature/Api/CommentTest.php
@@ -34,6 +34,7 @@ class CommentTest extends TestCase
         'type',
         'updated_at',
         'created_at',
+        'case_number',
     ];
 
     protected function withUserSetup()


### PR DESCRIPTION
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19490

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-webentry:feature/FOUR-19490
ci:connector-send-email:feature/FOUR-19490
ci:package-comments:feature/FOUR-19490