### PR TITLE
FOUR-19920: The upgrade procedure with customer backups is given an error: Column 'id' in where clause is ambiguous

### DIFF
--- a/ProcessMaker/Console/Commands/UpdateCommentsCaseNumber.php
+++ b/ProcessMaker/Console/Commands/UpdateCommentsCaseNumber.php
@@ -40,7 +40,8 @@ class UpdateCommentsCaseNumber extends Command
             ->where('comments.commentable_type', 'ProcessMaker\\Models\\ProcessRequestToken')
             ->whereNull('comments.case_number')
             ->select('comments.id', 'process_requests.case_number')
-            ->chunkById($chunkSize, function ($comments) {
+            ->orderBy('comments.id', 'asc')
+            ->chunk($chunkSize, function ($comments) {
                 foreach ($comments as $comment) {
                     // Update the comments.case_number with ptrocess_requests.case_number
                     DB::table('comments')
@@ -54,7 +55,8 @@ class UpdateCommentsCaseNumber extends Command
             ->where('comments.commentable_type', 'ProcessMaker\\Models\\ProcessRequest')
             ->whereNull('comments.case_number')
             ->select('comments.id', 'process_requests.case_number')
-            ->chunkById($chunkSize, function ($comments) {
+            ->orderBy('comments.id', 'asc')
+            ->chunk($chunkSize, function ($comments) {
                 foreach ($comments as $comment) {
                     // Update the comments.case_number with ptrocess_requests.case_number
                     DB::table('comments')

--- a/upgrades/2024_10_08_113301_populate_comments_case_number.php
+++ b/upgrades/2024_10_08_113301_populate_comments_case_number.php
@@ -41,7 +41,8 @@ class PopulateCommentsCaseNumber extends Upgrade
             ->where('comments.commentable_type', 'ProcessMaker\\Models\\ProcessRequestToken')
             ->whereNull('comments.case_number')
             ->select('comments.id', 'process_requests.case_number')
-            ->chunkById($chunkSize, function ($comments) {
+            ->orderBy('comments.id', 'asc')
+            ->chunk($chunkSize, function ($comments) {
                 foreach ($comments as $comment) {
                     // Update the comments.case_number with ptrocess_requests.case_number
                     DB::table('comments')
@@ -55,7 +56,8 @@ class PopulateCommentsCaseNumber extends Upgrade
             ->where('comments.commentable_type', 'ProcessMaker\\Models\\ProcessRequest')
             ->whereNull('comments.case_number')
             ->select('comments.id', 'process_requests.case_number')
-            ->chunkById($chunkSize, function ($comments) {
+            ->orderBy('comments.id', 'asc')
+            ->chunk($chunkSize, function ($comments) {
                 foreach ($comments as $comment) {
                     // Update the comments.case_number with ptrocess_requests.case_number
                     DB::table('comments')


### PR DESCRIPTION
## Issue & Reproduction Steps
The upgrade procedure with customer backups is given an error: Column 'id' in where clause is ambiguous

## Solution
- The chunckById use the ID to apply some order but this query has two columns id 

## How to Test
Execute the commands:
`php artisan upgrade
php artisan processmaker:update-comments-case-number`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19920

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
