### PR TITLE
FOUR-20013: Apply Translation Error When a ‘Cancel Screen’ is Configured

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -679,21 +679,18 @@ class ScreenController extends Controller
      */
     public function translate(Request $request, Screen $screen, $language)
     {
-        $draft = $screen->versions()->draft()->first();
-        if (!$draft) {
-            $draft = $screen;
-            $draft->screen_id = $draft->id;
-        }
+        // get latest version published
+        $screenVersion = $screen->getLatestVersion();
 
-        $screenArray = $draft->toArray();
         $screenTranslation = new ScreenTranslation();
-        $screenArray['config'] = $screenTranslation->evaluateMustache(
+
+        // evaluate mustache
+        $screenVersion->config = $screenTranslation->evaluateMustache(
             $request->input('screenConfig'),
             $request->input('inputData')
         );
-        $translatedConfig = $screenTranslation->applyTranslations($screenArray, $language);
 
-        return $translatedConfig;
+        return $screenTranslation->applyTranslations($screenVersion, $language);
     }
 
     public function updateDefaultTemplate(string $screenType, int $isPublic)

--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -116,9 +116,8 @@ class CasesController extends Controller
     public function summaryScreenTranslation(ProcessRequest $request): void
     {
         if ($request->summary_screen) {
-            $screenArray = $request->summary_screen->toArray();
             $screenTranslation = new ScreenTranslation();
-            $request->summary_screen['config'] = $screenTranslation->applyTranslations($screenArray);
+            $request->summary_screen['config'] = $screenTranslation->applyTranslations($request->summary_screen->getLatestVersion());
         }
     }
 }

--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -287,8 +287,7 @@ class RequestController extends Controller
     {
         if ($request->summary_screen) {
             $screenTranslation = new ScreenTranslation();
-            $translatedConf = $screenTranslation->applyTranslations($request->summary_screen->toArray());
-            $request->summary_screen['config'] = $translatedConf;
+            $request->summary_screen['config'] = $screenTranslation->applyTranslations($request->summary_screen->getLatestVersion());
         }
     }
 }

--- a/ProcessMaker/Http/Resources/ScreenVersion.php
+++ b/ProcessMaker/Http/Resources/ScreenVersion.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Http\Resources;
 
 use Illuminate\Support\Arr;
 use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\ScreenVersion as ScreenVersionModel;
 use ProcessMaker\ProcessTranslations\ScreenTranslation;
 
 class ScreenVersion extends ApiResource
@@ -44,13 +45,13 @@ class ScreenVersion extends ApiResource
         if (!$task) {
             // Apply translations to screen
             $screenTranslation = new ScreenTranslation();
-            $screenVersion['config'] = $screenTranslation->applyTranslations($screenVersion);
+            $screenVersion['config'] = $screenTranslation->applyTranslations(new ScreenVersionModel($screenVersion));
             // Apply translations to nested screens
             if (!array_key_exists('nested', $screenVersion)) {
                 return $screenVersion;
             }
             foreach ($screenVersion['nested'] as &$nestedScreen) {
-                $nestedScreen['config'] = $screenTranslation->applyTranslations($nestedScreen);
+                $nestedScreen['config'] = $screenTranslation->applyTranslations(new ScreenVersionModel($nestedScreen));
             }
         }
 

--- a/ProcessMaker/Http/Resources/V1_1/TaskScreen.php
+++ b/ProcessMaker/Http/Resources/V1_1/TaskScreen.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Http\Resources\V1_1;
 
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\ScreenVersion as ScreenVersionResource;
+use ProcessMaker\Models\ScreenVersion as ScreenVersionModel;
 use ProcessMaker\ProcessTranslations\ScreenTranslation;
 use ProcessMaker\Traits\TaskScreenResourceTrait;
 
@@ -42,13 +43,13 @@ class TaskScreen extends ApiResource
         if ($array['screen']) {
             // Apply translations to screen
             $screenTranslation = new ScreenTranslation();
-            $array['screen']['config'] = $screenTranslation->applyTranslations($array['screen']);
+            $array['screen']['config'] = $screenTranslation->applyTranslations(new ScreenVersionModel($array['screen']));
             $array['screen']['config'] = $this->removeInspectorMetadata($array['screen']['config']);
 
             // Apply translations to nested screens
             if (array_key_exists('nested', $array['screen'])) {
                 foreach ($array['screen']['nested'] as &$nestedScreen) {
-                    $nestedScreen['config'] = $screenTranslation->applyTranslations($nestedScreen);
+                    $nestedScreen['config'] = $screenTranslation->applyTranslations(new ScreenVersionModel($nestedScreen));
                     $nestedScreen['config'] = $this->removeInspectorMetadata($nestedScreen['config']);
                 }
             }

--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -71,7 +71,6 @@ trait TaskResourceIncludes
 
     private function includeScreen($request)
     {
-        \Log::info('includeScreen');
         $array = ['screen' => null];
 
         $screen = $this->getScreenVersion();

--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -7,7 +7,7 @@ use ProcessMaker\Http\Resources\ScreenVersion as ScreenVersionResource;
 use ProcessMaker\Http\Resources\Users;
 use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\ProcessRequest;
-use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\ScreenVersion as ScreenVersionModel;
 use ProcessMaker\Models\TaskDraft;
 use ProcessMaker\Models\User;
 use ProcessMaker\ProcessTranslations\ScreenTranslation;
@@ -71,6 +71,7 @@ trait TaskResourceIncludes
 
     private function includeScreen($request)
     {
+        \Log::info('includeScreen');
         $array = ['screen' => null];
 
         $screen = $this->getScreenVersion();
@@ -88,13 +89,13 @@ trait TaskResourceIncludes
         if ($array['screen']) {
             // Apply translations to screen
             $screenTranslation = new ScreenTranslation();
-            $array['screen']['config'] = $screenTranslation->applyTranslations($array['screen']);
+            $array['screen']['config'] = $screenTranslation->applyTranslations(new ScreenVersionModel($array['screen']));
             $array['screen']['config'] = $this->removeInspectorMetadata($array['screen']['config']);
 
             // Apply translations to nested screens
             if (array_key_exists('nested', $array['screen'])) {
                 foreach ($array['screen']['nested'] as &$nestedScreen) {
-                    $nestedScreen['config'] = $screenTranslation->applyTranslations($nestedScreen);
+                    $nestedScreen['config'] = $screenTranslation->applyTranslations(new ScreenVersionModel($nestedScreen));
                     $nestedScreen['config'] = $this->removeInspectorMetadata($nestedScreen['config']);
                 }
             }
@@ -142,7 +143,7 @@ trait TaskResourceIncludes
         if ($interstitial['interstitial_screen']) {
             // Translate interstitials
             $screenTranslation = new ScreenTranslation();
-            $translatedConf = $screenTranslation->applyTranslations($interstitial['interstitial_screen']);
+            $translatedConf = $screenTranslation->applyTranslations($interstitial['interstitial_screen']->getLatestVersion());
             $interstitial['interstitial_screen']['config'] = $translatedConf;
 
             // Remove inspector metadata


### PR DESCRIPTION
# Issue
Ticket: [FOUR-20013](https://processmaker.atlassian.net/browse/FOUR-20013)

When a cancelled Request with a configured 'Cancel Screen' is opened, an 'Undefined array key `screen_id`' error is shown.

# Solution
- It is observed that the applyTranslations function parameter needs to be normalized and ScreenVersions used for all calls.

# How to Test
1. Go to branch `observation/FOUR-20013` in `processmaker`.
2. Go to Designer → Screens. Create a Display Screen.
3. Go to Designer → Processes. Create a Process.
4. Configure your Screen as the 'Cancel Screen'.
5. Add a Start Event, Task, and End Event to the Process. Configure the Task. (It does not matter what Screen is used for the Task.)
6. Start a Case.
7. Cancel the Case.
8. Open the Request.
	- The 'Cancel Screen' should display in the Request Summary. There should be no error message.


Dependencies:
ci:package-dynamic-ui:observation/FOUR-20013
ci:package-translations:observation/FOUR-20013

ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-20013]: https://processmaker.atlassian.net/browse/FOUR-20013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ