### PR TITLE
FOUR-19816 when I start a case and route to the next task with the same user the "In Progress" cases list is empty

### DIFF
--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -71,7 +71,7 @@ class CaseRepository implements CaseRepositoryInterface
                 'user_id' => $instance->user_id,
                 'case_title' => $instance->case_title,
                 'case_title_formatted' => $instance->case_title_formatted,
-                'case_status' => $instance->status === CaseStatusConstants::ACTIVE ? CaseStatusConstants::IN_PROGRESS : $instance->status,
+                'case_status' => CaseUtils::getStatus($instance->status),
                 'processes' => CaseUtils::storeProcesses(collect(), $processData),
                 'requests' => CaseUtils::storeRequests(collect(), $requestData),
                 'request_tokens' => [],
@@ -118,7 +118,7 @@ class CaseRepository implements CaseRepositoryInterface
 
             $this->case->case_title = $instance->case_title;
             $this->case->case_title_formatted = $instance->case_title_formatted;
-            $this->case->case_status = $instance->status === CaseStatusConstants::ACTIVE ? CaseStatusConstants::IN_PROGRESS : $instance->status;
+            $this->case->case_status = CaseUtils::getStatus($instance->status);
             $this->case->request_tokens = CaseUtils::storeRequestTokens($this->case->request_tokens, $token->getKey());
             $this->case->tasks = CaseUtils::storeTasks($this->case->tasks, $taskData);
             $this->case->keywords = CaseUtils::getKeywords($dataKeywords);
@@ -146,11 +146,13 @@ class CaseRepository implements CaseRepositoryInterface
         }
 
         try {
+            $caseStatus = CaseUtils::getStatus($instance->status);
+
             $data = [
-                'case_status' => $instance->status,
+                'case_status' => $caseStatus,
             ];
 
-            if ($instance->status === CaseStatusConstants::COMPLETED) {
+            if ($caseStatus === CaseStatusConstants::COMPLETED) {
                 $data['completed_at'] = Carbon::now();
             }
 

--- a/ProcessMaker/Repositories/CaseSyncRepository.php
+++ b/ProcessMaker/Repositories/CaseSyncRepository.php
@@ -3,7 +3,6 @@
 namespace ProcessMaker\Repositories;
 
 use Illuminate\Support\Collection;
-use ProcessMaker\Constants\CaseStatusConstants;
 use ProcessMaker\Models\CaseParticipated;
 use ProcessMaker\Models\CaseStarted;
 use ProcessMaker\Models\ProcessRequest;
@@ -49,7 +48,7 @@ class CaseSyncRepository
                 $caseStartedRequestTokens = collect();
                 $caseStartedTasks = collect();
                 $participants = $instance->participants->pluck('id');
-                $status = $instance->status === CaseStatusConstants::ACTIVE ? CaseStatusConstants::IN_PROGRESS : $instance->status;
+                $status = CaseUtils::getStatus($instance->status);
 
                 $caseParticipatedData = self::prepareCaseStartedData($instance, $status, $participants);
 

--- a/ProcessMaker/Repositories/CaseUtils.php
+++ b/ProcessMaker/Repositories/CaseUtils.php
@@ -3,8 +3,7 @@
 namespace ProcessMaker\Repositories;
 
 use Illuminate\Support\Collection;
-use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
-use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
+use ProcessMaker\Constants\CaseStatusConstants;
 
 class CaseUtils
 {
@@ -166,5 +165,21 @@ class CaseUtils
             $data[$key] = data_get($object, $property);
         }
         return $data;
+    }
+
+    /**
+     * The getStatus function returns the status of a case as "IN_PROGRESS" if it is "ACTIVE", otherwise it returns the
+     * current status.
+     *
+     * @param string instanceStatus The `instanceStatus` parameter is a string that represents the status of a case
+     * instance. The `getStatus` function compares this status with the `ACTIVE` status defined in the
+     * `CaseStatusConstants` class. If the `instanceStatus` is `ACTIVE`, the function returns `IN_PROGRESS
+     *
+     * @return If the  is equal to CaseStatusConstants::ACTIVE, then CaseStatusConstants::IN_PROGRESS will
+     * be returned. Otherwise,  will be returned as is.
+     */
+    public static function getStatus(string $instanceStatus)
+    {
+        return $instanceStatus === CaseStatusConstants::ACTIVE ? CaseStatusConstants::IN_PROGRESS : $instanceStatus;
     }
 }

--- a/tests/Feature/Api/V1_1/CaseUtilsTest.php
+++ b/tests/Feature/Api/V1_1/CaseUtilsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api\V1_1;
 
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
+use ProcessMaker\Constants\CaseStatusConstants;
 use ProcessMaker\Repositories\CaseUtils;
 
 class CaseUtilsTest extends TestCase
@@ -173,5 +174,26 @@ class CaseUtilsTest extends TestCase
             'nested_property' => null
         ];
         $this->assertEquals($expected, CaseUtils::extractData($object, $mapping));
+    }
+
+    public function testGetStatusInProgress()
+    {
+        $instanceStatus = CaseStatusConstants::ACTIVE;
+        $expected = CaseStatusConstants::IN_PROGRESS;
+        $this->assertEquals($expected, CaseUtils::getStatus($instanceStatus));
+    }
+
+    public function testGetStatusCompleted()
+    {
+        $instanceStatus = CaseStatusConstants::COMPLETED;
+        $expected = CaseStatusConstants::COMPLETED;
+        $this->assertEquals($expected, CaseUtils::getStatus($instanceStatus));
+    }
+
+    public function testGetStatusError()
+    {
+        $instanceStatus = 'ERROR';
+        $expected = 'ERROR';
+        $this->assertEquals($expected, CaseUtils::getStatus($instanceStatus));
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
When I start a case and route to the next task with the same user the "In Progress" cases list is empty

## Solution
- Store the correct status in the instance updating

https://github.com/user-attachments/assets/3b4f4885-ab17-456e-abfd-4af0c1f3dfeb

## How to Test
1. Create a cases with Admin user
2. Route to the next task
3. Review the data in the My Cases and In progress list

## Related Tickets & Packages
[FOUR-19816](https://processmaker.atlassian.net/browse/FOUR-19816)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19816]: https://processmaker.atlassian.net/browse/FOUR-19816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ