### PR TITLE
FOUR-20110 : The filters in Case Details does not update correctly when update the operator

### DIFF
--- a/resources/jscomposition/cases/casesMain/utils/filters.js
+++ b/resources/jscomposition/cases/casesMain/utils/filters.js
@@ -23,7 +23,7 @@ export const formatFilters = (filters) => {
         value: element.field,
       },
       operator: element.operator,
-      value,
+      value: value || "",
     };
   });
 
@@ -51,7 +51,7 @@ export const formatFilterBadges = (filters, columns) => {
 
     // Format datetime value to badges
     if (col.filter.dataType === "datetime") {
-      value = value.find ? value.map((o) => formatDate(o)) : formatDate(value);
+      value = value && value.find ? value.map((o) => formatDate(o)) : formatDate(value);
     }
 
     return {

--- a/resources/jscomposition/system/table/filter/defaultFilter/operator/DateOperator.vue
+++ b/resources/jscomposition/system/table/filter/defaultFilter/operator/DateOperator.vue
@@ -1,5 +1,6 @@
 <template>
   <input
+    :value="model"
     type="datetime-local"
     class="tw-px-2 tw-block tw-w-full tw-rounded-md
         tw-border-0 tw-py-2 tw-text-gray-900 tw-shadow-sm tw-ring-1
@@ -7,12 +8,22 @@
           focus:tw-ring-2 focus:tw-ring-inset"
     @change="$emit('change', $event.target.value)">
 </template>
-<script>
-import { defineComponent } from "vue";
+<script setup>
+import { computed } from "vue";
 
-export default defineComponent({
-  setup() {
-    return {};
+const props = defineProps({
+  value: {
+    type: String,
+    default: () => "",
+  },
+});
+
+const emit = defineEmits(["change"]);
+
+const model = computed({
+  get: () => props.value,
+  set: (value) => {
+    emit("change", value);
   },
 });
 </script>

--- a/resources/jscomposition/system/table/filter/defaultFilter/operator/FilterOperator.vue
+++ b/resources/jscomposition/system/table/filter/defaultFilter/operator/FilterOperator.vue
@@ -38,7 +38,7 @@ const defaultOperators = [
   },
   {
     value: "<",
-    label: ">",
+    label: "<",
   },
   {
     value: "<=",

--- a/resources/jscomposition/system/table/filter/defaultFilter/operator/InputOperator.vue
+++ b/resources/jscomposition/system/table/filter/defaultFilter/operator/InputOperator.vue
@@ -8,7 +8,7 @@
     @change="$emit('change', $event.target.value)">
 </template>
 <script setup>
-import { ref } from "vue";
+import { computed } from "vue";
 
 const props = defineProps({
   value: {
@@ -17,5 +17,13 @@ const props = defineProps({
   },
 });
 
-const model = ref(props.value);
+const emit = defineEmits(["change"]);
+
+const model = computed({
+  get: () => props.value,
+  set: (value) => {
+    emit("change", value);
+  },
+});
+
 </script>


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process
2. Start a case
3. Go to cases list
4. Apply a filter
5. Update the operator
6. Apply the filter

## Solution
- Adding validation in filters

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20110

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
