### PR TITLE
Fix Default Template Author Display Regression

### DIFF
--- a/resources/js/components/AvatarImage.vue
+++ b/resources/js/components/AvatarImage.vue
@@ -44,7 +44,8 @@
             <template v-else>
               {{ limitCharacters(value.name) }}
             </template>
-          </span>
+          </span> 
+          <span v-else-if="usePmDefaultLabel">{{ $t('ProcessMaker') }}</span>
           <span v-else><b-badge class="status-alternative-a">{{ $t('Unclaimed') }}</b-badge></span>
       </span>
       </div>
@@ -93,6 +94,10 @@ export default {
     customStyle: {
       type: String,
       default: '',
+    },
+    usePmDefaultLabel: {
+      type: Boolean,
+      default: false,
     }
   },
   data() {

--- a/resources/js/components/shared/FilterTableBodyMixin.js
+++ b/resources/js/components/shared/FilterTableBodyMixin.js
@@ -39,7 +39,7 @@ export default {
       this.perPage = value;
       this.fetch();
     },
-    formatAvatar(user) {
+    formatAvatar(user, $usePmDefaultLabel = false) {
       return {
         component: "AvatarImage",
         props: {
@@ -47,6 +47,7 @@ export default {
           "input-data": user,
           "hide-name": false,
           "name-clickable": true,
+          'use-pm-default-label': $usePmDefaultLabel
         },
       };
     },

--- a/resources/js/templates/components/ProcessTemplatesListing.vue
+++ b/resources/js/templates/components/ProcessTemplatesListing.vue
@@ -242,7 +242,8 @@
 
           for (let record of data.data) {
             //format Status
-            record["owner"] = this.formatAvatar(record["user"]);
+            const usePmDefaultLabel = !record['user'];
+            record["owner"] = this.formatAvatar(record["user"], usePmDefaultLabel);
             record["category_list"] = this.formatCategory(record["categories"]);
           }
           return data;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves a regression where the default template author was incorrectly displayed as 'Unclaimed' instead of 'ProcessMaker'. The issue stemmed from the implementation of [FOUR-20005](https://processmaker.atlassian.net/browse/FOUR-20005), which inadvertently updated the 'ProcessMaker' label to 'Unclaimed'.

## Solution
- Introduced a new flag, userDefaultPmLabel, to conditionally render the correct label.
     - If `userDefaultPmLabel` is true, the label displays as 'ProcessMaker'.
     - If `userDefaultPmLabel` is false and no user is assigned, the label defaults to 'Unclaimed'.

## How to Test

1. Ensure default process templates are available in your environment by running: 
`php artisan processmaker:sync-default-templates`
2. Navigate to Processes > Templates in the ProcessMaker UI.
3. Confirm that default templates display 'ProcessMaker' as the template author.
4. Verify that templates without assigned authors show 'Unclaimed' when the flag is set to false.

## Related Tickets & Packages
- [FOUR-20253](https://processmaker.atlassian.net/browse/FOUR-20253)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20005]: https://processmaker.atlassian.net/browse/FOUR-20005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-20253]: https://processmaker.atlassian.net/browse/FOUR-20253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ