### PR TITLE
FOUR-19928 cases participated does not have all the participations updated

### DIFF
--- a/ProcessMaker/Repositories/CaseUtils.php
+++ b/ProcessMaker/Repositories/CaseUtils.php
@@ -152,6 +152,7 @@ class CaseUtils
             && in_array($taskData['element_type'], self::ALLOWED_ELEMENT_TYPES)
         ) {
             unset($taskData['element_type']);
+            // This field is converted to string because: The Json_Search in MySQL only works with strings
             $taskData['id'] = (string)$taskData['id'];
             $tasks->prepend($taskData);
         }

--- a/tests/Feature/Cases/CaseParticipatedTest.php
+++ b/tests/Feature/Cases/CaseParticipatedTest.php
@@ -191,11 +191,18 @@ class CaseParticipatedTest extends TestCase
             'case_title' => $instance->case_title,
             'case_title_formatted' => $instance->case_title_formatted,
             'case_status' => 'IN_PROGRESS',
-            'request_tokens->[0]' => $token2->id,
+            'request_tokens->[0]' => $token->id,
             'tasks->[0]->id' => $token2->id,
             'tasks->[0]->element_id' => $token2->element_id,
             'tasks->[0]->name' => $token2->element_name,
             'tasks->[0]->process_id' => $token2->process_id,
+            'tasks->[0]->status' => $token2->status,
+            'request_tokens->[1]' => $token2->id,
+            'tasks->[1]->id' => $token->id,
+            'tasks->[1]->element_id' => $token->element_id,
+            'tasks->[1]->name' => $token->element_name,
+            'tasks->[1]->process_id' => $token->process_id,
+            'tasks->[1]->status' => $token->status,
         ]);
     }
 
@@ -245,11 +252,18 @@ class CaseParticipatedTest extends TestCase
         $this->assertDatabaseHas('cases_participated', [
             'user_id' => $user2->id,
             'case_number' => $instance->case_number,
-            'request_tokens->[0]' => $token2->id,
+            'request_tokens->[0]' => $token->id,
             'tasks->[0]->id' => $token2->id,
             'tasks->[0]->element_id' => $token2->element_id,
             'tasks->[0]->name' => $token2->element_name,
             'tasks->[0]->process_id' => $token2->process_id,
+            'tasks->[0]->status' => $token2->status,
+            'request_tokens->[1]' => $token2->id,
+            'tasks->[1]->id' => $token->id,
+            'tasks->[1]->element_id' => $token->element_id,
+            'tasks->[1]->name' => $token->element_name,
+            'tasks->[1]->process_id' => $token->process_id,
+            'tasks->[1]->status' => $token->status,
         ]);
 
         $token3 = ProcessRequestToken::factory()->create([
@@ -265,17 +279,23 @@ class CaseParticipatedTest extends TestCase
             'user_id' => $user->id,
             'case_number' => $instance->case_number,
             'request_tokens->[0]' => $token->id,
-            'request_tokens->[1]' => $token3->id,
+            'request_tokens->[1]' => $token2->id,
+            'request_tokens->[2]' => $token3->id,
             'tasks->[0]->id' => $token3->id,
             'tasks->[0]->element_id' => $token3->element_id,
             'tasks->[0]->name' => $token3->element_name,
             'tasks->[0]->process_id' => $token3->process_id,
             'tasks->[0]->status' => $token3->status,
-            'tasks->[1]->id' => $token->id,
-            'tasks->[1]->element_id' => $token->element_id,
-            'tasks->[1]->name' => $token->element_name,
-            'tasks->[1]->process_id' => $token->process_id,
-            'tasks->[1]->status' => $token->status,
+            'tasks->[1]->id' => $token2->id,
+            'tasks->[1]->element_id' => $token2->element_id,
+            'tasks->[1]->name' => $token2->element_name,
+            'tasks->[1]->process_id' => $token2->process_id,
+            'tasks->[1]->status' => $token2->status,
+            'tasks->[2]->id' => $token->id,
+            'tasks->[2]->element_id' => $token->element_id,
+            'tasks->[2]->name' => $token->element_name,
+            'tasks->[2]->process_id' => $token->process_id,
+            'tasks->[2]->status' => $token->status,
         ]);
     }
 
@@ -327,11 +347,18 @@ class CaseParticipatedTest extends TestCase
             'user_id' => $user2->id,
             'case_number' => $instance->case_number,
             'case_status' => 'IN_PROGRESS',
-            'request_tokens->[0]' => $token2->id,
+            'request_tokens->[0]' => $token->id,
+            'request_tokens->[1]' => $token2->id,
             'tasks->[0]->id' => $token2->id,
             'tasks->[0]->element_id' => $token2->element_id,
             'tasks->[0]->name' => $token2->element_name,
             'tasks->[0]->process_id' => $token2->process_id,
+            'tasks->[0]->status' => $token2->status,
+            'tasks->[1]->id' => $token->id,
+            'tasks->[1]->element_id' => $token->element_id,
+            'tasks->[1]->name' => $token->element_name,
+            'tasks->[1]->process_id' => $token->process_id,
+            'tasks->[1]->status' => $token->status,
         ]);
 
         $token3 = ProcessRequestToken::factory()->create([
@@ -348,27 +375,34 @@ class CaseParticipatedTest extends TestCase
             'case_number' => $instance->case_number,
             'case_status' => 'IN_PROGRESS',
             'request_tokens->[0]' => $token->id,
-            'request_tokens->[1]' => $token3->id,
+            'request_tokens->[1]' => $token2->id,
+            'request_tokens->[2]' => $token3->id,
             'tasks->[0]->id' => $token3->id,
             'tasks->[0]->element_id' => $token3->element_id,
             'tasks->[0]->name' => $token3->element_name,
             'tasks->[0]->process_id' => $token3->process_id,
             'tasks->[0]->status' => $token3->status,
-            'tasks->[1]->id' => $token->id,
-            'tasks->[1]->element_id' => $token->element_id,
-            'tasks->[1]->name' => $token->element_name,
-            'tasks->[1]->process_id' => $token->process_id,
-            'tasks->[1]->status' => $token->status,
+            'tasks->[1]->id' => $token2->id,
+            'tasks->[1]->element_id' => $token2->element_id,
+            'tasks->[1]->name' => $token2->element_name,
+            'tasks->[1]->process_id' => $token2->process_id,
+            'tasks->[1]->status' => $token2->status,
+            'tasks->[2]->id' => $token->id,
+            'tasks->[2]->element_id' => $token->element_id,
+            'tasks->[2]->name' => $token->element_name,
+            'tasks->[2]->process_id' => $token->process_id,
+            'tasks->[2]->status' => $token->status,
         ]);
 
         $instance->status = 'COMPLETED';
+        $instance->completed_at = now();
         $repo->updateStatus($instance);
 
         $this->assertDatabaseCount('cases_participated', 2);
         $this->assertDatabaseHas('cases_participated', [
             'case_number' => $instance->case_number,
             'case_status' => 'COMPLETED',
-            'completed_at' => now(),
+            'completed_at' => $instance->completed_at,
         ]);
     }
 

--- a/tests/Feature/Cases/CaseStartedSubProcessTest.php
+++ b/tests/Feature/Cases/CaseStartedSubProcessTest.php
@@ -208,8 +208,10 @@ class CaseStartedSubProcessTest extends TestCase
             'user_id' => $this->user2->id,
             'case_title' => $this->parentRequest->case_title,
             'case_status' => 'IN_PROGRESS',
-            'processes->[0]->id' => $this->subProcess->id,
-            'processes->[0]->name' => $this->subProcess->name,
+            'processes->[0]->id' => $this->process->id,
+            'processes->[0]->name' => $this->process->name,
+            'processes->[1]->id' => $this->subProcess->id,
+            'processes->[1]->name' => $this->subProcess->name,
         ]);
     }
 
@@ -243,9 +245,12 @@ class CaseStartedSubProcessTest extends TestCase
             'user_id' => $this->user2->id,
             'case_title' => $this->parentRequest->case_title,
             'case_status' => 'IN_PROGRESS',
-            'requests->[0]->id' => $this->childRequest->id,
-            'requests->[0]->name' => $this->childRequest->name,
-            'requests->[0]->parent_request_id' => $this->childRequest->parent_request_id,
+            'requests->[0]->id' => $this->parentRequest->id,
+            'requests->[0]->name' => $this->parentRequest->name,
+            'requests->[0]->parent_request_id' => $this->parentRequest->parent_request_id,
+            'requests->[1]->id' => $this->childRequest->id,
+            'requests->[1]->name' => $this->childRequest->name,
+            'requests->[1]->parent_request_id' => $this->childRequest->parent_request_id,
         ]);
     }
 
@@ -275,7 +280,8 @@ class CaseStartedSubProcessTest extends TestCase
             'user_id' => $this->user2->id,
             'case_title' => $this->parentRequest->case_title,
             'case_status' => 'IN_PROGRESS',
-            'request_tokens->[0]' => $this->childToken2->id,
+            'request_tokens->[0]' => $this->parentToken->id,
+            'request_tokens->[1]' => $this->childToken->id,
         ]);
     }
 
@@ -297,16 +303,21 @@ class CaseStartedSubProcessTest extends TestCase
             'user_id' => $this->user->id,
             'case_title' => $this->parentRequest->case_title,
             'case_status' => 'IN_PROGRESS',
-            'tasks->[0]->id' => $this->childToken->id,
-            'tasks->[0]->element_id' => $this->childToken->element_id,
-            'tasks->[0]->name' => $this->childToken->element_name,
-            'tasks->[0]->process_id' => $this->childToken->process_id,
-            'tasks->[0]->status' => $this->childToken->status,
-            'tasks->[1]->id' => $this->parentToken->id,
-            'tasks->[1]->element_id' => $this->parentToken->element_id,
-            'tasks->[1]->name' => $this->parentToken->element_name,
-            'tasks->[1]->process_id' => $this->parentToken->process_id,
-            'tasks->[1]->status' => $this->parentToken->status,
+            'tasks->[0]->id' => $this->childToken2->id,
+            'tasks->[0]->element_id' => $this->childToken2->element_id,
+            'tasks->[0]->name' => $this->childToken2->element_name,
+            'tasks->[0]->process_id' => $this->childToken2->process_id,
+            'tasks->[0]->status' => $this->childToken2->status,
+            'tasks->[1]->id' => $this->childToken->id,
+            'tasks->[1]->element_id' => $this->childToken->element_id,
+            'tasks->[1]->name' => $this->childToken->element_name,
+            'tasks->[1]->process_id' => $this->childToken->process_id,
+            'tasks->[1]->status' => $this->childToken->status,
+            'tasks->[2]->id' => $this->parentToken->id,
+            'tasks->[2]->element_id' => $this->parentToken->element_id,
+            'tasks->[2]->name' => $this->parentToken->element_name,
+            'tasks->[2]->process_id' => $this->parentToken->process_id,
+            'tasks->[2]->status' => $this->parentToken->status,
         ]);
         $this->assertDatabaseHas('cases_participated', [
             'case_number' => $this->parentRequest->case_number,
@@ -317,10 +328,17 @@ class CaseStartedSubProcessTest extends TestCase
             'tasks->[0]->element_id' => $this->childToken2->element_id,
             'tasks->[0]->name' => $this->childToken2->element_name,
             'tasks->[0]->process_id' => $this->childToken2->process_id,
-            'tasks->[1]->id' => null,
-            'tasks->[1]->element_id' => null,
-            'tasks->[1]->name' => null,
-            'tasks->[1]->process_id' => null,
+            'tasks->[0]->status' => $this->childToken2->status,
+            'tasks->[1]->id' => $this->childToken->id,
+            'tasks->[1]->element_id' => $this->childToken->element_id,
+            'tasks->[1]->name' => $this->childToken->element_name,
+            'tasks->[1]->process_id' => $this->childToken->process_id,
+            'tasks->[1]->status' => $this->childToken->status,
+            'tasks->[2]->id' => $this->parentToken->id,
+            'tasks->[2]->element_id' => $this->parentToken->element_id,
+            'tasks->[2]->name' => $this->parentToken->element_name,
+            'tasks->[2]->process_id' => $this->parentToken->process_id,
+            'tasks->[2]->status' => $this->parentToken->status,
         ]);
     }
 
@@ -338,6 +356,7 @@ class CaseStartedSubProcessTest extends TestCase
         $this->assertDatabaseCount('cases_participated', 2);
 
         $this->childRequest->status = 'COMPLETED';
+        $this->childRequest->completed_at = now();
         $repo->updateStatus($this->childRequest);
 
         $this->assertDatabaseHas('cases_started', [
@@ -359,24 +378,25 @@ class CaseStartedSubProcessTest extends TestCase
         ]);
 
         $this->parentRequest->status = 'COMPLETED';
+        $this->parentRequest->completed_at = now();
         $repo->updateStatus($this->parentRequest);
 
         $this->assertDatabaseHas('cases_started', [
             'case_number' => $this->parentRequest->case_number,
             'case_status' => 'COMPLETED',
-            'completed_at' => now(),
+            'completed_at' => $this->parentRequest->completed_at,
         ]);
         $this->assertDatabaseHas('cases_participated', [
             'case_number' => $this->parentRequest->case_number,
             'user_id' => $this->user->id,
             'case_status' => 'COMPLETED',
-            'completed_at' => now(),
+            'completed_at' => $this->parentRequest->completed_at,
         ]);
         $this->assertDatabaseHas('cases_participated', [
             'case_number' => $this->parentRequest->case_number,
             'user_id' => $this->user2->id,
             'case_status' => 'COMPLETED',
-            'completed_at' => now(),
+            'completed_at' => $this->parentRequest->completed_at,
         ]);
     }
 }

--- a/tests/Feature/Cases/CaseStartedTest.php
+++ b/tests/Feature/Cases/CaseStartedTest.php
@@ -359,13 +359,14 @@ class CaseStartedTest extends TestCase
         ]);
 
         $instance->status = 'COMPLETED';
+        $instance->completed_at = now();
         $repo->updateStatus($instance, $token);
         $this->assertDatabaseHas('cases_started', [
             'case_number' => $instance->case_number,
             'user_id' => $user->id,
             'case_title' => $instance->case_title,
             'case_status' => 'COMPLETED',
-            'completed_at' => now(),
+            'completed_at' => $instance->completed_at,
             'tasks->[0]->id' => $token->id,
             'tasks->[0]->element_id' => $token->element_id,
             'tasks->[0]->name' => $token->element_name,

--- a/tests/Feature/Cases/CaseSyncRepositoryTest.php
+++ b/tests/Feature/Cases/CaseSyncRepositoryTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature\Cases;
+
+use ProcessMaker\Repositories\CaseSyncRepository;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use Tests\TestCase;
+use Illuminate\Support\Facades\DB;
+
+class CaseSyncRepositoryTest extends TestCase
+{
+    public function testSyncCases()
+    {
+        // Create some ProcessRequest instances
+        $processRequest1 = ProcessRequest::factory()->create();
+        $processRequest2 = ProcessRequest::factory()->create(['parent_request_id' => $processRequest1->id, 'case_number' => $processRequest1->case_number]);
+
+        // Create some tokens for both ProcessRequest instances
+        $processRequest1->tokens()->createMany([
+            ProcessRequestToken::factory()->make([
+                'element_name' => 'Task 1',
+                'element_type' => 'task',
+                'status' => 'ACTIVE',
+                'element_id' => 'task-1',
+                'process_request_id' => $processRequest1->id,
+                'process_id' => $processRequest1->process_id
+            ])->toArray(),
+            ProcessRequestToken::factory()->make([
+                'element_name' => 'Task 2',
+                'element_type' => 'task',
+                'status' => 'CLOSED',
+                'element_id' => 'task-2',
+                'process_request_id' => $processRequest1->id,
+                'process_id' => $processRequest1->process_id
+            ])->toArray(),
+            ProcessRequestToken::factory()->make([
+                'element_name' => 'Task 3',
+                'element_type' => 'callActivity',
+                'status' => 'ACTIVE',
+                'element_id' => 'call-activity-1',
+                'process_request_id' => $processRequest1->id,
+                'process_id' => $processRequest1->process_id
+            ])->toArray(),
+        ]);
+
+        $processRequest2->tokens()->createMany([
+            ProcessRequestToken::factory()->make([
+                'element_name' => 'Task 4',
+                'element_type' => 'scriptTask',
+                'status' => 'CLOSED',
+                'element_id' => 'task-4',
+                'process_request_id' => $processRequest2->id,
+                'process_id' => $processRequest2->process_id
+            ])->toArray(),
+            ProcessRequestToken::factory()->make([
+                'element_name' => 'Task 5',
+                'element_type' => 'task',
+                'status' => 'ACTIVE',
+                'element_id' => 'task-5',
+                'process_request_id' => $processRequest2->id,
+                'process_id' => $processRequest2->process_id
+            ])->toArray(),
+        ]);
+
+        // Call the syncCases method
+        $result = CaseSyncRepository::syncCases([$processRequest1->id, $processRequest2->id]);
+
+        // Assert that the response contains the correct data
+        $this->assertArrayHasKey('successes', $result);
+        $this->assertArrayHasKey('errors', $result);
+
+        // Check that the successes array contains the case numbers
+        $this->assertContains($processRequest1->case_number, $result['successes']);
+        $this->assertContains($processRequest2->case_number, $result['successes']);
+
+        // Check that the CaseStarted records were created
+        $caseStarted = DB::table('cases_started')->where('case_number', $processRequest1->case_number)->first();
+        $tasks = json_decode($caseStarted->tasks, true);
+        $participants = json_decode($caseStarted->participants, true);
+
+        $expectedTasks = [
+            [
+                'id' => $processRequest2->tokens()->where('element_id', 'task-5')->first()->id,
+                'name' => 'Task 5',
+                'status' => 'ACTIVE',
+                'element_id' => 'task-5',
+                'process_id' => $processRequest2->process_id
+            ],
+            [
+                'id' => $processRequest1->tokens()->where('element_id', 'task-2')->first()->id,
+                'name' => 'Task 2',
+                'status' => 'CLOSED',
+                'element_id' => 'task-2',
+                'process_id' => $processRequest1->process_id
+            ],
+            [
+                'id' => $processRequest1->tokens()->where('element_id', 'task-1')->first()->id,
+                'name' => 'Task 1',
+                'status' => 'ACTIVE',
+                'element_id' => 'task-1',
+                'process_id' => $processRequest1->process_id
+            ],
+        ];
+        $expectedParticipants = [
+            $processRequest1->tokens()->where('element_id', 'task-1')->first()->user_id,
+            $processRequest1->tokens()->where('element_id', 'task-2')->first()->user_id,
+            $processRequest2->tokens()->where('element_id', 'task-5')->first()->user_id,
+        ];
+
+        $this->assertEquals($expectedTasks, $tasks);
+        $this->assertEquals($expectedParticipants, $participants);
+
+        // There are 3 case_participated records created
+        $this->assertDatabaseCount('cases_participated', 3);
+
+        // participant assigned to task-1
+        $caseParticipated = DB::table('cases_participated')
+            ->where('case_number', $processRequest1->case_number)
+            ->where('user_id', $processRequest1->tokens()->where('element_id', 'task-1')->first()->user_id)
+            ->first();
+        $participatedTasks = json_decode($caseParticipated->tasks, true);
+        $participants = json_decode($caseParticipated->participants, true);
+        $this->assertEquals($expectedTasks, $participatedTasks);
+        $this->assertEquals($expectedParticipants, $participants);
+
+        // participant assigned to task-2
+        $caseParticipated = DB::table('cases_participated')
+            ->where('case_number', $processRequest1->case_number)
+            ->where('user_id', $processRequest1->tokens()->where('element_id', 'task-2')->first()->user_id)
+            ->first();
+        $participatedTasks = json_decode($caseParticipated->tasks, true);
+        $participants = json_decode($caseParticipated->participants, true);
+        $this->assertEquals($expectedTasks, $participatedTasks);
+        $this->assertEquals($expectedParticipants, $participants);
+
+        // participant assigned to task-4
+        $caseParticipated = DB::table('cases_participated')
+            ->where('case_number', $processRequest2->case_number)
+            ->where('user_id', $processRequest2->tokens()->where('element_id', 'task-4')->first()->user_id)
+            ->first();
+    }
+}

--- a/upgrades/2024_10_09_152947_populate_cases_participated.php
+++ b/upgrades/2024_10_09_152947_populate_cases_participated.php
@@ -18,6 +18,10 @@ class PopulateCasesParticipated extends Upgrade
         try {
             DB::table('cases_participated')->truncate();
 
+            $this->createProcessRequestsTempTable();
+            $this->createProcessRequestTokensTempTable();
+            $this->process_request_participants_temp();
+
             $this->getProcessRequests()
                 ->chunk(1000, function ($rows) {
                     $casesParticipated = [];
@@ -73,45 +77,113 @@ class PopulateCasesParticipated extends Upgrade
         DB::table('cases_participated')->truncate();
     }
 
-    protected function getProcessRequests(): Builder
+    protected function createProcessRequestsTempTable(): void
     {
-        return DB::table('process_requests as pr')
-            ->select([
-                'u.id as user_id',
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS process_requests_temp');
+
+        $query = DB::table('process_requests as pr')
+            ->select(
+                'pr.id',
+                'pr.name',
                 'pr.case_number',
                 'pr.case_title',
                 'pr.case_title_formatted',
-                DB::raw("IF(pr.status = 'ACTIVE', 'IN_PROGRESS', pr.status) as case_status"),
-                DB::raw('JSON_ARRAYAGG(JSON_OBJECT("id", pc.id, "name", pc.name)) as processes'),
-                DB::raw('JSON_ARRAYAGG(JSON_OBJECT("id", pr.id, "name", pc.name, "parent_request_id", pr.parent_request_id)) as requests'),
-                DB::raw('JSON_ARRAYAGG(prt.id) as request_tokens'),
-                DB::raw('JSON_ARRAYAGG(IF(prt.element_type != "callActivity", JSON_OBJECT("id", prt.id, "name", prt.element_name, "element_id", prt.element_id, "process_id", prt.process_id), NULL)) as tasks'),
-                'par.participants',
+                'pr.status',
+                'pr.parent_request_id',
                 'pr.initiated_at',
                 'pr.completed_at',
                 'pr.created_at',
                 'pr.updated_at',
-            ])
-            ->join('process_request_tokens as prt', 'pr.id', '=', 'prt.process_request_id')
-            ->join('users as u', 'prt.user_id', '=', 'u.id')
-            ->join('processes as pc', 'pr.process_id', '=', 'pc.id')
-            ->joinSub(
-                DB::table('users as u2')
-                    ->selectRaw('JSON_ARRAYAGG(u2.id) as participants, pr2.case_number')
-                    ->join('process_request_tokens as prt2', 'u2.id', '=', 'prt2.user_id')
-                    ->join('process_requests as pr2', 'prt2.process_request_id', '=', 'pr2.id')
-                    ->whereNotNull('pr2.case_number')
-                    ->groupBy('pr2.case_number'),
-                'par',
-                'par.case_number',
-                '=',
-                'pr.case_number'
+                'pc.id as process_id',
+                'pc.name as process_name'
             )
+            ->join('processes as pc', 'pr.process_id', '=', 'pc.id')
             ->whereIn('pr.status', ['ACTIVE', 'COMPLETED'])
+            ->whereNotNull('pr.case_number');
+
+        DB::statement("CREATE TEMPORARY TABLE IF NOT EXISTS process_requests_temp AS ({$query->toSql()})", $query->getBindings());
+    }
+
+    protected function createProcessRequestTokensTempTable(): void
+    {
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS process_request_tokens_temp');
+
+        $query = DB::table('process_request_tokens as prt')
+            ->select([
+                'prt.id',
+                DB::raw('CAST(prt.id AS CHAR(50)) as task_id'),
+                'prt.element_name',
+                'prt.element_id',
+                'prt.element_type',
+                'prt.process_id',
+                'prt.status',
+                'prt.user_id',
+                'prt.process_request_id',
+            ])
+            ->join('process_requests_temp as prt2', 'prt.process_request_id', '=', 'prt2.id')
             ->whereIn('prt.element_type', ['task', 'callActivity', 'scriptTask'])
-            ->whereNotNull('pr.case_number')
-            ->groupBy('u.id', 'pr.id')
-            ->orderBy('pr.id')
-            ->orderBy('u.id');
+            ->whereNotNull('prt.user_id');
+
+        DB::statement("CREATE TEMPORARY TABLE IF NOT EXISTS process_request_tokens_temp AS ({$query->toSql()})", $query->getBindings());
+    }
+
+    protected function process_request_participants_temp(): void
+    {
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS process_request_participants_temp');
+
+        $query = DB::table('process_request_tokens_temp as prt2')
+            ->select([
+                DB::raw('JSON_ARRAYAGG(prt2.user_id) as participants'),
+                'pr2.case_number'
+            ])
+            ->join('process_requests_temp as pr2', 'prt2.process_request_id', '=', 'pr2.id')
+            ->groupBy('pr2.case_number');
+
+        DB::statement("CREATE TEMPORARY TABLE IF NOT EXISTS process_request_participants_temp AS ({$query->toSql()})", $query->getBindings());
+    }
+
+    protected function getProcessRequests(): Builder
+    {
+        return DB::table('process_requests_temp as pr')
+            ->select([
+                'prt.user_id',
+                'pr.case_number',
+                'pr.case_title',
+                'pr.case_title_formatted',
+                DB::raw("IF(pr.status = 'ACTIVE', 'IN_PROGRESS', pr.status) as case_status"),
+                DB::raw("JSON_ARRAYAGG(JSON_OBJECT('id', pr.process_id, 'name', pr.process_name)) as processes"),
+                DB::raw("JSON_ARRAYAGG(JSON_OBJECT('id', pr.id, 'name', pr.name, 'parent_request_id', pr.parent_request_id)) as requests"),
+                DB::raw("JSON_ARRAYAGG(prt.id) as request_tokens"),
+                DB::raw("JSON_ARRAYAGG(
+                            IF(prt.element_type != 'callActivity',
+                                JSON_OBJECT(
+                                    'id', prt.task_id,
+                                    'name', prt.element_name,
+                                    'element_id', prt.element_id,
+                                    'process_id', prt.process_id,
+                                    'status', prt.status
+                                ), JSON_OBJECT())
+                        ) as tasks"),
+                'par.participants',
+                'pr.initiated_at',
+                'pr.completed_at',
+                'pr.created_at',
+                'pr.updated_at'
+            ])
+            ->join('process_request_tokens_temp as prt', 'pr.id', '=', 'prt.process_request_id')
+            ->join('process_request_participants_temp as par', 'pr.case_number', '=', 'par.case_number')
+            ->groupBy(
+                'prt.user_id',
+                'pr.case_number',
+                'pr.case_title',
+                'pr.case_title_formatted',
+                DB::raw("IF(pr.status = 'ACTIVE', 'IN_PROGRESS', pr.status)"),
+                'par.participants',
+                'pr.initiated_at',
+                'pr.completed_at',
+                'pr.created_at',
+                'pr.updated_at'
+            )
+            ->orderBy('pr.case_number');
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Cases participated does not have all the participations updated

## Solution
- Refactor of the cases_participated population

## Related Tickets & Packages
- [FOUR-19928](https://processmaker.atlassian.net/browse/FOUR-19928)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19928]: https://processmaker.atlassian.net/browse/FOUR-19928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ