### PR TITLE
bugfix/FOUR-19663: Collection Record Control Not Persisting in Screen Templates

### DIFF
--- a/ProcessMaker/Templates/ScreenComponents.php
+++ b/ProcessMaker/Templates/ScreenComponents.php
@@ -29,6 +29,7 @@ class ScreenComponents
                 'FormRecordList',
                 'FormLoop',
                 'FormNestedScreen',
+                'FormCollectionRecordControl',
                 'FormButton',
                 'FileUpload',
                 'FileDownload',


### PR DESCRIPTION
## Solution
- The new component Control Record List was added to ScreenComponents.php file

## How to Test
- Create a new screen in the Screen Builder.
- Add a Collection Record Control to the screen.
- Convert the screen to a template.
- Create a new screen from the saved template or apply the template to an existing screen.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19663

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
