### PR TITLE
FOUR-19659: Footer Padding Issue in Template Card Details

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,9 @@ module.exports = {
     extend: {},
   },
   plugins: [],
+  corePlugins: {
+    preflight: false,
+  },
   safelist: [
     {
       pattern: /(bg|outline|border|text)-(gray|purple|blue|amber|green|gray|emerald|red)-(100|200|300|400|500)/,


### PR DESCRIPTION
## Issue & Reproduction Steps
The padding of the footer in the template card details needs to be increased.

## Solution
- Disabled Tailwind's Preflight in the tailwind.config.js to prevent unwanted margin and padding resets on native HTML elements (e.g., hr, h1-h6, etc.).
- Bootstrap already provides normalization for HTML elements, making Preflight redundant and potentially conflicting.

## How to Test
- Run `npm run dev` and check the Edit Screen -> Templates section.
- The `hr` tag should not have any tailwind.css rules.

## Related Tickets & Packages
- [FOUR-19659](https://processmaker.atlassian.net/browse/FOUR-19659)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19659]: https://processmaker.atlassian.net/browse/FOUR-19659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ