### PR TITLE
FOUR-19955 | Template Is Not Consistently Applied to Screen

### DIFF
--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -736,8 +736,6 @@ class ScreenTemplate implements TemplateInterface
                 $currentScreen->save();
 
                 $screen->save(); // Save the updated screen
-
-                $screen->save(); // Save the updated screen
             }
             Screen::where('id', $newScreenId)->delete(); // Clean up the temporary imported template screen
         } catch (ModelNotFoundException $e) {


### PR DESCRIPTION
# Issue
Ticket: [FOUR-19955](https://processmaker.atlassian.net/browse/FOUR-19955)

When attempting to apply a Screen Template to a Screen via the Screen Builder, after receiving the 'Template Successfully Applied' message, the page refreshes and the screen is still empty. The cause of this issue is that the screen version was being updated and saved in the database, however the screen was not being updated and saved in some cases.

# Solution
- In the `applyTemplate` function in `ScreenTemplate.php`, when applying a template to a screen version (if `package-versions` is installed), ensure that the changes to the current screen are saved.

# How to Test
1. Go to branch `observation/FOUR-19955` in `processmaker`.
2. Go to Designer → Screens.
3. Create a new Screen.
4. Open the Screen to edit. Select 'Templates' from the top menu bar.
5. Select a template. Select the options to apply 'CSS', 'Fields', and 'Layout' and click 'Apply'.
6. When the Screen refreshes, the template should be applied. The Screen should not be empty.

ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-19955]: https://processmaker.atlassian.net/browse/FOUR-19955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ