### PR TITLE
FOUR-19272 : CSS style is not rendering in Summary section

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -120,7 +120,7 @@
                 <template v-if="showScreenSummary">
                   <div class="p-3">
                     <vue-form-renderer ref="screen" :config="screenSummary.config" v-model="dataSummary"
-                      :custom-css="screenSummary.custom_css"
+                      :custom-css="screenSummary?.custom_css"
                       :computed="screenSummary.computed" />
                   </div>
                 </template>
@@ -128,7 +128,7 @@
                   <div class="card">
                     <div class="card-body">
                       <vue-form-renderer ref="screenRequestDetail" :config="screenRequestDetail"
-                        :custom-css="screenSummary.custom_css"
+                        :custom-css="screenSummary?.custom_css"
                         v-model="dataSummary" />
                     </div>
                   </div>


### PR DESCRIPTION
## Issue & Reproduction Steps
FOUR-19272 : CSS style is not rendering in Summary section

## Solution
- Add the missing variable in the vue component vue-form-renderer

## How to Test
Go to the screen in end event

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19272

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy