### PR TITLE
Bugfix/FOUR-19832: Focus is not visible in the hamburger menu (mobile view)

### DIFF
--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -176,4 +176,8 @@
     .separator-ol {
         padding: 0px 0px 0px 2px;
     }
+    .navbar-toggler:focus {
+        outline: 0;
+        box-shadow: 0 0 0 0.2rem rgba(114, 128, 146, 0.5);
+    }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps

- Login in ProcessMaker and change the view to mobile
- Use the tab key to navigate between interactive elements
- In the mobile view the hamburger menu in the top right is not focused when the tab key is pressed

**Current Behavior:**
The hamburger menu is nos focused when the tab key is used 

**Expected Behavior:*
The hamburger menu should be focused when the user navigates using the tab key

## Solution
- Add styles to focused toggler button

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-19832](https://processmaker.atlassian.net/browse/FOUR-19832)


[FOUR-19832]: https://processmaker.atlassian.net/browse/FOUR-19832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ