### PR TITLE
FOUR-19807 : Task column should be display the last active task (or tasks if are possible)

### DIFF
--- a/resources/jscomposition/cases/casesMain/config/columns.js
+++ b/resources/jscomposition/cases/casesMain/config/columns.js
@@ -86,6 +86,12 @@ export const taskColumn = () => ({
     params: {
       href: (option) => `/tasks/${option.id}/edit`,
       formatterOptions: (option, row, column, columns) => option.name,
+      filterData: (row, column, columns) => {
+        if (row.case_status === "COMPLETED") {
+          return [];
+        }
+        return row.tasks.filter((el) => el.status === "ACTIVE");
+      },
     },
   }),
 });

--- a/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
+++ b/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
@@ -1,20 +1,22 @@
 <template>
   <div class="tw-flex tw-relative tw-text-nowrap tw-whitespace-nowrap tw-p-3">
-    <div class="tw-overflow-hidden tw-text-ellipsis ">
+    <div
+      v-if="optionsModel.length"
+      class="tw-overflow-hidden tw-text-ellipsis">
       <a
         v-if="href !== null"
         class="hover:tw-text-blue-400 tw-text-gray-500"
-        :href="href(row[column.field][0])"
+        :href="href(optionsModel[0])"
       >
-        {{ getValue() }}
+        {{ getValueOption(optionsModel[0], 0) }}
       </a>
       <span
         v-else
         class="hover:tw-text-blue-400 tw-text-gray-500 hover:tw-cursor-pointer"
         href="#"
-        @click.prevent.stop="onClickOption(row[column.field][0], 0)"
+        @click.prevent.stop="onClickOption(optionsModel[0], 0)"
       >
-        {{ getValue() }}
+        {{ getValueOption(optionsModel[0], 0) }}
       </span>
     </div>
     <AppPopover
@@ -106,14 +108,7 @@ export default defineComponent({
     const show = ref(false);
     const optionsModel = ref(props.row[props.column.field]);
 
-    const getValue = () => {
-      if (isFunction(props.column?.formatter)) {
-        return props.column?.formatter(props.row, props.column, props.columns);
-      }
-      return props.row[props.column.field].length ? props.row[props.column.field][0].name : "";
-    };
-
-    const getValueOption = (option, index) => {
+    const getValueOption = (option) => {
       if (isFunction(props.formatterOptions)) {
         return props.formatterOptions(option, props.row, props.column, props.columns);
       }
@@ -145,7 +140,6 @@ export default defineComponent({
       onClose,
       onClickOption,
       onClick,
-      getValue,
       getValueOption,
     };
   },

--- a/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
+++ b/resources/jscomposition/system/table/cell/TruncatedOptionsCell.vue
@@ -43,7 +43,7 @@
             >
               <a
                 v-if="href !== null"
-                class="tw-flex tw-py-2 tw-px-4 transition duration-300 hover:tw-bg-gray-200"
+                class="tw-flex tw-py-2 tw-px-4 transition duration-300 tw-text-gray-500 hover:tw-bg-gray-200 hover:tw-text-blue-400"
                 :href="href(option)"
               >
                 {{ getValueOption(option, index) }}
@@ -63,7 +63,7 @@
   </div>
 </template>
 <script>
-import { defineComponent, ref } from "vue";
+import { defineComponent, ref, onMounted } from "vue";
 import { isFunction } from "lodash";
 import { AppPopover } from "../../../base/index";
 
@@ -93,6 +93,11 @@ export default defineComponent({
       default: new Function(),
     },
     href: {
+      type: Function,
+      default: null,
+    },
+    // Filter Data, method to filter the input data
+    filterData: {
       type: Function,
       default: null,
     },
@@ -126,6 +131,13 @@ export default defineComponent({
     const onClose = () => {
       show.value = false;
     };
+
+    onMounted(() => {
+      // Filter the data before render
+      if (props.filterData) {
+        optionsModel.value = props.filterData(props.row, props.column, props.columns);
+      }
+    });
 
     return {
       show,


### PR DESCRIPTION
"Task" column should be display the last task (or tasks if are possible), Currently is displaying always the first task.
In the next process the token is in the third task the previous two tasks were completed. The name of the first task is displayed always.
'status' => 'ACTIVE',

## Issue & Reproduction Steps
1. Go to cases
2 check the columns tasks

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19807

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
