### PR TITLE
observation/FOUR-19719: Added validation for missing package-translations

### DIFF
--- a/ProcessMaker/ProcessTranslations/MenuTranslation.php
+++ b/ProcessMaker/ProcessTranslations/MenuTranslation.php
@@ -36,7 +36,7 @@ class MenuTranslation extends TranslationManager
 
     private function applyTranslations($translations)
     {
-        if (!$translations) {
+        if (!$translations || !hasPackage('package-translations')) {
             return $this->menu;
         }
 

--- a/ProcessMaker/ProcessTranslations/ScreenTranslation.php
+++ b/ProcessMaker/ProcessTranslations/ScreenTranslation.php
@@ -22,7 +22,12 @@ class ScreenTranslation extends TranslationManager
     public function applyTranslations($screen, $defaultLanguage = '')
     {
         $config = $screen['config'];
+        if (!hasPackage('package-translations')) {
+            return $config;
+        }
+
         $language = $this->getTargetLanguage($defaultLanguage);
+
 
         return $this->searchTranslations($screen['screen_id'], $config, $language);
     }

--- a/ProcessMaker/ProcessTranslations/TranslationManager.php
+++ b/ProcessMaker/ProcessTranslations/TranslationManager.php
@@ -18,7 +18,9 @@ class TranslationManager
             $targetLanguage = self::getUserLanguage($targetLanguage);
         }
 
-        $targetLanguage = self::validateLanguage($targetLanguage);
+        if (hasPackage('package-translations')) {
+            $targetLanguage = self::validateLanguage($targetLanguage);
+        }
 
         return $targetLanguage;
     }


### PR DESCRIPTION
## Ticket solved by this PR:
- https://processmaker.atlassian.net/browse/FOUR-19719

## Solution
- Added validations for classes that use Models that are contained in `package-translations`

