### PR TITLE
FOUR-19591 API related to cases is showing cases after the execution of 'processmaker:clear-requests'

### DIFF
--- a/ProcessMaker/Console/Commands/ProcessmakerClearRequests.php
+++ b/ProcessMaker/Console/Commands/ProcessmakerClearRequests.php
@@ -3,6 +3,8 @@
 namespace ProcessMaker\Console\Commands;
 
 use Illuminate\Console\Command;
+use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Models\CaseStarted;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\Media;
 use ProcessMaker\Models\ProcessCollaboration;
@@ -13,7 +15,7 @@ use ProcessMaker\Models\ScheduledTask;
 
 class ProcessmakerClearRequests extends Command
 {
-    const message = 'Are you sure you\'d like to remove all requests and related data? Make sure you have backed up your database as this cannot be undone.';
+    const message = 'Are you sure you\'d like to remove all requests, cases and related data? Make sure you have backed up your database as this cannot be undone.';
 
     /**
      * The name and signature of the console command.
@@ -27,7 +29,7 @@ class ProcessmakerClearRequests extends Command
      *
      * @var string
      */
-    protected $description = 'Clear all requests / task data';
+    protected $description = 'Clear all requests / cases / task data';
 
     /**
      * Execute the console command.
@@ -45,6 +47,8 @@ class ProcessmakerClearRequests extends Command
             Comment::where('commentable_type', ProcessRequestToken::class)->delete();
             ProcessCollaboration::query()->truncate();
             ProcessRequest::query()->truncate();
+            CaseParticipated::query()->truncate();
+            CaseStarted::query()->truncate();
         }
     }
 }

--- a/tests/Feature/ClearRequestsTest.php
+++ b/tests/Feature/ClearRequestsTest.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
 use ProcessMaker\Console\Commands\ProcessmakerClearRequests;
 use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Models\CaseStarted;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\Media;
 use ProcessMaker\Models\Process;
@@ -311,6 +313,8 @@ class ClearRequestsTest extends TestCase
         $this->assertEquals(4, ScheduledTask::count());
         $this->assertEquals(5, ProcessRequest::count());
         $this->assertEquals(1, ProcessCollaboration::count());
+        $this->assertEquals(3, CaseParticipated::count());
+        $this->assertEquals(3, CaseStarted::count());
         $this->assertEquals(28, Comment::count());
         $this->assertEquals(2, Media::where('collection_name', 'local')->count());
 
@@ -322,6 +326,8 @@ class ClearRequestsTest extends TestCase
         $this->assertEquals(0, ProcessRequestToken::count());
         $this->assertEquals(0, ProcessRequest::count());
         $this->assertEquals(0, ProcessCollaboration::count());
+        $this->assertEquals(0, CaseParticipated::count());
+        $this->assertEquals(0, CaseStarted::count());
         // 3 comments about Process should remain
         $this->assertEquals(3, Comment::count());
         $this->assertEquals(1, Media::where('collection_name', 'local')->count());


### PR DESCRIPTION
## Issue & Reproduction Steps
The cases are listed after execute the command to clear requests.

## Solution
Added code to clean new tables.

## How to Test
Create some requests, after execute the artisan command: `php artisan processmaker:clear-requests` 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19591

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
