### PR TITLE
FOUR-19738: UI: When a case is open some styles are broken

### DIFF
--- a/resources/sass/tailwind.css
+++ b/resources/sass/tailwind.css
@@ -3,7 +3,23 @@
 @tailwind utilities;
 
 @layer base {
-    a{
-      color: #0872C2;
+    /* Tailwind preflight is disabled by default
+      In order to make it easy to add a border by simply adding the border class,
+      Tailwind overrides the default border styles for all elements with the following rules: */
+    *,
+    ::before,
+    ::after {
+      border-width: 0;
+      border-style: solid;
+      border-color: theme('borderColor.DEFAULT', currentColor);
+    }
+
+    /* Ordered and unordered lists are unstyled by default,
+      with no bullets/numbers and no margin or padding. */
+    ol,
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
     }
   }


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Open the tab Cases in processmaker
2. Check the UI table styles

## Solution
- Add preconfig in tailwind css

## How to Test
Check the UI tables in route /cases

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19738

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy