### PR TITLE
FOUR-19807 : Task column should be display the last active task (or tasks if are possible)

### DIFF
--- a/resources/jscomposition/cases/casesMain/config/columns.js
+++ b/resources/jscomposition/cases/casesMain/config/columns.js
@@ -90,7 +90,6 @@ export const taskColumn = () => ({
         if (row.case_status === "COMPLETED") {
           return [];
         }
-
         return row.tasks.filter((el) => el.status === "ACTIVE");
       },
     },

--- a/resources/jscomposition/cases/casesMain/config/columns.js
+++ b/resources/jscomposition/cases/casesMain/config/columns.js
@@ -1,3 +1,4 @@
+import { t } from "i18next";
 import {
   CaseTitleCell,
   TruncatedOptionsCell,
@@ -7,7 +8,6 @@ import {
   TruncatedColumn,
 } from "../../../system/index";
 import { formatDate } from "../../../utils";
-import { t } from "i18next";
 
 export default {};
 /**
@@ -86,6 +86,13 @@ export const taskColumn = () => ({
     params: {
       href: (option) => `/tasks/${option.id}/edit`,
       formatterOptions: (option, row, column, columns) => option.name,
+      filterData: (row, column, columns) => {
+        if (row.case_status === "COMPLETED") {
+          return [];
+        }
+
+        return row.tasks.filter((el) => el.status === "ACTIVE");
+      },
     },
   }),
 });

--- a/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
+++ b/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
@@ -130,7 +130,7 @@ export default defineComponent({
     onMounted(() => {
       // Filter the data before render
       if (props.filterData) {
-        optionsModel.value = props.filterData(props.row, props.column.field, props.columns);
+        optionsModel.value = props.filterData(props.row, props.column, props.columns);
       }
     });
 

--- a/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
+++ b/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
@@ -41,7 +41,8 @@
                 v-if="href !== null"
                 class="tw-flex tw-py-2 tw-px-4 transition duration-300
                  hover:tw-bg-gray-100 tw-text-gray-500 hover:tw-text-blue-400"
-                :href="href(option)">
+                :href="getLink(option)"
+              >
                 {{ getValueOption(option, index) }}
               </a>
               <span

--- a/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
+++ b/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="tw-flex tw-relative tw-text-nowrap tw-whitespace-nowrap tw-p-3">
-    <div class="tw-overflow-hidden tw-text-ellipsis ">
+    <div
+      v-if="optionsModel.length"
+      class="tw-overflow-hidden tw-text-ellipsis ">
       <a
         v-if="href !== null"
         class="hover:tw-text-blue-400 tw-text-gray-500"
-        :href="href(row[column.field][0])"
-      >
+        :href="href(optionsModel[0])">
         {{ getValue() }}
       </a>
       <span
         v-else
-        class="hover:tw-text-blue-400 tw-text-gray-500 hover:tw-cursor-pointer"
+        class="tw-text-gray-500 hover:tw-cursor-pointer"
         href="#"
-        @click.prevent.stop="onClickOption(row[column.field][0], 0)"
-      >
+        @click.prevent.stop="onClickOption(optionsModel[0], 0)">
         {{ getValue() }}
       </span>
     </div>
@@ -22,37 +22,32 @@
       v-model="show"
       :hover="false"
       position="bottom"
-      class="!tw-absolute tw-right-0 tw-top-0  tw-h-full tw-flex tw-items-center"
-    >
+      class="!tw-absolute tw-right-0 tw-top-0  tw-h-full tw-flex tw-items-center">
       <div
         class="tw-self-center tw-px-2 tw-rounded-md hover:tw-cursor-pointer hover:tw-bg-gray-200 tw-bg-white "
-        @click.prevent="onClick"
-      >
+        @click.prevent="onClick">
         <i class="fas fa-ellipsis-v" />
       </div>
       <template #content>
         <ul
           class="tw-bg-white tw-list-none tw-text-gray-600
-            tw-overflow-hidden tw-rounded-lg tw-w-50 tw-text-sm tw-border tw-border-gray-300"
-        >
+            tw-overflow-hidden tw-rounded-lg tw-w-50 tw-text-sm tw-border tw-border-gray-300">
           <template v-for="(option, index) in optionsModel">
             <li
               v-if="index > 0"
               :key="index"
-              class="hover:tw-bg-gray-100"
-            >
+              class="hover:tw-bg-gray-100">
               <a
                 v-if="href !== null"
-                class="tw-flex tw-py-2 tw-px-4 transition duration-300 hover:tw-bg-gray-200"
-                :href="getLink(option)"
-              >
+                class="tw-flex tw-py-2 tw-px-4 transition duration-300
+                 hover:tw-bg-gray-100 tw-text-gray-500 hover:tw-text-blue-400"
+                :href="href(option)">
                 {{ getValueOption(option, index) }}
               </a>
               <span
                 v-else
-                class="tw-flex tw-py-2 tw-px-4 transition duration-300 hover:tw-bg-gray-200 hover:tw-cursor-pointer"
-                @click.prevent.stop="onClickOption(option, index)"
-              >
+                class="tw-flex tw-py-2 tw-px-4 transition duration-300 hover:tw-bg-gray-100 hover:tw-cursor-pointer"
+                @click.prevent.stop="onClickOption(option, index)">
                 {{ getValueOption(option, index) }}
               </span>
             </li>
@@ -63,7 +58,7 @@
   </div>
 </template>
 <script>
-import { defineComponent, ref } from "vue";
+import { defineComponent, ref, onMounted } from "vue";
 import { isFunction } from "lodash";
 import { AppPopover } from "../../../base/index";
 
@@ -93,6 +88,11 @@ export default defineComponent({
       default: new Function(),
     },
     href: {
+      type: Function,
+      default: null,
+    },
+    // Filter Data, method to filter the input data
+    filterData: {
       type: Function,
       default: null,
     },
@@ -126,6 +126,13 @@ export default defineComponent({
     const onClose = () => {
       show.value = false;
     };
+
+    onMounted(() => {
+      // Filter the data before render
+      if (props.filterData) {
+        optionsModel.value = props.filterData(props.row, props.column.field, props.columns);
+      }
+    });
 
     return {
       show,

--- a/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
+++ b/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
@@ -39,8 +39,7 @@
               class="hover:tw-bg-gray-100">
               <a
                 v-if="href !== null"
-                class="tw-flex tw-py-2 tw-px-4 transition duration-300
-                 hover:tw-bg-gray-100 tw-text-gray-500 hover:tw-text-blue-400"
+                class="tw-flex tw-py-2 tw-px-4 transition duration-300 hover:tw-bg-gray-100 hover:tw-text-blue-400"
                 :href="getLink(option)"
               >
                 {{ getValueOption(option, index) }}


### PR DESCRIPTION
"Task" column should be display the last task (or tasks if are possible), Currently is displaying always the first task.
In the next process the token is in the third task the previous two tasks were completed. The name of the first task is displayed always.
'status' => 'ACTIVE',

## Issue & Reproduction Steps
1. Go to cases
2 check the columns tasks

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19807

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
