### PR TITLE
FOUR-19696 creation and refresh of case status has a significant delay

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -322,14 +322,14 @@ class TaskController extends Controller
 
             $taskRefreshed = $task->refresh();
 
-            CaseUpdate::dispatch($task->processRequest, $taskRefreshed);
+            CaseUpdate::dispatchSync($task->processRequest, $taskRefreshed);
 
             return new Resource($taskRefreshed);
         } else {
             return abort(422);
         }
     }
-    
+
     public function updateReassign(Request $request)
     {
         $userToAssign = $request->input('user_id');
@@ -342,7 +342,7 @@ class TaskController extends Controller
                 //Reassign to the user.
                 $processRequestToken->reassign($userToAssign, $request->user());
                 $taskRefreshed = $processRequestToken->refresh();
-                CaseUpdate::dispatch($processRequestToken->processRequest, $taskRefreshed);
+                CaseUpdate::dispatchSync($processRequestToken->processRequest, $taskRefreshed);
             }
         }
     }

--- a/ProcessMaker/Repositories/CaseSyncRepository.php
+++ b/ProcessMaker/Repositories/CaseSyncRepository.php
@@ -48,7 +48,7 @@ class CaseSyncRepository
                 $caseStartedRequests = CaseUtils::storeRequests(collect(), $requestData);
                 $caseStartedRequestTokens = collect();
                 $caseStartedTasks = collect();
-                $participants = $instance->participants->map->only('id', 'fullName', 'title', 'avatar');
+                $participants = $instance->participants->pluck('id');
                 $status = $instance->status === CaseStatusConstants::ACTIVE ? CaseStatusConstants::IN_PROGRESS : $instance->status;
 
                 $caseParticipatedData = self::prepareCaseStartedData($instance, $status, $participants);
@@ -214,8 +214,8 @@ class CaseSyncRepository
             $caseStartedRequests = CaseUtils::storeRequests($caseStartedRequests, $requestData);
 
             $participants = $participants
-                ->merge($subProcess->participants->map->only('id', 'fullName', 'title', 'avatar'))
-                ->unique('id')
+                ->merge($subProcess->participants->pluck('id'))
+                ->unique()
                 ->values();
 
             foreach ($subProcess->tokens as $spToken) {

--- a/ProcessMaker/Repositories/ExecutionInstanceRepository.php
+++ b/ProcessMaker/Repositories/ExecutionInstanceRepository.php
@@ -186,7 +186,7 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         // Set id
         $instance->setId($instance->getKey());
 
-        CaseStore::dispatch($instance);
+        CaseStore::dispatchSync($instance);
 
         // Persists collaboration
         $this->persistCollaboration($instance);
@@ -213,7 +213,7 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         $instance->mergeLatestStoredData();
         $instance->saveOrFail();
 
-        CaseUpdateStatus::dispatch($instance);
+        CaseUpdateStatus::dispatchSync($instance);
     }
 
     /**
@@ -238,6 +238,8 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         }
         $instance->mergeLatestStoredData();
         $instance->saveOrFail();
+
+        CaseUpdateStatus::dispatchSync($instance);
     }
 
     /**
@@ -262,7 +264,7 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
         $instance->mergeLatestStoredData();
         $instance->saveOrFail();
 
-        CaseUpdateStatus::dispatch($instance);
+        CaseUpdateStatus::dispatchSync($instance);
     }
 
     /**

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -164,7 +164,7 @@ class TokenRepository implements TokenRepositoryInterface
         $request = $token->getInstance();
         $request->notifyProcessUpdated('ACTIVITY_ACTIVATED', $token);
 
-        CaseUpdate::dispatch($request, $token);
+        CaseUpdate::dispatchSync($request, $token);
 
         if (!is_null($user)) {
             $this->validateAndSendActionByEmail($activity, $token, $user->email);

--- a/tests/Feature/Cases/CasesJobTest.php
+++ b/tests/Feature/Cases/CasesJobTest.php
@@ -25,7 +25,7 @@ class CasesJobTest extends TestCase
             'user_id' => $user->id,
         ]);
 
-        CaseStore::dispatch($instance);
+        CaseStore::dispatchSync($instance);
 
         Queue::assertPushed(CaseStore::class, 1);
     }
@@ -43,7 +43,7 @@ class CasesJobTest extends TestCase
             'process_request_id' => $instance->id,
         ]);
 
-        CaseUpdate::dispatch($instance, $token);
+        CaseUpdate::dispatchSync($instance, $token);
 
         Queue::assertPushed(CaseUpdate::class, 1);
     }
@@ -61,7 +61,7 @@ class CasesJobTest extends TestCase
             'process_request_id' => $instance->id,
         ]);
 
-        CaseUpdateStatus::dispatch($instance, $token);
+        CaseUpdateStatus::dispatchSync($instance, $token);
 
         Queue::assertPushed(CaseUpdateStatus::class, 1);
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
The creation and refresh of case status have caused a significant delay.

## Solution
- Make the Cases jobs synchronous
- Store only the participant ID on cases:sync

## How to Test
1. Create a process with one task
2. Start the case
3. Go to the Cases list
4. When the queue was delayed, the case was not created immediately
5. The user views the cases and the cases do not appears
6. User Refresh page

## Related Tickets & Packages
[FOUR-19696](https://processmaker.atlassian.net/browse/FOUR-19696)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19696]: https://processmaker.atlassian.net/browse/FOUR-19696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ