### PR TITLE
FOUR-19662: Enforce Height Limit on Thumbnail and Character Limit on Description in Template Card

### DIFF
--- a/ProcessMaker/Models/Template.php
+++ b/ProcessMaker/Models/Template.php
@@ -119,19 +119,26 @@ class Template extends ProcessMakerModel
         return $this->belongsTo($categoryClass, $categoryColumn)->withDefault();
     }
 
-    public static function rules($existing = null, $table = null)
+    /**
+     * Generate validation rules for the Template model.
+     *
+     * @param mixed $existing The existing record to ignore during uniqueness check.
+     * @param string|null $table The table name to use for the uniqueness check. Defaults to 'templates'.
+     */
+    public static function rules($existing = null, $table = null): array
     {
         $user = Auth::user();
-
-        $unique = Rule::unique($table ?? 'templates')->where(function ($query) use ($user, $table) {
-            if ($table === 'screen_templates') {
-                return $query->where('user_id', $user->id)->where('is_public', 0);
-            }
-        })->ignore($existing);
+        $unique = Rule::unique($table ?? 'templates')
+            ->where(function ($query) use ($user, $table) {
+                if ($table === 'screen_templates') {
+                    return $query->where('user_id', $user->id)->where('is_public', 0);
+                }
+            })
+            ->ignore($existing);
 
         return [
             'name' => ['required', $unique, 'alpha_spaces', 'max:255'],
-            'description' => 'required',
+            'description' => ['required', 'string', 'max:100'],
             'version' => ['required', 'regex:/^[0-9.]+$/'],
         ];
     }

--- a/database/factories/ProcessMaker/Models/ScreenTemplatesFactory.php
+++ b/database/factories/ProcessMaker/Models/ScreenTemplatesFactory.php
@@ -27,7 +27,7 @@ class ScreenTemplatesFactory extends Factory
         return [
             'unique_template_id' => '',
             'name' => $this->faker->unique()->name(),
-            'description' => $this->faker->unique()->sentence(20),
+            'description' => $this->faker->unique()->text(100),
             'user_id' => User::factory()->create()->getKey(),
             'editing_screen_uuid' => null,
             'screen_type' => 'FORM',


### PR DESCRIPTION
## Issue & Reproduction Steps
There is no enforced height limit on the thumbnail or character limit on the description for templates, resulting in inconsistent display and layout issues within the template card. Per the PRD the description should have a 100 character limit

## Solution
- Ensured 'description' field has a max length of 100 characters.

## How to Test
- Perform a manual test.

## Related Tickets & Packages
- [FOUR-19662](https://processmaker.atlassian.net/browse/FOUR-19662)
- [Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1752)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19662]: https://processmaker.atlassian.net/browse/FOUR-19662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ