### PR TITLE
FOUR-19940 `Process Manager` user can not see all Tasks

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -140,6 +140,10 @@ class TaskController extends Controller
         // Apply filter overdue
         $query->overdue($request->input('overdue'));
 
+        if ($request->input('processesIManage') === 'true') {
+            $this->applyProcessManager($query, $user);
+        }
+
         // If only the total is being requested (by a Saved Search), send it now
         if ($getTotal === true) {
             return $query->count();

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ProcessMaker\Filters\Filter;
 use ProcessMaker\Managers\DataManager;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\User;
@@ -317,6 +318,20 @@ trait TaskControllerIndexMethods
         $query->where(function ($query) use ($user) {
             $query->where('user_id', $user->id)
                 ->orWhereIn('id', $user->availableSelfServiceTaskIds());
+        });
+    }
+    
+    public function applyProcessManager($query, $user)
+    {
+        $ids = Process::select(['id'])
+            ->where('properties->manager_id', $user->id)
+            ->where('status', 'ACTIVE')
+            ->get()
+            ->toArray();
+
+        $query->orWhere(function ($query) use ($ids) {
+            $query->whereIn('process_request_tokens.process_id', array_column($ids, 'id'))
+                ->where('process_request_tokens.status', 'ACTIVE');
         });
     }
 }

--- a/resources/js/tasks/components/ListMixin.js
+++ b/resources/js/tasks/components/ListMixin.js
@@ -107,6 +107,7 @@ const ListMixin = {
               }${filterParams
               }${this.getSortParam()
               }&non_system=true` +
+              `&processesIManage=${(this.processesIManage ? 'true' : 'false')}` +
               advancedFilter +
               this.columnsQuery,
               {

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -339,7 +339,7 @@ export default {
       type: String,
       default: "tasks",
     },
-    verifyUrlToFalse: {
+    processesIManage: {
       type: Boolean,
       default: false
     }
@@ -866,7 +866,7 @@ export default {
     verifyURL(string) {
       const currentUrl = window.location.href;
       let isInUrl = currentUrl.includes(string);
-      if (this.verifyUrlToFalse) {
+      if (this.processesIManage) {
         isInUrl = false;
       }
       return isInUrl;


### PR DESCRIPTION
## Issue & Reproduction Steps
`Process Manager` user can not see all Tasks

## Current Behavior
The user assigned in as process manager can not see all requests.

## Expected Behavior
The user assigned as process manager should see all tasks without any permission.


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19940
