### PR TITLE
FOUR-19821: AI documentation and PDF button not showing in template documentation.

### DIFF
--- a/resources/js/templates/components/ProcessTemplatesListing.vue
+++ b/resources/js/templates/components/ProcessTemplatesListing.vue
@@ -143,6 +143,7 @@
         return {
           orderBy: "name",
           previousFilter: "",
+          documentationUrl: "test",
           sortOrder: [
             {
               field: "name",
@@ -207,7 +208,7 @@
             }
           ],
           actions: [
-            { value: "view-documentation", content: "Template Documentation", link: true, href:"/modeler/template/{{id}}/documentation", permission: "view-process-templates", icon: "fas fa-sign", conditional: "isDocumenterInstalled"},
+            { value: "view-documentation", content: "Template Documentation", link: true, href: "", permission: "view-process-templates", icon: "fas fa-sign", conditional: "isDocumenterInstalled"},
             { value: "edit-designer", content: "Edit Template", link: true, href:"/modeler/templates/{{id}}", permission: "edit-process-templates", icon: "fas fa-edit"},
             { value: "export-item", content: "Export Template", permission: "export-process-templates", icon: "fas fa-file-export"},
             { value: "edit-item", content: "Configure Template", link: true, href:"/template/process/{{id}}/configure", permission: "edit-process-templates", icon: "fas fa-cog"},
@@ -219,6 +220,17 @@
         ProcessMaker.EventBus.$on("api-data-process-templates", (val) => {
           this.fetch();
         });
+      },
+      mounted() {
+        const action = this.actions.find(x => x.value === "view-documentation");
+        let documentationUrl = "";
+        if (window.ProcessMaker.packages.includes("package-ai")) {
+          documentationUrl = "/modeler/template/{{id}}/documentation";
+        } else if (this.isDocumenterInstalled) {
+          documentationUrl = "/modeler/template/{{id}}/print";
+        }
+
+        action.href = documentationUrl;
       },
       methods: {
         transform(data) {


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to Designer
- Got to processes list
-  Click on tab "templates"
- Select any template
- Click on view documentation

Current Behavior:

AI documentation and PDF buttons not showing
## Solution
- That condition that hid documentation when viewing a template has been removed (introduced in FOUR-18944)
- When AI is not installed the URL of package-process-documenter is used.


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19821

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
