### PR TITLE
FOUR-19881 : Remove status column from In Progress and Completed

### DIFF
--- a/resources/jscomposition/cases/casesMain/config/columns.js
+++ b/resources/jscomposition/cases/casesMain/config/columns.js
@@ -171,7 +171,6 @@ export const getColumns = (type) => {
       processColumn(),
       taskColumn(),
       participantsColumn(),
-      statusColumn(),
       startedColumn(),
     ],
     completed: [
@@ -180,7 +179,6 @@ export const getColumns = (type) => {
       processColumn(),
       taskColumn(),
       participantsColumn(),
-      statusColumn(),
       startedColumn(),
       completedColumn(),
     ],


### PR DESCRIPTION
## Issue & Reproduction Steps
When a user go to InProgress and Completed list the column status does not have a use because per default the filter by status was apply

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19881

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
