### PR TITLE
Allow the SDK to get sync script responses

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -222,6 +222,10 @@ class ScriptController extends Controller
      *                 type="array",
      *                 @OA\Items (type="object"),
      *             ),
+     *             @OA\Property(
+     *                 property="sync",
+     *                 type="boolean",
+     *             ),
      *           ),
      *         ),
      *

--- a/ProcessMaker/Models/Script.php
+++ b/ProcessMaker/Models/Script.php
@@ -58,6 +58,7 @@ use ProcessMaker\Validation\CategoryRule;
  *   schema="scriptsPreview",
  *   @OA\Property(property="status", type="string"),
  *   @OA\Property(property="key", type="string"),
+ *   @OA\Property(property="output", type="object"),
  * )
  */
 class Script extends ProcessMakerModel implements ScriptInterface


### PR DESCRIPTION
## Issue & Reproduction Steps
SDK does not allow sync=true parameter

## Solution
- Add it

## How to Test
Script 1
```
return ['foo' => 'bar'];
```
Script 2
```
$response = $api->scripts()->executeScript(1, ['sync' => true]);
return ['response' => $response['output']];
```
Change the first argument to `executeScript` above to the Script 1 ID
Run Script 2 and ensure we get the response from script 1: `['response' => ['foo' => 'bar']];`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17328

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
