### PR TITLE
Users with process permissions does not have access documentation by default

### DIFF
--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -85,7 +85,7 @@ export default {
           content: "View Documentation",
           link: true,
           href: ProcessMaker.packages.includes('package-ai') ? "/modeler/{{id}}/documentation" : "/modeler/{{id}}/print",
-          permission: ["view-documentation", "edit-documentation", "view-additional-asset-actions"],
+          permission: ["view-documentation", "edit-documentation", "view-additional-asset-actions", "edit-processes"],
           icon: "fas fa-sign",
           conditional: "isDocumenterInstalled",
         },

--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -47,7 +47,8 @@
         'process-templates',
         'pm-blocks',
         'projects',
-        'additional-asset-actions'
+        'additional-asset-actions',
+        'documentation'
     );
     @endphp
     <div class="container-fluid">


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19146

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
ci:release-2024-fall
ci:package-process-documenter:bugfix/FOUR-19146