### PR TITLE
FOUR-19599 Fix The "Case Title" is empty in the caseList

### DIFF
--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -117,6 +117,7 @@ class CaseRepository implements CaseRepositoryInterface
             ]);
 
             $this->case->case_title = $instance->case_title;
+            $this->case->case_title_formatted = $instance->case_title_formatted;
             $this->case->case_status = $instance->status === CaseStatusConstants::ACTIVE ? CaseStatusConstants::IN_PROGRESS : $instance->status;
             $this->case->request_tokens = CaseUtils::storeRequestTokens($this->case->request_tokens, $token->getKey());
             $this->case->tasks = CaseUtils::storeTasks($this->case->tasks, $taskData);

--- a/tests/Feature/Cases/CaseParticipatedTest.php
+++ b/tests/Feature/Cases/CaseParticipatedTest.php
@@ -365,4 +365,54 @@ class CaseParticipatedTest extends TestCase
             'completed_at' => now(),
         ]);
     }
+
+    public function test_update_case_title()
+    {
+        $user = User::factory()->create();
+        $user2 = User::factory()->create();
+        $process = Process::factory()->create([
+            'case_title' => 'New Expense report for {{name}}'
+        ]);
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $repo = new CaseRepository();
+        $repo->create($instance);
+
+        $this->assertDatabaseHas('cases_started', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'process_request_id' => $instance->id,
+            'element_type' => 'task',
+        ]);
+        $instance->data = [
+            'name' => 'John Doe'
+        ];
+        $instance->save();
+
+        $repo->update($instance, $token);
+
+        $this->assertDatabaseCount('cases_participated', 1);
+        $this->assertDatabaseHas('cases_participated', [
+            'user_id' => $user->id,
+            'case_number' => $instance->case_number,
+            'case_title' => $instance->case_title,
+            'case_title_formatted' => $instance->case_title_formatted,
+            'case_status' => 'IN_PROGRESS',
+            'request_tokens->[0]' => $token->id,
+            'tasks->[0]->id' => $token->id,
+            'tasks->[0]->element_id' => $token->element_id,
+            'tasks->[0]->name' => $token->element_name,
+            'tasks->[0]->process_id' => $token->process_id,
+        ]);
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The case title formatted was not being updated after the creation.

## Solution
- Update case title formatted on case update.

## How to Test
- Create a process with case title configured that includes a case variable like:
```
New Expense report for {{name}}
```
And a task to update the used variable
- Run the process
- Update the process variable used in the title
- Review the case title formatted were updated

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19599

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
