### PR TITLE
FOUR-20158 script executors option is not displayed in the left sidebar

### DIFF
--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -115,6 +115,11 @@ class GenerateMenus
                     'icon' => 'fa-infinity',
                 ]);
 
+                $submenu->add(__('Script Executors'), [
+                    'route' => 'script-executors.index',
+                    'icon' => 'fa-code',
+                ]);
+
                 $devlinkIcon = base64_encode(file_get_contents(base_path('resources/img/devlink.svg')));
                 $submenu->add(__('DevLink'), [
                     'route' => 'devlink.index',


### PR DESCRIPTION
## Issue & Reproduction Steps
Script executors option is not displayed in the left sidebar

## Solution
- Restore the `Script executors` option in the sidebar

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-20158](https://processmaker.atlassian.net/browse/FOUR-20158)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20158]: https://processmaker.atlassian.net/browse/FOUR-20158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ