### PR TITLE
FOUR-20052 Show case_number instead of process_request.id for tasks

### DIFF
--- a/resources/js/Mobile/Card.vue
+++ b/resources/js/Mobile/Card.vue
@@ -131,7 +131,7 @@ export default {
         return this.item.case_number;
       }
       if (this.type === "tasks") {
-        return this.item.process_request.id;
+        return this.item.process_request.case_number;
       }
       return null;
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
At mobile view the card was showing the Request ID, this cause confusion about the tasks.

## Solution
- Show case_number instead of process_request.id for tasks.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20052

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
