### PR TITLE
FOUR-20010: The link does not show the correct location after refreshing the page in Cases options

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
@@ -1,11 +1,12 @@
 <template>
   <Tabs
     :tab-default="tabDefault"
-    :tabs="tabs" />
+    :tabs="tabs"
+  />
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { ref, onBeforeMount } from "vue";
 import Tabs from "./Tabs.vue";
 import TaskTable from "./TaskTable.vue";
 import RequestTable from "./RequestTable.vue";
@@ -27,7 +28,7 @@ const tabs = [
     name: translate.t("Overview"), href: "#overview", current: "overview", show: true, content: Overview,
   },
   {
-    name: translate.t("Completed & Form"), href: "#completed_form", current: "completed", show: true, content: CompletedForms,
+    name: translate.t("Completed & Form"), href: "#completed_form", current: "completed_form", show: true, content: CompletedForms,
   },
   {
     name: translate.t("File Manager"), href: "#file_manager", current: "file_manager", show: true, content: TabFiles,
@@ -39,5 +40,25 @@ const tabs = [
     name: translate.t("Requests"), href: "#requests", current: "requests", show: getRequestCount() !== 1, content: RequestTable,
   },
 ];
+
+const urlTabs = [
+  "tasks",
+  "overview",
+  "completed_form",
+  "file_manager",
+  "history",
+  "requests",
+];
+
+const checkURL = () => {
+  const hash = window.location.hash.substring(1);
+  if (urlTabs.includes(hash)) {
+    tabDefault.value = hash;
+  }
+};
+
+onBeforeMount(() => {
+  checkURL();
+});
 
 </script>

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -117,11 +117,6 @@
 @endsection
 
 @section('js')
-  @if (hasPackage('package-files'))
-  <!-- TODO: Replace with script injector like we do for modeler and screen builder -->
-  <script src="{{ mix('js/manager.js', 'vendor/processmaker/packages/package-files') }}"></script>
-  @endif
-
   <script>
     const data = @json($request->getRequestData());
     const requestId = @json($request->getKey());
@@ -134,6 +129,12 @@
     const comentable_type = @json(get_class($request));
     const requestCount = @json($requestCount);
   </script>
+  
+  @if (hasPackage('package-files'))
+  <!-- TODO: Replace with script injector like we do for modeler and screen builder -->
+  <script src="{{ mix('js/manager.js', 'vendor/processmaker/packages/package-files') }}"></script>
+  @endif
+
   <script src="{{mix('js/composition/cases/casesDetail/edit.js')}}"></script>
 
   @foreach($manager->getScripts() as $script)

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -117,6 +117,11 @@
 @endsection
 
 @section('js')
+  @if (hasPackage('package-files'))
+  <!-- TODO: Replace with script injector like we do for modeler and screen builder -->
+  <script src="{{ mix('js/manager.js', 'vendor/processmaker/packages/package-files') }}"></script>
+  @endif
+
   <script>
     const data = @json($request->getRequestData());
     const requestId = @json($request->getKey());
@@ -130,10 +135,6 @@
     const requestCount = @json($requestCount);
   </script>
   <script src="{{mix('js/composition/cases/casesDetail/edit.js')}}"></script>
-  @if (hasPackage('package-files'))
-    <!-- TODO: Replace with script injector like we do for modeler and screen builder -->
-    <script src="{{ mix('js/manager.js', 'vendor/processmaker/packages/package-files') }}"></script>
-  @endif
 
   @foreach($manager->getScripts() as $script)
     <script src="{{$script}}"></script>


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Create a case
3. Open the case 
4. Click on : (Overview | Completed & Form | File Manager)
5. Refresh the page with the route {{server}}/cases//{{number_case}}/{{route}}
6. Check the content after the refresh 


**Current Behavior**
After refreshing the page, the selected option is not displayed, it always shows task by default 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20010

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy