### PR TITLE
FOUR-19523 API getAllCasesCounter does not considered the new permissions for 'admin' user

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/CaseController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/CaseController.php
@@ -123,7 +123,7 @@ class CaseController extends Controller
         $totalMyRequest = null;
 
         // Check permission
-        if ($user->hasPermission('view-all_cases')) {
+        if ($user->hasPermission('view-all_cases') || $user->is_administrator) {
             // The total number of cases recorded in the platform. User Id send is overridden.
             $request->merge(['userId' => null]);
             $queryAllCases = $this->caseRepository->getAllCases($request);
@@ -146,7 +146,7 @@ class CaseController extends Controller
         $totalCompleted = $queryCompletedCases->count();
 
         // Check permission
-        if ($user->hasPermission('view-my_requests')) {
+        if ($user->hasPermission('view-my_requests') || $user->is_administrator) {
             // Only in progress requests
             $requestAux = new Request();
             $requestAux->replace(['type' => 'in_progress']);


### PR DESCRIPTION
## Issue & Reproduction Steps
The API not return a value different to null when is an administrator.

## Solution
The user can have the property "is_administrator" enabled.

## How to Test
Consume the endpoint "GET /api/1.1/cases/get_my_cases_counters"

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19523

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
