### PR TITLE
20045 - Fix process name filter in "Processes I Manage"

### DIFF
--- a/ProcessMaker/Filters/BaseFilter.php
+++ b/ProcessMaker/Filters/BaseFilter.php
@@ -27,6 +27,8 @@ abstract class BaseFilter
 
     public const TYPE_PROCESS = 'Process';
 
+    public const TYPE_PROCESS_NAME = 'ProcessName';
+
     public const TYPE_RELATIONSHIP = 'Relationship';
 
     public string|null $subjectValue;
@@ -96,6 +98,8 @@ abstract class BaseFilter
             $this->valueAliasAdapter($valueAliasMethod, $query);
         } elseif ($this->subjectType === self::TYPE_PROCESS) {
             $this->filterByProcessId($query);
+        } elseif ($this->subjectType === self::TYPE_PROCESS_NAME) {
+            $this->filterByProcessName($query);
         } elseif ($this->subjectType === self::TYPE_RELATIONSHIP) {
             $this->filterByRelationship($query);
         } elseif ($this->isJsonData() && $query->getModel() instanceof ProcessRequestToken) {
@@ -224,6 +228,10 @@ abstract class BaseFilter
             return $this->relationshipSubjectTypeParts()[1];
         }
 
+        if ($this->subjectType === self::TYPE_PROCESS_NAME) {
+            return 'name';
+        }
+
         return $this->subjectValue;
     }
 
@@ -295,6 +303,18 @@ abstract class BaseFilter
             });
         } else {
             $this->applyQueryBuilderMethod($query);
+        }
+    }
+
+    private function filterByProcessName(Builder $query): void
+    {
+        if ($query->getModel() instanceof ProcessRequestToken) {
+            $query->whereIn('process_request_id', function ($query) {
+                $query->select('id')->from('process_requests');
+                $this->applyQueryBuilderMethod($query);
+            });
+        } else {
+            $query->whereIn('name', (array) $this->value());
         }
     }
 

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -320,7 +320,7 @@ trait TaskControllerIndexMethods
                 ->orWhereIn('id', $user->availableSelfServiceTaskIds());
         });
     }
-    
+
     public function applyProcessManager($query, $user)
     {
         $ids = Process::select(['id'])
@@ -329,7 +329,7 @@ trait TaskControllerIndexMethods
             ->get()
             ->toArray();
 
-        $query->orWhere(function ($query) use ($ids) {
+        $query->where(function ($query) use ($ids) {
             $query->whereIn('process_request_tokens.process_id', array_column($ids, 'id'))
                 ->where('process_request_tokens.status', 'ACTIVE');
         });


### PR DESCRIPTION
## Issue & Reproduction Steps
No process name filter exists in the backend for process name (only for Case name)

## Solution
- Add the process name filter
- Fix one other issues where a query should be 'and' instead of 'or'
- Remove the "Reassign" button since it does not work on that page

## How to Test
See jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20045
- Requires: https://github.com/ProcessMaker/package-savedsearch/pull/487

ci:package-savedsearch:bugfix/FOUR-20045

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
