### PR TITLE
FOUR-20266 Improve modifying exception messages in RunServiceTask

### DIFF
--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Jobs;
 
+use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Log;
 use ProcessMaker\Exception\ConfigurationException;
@@ -127,8 +128,11 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
             $error->setName($message);
 
             $token->setProperty('error', $error);
-            $exceptionClass = get_class($exception);
-            $modifiedException = new $exceptionClass($message);
+            if ($message !== $exception->getMessage()) {
+                $modifiedException = new Exception($message, $exception->getCode(), $exception);
+            } else {
+                $modifiedException = $exception;
+            }
             $token->logError($modifiedException, $element);
 
             Log::error('Service task failed: ' . $implementation . ' - ' . $message);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,18 +3,15 @@
 namespace Tests;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-use Illuminate\Database\DatabaseManager;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Bus;
 use PDOException;
+use ProcessMaker\ImportExport\Importer;
+use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Jobs\RefreshArtisanCaches;
 use ProcessMaker\Models\Process;
-use ProcessMaker\Models\ProcessRequest;
-use ProcessMaker\Models\ProcessRequestLock;
-use ProcessMaker\Models\SecurityLog;
-use ProcessMaker\Models\Setting;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -125,6 +122,30 @@ abstract class TestCase extends BaseTestCase
         ];
 
         return Process::factory()->create(array_merge($data, $attributes));
+    }
+
+    /**
+     * Creates a Process instance from a JSON file.
+     *
+     * This method reads the specified JSON file, merges the provided attributes,
+     * and creates a new Process instance.
+     *
+     * @param string $jsonFile The path to the JSON file containing the process definition.
+     * @param array $attributes Additional attributes to merge into the process definition.
+     * @return Process The created Process instance.
+     */
+    protected function createProcessFromJSON(string $jsonFile, array $attributes = []): Process
+    {
+        $payload = json_decode(file_get_contents($jsonFile), true);
+        $options = new Options([]);
+        $importer = new Importer($payload, $options);
+        $importer->previewImport();
+        $manifest = $importer->doImport();
+        $processId = $manifest[$payload['root']]->log['newId'];
+        $process = Process::find($processId);
+        $process->update($attributes);
+
+        return $process;
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Wrong modifying exception messages in RunServiceTask

## Solution
- Improve modifying exception messages in RunServiceTask.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20266

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
