### PR TITLE
Add lang.orig for new installed languages for reset to default

### DIFF
--- a/ProcessMaker/Managers/PackageManager.php
+++ b/ProcessMaker/Managers/PackageManager.php
@@ -55,18 +55,28 @@ class PackageManager
     }
 
     /**
+     * Get all json translations registered from packages
+     *
+     * @return array
+     */
+    public function getJsonTranslationsRegistered() : array
+    {
+        return app()->translator->getLoader()->jsonPaths();
+    }
+
+    /**
      * Look into current packages and create a language file for each one
-     * 
+     *
      * @param $code The language code to create a language file of
      */
     public function createLanguageFile($code)
     {
         // Get current packages
-        $packages = app()->translator->getLoader()->jsonPaths();
+        $packages = $this->getJsonTranslationsRegistered();
 
         foreach ($packages as $package) {
             if (!file_exists("{$package}/en.json")) {
-                return ;
+                return;
             } else {
                 // If language does not exist, clone en.json without values
                 if (!file_exists("{$package}/{$code}.json")) {
@@ -78,8 +88,8 @@ class PackageManager
                         $value = '';
                     }
 
-                    // Get empty file with only keys, empty values 
-                    $baseFile = json_encode($data);
+                    // Get empty file with only keys, empty values
+                    $baseFile = json_encode($data, JSON_PRETTY_PRINT);
 
                     // Create file in package
                     file_put_contents("{$package}/{$code}.json", $baseFile);
@@ -90,15 +100,15 @@ class PackageManager
 
     /**
      * Delete a language file form all currently installed packages
-     * 
-     * @param $code The language code of which to delete the language file 
+     *
+     * @param $code The language code of which to delete the language file
      */
     public function deleteLanguageFile($code)
     {
-         // Get current packages
-         $packages = app()->translator->getLoader()->jsonPaths();
+        // Get current packages
+        $packages = $this->getJsonTranslationsRegistered();
 
-         foreach ($packages as $package) {
+        foreach ($packages as $package) {
             // Check if file exists in package
             if (File::exists("{$package}/{$code}.json")) {
                 // Delete file


### PR DESCRIPTION
## Issue & Reproduction Steps
When a new language is installed and the folder lang.orig exists, the language should be created in this folder as well.
## Solution
- add method to load json translations registered

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-19690](https://processmaker.atlassian.net/browse/FOUR-19690)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-translations:observation/FOUR-19690


[FOUR-19690]: https://processmaker.atlassian.net/browse/FOUR-19690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ