### PR TITLE
FOUR-20218 the cases list does not search correctly when the case_title has an underscore

### DIFF
--- a/ProcessMaker/Repositories/CaseApiRepository.php
+++ b/ProcessMaker/Repositories/CaseApiRepository.php
@@ -155,7 +155,7 @@ class CaseApiRepository implements CaseApiRepositoryInterface
                 $search = CaseUtils::CASE_NUMBER_PREFIX . $search;
             } else {
                 // Remove special characters except another languages
-                $search = preg_replace(['/[^\p{L}\p{N}\s\']/u', '/\s{2,}/'], [' ', ' '], $search);
+                $search = preg_replace(['/[^\p{L}\p{N}\s\_\']/u', '/\s{2,}/'], [' ', ' '], $search);
             }
 
             // Add a plus (+) to the beginning and an asterisk (*) to the end of each word


### PR DESCRIPTION
## Issue & Reproduction Steps
The cases list does not search correctly when the case_title has an underscore

## Solution
- Accept underscores on case_title for the FullText search

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-20218](https://processmaker.atlassian.net/browse/FOUR-20218)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20218]: https://processmaker.atlassian.net/browse/FOUR-20218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ