### PR TITLE
FOUR-20060 | The Custom CSS Style Configured in the Request Detail Screen Is Not Rendering

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -130,8 +130,8 @@
                     <template v-if="showScreenRequestDetail && !showScreenSummary">
                       <div class="card">
                         <div class="card-body">
-                          <vue-form-renderer ref="screenRequestDetail" :config="screenRequestDetail"
-                            :custom-css="screenSummary?.custom_css"
+                          <vue-form-renderer ref="screenRequestDetail" :config="screenRequestDetail.config"
+                            :custom-css="screenRequestDetail.custom_css"
                             v-model="dataSummary" />
                         </div>
                       </div>
@@ -615,7 +615,17 @@
          * Get Screen request detail
          * */
         screenRequestDetail() {
-          return this.request.request_detail_screen ? this.request.request_detail_screen.config : null;
+          if (!this.request.request_detail_screen) {
+            return {
+              config: null,
+              custom_css: null,
+            };
+          }
+
+          return {
+            config: this.request.request_detail_screen.config,
+            custom_css: this.request.request_detail_screen.custom_css
+          };
         },
         classStatusCard() {
           let header = {


### PR DESCRIPTION
# Issue
Ticket: [FOUR-20060](https://processmaker.atlassian.net/browse/FOUR-20060)

When a Request Detail Screen is configured in a Process, users are unable to see the intended styling on completed Request Detail Screens due to missing custom CSS.

# Solution
- Update the `screenRequestDetail` computed property in `/resources/views/requests/show.blade.php`. The property was only returning the `request_detail_screen.config`. Now it returns the `config` and the `custom_css`.
- Update the props passed to `vue-form-renderer` for Request Detail Screens
	- `config` prop is now `screenRequestDetail.config`
	- `custom-css` prop is now `screenRequestDetail.custom_css`

# How to Test
1. Go to branch `observation/FOUR-20060` in `processmaker`.
2. Go to Designer → Screens. Create a Screen with Custom CSS.
3. Go to Designer → Processes. Create a Process.
4. Configure your created screen as the 'Request Detail Screen'.
5. Add a Start Event, Task, and End Event to the Process. Configure the task. (It does not matter what Screen is used for the Task.)
6. Start a Case.
7. Complete the Case.
8. In the Summary tab of the Request Detail page, the Screen should display with CSS.

ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-20060]: https://processmaker.atlassian.net/browse/FOUR-20060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ