### PR TITLE
FOUR-19984: Status and Pagination translation does not work

### DIFF
--- a/resources/js/components/shared/PaginationTable.vue
+++ b/resources/js/components/shared/PaginationTable.vue
@@ -130,11 +130,9 @@ export default {
     },
     totalItems() {
       if (this.meta.total === 1) {
-        //return `${this.meta.total} ${this.$t("item")}`;
         return this.$t('{{count}} Item', { count: this.meta.total });
       }
       return this.$t('{{count}} Items', { count: this.meta.total });
-      //return `${this.meta.total} ${this.$t("items")}`;
     },
     perPageButton() {
       return `${this.meta.per_page} ${this.$t("Per page")}`;

--- a/resources/js/components/shared/PaginationTable.vue
+++ b/resources/js/components/shared/PaginationTable.vue
@@ -27,7 +27,7 @@
     >
 
     <span class="pagination-total">
-      of {{ totalPageCount }}
+      {{ totalPageCountLabel }}
     </span>
 
     <b-button
@@ -125,14 +125,19 @@ export default {
     totalPageCount() {
       return this.meta.total_pages;
     },
+    totalPageCountLabel() {
+      return `${this.$t("of")} ${this.meta.total_pages}`;
+    },
     totalItems() {
       if (this.meta.total === 1) {
-        return `${this.meta.total} item`;
+        //return `${this.meta.total} ${this.$t("item")}`;
+        return this.$t('{{count}} Item', { count: this.meta.total });
       }
-      return `${this.meta.total} items`;
+      return this.$t('{{count}} Items', { count: this.meta.total });
+      //return `${this.meta.total} ${this.$t("items")}`;
     },
     perPageButton() {
-      return `${this.meta.per_page} per Page`;
+      return `${this.meta.per_page} ${this.$t("Per page")}`;
     },
     pageInputPlaceholder() {
       return `${this.currentPage}`;

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -684,19 +684,19 @@ export default {
     },
     formatStatus(props) {
       let color = "success";
-      let label = "In Progress";
+      let label = this.$t("In Progress");
 
       if (props.status === "ACTIVE") {
         if (props.is_self_service) {
           color = "danger";
-          label = "Self Service";
+          label = this.$t("Self Service");
         } else if (props.advanceStatus === "overdue") {
           color = "danger";
-          label = "Overdue";
+          label = this.$t("Overdue");
         }
       } else if (props.status === "CLOSED") {
         color = "primary";
-        label = "Completed";
+        label = this.$t("Completed");
       }
 
       return `

--- a/resources/jscomposition/system/table/Pagination.vue
+++ b/resources/jscomposition/system/table/Pagination.vue
@@ -102,7 +102,7 @@
     </svg>
 
     <div class="tw-px-2">
-      <span>{{ `${totalModel} items` }} </span>
+      <span>{{ totalModelLabel }} </span>
     </div>
 
     <div>
@@ -116,7 +116,7 @@
             class="tw-flex tw-full tw-items-center tw-space-x-2"
             @click.prevent.stop="toogleShow()">
             <span>
-              {{ `${selectedOption.value} ${$t("per page")}` }}
+              {{ `${selectedOption.value} ${$t("Per page")}` }}
             </span>
             <i
               class=" hover:tw-bg-gray-100 tw-rounded-md hover:tw-cursor-pointer tw-p-1 fas fa-chevron-down" />
@@ -152,20 +152,26 @@ const props = defineProps({
 
 const emit = defineEmits(["perPage", "go"]);
 
-const totalModel = computed(() => props.total);
+const totalModelLabel = computed(() => {
+  if (props.total === 0) {
+    return `${t("{{count}} Item", { count: props.total })}`;
+  }
+  return `${t("{{count}} Items", { count: props.total })}`;
+});
+
 const pageModel = ref(props.page);
 const optionsPerPage = [
   {
     value: 15,
-    label: `15 ${t("items")}`,
+    label: `${t("15 items")}`,
   },
   {
     value: 30,
-    label: `30 ${t("items")}`,
+    label: `${t("30 items")}`,
   },
   {
     value: 50,
-    label: `50 ${t("items")}`,
+    label: `${t("50 items")}`,
   },
 ];
 

--- a/resources/jscomposition/system/table/cell/StatusCell.vue
+++ b/resources/jscomposition/system/table/cell/StatusCell.vue
@@ -9,31 +9,32 @@
 </template>
 <script>
 import { defineComponent, computed } from "vue";
+import { t } from "i18next";
 
 export const statuses = {
   DRAFT: {
     color: "red",
-    label: "Draft",
+    label: `${t("Draft")}`,
   },
   CANCELED: {
     color: "red",
-    label: "Canceled",
+    label: `${t("Canceled")}`,
   },
   COMPLETED: {
     color: "blue",
-    label: "Completed",
+    label: `${t("Completed")}`,
   },
   ERROR: {
     color: "red",
-    label: "Error",
+    label: `${t("Error")}`,
   },
   IN_PROGRESS: {
     color: "green",
-    label: "In progress",
+    label: `${t("In Progress")}`,
   },
   ACTIVE: {
     color: "green",
-    label: "In progress",
+    label: `${t("In Progress")}`,
   },
 };
 


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to Tasks page
- Delete all filters (in order to check all statuses)
- Press flag icon
- Select Spanish option

Current Behavior:
 status column and pagination are not translated

## Solution
- Added the translation for statuses and pagination table.
![image](https://github.com/user-attachments/assets/760bfee1-033e-4fdc-b0ff-a434c34423e2)


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19984

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
