### PR TITLE
Fix reinstall button and refactor

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/DevLinkController.php
+++ b/ProcessMaker/Http/Controllers/Api/DevLinkController.php
@@ -123,7 +123,7 @@ class DevLinkController extends Controller
 
     public function remoteBundles(Request $request, DevLink $devLink)
     {
-        return $devLink->remoteBundles($request);
+        return $devLink->remoteBundles($request->input('filter'));
     }
 
     public function createBundle(Request $request)

--- a/resources/js/admin/devlink/components/Instance.vue
+++ b/resources/js/admin/devlink/components/Instance.vue
@@ -123,7 +123,8 @@ const executeUpdate = (updateType) => {
           <div class="btn-menu-container">
             <button
               class="btn install-bundle-btn"
-              @click.prevent="updateVersionBundle(data.item)"
+              @click.prevent="install(data.item)"
+              v-if="!data.item.is_installed"
             >
               <i class="fp-cloud-download-outline"></i>
             </button>
@@ -151,37 +152,6 @@ const executeUpdate = (updateType) => {
         </div>
       </div>
     </div>
-    <b-modal
-      ref="confirmUpdateVersion"
-      centered
-      size="lg"
-      content-class="modal-style"
-      :title="$t('Update Bundle Version')"
-      :ok-title="$t('Continue')"
-      :cancel-title="$t('Cancel')"
-      @ok="executeUpdate(selectedOption)"
-    >
-      <div>
-        <p class="mb-4">Select how you want to update the bundle <strong>Testing Processes and Assets</strong></p>
-
-        <b-form-group>
-          <b-form-radio-group v-model="selectedOption" name="bundleUpdateOptions">
-            <b-form-radio
-              class="mb-4"
-              value="update"
-            >
-              {{ $t('Quick Update') }}
-              <p class="text-muted">{{ $t('The current bundle will be replaced completely for the new version immediately.') }}</p>
-            </b-form-radio>
-
-            <b-form-radio value="copy">
-              {{ $t('Copy Changes') }}
-              <p class="text-muted">{{ $t('Copy and update bundle.') }}</p>
-            </b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </div>
-    </b-modal>
     <b-modal id="install-progress" size="lg" v-model="showInstallModal" :title="$t('Installation Progress')" hide-footer>
       <install-progress />
     </b-modal>

--- a/resources/js/admin/devlink/components/LocalBundles.vue
+++ b/resources/js/admin/devlink/components/LocalBundles.vue
@@ -5,8 +5,8 @@ import Origin from './Origin.vue';
 import VersionCheck from './VersionCheck.vue';
 import EllipsisMenu from '../../../components/shared/EllipsisMenu.vue';
 import BundleModal, { show as showBundleModal, hide as hideBundleModal } from './BundleModal.vue';
-import InstallProgress from './InstallProgress.vue';
 import { useRouter, useRoute } from 'vue-router/composables';
+import UpdateBundle from './UpdateBundle.vue';
 
 const vue = getCurrentInstance().proxy;
 const router = useRouter();
@@ -14,15 +14,14 @@ const route = useRoute();
 const bundles = ref([]);
 const editModal = ref(null);
 const confirmDeleteModal = ref(null);
-const confirmIncreaseVersion = ref(null);
+const confirmPublishNewVersion = ref(null);
 const confirmUpdateVersion = ref(null);
-const selectedOption = ref('update');
-const showInstallModal = ref(false);
 const filter = ref("");
 const bundleModal = ref(null);
+const updateBundle = ref(null);
 
 const actions = [
-  { value: "increase-item", content: "Increase Version", conditional: "if(not(dev_link_id), true, false)" },
+  { value: "increase-item", content: "Publish New Version", conditional: "if(not(dev_link_id), true, false)" },
   { value: "update-item", content: "Update Version", conditional: "if(dev_link_id, true, false)" },
   { value: "edit-item", content: "Edit", conditional: "if(not(dev_link_id) , true, false)" },
   { value: "delete-item", content: "Delete" },
@@ -146,19 +145,19 @@ const deleteBundle = (bundle) => {
 
 const updateVersionBundle = (bundle) => {
   selected.value = bundle;
-  confirmUpdateVersion.value.show();
+  updateBundle.value.show(bundle);
 };
 
 const increaseVersionBundle = (bundle) => {
   selected.value = bundle;
-  confirmIncreaseVersion.value.show();
+  confirmPublishNewVersion.value.show();
 };
 
 const executeIncrease = () => {
   ProcessMaker.apiClient
     .post(`devlink/local-bundles/${selected.value.id}/increase-version`)
     .then((result) => {
-      confirmIncreaseVersion.value.hide();
+      confirmPublishNewVersion.value.hide();
       load();
     });
 };
@@ -169,17 +168,6 @@ const executeDelete = () => {
     .then((result) => {
       confirmDeleteModal.value.hide();
       load();
-    });
-};
-
-const executeUpdate = (updateType) => {
-  showInstallModal.value = true;
-  ProcessMaker.apiClient
-    .post(`/devlink/${selected.value.dev_link_id}/remote-bundles/${selected.value.remote_id}/install`, {
-      updateType,
-    })
-    .then((response) => {
-      // Handle the response as needed
     });
 };
 
@@ -202,7 +190,12 @@ const goToBundleAssets = (bundle) => {
 const deleteWaring = computed(() => {
   const name = selected?.value.name;
   return vue.$t('Are you sure you want to delete {{name}}?', { name });
-})
+});
+
+const confirmPublishNewVersionText = computed(() => {
+  return vue.$t('Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?', { selectedBundleName: selected.value?.name });
+});
+
 </script>
 
 <template>
@@ -235,50 +228,17 @@ const deleteWaring = computed(() => {
     <BundleModal ref="bundleModal" :bundle="selected" @update="update" />
 
     <b-modal
-      ref="confirmIncreaseVersion"
+      ref="confirmPublishNewVersion"
       centered
       content-class="modal-style"
-      title="Increase Version"
+      title="Publish New Version"
       @ok="executeIncrease"
     >
-      <p>Are you sure you increase the version of {{ selected?.name }}?</p>
+      <p v-html="confirmPublishNewVersionText"></p>
     </b-modal>
 
-    <b-modal
-      ref="confirmUpdateVersion"
-      centered
-      size="lg"
-      content-class="modal-style"
-      :title="$t('Update Bundle Version')"
-      :ok-title="$t('Continue')"
-      :cancel-title="$t('Cancel')"
-      @ok="executeUpdate(selectedOption)"
-    >
-      <div>
-        <p class="mb-4">Select how you want to update the bundle <strong>Testing Processes and Assets</strong></p>
+    <UpdateBundle ref="updateBundle"></UpdateBundle>
 
-        <b-form-group>
-          <b-form-radio-group v-model="selectedOption" name="bundleUpdateOptions">
-            <b-form-radio
-              class="mb-4"
-              value="update"
-            >
-              {{ $t('Quick Update') }}
-              <p class="text-muted">{{ $t('The current bundle will be replaced completely for the new version immediately.') }}</p>
-            </b-form-radio>
-
-            <b-form-radio value="copy">
-              {{ $t('Copy Changes') }}
-              <p class="text-muted">{{ $t('Copy and update bundle.') }}</p>
-            </b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </div>
-    </b-modal>
-
-    <b-modal id="install-progress" size="lg" v-model="showInstallModal" :title="$t('Installation Progress')" hide-footer>
-      <install-progress />
-    </b-modal>
     <div class="card local-bundles-card">
       <b-table
         hover

--- a/resources/js/admin/devlink/components/UpdateBundle.vue
+++ b/resources/js/admin/devlink/components/UpdateBundle.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { ref, onMounted, computed, getCurrentInstance, defineExpose } from 'vue';
+import InstallProgress from './InstallProgress.vue';
+
+const vue = getCurrentInstance().proxy;
+const confirmUpdateVersion = ref(null);
+const selected = ref(null);
+const selectedOption = ref('update');
+const showInstallModal = ref(false);
+
+const show = (bundle) => {
+  selected.value = bundle;
+  confirmUpdateVersion.value.show();
+}
+
+defineExpose({
+  show
+});
+
+const updateBundleText = computed(() => {
+  return vue.$t('Select how you would like to update the bundle <strong>{{ selectedBundleName }}</strong>.', { selectedBundleName: selected.value?.name });
+});
+
+const executeUpdate = (updateType) => {
+  showInstallModal.value = true;
+  ProcessMaker.apiClient
+    .post(`/devlink/${selected.value.dev_link_id}/remote-bundles/${selected.value.remote_id}/install`, {
+      updateType,
+    })
+    .then((response) => {
+      // Handle the response as needed
+    });
+};
+
+</script>
+
+<template>
+  <div>
+    <b-modal
+      ref="confirmUpdateVersion"
+      centered
+      size="lg"
+      content-class="modal-style"
+      :title="$t('Update Bundle')"
+      :ok-title="$t('Continue')"
+      :cancel-title="$t('Cancel')"
+      @ok="executeUpdate(selectedOption)"
+    >
+      <div>
+        <p v-html="updateBundleText"></p>
+
+        <b-form-group>
+          <b-form-radio-group
+            v-model="selectedOption"
+            name="bundleUpdateOptions"
+            stacked
+          >
+            <b-form-radio value="update">
+              {{ $t('Update Bundle Assets') }}
+              <p class="text-muted">{{ $t('Existing assets on this instance will be updated.') }}</p>
+            </b-form-radio>
+
+            <b-form-radio value="copy">
+              {{ $t('Copy Bundle Assets') }}
+              <p class="text-muted">{{ $t('Create new copies of bundle assets.') }}</p>
+            </b-form-radio>
+          </b-form-radio-group>
+        </b-form-group>
+      </div>
+    </b-modal>
+
+    <b-modal id="install-progress" size="lg" v-model="showInstallModal" :title="$t('Installation Progress')" hide-footer>
+      <install-progress />
+    </b-modal>
+  </div>
+</template>

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2403,5 +2403,12 @@
   "Create new DevLink": "Create new DevLink",
   "Edit DevLink": "Edit DevLink",
   "Instance URL": "Instance URL",
-  "Reconnect": "Reconnect"
+  "Reconnect": "Reconnect",
+  "Update Bundle": "Update Bundle",
+  "Update Bundle Assets" : "Update Bundle Assets",
+  "Copy Bundle Assets" : "Copy Bundle Assets",
+  "Create new copies of bundle assets." : "Create new copies of bundle assets.",
+  "Existing assets on this instance will be updated." : "Existing assets on this instance will be updated.",
+  "Select how you would like to update the bundle <strong>{{ selectedBundleName }}</strong>.": "Select how you would like to update the bundle <strong>{{ selectedBundleName }}</strong>.",
+  "Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?": "Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?"
 }

--- a/tests/Model/DevLinkTest.php
+++ b/tests/Model/DevLinkTest.php
@@ -106,7 +106,7 @@ class DevLinkTest extends TestCase
         ]);
 
         Http::fake([
-            'http://remote-instance.test/api/1.0/devlink/local-bundles?published=1&filter=' => Http::response([
+            'http://remote-instance.test/api/1.0/devlink/local-bundles?published=1' => Http::response([
                 'data' => [
                     [
                         'id' => $existingInstalledRemoteBundle->remote_id,
@@ -118,7 +118,7 @@ class DevLinkTest extends TestCase
             ]),
         ]);
 
-        $bundles = $devLink->remoteBundles();
+        $bundles = $devLink->remoteBundles(null);
         $this->assertCount(2, $bundles['data']);
         $this->assertEquals($bundles['data'][0]['is_installed'], true);
         $this->assertEquals($bundles['data'][1]['is_installed'], false);


### PR DESCRIPTION
## Issue & Reproduction Steps
The Reinstall bundle button is not working

## Solution
- Add logic to button
- Refactor to dry up code
- Add missing translations

## How to Test
Ensure you can reinstall a bundle from the button on the bundle assets page

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19797

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
