### PR TITLE
FOUR-18912 [FALL] Fix get data in tasks endpoint

### DIFF
--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -17,8 +17,17 @@ trait TaskControllerIndexMethods
 {
     private function indexBaseQuery($request)
     {
+        // Parse the includes parameter
+        $includes = $request->has('include') ? explode(',', $request->input('include')) : [];
+        // Determine if the data should be included
+        $includeData = in_array('data', $includes);
+
         $query = ProcessRequestToken::exclude(['data'])->with([
-            'processRequest' => fn ($q) => $q->exclude(['data']),
+            'processRequest' => function($q) use ($includeData) {
+                if (!$includeData) {
+                    return $q->exclude(['data']);
+                }
+            },
             // review if bpmn is reuiqred here process
             'process' => fn ($q) => $q->exclude(['svg', 'warnings']),
             // review if bpmn is reuiqred here processRequest.process

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use ProcessMaker\Http\Controllers\Api\ProcessRequestController;
+use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\Process;
@@ -1026,5 +1027,36 @@ class ProcessRequestsTest extends TestCase
         //Validate the header status code
         $response->assertStatus(422);
         $this->assertEquals('The Case number field is required.', $response->json()['message']);
+    }
+
+    /**
+     * Get task list with data
+     */
+    public function testGetTaskListWithData()
+    {
+        // Create a request with a token
+        $request = ProcessRequest::factory()->create([
+            'data' => ['foo' => 'bar'],
+        ]);
+        ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+        ]);
+
+        $route = route('api.tasks.index', ['order_direction'=>'asc', 'include' => 'data']);
+        $response = $this->apiCall('GET', $route);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    // has id, data
+                    'data',
+                ],
+            ],
+            'meta',
+        ]);
+
+        // has foo => bar
+        $this->assertEquals('bar', $response->json()['data'][0]['data']['foo']);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
/api/1.0/tasks endpoint failed becuase an exception in DataManager.
Cause: Missing scenario when task endpoint was improved in FOUR-16575 https://github.com/ProcessMaker/processmaker/pull/7123


## Solution
- Consider the parameter `includes=data` to load the request data.

## How to Test
Call the api `/api/1.0/task?include=data`

![image](https://github.com/user-attachments/assets/842b4266-fc04-4a12-90a7-a19e2aa14808)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18912

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
