### PR TITLE
bugfix/FOUR-17731: 39399 -Missing INDEX for task_drafts table

### DIFF
--- a/database/migrations/2024_02_20_193849_create_task_drafts_table.php
+++ b/database/migrations/2024_02_20_193849_create_task_drafts_table.php
@@ -16,6 +16,8 @@ return new class extends Migration
             $table->integer('task_id');
             $table->json('data');
             $table->timestamps();
+            
+            $table->index('task_id', 'taskId');
         });
     }
 

--- a/database/migrations/2024_02_20_193849_create_task_drafts_table.php
+++ b/database/migrations/2024_02_20_193849_create_task_drafts_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -16,8 +15,6 @@ return new class extends Migration
             $table->integer('task_id');
             $table->json('data');
             $table->timestamps();
-            
-            $table->index('task_id', 'taskId');
         });
     }
 

--- a/database/migrations/2024_11_15_122455_add_index_to_task_id_column_for_task_drafts_table.php
+++ b/database/migrations/2024_11_15_122455_add_index_to_task_id_column_for_task_drafts_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('task_drafts', function (Blueprint $table) {
+            $table->index('task_id', 'taskId');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('task_drafts', function (Blueprint $table) {
+            $table->dropIndex('taskId');
+        });
+    }
+};

--- a/database/migrations/2024_11_15_122455_add_index_to_task_id_column_for_task_drafts_table.php
+++ b/database/migrations/2024_11_15_122455_add_index_to_task_id_column_for_task_drafts_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('task_drafts', function (Blueprint $table) {


### PR DESCRIPTION
## Solution
- A new migration file was created to add the INDEX to task_id column in task_drafts table after this table is created. Notice this index was not added into create migration file for task_drafts table, because this table might already exist in some environments.

This INDEX was created following the suggestion in ticket mentioned below FOUR-17731.

## How to Test
- Verify indexes in table task_drafts in database before execute migrations command (there should not be Index for task_id column)
- Execute: php artisan migrate
- Verify a new INDEX called taskId was created for task_id column in task_drafts table

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17731

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
