### PR TITLE
FOUR-19990

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -133,6 +133,11 @@ class RequestController extends Controller
         if (!$userHasCommentsForMedia && !$userHasCommentsForRequest) {
             $this->authorize('view', $request);
         }
+        // Get the case number of parent request if the case number is null
+        // The case_number is null when the subprocess is related to the system like [ActionByEmail]
+        if (is_null($request->case_number)) {
+            $request->case_number = ProcessRequest::where('id', $request->parent_request_id)->value('case_number');
+        }
 
         $request->participants;
         $request->user;


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process with Action by email like:
2. Create a case
3. Route to action by email task
4. Go to request main 
5. Click on open child action by email

## Solution
- It is not possible to open child request of Action by Email, and the request of action by email is not listed in case main

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19990

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next