### PR TITLE
FOUR-19892:The GO TO CASE needs to refresh the same page instead of open a new tab

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -817,7 +817,7 @@
           );
         },
         onReturnCase() {
-          window.open(`../cases/${request.case_number}`);
+          window.location = `../cases/${request.case_number}`;
         },
         completeRequest() {
           ProcessMaker.confirmModal(


### PR DESCRIPTION
## Issue & Reproduction Steps
The button GO TO CASE needs to open the case in the same page NOT OPEN A NEW TAB

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19892

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
