### PR TITLE
FOUR-19924 : Title in cases pages is empty

### DIFF
--- a/resources/views/cases/casesMain.blade.php
+++ b/resources/views/cases/casesMain.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.layout',['content_margin' => '', 'overflow-auto' => ''])
 
 @section('title')
+  {{ __('Cases') }}
 @endsection
 
 @section('sidebar')


### PR DESCRIPTION
##Steps to Reproduce
1. Log in to PM4
2. Go to Cases page
3. Check the title

##Current Behavior
The title in Cases page is empty

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19924

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
