### PR TITLE
FOUR-20049: In task two tabs are highlighted

### DIFF
--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Lavary\Menu\Facade as Menu;
 use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\Setting;
@@ -208,7 +209,7 @@ class GenerateMenus
                     'id' => 'process-scripts',
                 ])->data('order', 2);
             }
-            if ($this->userHasPermission('view-collections')) {
+            if (hasPackage('package-collections') && $this->userHasPermission('view-collections')) {
                 $submenu->add(__('Collections'), [
                     'route' => 'plugin-collections-index',
                     'customicon' => 'nav-icon fas fa-database',
@@ -323,7 +324,7 @@ class GenerateMenus
 
     public static function userHasPermission($permission)
     {
-        $user = \Auth::user();
+        $user = Auth::user();
 
         if (!$user || !$user->is_administrator) {
             return $user && $user->can($permission) && $user->hasPermission($permission);

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -33,11 +33,12 @@
               class="nav-link task-nav-link"
               id="inbox-tab"
               :data-toggle="isDataLoading ? '' : 'tab'"
-              href="#inbox" role="tab"
+              href="#"
+              role="tab"
               aria-controls="inbox"
               @click.prevent="!isDataLoading ? switchTab('inbox') : null"
               aria-selected="true"
-              :class="{ 'active': inbox }"
+              :class="{ 'active': tab === 'inbox' }"
             >
               {{ __('Inbox') }}
             </a>
@@ -47,11 +48,12 @@
               class="nav-link task-nav-link"
               id="priority-tab"
               :data-toggle="isDataLoading ? '' : 'tab'"
-              href="#inbox" role="tab"
+              href="#"
+              role="tab"
               aria-controls="inbox"
               @click.prevent="!isDataLoading ? switchTab('priority') : null"
               aria-selected="true"
-              :class="{ 'active': priority }"
+              :class="{ 'active': tab === 'priority' }"
             >
               {{ __('Priority') }}
             </a>
@@ -61,12 +63,12 @@
               class="nav-link task-nav-link"
               id="drafts-tab"
               :data-toggle="isDataLoading ? '' : 'tab'"
-              href="#inbox"
+              href="#"
               role="tab"
               aria-controls="inbox"
               @click.prevent="!isDataLoading ? switchTab('draft') : null"
               aria-selected="true"
-              :class="{ 'active': draft }"
+              :class="{ 'active': tab === 'draft' }"
               v-if="taskDraftsEnabled"
             >
               {{ __('Drafts') }}


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Go to tasks
2. Mark any task as priority
3. Right click on the priority tab
4. Select "Open link in a new tab"

This PR addresses an issue in the tab navigation where multiple tabs (Inbox, Priority, Drafts) appeared as active simultaneously when accessing /tasks#inbox. The issue was caused by the href="#inbox" attribute in each tab link, which attempted to link to a specific anchor in the URL. This behavior confused the browser, especially when there was no element with id="inbox" in the DOM, causing multiple tabs to remain in an active state.

## Solution
- Changed the href="#inbox" attribute to href="#" in each tab link to prevent the browser from attempting to scroll to a specific anchor, allowing Vue to control the active state of the tabs without browser interference.
- This change ensures that only the selected tab appears active at any given time resolving the unexpected behavior.
- The change related to `hasPackage` is a fix for cases where the package-collection is not installed, avoiding errors.

## How to Test
1. /tasks#inbox again.
2. Verify that only the Inbox tab is marked as active when the page loads.
3. Click on each tab (Inbox, Priority, Drafts) and confirm that the active state only applies to the selected tab.
4. Ensure that when switching between tabs, no other tab remains in the active state simultaneously.

## Related Tickets & Packages
- [FOUR-20049](https://processmaker.atlassian.net/browse/FOUR-20049)


[FOUR-20049]: https://processmaker.atlassian.net/browse/FOUR-20049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ