### PR TITLE
observation/FOUR-19802 Changed Logs permissions

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -250,7 +250,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     // Files
     Route::get('files', [FileController::class, 'index'])->name('files.index')->middleware('can:view-files');
     Route::get('files/{file}', [FileController::class, 'show'])->name('files.show')->middleware('can:view,file');
-    Route::get('files/{file}/logs', [FileController::class, 'showLogs'])->name('file_logs.show')->middleware('can:view,file');
+    Route::get('files/{file}/logs', [FileController::class, 'showLogs'])->name('file_logs.show');
     Route::get('files/{file}/contents', [FileController::class, 'download'])->name('files.download')->middleware('can:view,file');
     Route::post('files', [FileController::class, 'store'])->name('files.store')->middleware('can:create,ProcessMaker\Models\Media');
     Route::put('files/{file}', [FileController::class, 'update'])->name('files.update')->middleware('can:update,file');


### PR DESCRIPTION
## Issue & Reproduction Steps
Normal user can not see all public files from Preview pane

## Solution
Changed Logs permissions

## How to Test
Login with admin
Create a new user
Check View settings option in the Settings accordion on the Permissions tab 
Go to Admin > file manager page 
Select public option
Upload five files
Login with the new user
Go to Admin > file manager page 
Select public option
Press preview button to first file

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19802
