### PR TITLE
FOUR-19749 Missed label 'Users/Groups to View Encrypted Fields'

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -2355,7 +2355,7 @@
   "This actions is taking longer than expected. We will continue updating your tasks in the background.": "Diese Aktion dauert länger als erwartet. Wir werden Ihre Aufgaben weiterhin im Hintergrund aktualisieren.",
   "No user selected": "Kein Benutzer ausgewählt",
   "Encrypted": "Verschlüsselt",
-  "Users/Groups to View": "Benutzer/Gruppen zum Anzeigen",
+  "Users/Groups to View Encrypted Fields": "Benutzer/Gruppen zum Anzeigen verschlüsselter Felder",
   "Conceal": "Verbergen",
   "Reveal": "Offenbaren",
   "There is no field with the name ':fieldName'.": "Es gibt kein Feld mit dem Namen ':fieldName'.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2369,7 +2369,7 @@
   "This actions is taking longer than expected. We will continue updating your tasks in the background.": "This actions is taking longer than expected. We will continue updating your tasks in the background.",
   "No user selected": "No user selected",
   "Encrypted": "Encrypted",
-  "Users/Groups to View": "Users/Groups to View",
+  "Users/Groups to View Encrypted Fields": "Users/Groups to View Encrypted Fields",
   "Conceal": "Conceal",
   "Reveal": "Reveal",
   "There is no field with the name ':fieldName'.": "There is no field with the name ':fieldName'.",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -2352,7 +2352,7 @@
   "This actions is taking longer than expected. We will continue updating your tasks in the background.": "Esta acción está tomando más tiempo de lo esperado. Continuaremos actualizando tus tareas en segundo plano.",
   "No user selected": "Ningún usuario seleccionado",
   "Encrypted": "Encriptado",
-  "Users/Groups to View": "Usuarios/Grupos que pueden ver",
+  "Users/Groups to View Encrypted Fields": "Usuarios/Grupos que pueden ver campos encriptados",
   "Conceal": "Ocultar",
   "Reveal": "Revelar",
   "There is no field with the name ':fieldName'.": "No hay un campo con el nombre ':fieldName'.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -2354,7 +2354,7 @@
   "This actions is taking longer than expected. We will continue updating your tasks in the background.": "Cette action prend plus de temps que prévu. Nous continuerons à mettre à jour vos tâches en arrière-plan.",
   "No user selected": "Aucun utilisateur sélectionné",
   "Encrypted": "Chiffrée",
-  "Users/Groups to View": "Utilisateurs/Groupes à afficher",
+  "Users/Groups to View Encrypted Fields": "Utilisateurs/Groupes pour afficher les champs chiffrés",
   "Conceal": "Cacher",
   "Reveal": "Révéler",
   "There is no field with the name ':fieldName'.": "Il n'y a pas de champ avec le nom ':fieldName'.",


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to screen designer
- Add or edit a line input field
- Enable "encrypted" in "Advanced" section

Expected behavior: 
Should be displayed the label "Users/Groups to View Encrypted Fields"

Actual behavior: 
Is displayed the label "Users/Groups to View"

## Solution
Update label

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19749

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
