### PR TITLE
FOUR-19815:UI: The mouse over the links does not show the link

### DIFF
--- a/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
+++ b/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
@@ -44,7 +44,7 @@
               <a
                 v-if="href !== null"
                 class="tw-flex tw-py-2 tw-px-4 transition duration-300 hover:tw-bg-gray-200"
-                :href="getLink(option)"
+                :href="href(option)"
               >
                 {{ getValueOption(option, index) }}
               </a>


### PR DESCRIPTION
## Issue & Reproduction Steps

- Go to Cases
- See the list of cases
- Mouse over the links

**Current Behavior**
When a mouse is over the link, is not possible to see the link to open:

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19815

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
