### PR TITLE
FOUR-19671:  Selection Applies Both Fields and Layout to Screen

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -838,46 +838,20 @@ class ScreenTemplate implements TemplateInterface
                 $this->setScreenConfig($screen);
             }
 
-            $templateComponents = $this->removeFormMultiColumns($templateComponents);
-
             $screenConfig = $screen->config;
             // Check if the currentScreenPage exists in the screenConfig array
             if (!isset($screenConfig[$currentScreenPage])) {
                 throw new MissingScreenPageException();
             }
 
+            $templateComponents = ScreenTemplateHelper::getScreenComponents($newTemplateScreen->config,
+                $supportedComponents, false)[0]['items'];
+
             $screenConfig[$currentScreenPage]['items'] =
                 array_merge($screenConfig[$currentScreenPage]['items'], $templateComponents);
 
             $screen->config = $screenConfig;
         }
-    }
-
-    public function removeFormMultiColumns(&$templateComponents)
-    {
-        foreach ($templateComponents as $key => &$component) {
-            // Check if the component is "FormMultiColumn"
-            if (isset($component['component']) && $component['component'] === 'FormMultiColumn') {
-                // Extract the "items" from the FormMultiColumn
-                if (isset($component['items']) && is_array($component['items'])) {
-                    foreach ($component['items'] as $childItems) {
-                        foreach ($childItems as $childItem) {
-                            // Append child items to the main array
-                            $templateComponents[] = $childItem;
-                        }
-                    }
-                }
-                // Remove the FormMultiColumn component
-                unset($templateComponents[$key]);
-            } else {
-                // If the "items" key exists, recurse into it
-                if (isset($component['items']) && is_array($component['items'])) {
-                    $this->removeFormMultiColumns($component['items']);
-                }
-            }
-        }
-
-        return $templateComponents;
     }
 
     private function getTemplateComponents($newTemplateScreen, $templateOptions, $supportedComponents)

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -838,6 +838,8 @@ class ScreenTemplate implements TemplateInterface
                 $this->setScreenConfig($screen);
             }
 
+            $templateComponents = $this->removeFormMultiColumns($templateComponents);
+
             $screenConfig = $screen->config;
             // Check if the currentScreenPage exists in the screenConfig array
             if (!isset($screenConfig[$currentScreenPage])) {
@@ -849,6 +851,33 @@ class ScreenTemplate implements TemplateInterface
 
             $screen->config = $screenConfig;
         }
+    }
+
+    public function removeFormMultiColumns(&$templateComponents)
+    {
+        foreach ($templateComponents as $key => &$component) {
+            // Check if the component is "FormMultiColumn"
+            if (isset($component['component']) && $component['component'] === 'FormMultiColumn') {
+                // Extract the "items" from the FormMultiColumn
+                if (isset($component['items']) && is_array($component['items'])) {
+                    foreach ($component['items'] as $childItems) {
+                        foreach ($childItems as $childItem) {
+                            // Append child items to the main array
+                            $templateComponents[] = $childItem;
+                        }
+                    }
+                }
+                // Remove the FormMultiColumn component
+                unset($templateComponents[$key]);
+            } else {
+                // If the "items" key exists, recurse into it
+                if (isset($component['items']) && is_array($component['items'])) {
+                    $this->removeFormMultiColumns($component['items']);
+                }
+            }
+        }
+
+        return $templateComponents;
     }
 
     private function getTemplateComponents($newTemplateScreen, $templateOptions, $supportedComponents)


### PR DESCRIPTION
## Issue & Reproduction Steps
When selecting only the "Fields" option to apply to a screen, both the fields and the layout from the template are applied. The expected behavior is that only the fields should be applied.

## Steps to Reproduce:

- Create a screen template with both fields and a specific layout.
- Create a new screen.
- Use the "Apply Template" option and select only the "Fields" to apply.
**Observe that both the fields and layout are applied to the screen.**

### Expected Behavior
When selecting the "Fields" option, only the fields from the selected template should be applied to the screen.

### Current Behavior
Selecting "Fields" applies both the fields and the layout of the template.


## Solution
- Implement removeFormMultiColumns function that will remove all components === 'FormMultiColumn' 

## How to Test
Please follow the reproduction steps and make sure that the expected behavior is met.

## Related Tickets & Packages
- Ticket: [FOUR-19671](https://processmaker.atlassian.net/browse/FOUR-19671)
- ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19671]: https://processmaker.atlassian.net/browse/FOUR-19671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ