### PR TITLE
FOUR-20108:Review estimate the errors tab is no longer displayed in the case details

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeMount } from "vue";
+import { computed } from "vue";
 import Tabs from "./Tabs.vue";
 import TaskTable from "./TaskTable.vue";
 import RequestTable from "./RequestTable.vue";
@@ -19,7 +19,19 @@ import { getRequestCount, isErrors } from "../variables/index";
 
 const translate = ProcessMaker.i18n;
 
+const urlTabs = [
+  "tasks",
+  "overview",
+  "completed_form",
+  "file_manager",
+  "history",
+  "requests",
+];
+
 const tabDefault = computed(() => {
+  if (urlTabs.includes(window.location.hash.substring(1))) {
+    return window.location.hash.substring(1);
+  }
   if (isErrors()) {
     return "errors";
   }
@@ -49,25 +61,5 @@ const tabs = [
     name: translate.t("Requests"), href: "#requests", current: "requests", show: getRequestCount() !== 1, content: RequestTable,
   },
 ];
-
-const urlTabs = [
-  "tasks",
-  "overview",
-  "completed_form",
-  "file_manager",
-  "history",
-  "requests",
-];
-
-const checkURL = () => {
-  const hash = window.location.hash.substring(1);
-  if (urlTabs.includes(hash)) {
-    tabDefault.value = hash;
-  }
-};
-
-onBeforeMount(() => {
-  checkURL();
-});
 
 </script>

--- a/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
@@ -1,11 +1,12 @@
 <template>
   <Tabs
     :tab-default="tabDefault"
-    :tabs="tabs" />
+    :tabs="tabs"
+  />
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { computed } from "vue";
 import Tabs from "./Tabs.vue";
 import TaskTable from "./TaskTable.vue";
 import RequestTable from "./RequestTable.vue";
@@ -13,13 +14,22 @@ import TabHistory from "./TabHistory.vue";
 import CompletedForms from "./CompletedForms.vue";
 import TabFiles from "./TabFiles.vue";
 import Overview from "./Overview.vue";
-import { getRequestCount } from "../variables/index";
+import ErrorsTab from "./ErrorsTab.vue";
+import { getRequestCount, isErrors } from "../variables/index";
 
 const translate = ProcessMaker.i18n;
 
-const tabDefault = ref("tasks");
+const tabDefault = computed(() => {
+  if (isErrors()) {
+    return "errors";
+  }
+  return "tasks";
+});
 
 const tabs = [
+  {
+    name: translate.t("Errors"), href: "#errors", current: "errors", show: isErrors(), content: ErrorsTab,
+  },
   {
     name: translate.t("Tasks"), href: "#tasks", current: "tasks", show: true, content: TaskTable,
   },

--- a/resources/jscomposition/cases/casesDetail/components/ErrorsTab.vue
+++ b/resources/jscomposition/cases/casesDetail/components/ErrorsTab.vue
@@ -1,0 +1,19 @@
+<template>
+  <RequestErrorsVue
+    class="tw-w-full"
+    :errors="errors"
+  />
+</template>
+
+<script setup>
+import { onMounted, ref } from "vue";
+import RequestErrorsVue from "../../../../js/requests/components/RequestErrors.vue";
+import { getErrors } from "../variables/index";
+
+const errors = ref([]);
+
+onMounted(() => {
+  errors.value = getErrors();
+});
+
+</script>

--- a/resources/jscomposition/cases/casesDetail/variables/index.js
+++ b/resources/jscomposition/cases/casesDetail/variables/index.js
@@ -17,3 +17,7 @@ export const getComentableType = () => comentable_type;
 export const getProcessName = () => request.process.name;
 
 export const getRequestCount = () => requestCount;
+
+export const getErrors = () => errorLogs;
+
+export const isErrors = () => request.status === "ERROR";


### PR DESCRIPTION
## Issue & Reproduction Steps
When the case has an error, the Error tab should appear and display the errors detected.
If the Case has more than  one Request, it should show all the errors like actually does when you open the request:

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20108

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy