### PR TITLE
FOUR-19812 Fix reisntall functionality

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/DevLinkController.php
+++ b/ProcessMaker/Http/Controllers/Api/DevLinkController.php
@@ -143,7 +143,6 @@ class DevLinkController extends Controller
 
         $bundle->name = $request->input('name');
         $bundle->published = (bool) $request->input('published', false);
-        $bundle->version = $bundle->version + 1;
         $bundle->saveOrFail();
 
         return $bundle;

--- a/ProcessMaker/Http/Controllers/Api/DevLinkController.php
+++ b/ProcessMaker/Http/Controllers/Api/DevLinkController.php
@@ -172,6 +172,17 @@ class DevLinkController extends Controller
         );
     }
 
+    public function reinstallBundle(Request $request, Bundle $bundle)
+    {
+        DevLinkInstall::dispatch(
+            $request->user()->id,
+            $bundle->dev_link_id,
+            $bundle->id,
+            'update',
+            true
+        );
+    }
+
     public function exportLocalBundle(Bundle $bundle)
     {
         return ['payloads' => $bundle->export()];

--- a/ProcessMaker/Models/Bundle.php
+++ b/ProcessMaker/Models/Bundle.php
@@ -208,6 +208,6 @@ class Bundle extends ProcessMakerModel implements HasMedia
 
         $this->install($payloads, $mode, $logger);
 
-        $logger->setStatus('done');
+        $logger?->setStatus('done');
     }
 }

--- a/ProcessMaker/Models/Bundle.php
+++ b/ProcessMaker/Models/Bundle.php
@@ -187,8 +187,6 @@ class Bundle extends ProcessMakerModel implements HasMedia
 
         $options = new Options([
             'mode' => $mode,
-            // 'saveAssetsMode' => 'saveAllAssets',
-            // 'isTemplate' => false,
         ]);
         $assets = [];
         foreach ($payloads as $payload) {
@@ -201,13 +199,15 @@ class Bundle extends ProcessMakerModel implements HasMedia
         }
     }
 
-    public function reinstall(string $mode)
+    public function reinstall(string $mode, Logger $logger = null)
     {
         $media = $this->newestVersionFile();
 
         $content = file_get_contents($media->getPath());
         $payloads = json_decode(gzdecode($content), true);
 
-        $this->install($payloads, $mode);
+        $this->install($payloads, $mode, $logger);
+
+        $logger->setStatus('done');
     }
 }

--- a/ProcessMaker/Models/DevLink.php
+++ b/ProcessMaker/Models/DevLink.php
@@ -131,7 +131,7 @@ class DevLink extends ProcessMakerModel
         );
     }
 
-    public function installRemoteBundle($bundleId, $updateType)
+    public function installRemoteBundle($remoteBundleId, $updateType)
     {
         if (!$this->logger) {
             $this->logger = new Logger();
@@ -139,15 +139,15 @@ class DevLink extends ProcessMakerModel
 
         $this->logger->status(__('Downloading bundle from remote instance'));
 
-        $bundleInfo = $this->remoteBundle($bundleId)->json();
+        $bundleInfo = $this->remoteBundle($remoteBundleId)->json();
 
         $bundleExport = $this->client()->get(
-            route('api.devlink.export-local-bundle', ['bundle' => $bundleId], false)
+            route('api.devlink.export-local-bundle', ['bundle' => $remoteBundleId], false)
         )->json();
 
         $bundle = Bundle::updateOrCreate(
             [
-                'remote_id' => $bundleId,
+                'remote_id' => $remoteBundleId,
                 'dev_link_id' => $this->id,
             ],
             [

--- a/ProcessMaker/Models/DevLink.php
+++ b/ProcessMaker/Models/DevLink.php
@@ -10,6 +10,7 @@ use ProcessMaker\ImportExport\Logger;
 use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Models\ProcessMakerModel;
 use Ramsey\Uuid\Type\Integer;
+use ZipArchive;
 
 class DevLink extends ProcessMakerModel
 {
@@ -156,34 +157,9 @@ class DevLink extends ProcessMakerModel
             ]
         );
 
-        $this->logger->status('Installing bundle on the this instance');
-        $this->logger->setSteps($bundleExport['payloads']);
-
-        $options = [
-            'mode' => $updateType,
-            'saveAssetsMode' => 'saveAllAssets',
-            'isTemplate' => false,
-        ];
-        $assets = [];
-        foreach ($bundleExport['payloads'] as $payload) {
-            $assets[] = $this->import($payload, $options);
-        }
-
-        if ($updateType === 'update') {
-            $this->logger->status('Syncing bundle assets');
-            $bundle->syncAssets($assets);
-        }
+        $bundle->install($bundleExport['payloads'], $updateType, $this->logger);
 
         $this->logger->setStatus('done');
-    }
-
-    private function import(array $payload, $options = null)
-    {
-        $options = $options === null ? new Options([]) : new Options($options);
-        $importer = new Importer($payload, $options, $this->logger);
-        $manifest = $importer->doImport();
-
-        return $manifest[$payload['root']]->model;
     }
 
     public function installRemoteAsset(string $class, int $id) : ProcessMakerModel
@@ -192,11 +168,24 @@ class DevLink extends ProcessMakerModel
             route('api.devlink.export-local-asset', ['class' => $class, 'id' => $id], false)
         )->json();
 
-        return $this->import($payload);
+        $logger = new Logger();
+        $options = new Options([
+            'mode' => 'update',
+        ]);
+
+        return self::import($payload, $options, $logger);
     }
 
     public function bundles()
     {
         return $this->hasMany(Bundle::class);
+    }
+
+    public static function import(array $payload, Options $options, Logger $logger)
+    {
+        $importer = new Importer($payload, $options, $logger);
+        $manifest = $importer->doImport();
+
+        return $manifest[$payload['root']]->model;
     }
 }

--- a/resources/js/admin/devlink/components/BundleAssets.vue
+++ b/resources/js/admin/devlink/components/BundleAssets.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute } from 'vue-router/composables';
 import BundleModal, { show as showBundleModal, hide as hideBundleModal } from './BundleModal.vue';
 import Header from './Header.vue';
 import UpdateBundle from './UpdateBundle.vue';
+import VersionCheck from './VersionCheck.vue';
 
 const vue = getCurrentInstance().proxy;
 const route = useRoute();
@@ -21,6 +22,7 @@ const fields = [
 const bundleModal = ref(null);
 const bundleForEdit = ref({});
 const reinstallBundle = ref(null);
+const updateAvailable = ref(false);
 
 const openBundleModalForEdit = () => {
   bundleForEdit.value = { ...bundle.value };
@@ -81,6 +83,7 @@ const remove = async (asset) => {
       <div class="col">
         <Header back="local-bundles">
           {{ bundle.name }} {{ $t("Assets") }}
+          <VersionCheck @updateAvailable="updateAvailable = $event" :dev-link="bundle"></VersionCheck>
         </Header>
       </div>
       <div class="col">
@@ -99,11 +102,18 @@ const remove = async (asset) => {
             </b-button>
 
             <b-button
-              v-if="bundle.dev_link_id !== null"
+              v-if="updateAvailable"
               @click.prevent="reinstallBundle.show(bundle)"
               variant="primary"
               class="install-btn">
-              <i class="fas fa-plus-circle" style="padding-right: 8px;"></i>{{ $t('Reinstall this Bundle') }}
+              <i class="fas fa-plus-circle" style="padding-right: 8px;"></i>{{ $t('Update Bundle') }}
+            </b-button>
+            <b-button
+              v-if="bundle.dev_link_id !== null"
+              @click.prevent="reinstallBundle.show(bundle, true)"
+              variant="primary"
+              class="install-btn">
+              <i class="fas fa-plus-circle" style="padding-right: 8px;"></i>{{ $t('Reinstall This Bundle') }}
             </b-button>
           </div>
         </div>

--- a/resources/js/admin/devlink/components/UpdateBundle.vue
+++ b/resources/js/admin/devlink/components/UpdateBundle.vue
@@ -57,7 +57,7 @@ const executeUpdate = (updateType) => {
           >
             <b-form-radio value="update">
               {{ $t('Update Bundle Assets') }}
-              <p class="text-muted">{{ $t('Existing assets on this instance will be updated.') }}</p>
+              <p class="text-muted">{{ $t('Existing assets on this instance will be updated. Warning: this will overwrite any changes you made to the assets on this instance.') }}</p>
             </b-form-radio>
 
             <b-form-radio value="copy">

--- a/resources/js/admin/devlink/components/VersionCheck.vue
+++ b/resources/js/admin/devlink/components/VersionCheck.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, defineEmits } from 'vue';
 import { useRouter, useRoute } from 'vue-router/composables';
 
 const router = useRouter();
+const emit = defineEmits(['updateAvailable']);
 
 const checkNewVersion = ref(false);
 
@@ -16,6 +17,9 @@ const remote = () => {
     .then((response) => {
       if (Number(response.data.version) > Number(props.devLink.version)) {
         checkNewVersion.value = true;
+        emit('updateAvailable', true);
+      } else {
+        emit('updateAvailable', false);
       }
     });
 };
@@ -25,6 +29,7 @@ onMounted(() => {
     remote();
   }
 });
+
 
 </script>
 

--- a/resources/js/components/shared/AddToBundle.vue
+++ b/resources/js/components/shared/AddToBundle.vue
@@ -33,7 +33,7 @@ const save = (event) => {
       modal.value.hide();
       window.ProcessMaker.alert(vue.$t('Asset added to bundle'), 'success');
     }).catch(e => {
-      error.value = e.response?.data?.message || e.message;
+      error.value = e.response?.data?.error?.message || e.message;
     })
   }
 };

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -65,13 +65,6 @@ export default {
           permission: "edit-processes",
         },
         {
-          value: "add-to-bundle",
-          content: "Add to Bundle",
-          icon: "fas fa-folder-plus",
-          permission: "admin",
-          emit_on_root: 'add-to-bundle',
-        },
-        {
           value: "edit-item",
           content: "Configure",
           link: true,

--- a/resources/js/processes/components/ProcessesListing.vue
+++ b/resources/js/processes/components/ProcessesListing.vue
@@ -103,7 +103,7 @@
                 <ellipsis-menu
                   v-if="header.field === 'actions'"
                   class="process-table"
-                  :actions="processActions"
+                  :actions="processActionsWithAddToBundle"
                   :permission="permission"
                   :data="row"
                   :is-documenter-installed="isDocumenterInstalled"
@@ -268,6 +268,17 @@ export default {
       this.apiDataLoading = false;
       this.apiNoResults = false;
     });
+  },
+  computed: {
+    processActionsWithAddToBundle() {
+      return this.processActions.toSpliced(7, 0, {
+        value: "add-to-bundle",
+        content: "Add to Bundle",
+        icon: "fas fa-folder-plus",
+        permission: "admin",
+        emit_on_root: 'add-to-bundle',
+      });
+    }
   },
 };
 </script>

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2408,7 +2408,7 @@
   "Update Bundle Assets" : "Update Bundle Assets",
   "Copy Bundle Assets" : "Copy Bundle Assets",
   "Create new copies of bundle assets." : "Create new copies of bundle assets.",
-  "Existing assets on this instance will be updated." : "Existing assets on this instance will be updated.",
+  "Existing assets on this instance will be updated. Warning: this will overwrite any changes you made to the assets on this instance." : "Existing assets on this instance will be updated. Warning: this will overwrite any changes you made to the assets on this instance.",
   "Select how you would like to update the bundle <strong>{{ selectedBundleName }}</strong>.": "Select how you would like to update the bundle <strong>{{ selectedBundleName }}</strong>.",
   "Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?": "Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?"
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2410,5 +2410,8 @@
   "Create new copies of bundle assets." : "Create new copies of bundle assets.",
   "Existing assets on this instance will be updated. Warning: this will overwrite any changes you made to the assets on this instance." : "Existing assets on this instance will be updated. Warning: this will overwrite any changes you made to the assets on this instance.",
   "Select how you would like to update the bundle <strong>{{ selectedBundleName }}</strong>.": "Select how you would like to update the bundle <strong>{{ selectedBundleName }}</strong>.",
-  "Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?": "Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?"
+  "Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?": "Are you sure you increase the version of <strong>{{ selectedBundleName }}</strong>?",
+  "Update Available": "Update Available",
+  "Reinstall This Bundle": "Reinstall This Bundle",
+  "Reinstall Bundle": "Reinstall Bundle"
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -401,7 +401,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
         Route::get('devlink/export-local-bundle/{bundle}', [DevLinkController::class, 'exportLocalBundle'])->name('devlink.export-local-bundle');
         Route::get('devlink/export-local-asset', [DevLinkController::class, 'exportLocalAsset'])->name('devlink.export-local-asset');
 
-        Route::post('devlink/{devLink}/remote-bundles/{removeBundleId}/install', [DevLinkController::class, 'installRemoteBundle'])->name('devlink.install-remote-bundle');
+        Route::post('devlink/{devLink}/remote-bundles/{remoteBundleId}/install', [DevLinkController::class, 'installRemoteBundle'])->name('devlink.install-remote-bundle');
         Route::post('devlink/{devLink}/install-remote-asset', [DevLinkController::class, 'installRemoteAsset'])->name('devlink.install-remote-asset');
 
         // Put these last to avoid conflicts with the other devlink routes

--- a/routes/api.php
+++ b/routes/api.php
@@ -403,6 +403,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
 
         Route::post('devlink/{devLink}/remote-bundles/{remoteBundleId}/install', [DevLinkController::class, 'installRemoteBundle'])->name('devlink.install-remote-bundle');
         Route::post('devlink/{devLink}/install-remote-asset', [DevLinkController::class, 'installRemoteAsset'])->name('devlink.install-remote-asset');
+        Route::post('devlink/local-bundles/{bundle}/reinstall', [DevLinkController::class, 'reinstallBundle'])->name('devlink.reinstall-bundle');
 
         // Put these last to avoid conflicts with the other devlink routes
         Route::get('devlink/{devLink}', [DevLinkController::class, 'show'])->name('devlink.show');


### PR DESCRIPTION
## Issue & Reproduction Steps
Reinstalling a bundle is getting current assets from the remote instance. It should use the assets as they were when the bunde was first installed or last upgraded.

## Solution
- Save a copy of the payload and replay it when reinstalling

ci:k8s-branch:upgrade-alpine
ci:deploy
..

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19812

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
