### PR TITLE
Fix import password prompt

### DIFF
--- a/resources/js/processes/import/components/ImportManagerView.vue
+++ b/resources/js/processes/import/components/ImportManagerView.vue
@@ -546,9 +546,9 @@ export default {
                     });
                 }
 
-                if (response.message === 'ProcessMaker\\Exception\\ImportPasswordException: password required') {
+                if (response.message.startsWith('ProcessMaker\\Exception\\ImportPasswordException: password required')) {
                     this.showEnterPasswordModal();
-                } else if (response.message === 'ProcessMaker\\Exception\\ImportPasswordException: incorrect password') {
+                } else if (response.message.startsWith('ProcessMaker\\Exception\\ImportPasswordException: incorrect password')) {
                     this.passwordError = "Incorrect password";
                 } else if (response.type === 'error') {
                     this.$root.allowDownloadDebug = true;


### PR DESCRIPTION
## Issue & Reproduction Steps
Instead of showing the password prompt, an error message was displayed.

## Solution
- Check for only the first part of the returned error message to see if a password is required.

## How to Test
Import a process that was exported with a password

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19954

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
