### PR TITLE
Observation/FOUR-19978: Not all strings are added to the Json file for translation.

### DIFF
--- a/resources/js/processes/designer/ProjectsLastModifiedListing.vue
+++ b/resources/js/processes/designer/ProjectsLastModifiedListing.vue
@@ -110,12 +110,12 @@ export default {
       ],
       fields: [
         {
-          title: () => "Name",
+          title: () => this.$t("Name"),
           name: "__slot:title",
           sortField: "title",
         },
         {
-          title: () => "Modified",
+          title: () => this.$t("Modified"),
           name: "updated_at",
           sortField: "updated_at",
           callback: "formatDate",

--- a/resources/jscomposition/base/table/THeader.vue
+++ b/resources/jscomposition/base/table/THeader.vue
@@ -5,7 +5,7 @@
     <div
       class="tw-py-4 tw-px-3 tw-text-left tw-text-nowrap tw-whitespace-nowrap tw-overflow-hidden tw-text-ellipsis">
       <slot>
-        {{ getValue() }}
+        {{ $t(getValue()) }}
       </slot>
     </div>
 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2427,5 +2427,9 @@
   "Create a bundle to easily share assets and settings between ProcessMaker instances.": "Create a bundle to easily share assets and settings between ProcessMaker instances.",
   "In addition to the process manager, these users and groups will have permission to reassign any task in this process, regardless of the \"Allow Reassignment\" task setting.": "In addition to the process manager, these users and groups will have permission to reassign any task in this process, regardless of the \"Allow Reassignment\" task setting.",
   "Reassignment Permission": "Reassignment Permission",
-  "This task can not be reassigned": "This task can not be reassigned"
+  "This task can not be reassigned": "This task can not be reassigned",
+  "Start New Case": "Start New Case",
+  "No Case to Start": "No Case to Start",
+  "No Cases to Show": "No Cases to Show",
+  "Drafts": "Drafts"
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduced:**

- Select a language
- Log in with an admin user
- Go to the Home tab
- Go to the Admin tab and click Translations
- Go to the Designer tab
- Go to the Tasks tab
- Go to the Cases tab
- Go to the Processes tab

**Current Behavior:**
There are several untranslated fields.
- In Home--No Cases to Show, START NEW CASE
- In translations--Add language, Source String (English), botton translate with AI, the options select all fields, select empty - files, Default Anon language
- In designer--Name, Modified
- In tasks--Drafts, status
- In Cases--My cases, In progress, All cases, my requests, case, Case title, Process, task, participants, status, started completed, No new cases at this moment.
- In processes--Search Categories and processes

## Solution
- Translate missing texts

## IMPORTANT
Some translations are missing in the **es.json** file, we need to manually run the script to translate missing transaltions.

## Related Tickets & Packages
- [FOUR- 19978](https://processmaker.atlassian.net/browse/FOUR-19978)
- Core PR
- Package Translations PR
- Screen Builder PR

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
