### PR TITLE
bugfix/FOUR-19967: background color is not displayed in a notification

### DIFF
--- a/resources/js/notifications/components/notification-message.vue
+++ b/resources/js/notifications/components/notification-message.vue
@@ -109,14 +109,14 @@ export default {
   margin-bottom: 1em;
 }
 .bubble {
-  background-color: lighten($primary, 55%);
+  background-color: lighten($primary, 40%);
   border-radius: 1em;
   padding: 1em;
   margin-top: 1em;
 }
 .bubble-sm {
   font-size: 0.8em;
-  background-color: lighten($primary, 55%);
+  background-color: lighten($primary, 40%);
   border-radius: 1em;
   padding: 1em;
   margin-top: 1em;


### PR DESCRIPTION
## Solution
- Style background color was modified to make visible

## How to Test
1. Create a simple process
2. Create a request
3. Add a comment to mention for a @user
4. Scenario A
 - Open the notification from bell icon
5. Scenario B
 - Open the notification page

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19967

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
