### PR TITLE
Add reconnect feature to devlink

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/DevLinkController.php
+++ b/ProcessMaker/Http/Controllers/Admin/DevLinkController.php
@@ -20,7 +20,7 @@ class DevLinkController extends Controller
 
         $updatedDevLink = $this->storeOauthCredentials($request);
         if ($updatedDevLink) {
-            return redirect(route('devlink.index'));
+            return redirect($updatedDevLink->redirect_uri);
         }
 
         return view('admin.devlink.index');
@@ -86,7 +86,7 @@ class DevLinkController extends Controller
                 'grant_type' => 'authorization_code',
                 'client_id' => $devlink->client_id,
                 'client_secret' => $devlink->client_secret,
-                'redirect_uri' => route('devlink.index'),
+                'redirect_uri' => $devlink->redirect_uri,
                 'code' => $request->input('code'),
             ]);
 

--- a/ProcessMaker/Http/Controllers/Api/DevLinkController.php
+++ b/ProcessMaker/Http/Controllers/Api/DevLinkController.php
@@ -56,10 +56,7 @@ class DevLinkController extends Controller
         $devLink->url = $request->input('url');
         $devLink->saveOrFail();
 
-        return [
-            ...$devLink->toArray(),
-            'redirect_uri' => route('devlink.index'),
-        ];
+        return $devLink;
     }
 
     public function update(Request $request, DevLink $devLink)

--- a/ProcessMaker/Models/DevLink.php
+++ b/ProcessMaker/Models/DevLink.php
@@ -25,6 +25,8 @@ class DevLink extends ProcessMakerModel
         'state',
     ];
 
+    protected $appends = ['redirect_uri'];
+
     public static function boot()
     {
         parent::boot();
@@ -36,11 +38,16 @@ class DevLink extends ProcessMakerModel
         });
     }
 
+    public function getRedirectUriAttribute()
+    {
+        return route('devlink.index');
+    }
+
     public function getClientUrl()
     {
         $params = [
             'devlink_id' => $this->id,
-            'redirect_uri' => route('devlink.index'),
+            'redirect_uri' => $this->redirect_uri,
         ];
 
         return $this->url . route('devlink.oauth-client', $params, false);
@@ -50,7 +57,7 @@ class DevLink extends ProcessMakerModel
     {
         $params = http_build_query([
             'client_id' => $this->client_id,
-            'redirect_uri' => route('devlink.index'),
+            'redirect_uri' => $this->redirect_uri,
             'response_type' => 'code',
             'state' => $this->generateNewState(),
         ]);

--- a/resources/js/admin/devlink/components/Index.vue
+++ b/resources/js/admin/devlink/components/Index.vue
@@ -127,7 +127,7 @@ const handleFilterChange = () => {
 };
 
 const urlIsValid = computed(() => {
-  return /^(https?:\/\/[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$/.test(newUrl.value);
+  return /^(https?:\/\/[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(:\d{1,5})?$/.test(newUrl.value);
 });
 
 </script>
@@ -176,7 +176,7 @@ const urlIsValid = computed(() => {
           {{ data.item.name }}
         </template>
         <template #cell(status)="data">
-          <Status :id="data.item.id" />
+          <Status :devlink="data.item" />
         </template>
         <template #cell(menu)="data">
           <div class="btn-menu-container">

--- a/resources/js/admin/devlink/components/Status.vue
+++ b/resources/js/admin/devlink/components/Status.vue
@@ -2,13 +2,13 @@
 import { ref, onMounted } from 'vue';
 
 const props = defineProps({
-  id: { type: Number, required: true }, 
+  devlink: { type: Object, required: true }, 
 });
 
 let status = ref('loading');
 
 onMounted(() => {
-  window.ProcessMaker.apiClient.get(`/devlink/${props.id}/ping`).then((result) => {
+  window.ProcessMaker.apiClient.get(`/devlink/${props.devlink.id}/ping`).then((result) => {
     if (result.status === 200 && result.data.status === "ok") {
       status.value = "ok";
     } else {
@@ -18,13 +18,24 @@ onMounted(() => {
     status.value = "error";
   });
 });
+
+const reconnect = () => {
+  const params = {
+    devlink_id: props.devlink.id,
+    redirect_uri: props.devlink.redirect_uri,
+  };
+  window.location.href = `${props.devlink.url}/admin/devlink/oauth-client?${new URLSearchParams(params).toString()}`;
+};
 </script>
 
 <template>
   <div>
     <b-spinner v-if="status === 'loading'"></b-spinner>
     <template v-if="status === 'ok'"><span class="badge badge-linked">{{ $t('Linked') }}</span></template>
-    <template v-if="status === 'error'"><span class="badge badge-not-available">{{ $t('Not available') }}</span></template>
+    <template v-if="status === 'error'">
+      <span class="badge badge-not-available">{{ $t('Not available') }}</span>
+      <b-button variant="primary" size="sm" @click="reconnect">{{ $t('Reconnect') }}</b-button>
+    </template>
   </div>
 </template>
 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2395,5 +2395,6 @@
   "Invalid URL": "Invalid URL",
   "Create new DevLink": "Create new DevLink",
   "Edit DevLink": "Edit DevLink",
-  "Instance URL": "Instance URL"
+  "Instance URL": "Instance URL",
+  "Reconnect": "Reconnect"
 }


### PR DESCRIPTION
Add a "reconnect" button to an instance that can not connect.

## How to Test
- From Instance A, add a new instance to Instance B. Make sure you are logged out of Instance B
- This will redirect you to the login page for Instance B
- Instead of logging in, go back to Instance A DevLinks. Notice the instance is not connected. You should see the "Reconnect" button
- Click the button and log in. Verify that it works now.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19519

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
