### PR TITLE
Fix screen interstitial null key

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -68,7 +68,14 @@ class ScreenExporter extends ExporterBase
 
         // There should only be one default interstitial screen
         if ($screen->key === 'interstitial') {
-            $screen->key = null;
+            $existingScreenInterstitial = Screen::where('key', 'interstitial')->first();
+            // If the screen we are trying to import is not this system's default interstitial screen
+            // then set the key to null since there should only be one default interstitial screen
+            if ($existingScreenInterstitial && $existingScreenInterstitial->id !== $screen->id) {
+                $screen->key = null;
+            }
+            // On the other hand, if this import is attempting to update the default interstitial screen,
+            // that should be allowed and there should be no changes to the key or id, but the config will be updated.
         }
 
         $success = $screen->saveOrFail();

--- a/upgrades/2024_11_07_222831_fix_interstitial_key.php
+++ b/upgrades/2024_11_07_222831_fix_interstitial_key.php
@@ -1,0 +1,55 @@
+<?php
+
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class FixInterstitialKey extends Upgrade
+{
+    /**
+     * Run any validations/pre-run checks to ensure the environment, settings,
+     * packages installed, etc. are right correct to run this upgrade.
+     *
+     * Throw a \RuntimeException if the conditions are *NOT* correct for this
+     * upgrade migration to run. If this is not a required upgrade, then it
+     * will be skipped. Otherwise the exception thrown will be caught, noted,
+     * and will prevent the remaining migrations from continuing to run.
+     *
+     * Returning void or null denotes the checks were successful.
+     *
+     * @return void
+     *
+     * @throws RuntimeException
+     */
+    public function preflightChecks()
+    {
+        //
+    }
+
+    /**
+     * Run the upgrade migration.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Screen::where('key', 'interstitial')->count() === 0) {
+            // get screen where config (json column) 0.name equals "Screen Interstitial"
+            if ($screen = Screen::whereRaw('JSON_EXTRACT(config, "$[0].name") = "Screen Interstitial"')->first()) {
+                $screen->key = 'interstitial';
+                $screen->save();
+            } else {
+                throw new Exception('Screen Interstitial not found');
+            }
+        }
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Importing a process with in update mode was erasing the default screen interstitial key

## Solution
- When importing, do not set to null unless there is already another screen with the interstitial key
- Create an upgrade script to fix instances where the key was erased

## How to Test
- Run `php artisan upgrade`
- In the DB, ensure you have one screen with the `interstitial` key
- Create a process with a task using the default screen interstitial
- Export the process
- Import the process, using "Basic" mode and the "update" button
- Ensure the same screen still has the `interstitial` key

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20043

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
