### PR TITLE
FOUR-20064  The cases list does not show the correct status when the case is CANCELED

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -24,6 +24,7 @@ use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\ProcessRequests as ProcessRequestResource;
 use ProcessMaker\Jobs\CancelRequest;
+use ProcessMaker\Jobs\CaseUpdateStatus;
 use ProcessMaker\Jobs\TerminateRequest;
 use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\Comment;
@@ -602,6 +603,8 @@ class ProcessRequestController extends Controller
         // Close process request
         $request->status = 'CANCELED';
         $request->save();
+        // Update case status
+        CaseUpdateStatus::dispatchSync($request);
 
         event(new RequestAction($request, RequestAction::ACTION_CANCELED));
     }

--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -130,7 +130,7 @@ class CaseRepository implements CaseRepositoryInterface
                 'case_status' => $caseStatus,
             ];
 
-            if ($caseStatus === CaseStatusConstants::COMPLETED) {
+            if (in_array($caseStatus, [CaseStatusConstants::COMPLETED, CaseStatusConstants::CANCELED])) {
                 $data['completed_at'] = $instance->completed_at;
             }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- Store the correct status when a case is canceled

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
[FOUR-20064](https://processmaker.atlassian.net/browse/FOUR-20064)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
