### PR TITLE
FOUR-20009: [summer] [unit test] The requests/{{id}} does not show information when the process is configured with "Request Detail Screen"

### DIFF
--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -225,4 +225,156 @@ class RequestTest extends TestCase
         // check custom detail screen is displayed instead default summary
         $response->assertSee('TEST WITH CUSTOM REQUEST DETAIL SCREEN');
     }
+
+    /**
+     * Test show default summary tab when the status is InProgress
+     * Without custom screen "Request Detail Screen"
+     * @return void
+     */
+    public function testRequestInProgressWithDataDefaultSummary()
+    {
+        $process = Process::factory()->create();
+        $requestCanceled = ProcessRequest::factory()->create([
+            'name' => $process->name,
+            'process_id' => $process->id,
+            'data' => ['form_input_1' => 'TEST DATA'],
+            'status' => 'ACTIVE',
+        ]);
+
+        // Get the URL
+        $response = $this->webCall('GET', '/requests/' . $requestCanceled->id);
+        $response->assertStatus(200);
+        // Check the correct view is called
+        $response->assertViewIs('requests.show');
+        $response->assertSee('Request In Progress');
+    }
+
+    /**
+     * Test show default summary tab when the status is Completed
+     * Without custom screen "Cancel Screen"
+     * @return void
+     */
+    public function testRequestCanceledDefaultSummary()
+    {
+        $process = Process::factory()->create();
+        $requestCompleted = ProcessRequest::factory()->create([
+            'name' => $process->name,
+            'process_id' => $process->id,
+            'data' => [],
+            'status' => 'CANCELED',
+        ]);
+
+        // Get the URL
+        $response = $this->webCall('GET', '/requests/' . $requestCompleted->id);
+        $response->assertStatus(200);
+        // Check the correct view is called
+        $response->assertViewIs('requests.show');
+        $response->assertSee('No Data Found');
+    }
+
+    /**
+     * Test show default summary tab when the status is Completed
+     * Without end event custom screen "Summary screen"
+     * @return void
+     */
+    public function testRequestCompletedDefaultSummary()
+    {
+        $process = Process::factory()->create();
+        $requestCompleted = ProcessRequest::factory()->create([
+            'name' => $process->name,
+            'process_id' => $process->id,
+            'data' => [],
+            'status' => 'COMPLETED',
+        ]);
+
+        // Get the URL
+        $response = $this->webCall('GET', '/requests/' . $requestCompleted->id);
+        $response->assertStatus(200);
+        // Check the correct view is called
+        $response->assertViewIs('requests.show');
+        $response->assertSee('No Data Found');
+    }
+
+    /**
+     * Test show default summary tab when the status is Completed
+     * Without end event custom screen "Summary screen"
+     * @return void
+     */
+    public function testRequestCompletedWithDataDefaultSummary()
+    {
+        $process = Process::factory()->create();
+        $requestCompleted = ProcessRequest::factory()->create([
+            'name' => $process->name,
+            'process_id' => $process->id,
+            'data' => ['form_input_1' => 'TEST DATA'],
+            'status' => 'COMPLETED',
+        ]);
+
+        // Get the URL
+        $response = $this->webCall('GET', '/requests/' . $requestCompleted->id);
+        $response->assertStatus(200);
+        // Check the correct view is called
+        $response->assertViewIs('requests.show');
+        $response->assertSee('TEST DATA');
+    }
+
+    /**
+     * Test show custom screen in the summary tab when the status is In Progress
+     * With custom screen "Request Detail Screen"
+     * @return void
+     */
+    public function testRequestInprogressWithCustomScreenSummaryTab()
+    {
+        $screen = Screen::factory()->create([
+            'type' => 'DISPLAY',
+            'config' => $this->screen,
+        ]);
+        $process = Process::factory()->create([
+            'request_detail_screen_id' => $screen->id,
+        ]);
+        $requestActive = ProcessRequest::factory()->create([
+            'name' => $process->name,
+            'process_id' => $process->id,
+            'data' => ['form_input_1' => 'TEST DATA'],
+            'status' => 'ACTIVE',
+        ]);
+
+        // Get the URL
+        $response = $this->webCall('GET', '/requests/' . $requestActive->id);
+        $response->assertStatus(200);
+        // Check the correct view is called
+        $response->assertViewIs('requests.show');
+        // Check custom detail screen is displayed instead default summary
+        $response->assertSee('TEST WITH CUSTOM REQUEST DETAIL SCREEN');
+    }
+
+    /**
+     * Test show custom screen in the summary tab when the status is Canceled
+     * With custom screen "Cancel Screen"
+     * @return void
+     */
+    public function testRequestCanceledWithCustomScreenSummaryTab()
+    {
+        $screen = Screen::factory()->create([
+            'type' => 'DISPLAY',
+            'config' => $this->screen,
+        ]);
+        $process = Process::factory()->create([
+            'cancel_screen_id' => $screen->id,
+        ]);
+        $requestCanceled = ProcessRequest::factory()->create([
+            'name' => $process->name,
+            'process_id' => $process->id,
+            'data' => ['form_input_1' => 'TEST DATA'],
+            'status' => 'CANCELED',
+        ]);
+
+        // Get the URL
+        $response = $this->webCall('GET', '/requests/' . $requestCanceled->id);
+        $response->assertStatus(200);
+        // Check the correct view is called
+        $response->assertViewIs('requests.show');
+        // Check custom detail screen is displayed instead default summary
+        $response->assertSee('TEST WITH CUSTOM REQUEST DETAIL SCREEN');
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Create a simple Display Screen like the process uploaded
3. Configure a "Request Detail Screen"
4. Start a Case
5. Tried to open the Request related with the link asociated 

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20009

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
