### PR TITLE
FOUR-19871 : My Cases Option should show In Progress status as default

### DIFF
--- a/resources/jscomposition/cases/casesMain/CasesDataSection.vue
+++ b/resources/jscomposition/cases/casesMain/CasesDataSection.vue
@@ -3,21 +3,18 @@
     <CaseFilter @enter="onChangeSearch" />
     <BadgesSection
       v-model="badgesData"
-      @remove="onRemoveBadge"
-    />
+      @remove="onRemoveBadge" />
     <FilterableTable
       ref="table"
       :columns="columnsConfig"
       :data="data"
       :placeholder="showPlaceholder"
       class="tw-flex tw-flex-col tw-grow tw-overflow-y-scroll"
-      @changeFilter="onChangeFilter"
-    >
+      @changeFilter="onChangeFilter">
       <template #placeholder>
         <TablePlaceholder
           :placeholder="placeholderType"
-          class="tw-grow"
-        />
+          class="tw-grow" />
       </template>
     </FilterableTable>
     <Pagination
@@ -28,8 +25,7 @@
       :page="dataPagination.page"
       :pages="dataPagination.pages"
       @perPage="onPerPage"
-      @go="onGo"
-    />
+      @go="onGo" />
   </div>
 </template>
 <script setup>
@@ -42,7 +38,7 @@ import { getColumns } from "./config/columns";
 import { FilterableTable, TablePlaceholder } from "../../system";
 import * as api from "./api";
 import { user } from "./variables";
-import { formatFilters, formatFilterBadges } from "./utils";
+import { formatFilters, formatFilterBadges, getDefaultFilters } from "./utils";
 
 const props = defineProps({
   listId: {
@@ -55,7 +51,7 @@ const badgesData = ref([]);
 const columnsConfig = ref();
 const data = ref();
 const search = ref();
-const filters = ref([]);
+const filters = ref(getDefaultFilters(props.listId) || []);
 const table = ref();
 const showPlaceholder = ref(false);
 const placeholderType = ref("loading");
@@ -151,6 +147,7 @@ onMounted(async () => {
   await hookGetData();
 
   columnsConfig.value = getColumns(props.listId);
+  badgesData.value = formatFilterBadges(filters.value, columnsConfig.value);
 });
 </script>
 <style scoped>

--- a/resources/jscomposition/cases/casesMain/utils/filters.js
+++ b/resources/jscomposition/cases/casesMain/utils/filters.js
@@ -64,3 +64,21 @@ export const formatFilterBadges = (filters, columns) => {
 
   return response.filter((e) => e);
 };
+
+export const getDefaultFilters = (id) => {
+  const filters = {
+    default: [{
+      field: "case_status",
+      operator: "=",
+      value: {
+        label: "In progress",
+        value: "in_progress",
+      },
+    }],
+    in_progress: [],
+    completed: [],
+    all: [],
+  };
+
+  return filters[id] || filters.default;
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
As a user when I open My Cases, this option should show the Status filteres by “In Progress” as default. Then the user should be able to change the filter if it is needed.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19871

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
