### PR TITLE
FOUR-20087 Fix logout flow

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -261,6 +261,9 @@ class LoginController extends Controller
             // Notify to listeners (package-auth, security logger)
             $eventResult = event(new Logout(Auth::user()));
 
+            // Perform the logout operation
+            $this->logout($request);
+
             // Remove the Laravel cookie
             Cookie::queue(Cookie::forget(Passport::cookie()));
 

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -59,7 +59,9 @@ return [
     // All of the Laravel SAML IdP event / listener mappings.
     'events' => [
         'CodeGreenCreative\SamlIdp\Events\Assertion' => [],
-        'Illuminate\Auth\Events\Logout' => ['CodeGreenCreative\SamlIdp\Listeners\SamlLogout'],
+        // Disable the logout event listener because it causes a redirect abort
+        // Note: saml logout redirect is being processed in the LoginController::beforeLogout
+        // 'Illuminate\Auth\Events\Logout' => ['CodeGreenCreative\SamlIdp\Listeners\SamlLogout'],
         'Illuminate\Auth\Events\Authenticated' => ['ProcessMaker\Listeners\SamlAuthenticated'],
         'Illuminate\Auth\Events\Login' => ['ProcessMaker\Listeners\SamlLogin'],
     ],

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -3,9 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\User;
 use Tests\TestCase;
 
@@ -73,5 +71,24 @@ class AuthTest extends TestCase
         $response->assertRedirect('/');
 
         $response->assertSessionHasNoErrors();
+    }
+
+    /**
+     * 
+     * Test logout flow
+     */
+    public function testLogoutStandard()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'web');
+        // open logout url
+        $response = $this->get('logout');
+
+        // Verify it redirects to the login page
+        $response->assertRedirect('/login');
+
+        // Verify if the user is logged out
+        $response = $this->get(route('home'));
+        $response->assertRedirect('/login');
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The logout flow was being aborted by a saml listener.

## Solution
- Fix the logout flow.

## How to Test
- Configure SAML.
- Test login with SAML.
- Logout
- Verify the SAML logout also logs out from ProcessMaker
- Test login with normal ProcessMaker login
- Logout
- Verify the user log out

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20087

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
