### PR TITLE
FOUR-20109 : The Task tab when open a case/{caseId}/ does not show correclty the process name

### DIFF
--- a/resources/jscomposition/base/table/TCell.vue
+++ b/resources/jscomposition/base/table/TCell.vue
@@ -2,16 +2,16 @@
   <td
     class="tw-relative"
     :style="{ width: `${column.width}px` }">
-    <div v-if="!column.cellRenderer">
+    <template v-if="!column.cellRenderer">
       <slot
         :columns="columns"
         :column="column"
         :row="row">
-        <div class="tw-p-3">
+        <div class="tw-p-3 tw-text-ellipsis tw-text-nowrap tw-overflow-hidden">
           {{ getValue() }}
         </div>
       </slot>
-    </div>
+    </template>
     <component
       :is="getComponent()"
       v-else


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process with large name
2. Start a case
3. Go to cases list
4. Open a case and go to task
5. Review the processName

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20109

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy