### PR TITLE
FOUR-19600: The Pagination in not working in the Tabs

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/CompletedForms.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CompletedForms.vue
@@ -77,7 +77,7 @@ const getData = async () => {
       orderBy: filter.value?.field,
       order_direction: filter.value?.value,
       page: dataPagination.value.page,
-      perPage: dataPagination.value.perPage,
+      per_page: dataPagination.value.perPage,
     },
   });
 

--- a/resources/jscomposition/cases/casesDetail/components/RequestTable.vue
+++ b/resources/jscomposition/cases/casesDetail/components/RequestTable.vue
@@ -54,7 +54,7 @@ const getData = async () => {
       orderBy: filter.value?.field,
       order_direction: filter.value?.value,
       page: dataPagination.value.page,
-      perPage: dataPagination.value.perPage,
+      per_page: dataPagination.value.perPage,
     },
   });
 

--- a/resources/jscomposition/cases/casesDetail/components/TaskTable.vue
+++ b/resources/jscomposition/cases/casesDetail/components/TaskTable.vue
@@ -54,7 +54,7 @@ const getData = async () => {
       orderBy: filter.value?.field,
       order_direction: filter.value?.value,
       page: dataPagination.value.page,
-      perPage: dataPagination.value.perPage,
+      per_page: dataPagination.value.perPage,
     },
   });
 

--- a/resources/jscomposition/cases/casesDetail/config/columns.js
+++ b/resources/jscomposition/cases/casesDetail/config/columns.js
@@ -99,10 +99,6 @@ const processRequestColumn = () => ({
   resizable: true,
   width: 200,
   filter: { type: "sortable" },
-  cellRenderer: () => ({
-    component: LinkCell,
-    params: {},
-  }),
 });
 
 const taskColumn = () => ({

--- a/resources/jscomposition/cases/casesDetail/config/columns.js
+++ b/resources/jscomposition/cases/casesDetail/config/columns.js
@@ -101,11 +101,7 @@ const processRequestColumn = () => ({
   filter: { type: "sortable" },
   cellRenderer: () => ({
     component: LinkCell,
-    params: {
-      click: (row, column, columns) => {
-        window.document.location = `/requests/${row.id}`;
-      },
-    },
+    params: {},
   }),
 });
 

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -1061,4 +1061,39 @@ class ProcessRequestsTest extends TestCase
         // has foo => bar
         $this->assertEquals('bar', $response->json()['data'][0]['data']['foo']);
     }
+
+    /**
+     * Get a list of Requests by Cases pagination
+     */
+    public function testRequestByCasePagination()
+    {
+        ProcessRequest::query()->delete();
+        $request = ProcessRequest::factory()->create();
+        ProcessRequest::factory()->count(11)->create([
+            'parent_request_id' => $request->id,
+        ]);
+        // Call the endpoint with the 'case_number' parameter page 1
+        $filter = "?case_number=$request->case_number&include=activeTasks&page=1&per_page=5";
+        $url = self::API_REQUESTS_BY_CASE . $filter;
+
+        // Check if the response is successful and contains the expected tasks
+        $response = $this->apiCall('GET', $url);
+        $this->assertCount(5, $response->json('data'));
+
+        // Call the endpoint with the 'case_number' parameter page 2
+        $filter = "?case_number=$request->case_number&include=activeTasks&page=2&per_page=5";
+        $url = self::API_REQUESTS_BY_CASE . $filter;
+
+        // Check if the response is successful and contains the expected tasks
+        $response = $this->apiCall('GET', $url);
+        $this->assertCount(5, $response->json('data'));
+
+        // Call the endpoint with the 'case_number' parameter page 3
+        $filter = "?case_number=$request->case_number&include=activeTasks&page=3&per_page=5";
+        $url = self::API_REQUESTS_BY_CASE . $filter;
+
+        // Check if the response is successful and contains the expected tasks
+        $response = $this->apiCall('GET', $url);
+        $this->assertCount(3, $response->json('data'));
+    }
 }

--- a/tests/Feature/Api/TaskControllerTest.php
+++ b/tests/Feature/Api/TaskControllerTest.php
@@ -31,7 +31,7 @@ class TaskControllerTest extends TestCase
      *
      * @return void
      */
-    public function test_index_case_requires_case_number()
+    public function testIndexCaseRequiresCaseNumber()
     {
         // Simulate an authenticated user
         $user = User::factory()->create();
@@ -46,11 +46,11 @@ class TaskControllerTest extends TestCase
     }
 
     /**
-     * Test indexCase returns active tasks related to the case_number.
+     * Test indexCase returns active tasks related to the case_number with pagination.
      *
      * @return void
      */
-    public function test_index_case_returns_active_tasks_for_case_number()
+    public function testIndexCaseReturnsActiveTasksForCaseNumberPagination()
     {
         // Simulate an authenticated user
         $user = User::factory()->create();
@@ -58,23 +58,35 @@ class TaskControllerTest extends TestCase
 
         // Create a ProcessRequestToken associated with a specific case_number
         $processRequest = ProcessRequest::factory()->create();
-        ProcessRequestToken::factory()->create([
+        ProcessRequestToken::factory(12)->create([
             'user_id' => $user->id,
             'status' => 'ACTIVE',
             'process_request_id' => $processRequest->id, // id del ProcessRequest
         ]);
 
-        // Call the endpoint with the 'case_number' parameter
-        $filter = "?case_number=$processRequest->case_number";
+        // Call the endpoint with the 'case_number' parameter page 1
+        $filter = "?case_number=$processRequest->case_number&page=1&per_page=5";
         $response = $this->apiCall('GET', self::API_TASK_BY_CASE . $filter);
 
         // Check if the response is successful and contains the expected tasks
         $response->assertStatus(200);
-        $this->assertCount(1, $response->json('data'));
-        $response->assertJsonStructure([
-            'data' => ['*' => self::TASK_BY_CASE_STRUCTURE],
-            'meta',
-        ]);
+        $this->assertCount(5, $response->json('data'));
+
+        // Call the endpoint with the 'case_number' parameter page 2
+        $filter = "?case_number=$processRequest->case_number&page=2&per_page=5";
+        $response = $this->apiCall('GET', self::API_TASK_BY_CASE . $filter);
+
+        // Check if the response is successful and contains the expected tasks
+        $response->assertStatus(200);
+        $this->assertCount(5, $response->json('data'));
+
+        // Call the endpoint with the 'case_number' parameter page 3
+        $filter = "?case_number=$processRequest->case_number&page=3&per_page=5";
+        $response = $this->apiCall('GET', self::API_TASK_BY_CASE . $filter);
+
+        // Check if the response is successful and contains the expected tasks
+        $response->assertStatus(200);
+        $this->assertCount(2, $response->json('data'));
     }
 
     /**
@@ -82,7 +94,7 @@ class TaskControllerTest extends TestCase
      *
      * @return void
      */
-    public function test_index_case_returns_inactive_tasks_for_case_number()
+    public function testIndexCaseReturnsInactiveTasksForCaseNumber()
     {
         // Simulate an authenticated user
         $user = User::factory()->create();
@@ -114,7 +126,51 @@ class TaskControllerTest extends TestCase
      *
      * @return void
      */
-    public function test_index_cas_returns_with_data()
+    public function testIndexCaseReturnsInactiveTasksForCaseNumberPagination()
+    {
+        // Simulate an authenticated user
+        $user = User::factory()->create();
+        Auth::login($user);
+
+        // Create a ProcessRequestToken associated with a specific case_number
+        $processRequest = ProcessRequest::factory()->create();
+        ProcessRequestToken::factory(12)->create([
+            'user_id' => $user->id,
+            'status' => 'CLOSED',
+            'process_request_id' => $processRequest->id, // id del ProcessRequest
+        ]);
+
+        // Call the endpoint with the 'case_number' parameter page 1
+        $filter = "?case_number=$processRequest->case_number&status=CLOSED&page=1&per_page=5";
+        $response = $this->apiCall('GET', self::API_TASK_BY_CASE . $filter);
+
+        // Check if the response is successful and contains the expected tasks
+        $response->assertStatus(200);
+        $this->assertCount(5, $response->json('data'));
+
+        // Call the endpoint with the 'case_number' parameter page 2
+        $filter = "?case_number=$processRequest->case_number&status=CLOSED&page=2&per_page=5";
+        $response = $this->apiCall('GET', self::API_TASK_BY_CASE . $filter);
+
+        // Check if the response is successful and contains the expected tasks
+        $response->assertStatus(200);
+        $this->assertCount(5, $response->json('data'));
+
+        // Call the endpoint with the 'case_number' parameter page 3
+        $filter = "?case_number=$processRequest->case_number&status=CLOSED&page=3&per_page=5";
+        $response = $this->apiCall('GET', self::API_TASK_BY_CASE . $filter);
+
+        // Check if the response is successful and contains the expected tasks
+        $response->assertStatus(200);
+        $this->assertCount(2, $response->json('data'));
+    }
+
+    /**
+     * Test indexCase returns completed tasks related to the case_number.
+     *
+     * @return void
+     */
+    public function testIndexCaseReturnsWithData()
     {
         // Simulate an authenticated user
         $user = User::factory()->create();


### PR DESCRIPTION
## Steps

1. Login in the server 
2. Go to cases list
3. Check the case # 23
4. Open the Case
5. Review the rows to return

## Current Behavior

Is only showed 10 rows

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19600

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

