### PR TITLE
FOUR-19891:The tab Request needs to show only when the case has more than 1 request

### DIFF
--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -75,7 +75,8 @@ class CasesController extends Controller
             'canViewComments',
             'canPrintScreens',
             'isProcessManager',
-            'manager'
+            'manager',
+            'requestCount'
         ));
     }
 

--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -75,8 +75,7 @@ class CasesController extends Controller
             'canViewComments',
             'canPrintScreens',
             'isProcessManager',
-            'manager',
-            'requestCount'
+            'manager'
         ));
     }
 

--- a/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
@@ -13,6 +13,7 @@ import TabHistory from "./TabHistory.vue";
 import CompletedForms from "./CompletedForms.vue";
 import TabFiles from "./TabFiles.vue";
 import Overview from "./Overview.vue";
+import { getRequestCount } from "../variables/index";
 
 const translate = ProcessMaker.i18n;
 
@@ -35,7 +36,7 @@ const tabs = [
     name: translate.t("History"), href: "#history", current: "history", show: true, content: TabHistory,
   },
   {
-    name: translate.t("Requests"), href: "#requests", current: "requests", show: true, content: RequestTable,
+    name: translate.t("Requests"), href: "#requests", current: "requests", show: getRequestCount() !== 1, content: RequestTable,
   },
 ];
 

--- a/resources/jscomposition/cases/casesDetail/variables/index.js
+++ b/resources/jscomposition/cases/casesDetail/variables/index.js
@@ -1,5 +1,9 @@
 export default {};
 
+export const api = window.ProcessMaker?.apiClient;
+
+export const useStore = () => Vue.globalStore;
+
 export const getRequestId = () => requestId;
 
 export const getCaseNumber = () => request.case_number;
@@ -12,6 +16,4 @@ export const getComentableType = () => comentable_type;
 
 export const getProcessName = () => request.process.name;
 
-export const api = window.ProcessMaker?.apiClient;
-
-export const useStore = () => Vue.globalStore;
+export const getRequestCount = () => requestCount;

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -127,6 +127,7 @@
     const processId = @json($request->process->id);
     const canViewComments = @json($canViewComments);
     const comentable_type = @json(get_class($request));
+    const requestCount = @json($requestCount);
   </script>
   <script src="{{mix('js/composition/cases/casesDetail/edit.js')}}"></script>
   @if (hasPackage('package-files'))


### PR DESCRIPTION
## Issue & Reproduction Steps
As a user when I open a case the Request tab needs to Hide if the case has only one Request and show when the request has more >= 2 


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19891

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
