### PR TITLE
FOUR-19882 Fix flaky tests

### DIFF
--- a/ProcessMaker/Http/Resources/V1_1/CaseResource.php
+++ b/ProcessMaker/Http/Resources/V1_1/CaseResource.php
@@ -34,6 +34,7 @@ class CaseResource extends ApiResource
     public function toArray($request): array
     {
         $data = [];
+        $attributes = $this->attributesToArray();
 
         foreach (static::$defaultFields as $field) {
             if ($field === 'participants') {
@@ -43,7 +44,7 @@ class CaseResource extends ApiResource
                 continue;
             }
 
-            $data[$field] = $this->$field;
+            $data[$field] = $attributes[$field] ?? $this->$field;
         }
 
         return $data;

--- a/ProcessMaker/Models/CaseParticipated.php
+++ b/ProcessMaker/Models/CaseParticipated.php
@@ -38,11 +38,8 @@ class CaseParticipated extends ProcessMakerModel
         'request_tokens' => AsCollection::class,
         'tasks' => AsCollection::class,
         'participants' => AsCollection::class,
-    ];
-
-    protected $dates = [
-        'initiated_at',
-        'completed_at',
+        'completed_at' => 'datetime:c',
+        'initiated_at' => 'datetime:c',
     ];
 
     protected $attributes = [

--- a/ProcessMaker/Models/CaseStarted.php
+++ b/ProcessMaker/Models/CaseStarted.php
@@ -38,11 +38,8 @@ class CaseStarted extends ProcessMakerModel
         'request_tokens' => AsCollection::class,
         'tasks' => AsCollection::class,
         'participants' => AsCollection::class,
-    ];
-
-    protected $dates = [
-        'initiated_at',
-        'completed_at',
+        'completed_at' => 'datetime:c',
+        'initiated_at' => 'datetime:c',
     ];
 
     protected static function newFactory(): Factory

--- a/tests/Feature/Api/V1_1/CaseControllerTest.php
+++ b/tests/Feature/Api/V1_1/CaseControllerTest.php
@@ -174,12 +174,12 @@ class CaseControllerTest extends TestCase
         $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['sortBy' => 'completed_at:asc']));
         $response->assertStatus(200);
         $response->assertJsonCount($cases->count(), 'data');
-        $response->assertJsonPath('data.0.completed_at', $casesSorted->first()->completed_at->format('Y-m-d H:i:s'));
+        $response->assertJsonPath('data.0.completed_at', $casesSorted->first()->completed_at->format('c'));
 
         $response = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['sortBy' => 'completed_at:desc']));
         $response->assertStatus(200);
         $response->assertJsonCount($cases->count(), 'data');
-        $response->assertJsonPath('data.0.completed_at', $casesSorted->last()->completed_at->format('Y-m-d H:i:s'));
+        $response->assertJsonPath('data.0.completed_at', $casesSorted->last()->completed_at->format('c'));
     }
 
     public function test_get_all_cases_sort_by_invalid_field(): void


### PR DESCRIPTION
## Issue & Reproduction Steps
Some tests fails when some test dates have different timezones and the format is not the same.
 
## Solution
- Use ISO 8601 date format `c`.
- Fix the resource format

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19882

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:processmaker:release-2024-fall