### PR TITLE
FOUR-19171:View documentation option is not visible to Participant user from Launch pad

### DIFF
--- a/resources/js/processes-catalogue/components/mixins/ProcessesMixin.js
+++ b/resources/js/processes-catalogue/components/mixins/ProcessesMixin.js
@@ -69,6 +69,8 @@ const ProcessHeader = {
         "create-pm-blocks",
         "create-process-templates",
         "view-projects",
+        "view-documentation",
+        "edit-documentation",
       ];
       this.showEllipsis = this.$root.permission.some( (permission) => permissionsNeeded.includes(permission));
     },

--- a/resources/views/processes-catalogue/index.blade.php
+++ b/resources/views/processes-catalogue/index.blade.php
@@ -30,7 +30,7 @@
       Js::from(\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled())
     }};
     window.ProcessMaker.permission = {{
-      Js::from(\Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects'))
+      Js::from(\Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects', 'process', 'documentation'))
     }};
   </script>
   @foreach($manager->getScripts() as $script)

--- a/resources/views/processes-catalogue/index.blade.php
+++ b/resources/views/processes-catalogue/index.blade.php
@@ -30,7 +30,7 @@
       Js::from(\ProcessMaker\PackageHelper::isPmPackageProcessDocumenterInstalled())
     }};
     window.ProcessMaker.permission = {{
-      Js::from(\Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects', 'process', 'documentation'))
+      Js::from(\Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects', 'documentation'))
     }};
   </script>
   @foreach($manager->getScripts() as $script)


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a participant user
2. Go to Permissions 
3. Enable documentation permissions
4. Enable launch pad permissions
5. Save the changes
6. Login with the user created 
7. Go to process browser
8. Open a process
9. Go to options

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19171

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:release-2024-fall