### PR TITLE
FOUR-20098 Fix redirect problem after login

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -261,6 +261,9 @@ class LoginController extends Controller
             // Notify to listeners (package-auth, security logger)
             $eventResult = event(new Logout(Auth::user()));
 
+            // Perform the logout operation
+            $this->logout($request);
+
             // Remove the Laravel cookie
             Cookie::queue(Cookie::forget(Passport::cookie()));
 

--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -41,6 +41,7 @@ class Kernel extends HttpKernel
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             Middleware\GenerateMenus::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
+            \ProcessMaker\Http\Middleware\IgnoreMapFiles::class,
         ],
         'api' => [
             // API Middleware is defined with routeMiddleware below.

--- a/ProcessMaker/Http/Middleware/IgnoreMapFiles.php
+++ b/ProcessMaker/Http/Middleware/IgnoreMapFiles.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+
+class IgnoreMapFiles
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        // Check if the request is for a .map file (this means it does not exist in public folder)
+        if ($request->is('*.map')) {
+            // Return a 204 No Content response to avoid use it as processmaker_intended url
+            return response('', 204);
+        }
+
+        // Continue with the request if it's not a .map file
+        return $next($request);
+    }
+}

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -59,7 +59,9 @@ return [
     // All of the Laravel SAML IdP event / listener mappings.
     'events' => [
         'CodeGreenCreative\SamlIdp\Events\Assertion' => [],
-        'Illuminate\Auth\Events\Logout' => ['CodeGreenCreative\SamlIdp\Listeners\SamlLogout'],
+        // Disable the logout event listener because it causes a redirect abort
+        // Note: saml logout redirect is being processed in the LoginController::beforeLogout
+        // 'Illuminate\Auth\Events\Logout' => ['CodeGreenCreative\SamlIdp\Listeners\SamlLogout'],
         'Illuminate\Auth\Events\Authenticated' => ['ProcessMaker\Listeners\SamlAuthenticated'],
         'Illuminate\Auth\Events\Login' => ['ProcessMaker\Listeners\SamlLogin'],
     ],

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -3,9 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\User;
 use Tests\TestCase;
 
@@ -73,5 +71,24 @@ class AuthTest extends TestCase
         $response->assertRedirect('/');
 
         $response->assertSessionHasNoErrors();
+    }
+
+    /**
+     * 
+     * Test logout flow
+     */
+    public function testLogoutStandard()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'web');
+        // open logout url
+        $response = $this->get('logout');
+
+        // Verify it redirects to the login page
+        $response->assertRedirect('/login');
+
+        // Verify if the user is logged out
+        $response = $this->get(route('home'));
+        $response->assertRedirect('/login');
     }
 }

--- a/tests/Feature/LoginRedirectTest.php
+++ b/tests/Feature/LoginRedirectTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Hash;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class LoginRedirectTest extends TestCase
+{
+    /**
+     * 
+     * Test to verify that the login page redirects to the about page
+     */
+    public function testLoginRedirect()
+    {
+        $user = User::factory()->create([
+            'username' =>'newuser',
+            'password' => Hash::make('password'),
+        ]);
+        $this->actingAs($user, 'web');
+        // open logout url
+        $response = $this->get('logout');
+
+        // Verify it redirects to the login page
+        $response->assertRedirect('/login');
+
+        // When we try to open the about page, we should be redirected to the login page 
+        $response = $this->get(route('about.index'));
+        $response->assertRedirect('/login');
+
+        // Do POST login and verify redirect to about page
+        $response = $this->post('login', [
+            'username' => 'newuser',
+            'password' => 'password',
+        ]);
+        $response->assertRedirect(route('about.index'));
+    }
+
+    public function testLoginRedirectWithDevtoolsOpeningMapFile()
+    {
+        $user = User::factory()->create([
+            'username' =>'newuser',
+            'password' => Hash::make('password'),
+        ]);
+        $this->actingAs($user, 'web');
+        // open logout url
+        $response = $this->get('logout');
+
+        // Verify it redirects to the login page
+        $response->assertRedirect('/login');
+
+        // When we try to open the about page, we should be redirected to the login page 
+        $response = $this->get(route('about.index'));
+        $response->assertRedirect('/login');
+
+        // Devtools opening a map file
+        $response = $this->get('/js/missing.js.map');
+
+        // Do POST login and verify redirect to about page not to the map file
+        $response = $this->post('login', [
+            'username' => 'newuser',
+            'password' => 'password',
+        ]);
+        $response->assertRedirect(route('about.index'));
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
When user opens devtools, and the map files from frontend assets are missing (in public/), it causes ProcessMaker try to return a map file registering its URL as the intended URL when user tries to login.

## Solution
- Ignore map files in ProcessMaker routes

## How to Test
- Open chrome devtools
- Without session, open a processmaker path like `/requests`
- Login
- Once fixed it will go to the `/requests` route

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20098
- Requires: https://github.com/ProcessMaker/processmaker/pull/7734

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
