### PR TITLE
FOUR-20005 PRocesses | manage > `unclaimed` status is not displayed

### DIFF
--- a/resources/js/components/AvatarImage.vue
+++ b/resources/js/components/AvatarImage.vue
@@ -4,6 +4,7 @@
     <template v-for="(value, key) in options">
       <div class="vertical-view">
       <b-button
+        v-if="value.initials"
         ref="button"
         :variant="variant(value)"
         class="avatar-button rounded-circle overflow-hidden p-0 m-0 d-inline-flex"
@@ -44,7 +45,7 @@
               {{ limitCharacters(value.name) }}
             </template>
           </span>
-          <span v-else>ProcessMaker</span>
+          <span v-else><b-badge class="status-alternative-a">{{ $t('Unclaimed') }}</b-badge></span>
       </span>
       </div>
     </template>


### PR DESCRIPTION
## Issue & Reproduction Steps
_PRocesses | manage > `unclaimed` status is not displayed_
The assign column does not display the unclaimed tag for Tasks with self service status

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-20005
