### PR TITLE
FOUR-19863 Use the right context of data to evaluate parallel task self service assignment

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 use Mustache_Engine;
 use ProcessMaker\Mail\TaskActionByEmail;
 use ProcessMaker\Managers\DataManager;
+use ProcessMaker\Models\FeelExpressionEvaluator;
 use ProcessMaker\Models\ProcessAbeRequestToken;
 use ProcessMaker\Models\ProcessCollaboration;
 use ProcessMaker\Models\ProcessRequest as Instance;
@@ -131,8 +132,9 @@ class TokenRepository implements TokenRepositoryInterface
                 case 'process_variable':
                     $dataManager = new DataManager();
                     $tokenData = $dataManager->getData($token);
-                    $evaluatedUsers = $selfServiceUsers ? $tokenData[$selfServiceUsers] ?? null: [];
-                    $evaluatedGroups = $selfServiceGroups ? $tokenData[$selfServiceGroups] ?? null : [];
+                    $feel = new FeelExpressionEvaluator();
+                    $evaluatedUsers = $selfServiceUsers ? $feel->render($selfServiceUsers, $tokenData) ?? null: [];
+                    $evaluatedGroups = $selfServiceGroups ? $feel->render($selfServiceGroups, $tokenData) ?? null : [];
 
                     // If we have single values we put it inside an array
                     $evaluatedUsers = is_array($evaluatedUsers) ? $evaluatedUsers : [$evaluatedUsers];

--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Mustache_Engine;
 use ProcessMaker\Mail\TaskActionByEmail;
+use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\ProcessAbeRequestToken;
 use ProcessMaker\Models\ProcessCollaboration;
 use ProcessMaker\Models\ProcessRequest as Instance;
@@ -128,8 +129,10 @@ class TokenRepository implements TokenRepositoryInterface
                     $token->self_service_groups = ['users' => $evaluatedUsers, 'groups' => $evaluatedGroups];
                     break;
                 case 'process_variable':
-                    $evaluatedUsers = $selfServiceUsers ? $token->getInstance()->getDataStore()->getData($selfServiceUsers) : [];
-                    $evaluatedGroups = $selfServiceGroups ? $token->getInstance()->getDataStore()->getData($selfServiceGroups) : [];
+                    $dataManager = new DataManager();
+                    $tokenData = $dataManager->getData($token);
+                    $evaluatedUsers = $selfServiceUsers ? $tokenData[$selfServiceUsers] ?? null: [];
+                    $evaluatedGroups = $selfServiceGroups ? $tokenData[$selfServiceGroups] ?? null : [];
 
                     // If we have single values we put it inside an array
                     $evaluatedUsers = is_array($evaluatedUsers) ? $evaluatedUsers : [$evaluatedUsers];


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently the Self Service assignment is not getting the users from the internal variable of each element of the array assigned to the multi-instance task.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19863

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
