### PR TITLE
FOUR-13941 : Inconsistent Button on Starting Request Layout

### DIFF
--- a/resources/js/components/requests/card.vue
+++ b/resources/js/components/requests/card.vue
@@ -20,12 +20,12 @@
                 ...
               </a>
             </div>
-            <div class="text-right">
+            <div class="d-flex justify-content-between align-items-center">
               <button
               :href="getNewRequestLinkHref(process, event)"
               @click.prevent="newRequestLink(process, event);"
               :disabled="disabled"
-              class="btn btn-primary btn-sm"
+              class="btn btn-primary btn-sm d-flex align-items-center"
               v-uni-aria-describedby="event.id.toString()"
               data-test="new-request-modal-process-start-button"
               :data-test-by-key="`new-request-modal-process-start-button-${process.id}-${event.id.toString()}`"


### PR DESCRIPTION
## Issue & Reproduction Steps
Login to Sena Cloud Environment
click on on the Green Request button to start a new Request

## Solution
- Fix the css

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13941

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy