### PR TITLE
FOUR-19215 GET {server}/api/1.0/files/{file_ID}/logs is displaying ex…

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -371,7 +371,7 @@ class FileController extends Controller
 
     public function showLogs(Media $file)
     {
-        $response = MediaLog::with('user')
+        $response = MediaLog::with('user:id,username,firstname,lastname')
                         ->where('media_id', $file->id)
                         ->orderBy('created_at', 'desc')
                         ->get();


### PR DESCRIPTION
## Issue & Reproduction Steps
User information is displayed for each user

## Solution
GET {server}/api/1.0/files/{file_id}/logs should not display all information about one or more users 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-15660
