### PR TITLE
FOUR-20504 enhance test coverage for settings functionality before adding cache

### DIFF
--- a/tests/Feature/Api/SettingAuthTest.php
+++ b/tests/Feature/Api/SettingAuthTest.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ProcessMaker\Models\ProcessCategory;
+use ProcessMaker\Models\ScriptExecutor;
+use ProcessMaker\Package\Auth\Database\Seeds\AtlassianSeeder;
+use ProcessMaker\Package\Auth\Database\Seeds\Auth0Seeder;
+use ProcessMaker\Package\Auth\Database\Seeds\AuthSeeder;
+use ProcessMaker\Package\Auth\Database\Seeds\FacebookSeeder;
+use ProcessMaker\Package\Auth\Database\Seeds\GitHubSeeder;
+use ProcessMaker\Package\Auth\Database\Seeds\GoogleSeeder;
+use ProcessMaker\Package\Auth\Database\Seeds\KeycloakSeeder;
+use ProcessMaker\Package\Auth\Database\Seeds\LdapSeeder;
+use ProcessMaker\Package\Auth\Database\Seeds\MicrosoftSeeder;
+use ProcessMaker\Package\Auth\Database\Seeds\SamlSeeder;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class SettingAuthTest extends TestCase
+{
+    use RequestHelper;
+    use RefreshDatabase;
+
+    private function seedLDAPSettings()
+    {
+        ScriptExecutor::factory()->create([
+            'title' => 'Node Executor',
+            'description' => 'Default Javascript/Node Executor',
+            'language' => 'javascript',
+        ]);
+
+        ProcessCategory::factory()->create([
+            'name' => 'System',
+            'status' => 'ACTIVE',
+            'is_system' => true,
+        ]);
+
+        \Artisan::call('db:seed', ['--class' => LdapSeeder::class, '--force' => true]);
+    }
+
+    public function testDefaultLdapSettings()
+    {
+        $this->seedLDAPSettings();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'LDAP', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $response->assertStatus(200);
+        $this->assertCount(18, $response['data']);
+
+        $this->assertDatabaseCount('settings', 38);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.enabled', 'name' => 'Enabled', 'format' => 'boolean']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.cron.period', 'name' => 'Synchronization Schedule', 'format' => 'object']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.type', 'name' => 'Type', 'format' => 'choice']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.server.address', 'name' => 'Server Address', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.server.port', 'name' => 'Server Port', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.server.tls', 'name' => 'TLS', 'format' => 'boolean']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.base_dn', 'name' => 'Base DN', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.authentication.username', 'name' => 'Username', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.authentication.password', 'name' => 'Password', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.groups', 'name' => 'Groups To Import', 'format' => 'checkboxes']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.departments', 'name' => 'Departments To Import', 'format' => 'checkboxes']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.identifiers.user', 'name' => 'User Identifier', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.identifiers.group', 'name' => 'Group Identifier', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.identifiers.user_class', 'name' => 'User Class Identifier', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.identifiers.group_class', 'name' => 'Group Class Identifier', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.variables', 'name' => 'Variable Map', 'format' => 'object']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.users.chunksize', 'name' => 'Chunk Size for User Import', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.log', 'name' => 'Logs', 'format' => 'button']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.certificate_file', 'name' => 'Certificate location', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.ldap.certificate', 'name' => 'Certificate', 'format' => 'file']);
+
+        $this->assertDatabaseCount('security_logs', 0);
+    }
+
+    public function testUpdateLdapSettings()
+    {
+        $this->seedLDAPSettings();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'LDAP', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(18, $response['data']);
+
+        $enabled = $response['data'][0];
+        $this->assertEquals('Enabled', $enabled['name']);
+        $this->assertEquals(0, $enabled['config']);
+
+        $syncSchedule = $response['data'][1];
+        $this->assertEquals('Synchronization Schedule', $syncSchedule['name']);
+        $this->assertEquals(['quantity' => 1, "units" => "days"], $syncSchedule['config']);
+
+        $type = $response['data'][2];
+        $this->assertEquals('Type', $type['name']);
+        $this->assertNull($type['config']);
+
+        $serverAddress = $response['data'][3];
+        $this->assertEquals('Server Address', $serverAddress['name']);
+        $this->assertNull($serverAddress['config']);
+
+        $serverPort = $response['data'][4];
+        $this->assertEquals('Server Port', $serverPort['name']);
+        $this->assertEquals(636, $serverPort['config']);
+
+        $tls = $response['data'][5];
+        $this->assertEquals('TLS', $tls['name']);
+        $this->assertEquals(1, $tls['config']);
+
+        $username = $response['data'][8];
+        $this->assertEquals('Username', $username['name']);
+        $this->assertNull($username['config']);
+
+        $password = $response['data'][9];
+        $this->assertEquals('Password', $password['name']);
+        $this->assertNull($password['config']);
+
+        $data = array_merge($enabled, ['config' => 1]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $enabled['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $enabled['id'], 'config' => 1]);
+
+        $data = array_merge($syncSchedule, ['config' => ['quantity' => 2, "units" => "hours"]]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $syncSchedule['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $syncSchedule['id'], 'config' => json_encode(['quantity' => 2, "units" => "hours"])]);
+
+        $data = array_merge($type, ['config' => 'ad']);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $type['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $type['id'], 'config' => 'ad']);
+
+        $data = array_merge($type, ['config' => '389ds']);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $type['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $type['id'], 'config' => '389ds']);
+
+        $data = array_merge($type, ['config' => 'openldap']);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $type['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $type['id'], 'config' => 'openldap']);
+
+        $data = array_merge($serverAddress, ['config' => 'ldap://ldap.example.com']);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $serverAddress['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $serverAddress['id'], 'config' => 'ldap://ldap.example.com']);
+
+        $data = array_merge($serverPort, ['config' => 389]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $serverPort['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $serverPort['id'], 'config' => 389]);
+
+        $data = array_merge($tls, ['config' => 0]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $tls['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $tls['id'], 'config' => 0]);
+
+        $data = array_merge($username, ['config' => 'admin']);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $username['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $username['id'], 'config' => 'admin']);
+
+        $data = array_merge($password, ['config' => 'password']);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $password['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $password['id'], 'config' => 'password']);
+
+        $this->assertDatabaseCount('security_logs', 10);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $enabled['id']]);
+    }
+
+    public function testDefaultSsoSettings()
+    {
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'SSO', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $response->assertStatus(200);
+        $this->assertCount(0, $response['data']);
+
+        \Artisan::call('db:seed', ['--class' => AuthSeeder::class, '--force' => true]);
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'SSO', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $response->assertStatus(200);
+        $this->assertCount(4, $response['data']);
+
+        $this->assertDatabaseCount('settings', 23);
+        $this->assertDatabaseHas('settings', ['key' => 'standard-login.enabled', 'name' => 'Allow Standard Login', 'format' => 'boolean']);
+        $this->assertDatabaseHas('settings', ['key' => 'sso.automatic_user_creation', 'name' => 'Automatic Registration', 'format' => 'boolean']);
+        $this->assertDatabaseHas('settings', ['key' => 'sso.user_default_config', 'name' => 'New User Default Config', 'format' => 'object']);
+        $this->assertDatabaseHas('settings', ['key' => 'sso.debug', 'name' => 'Debug Mode', 'format' => 'boolean']);
+        $this->assertDatabaseHas('settings', ['key' => 'package.auth.installed']);
+
+        \Artisan::call('db:seed', ['--class' => AtlassianSeeder::class, '--force' => true]);
+        \Artisan::call('db:seed', ['--class' => Auth0Seeder::class, '--force' => true]);
+        \Artisan::call('db:seed', ['--class' => FacebookSeeder::class, '--force' => true]);
+        \Artisan::call('db:seed', ['--class' => GitHubSeeder::class, '--force' => true]);
+        \Artisan::call('db:seed', ['--class' => GoogleSeeder::class, '--force' => true]);
+        \Artisan::call('db:seed', ['--class' => KeycloakSeeder::class, '--force' => true]);
+        \Artisan::call('db:seed', ['--class' => MicrosoftSeeder::class, '--force' => true]);
+        \Artisan::call('db:seed', ['--class' => SamlSeeder::class, '--force' => true]);
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'SSO', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $response->assertStatus(200);
+        $this->assertCount(12, $response['data']);
+        $this->assertDatabaseCount('settings', 69);
+
+        $this->assertDatabaseHas('settings', ['key' => 'services.atlassian.client_id', 'name' => 'Client ID', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.atlassian.client_secret', 'name' => 'Client Secret', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.atlassian.redirect', 'name' => 'Redirect', 'format' => 'text']);
+
+        $this->assertDatabaseHas('settings', ['key' => 'services.auth0.client_id', 'name' => 'Client ID', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.auth0.redirect', 'name' => 'Callback URL', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.auth0.client_secret', 'name' => 'Client Secret', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.auth0.base_url', 'name' => 'Domain', 'format' => 'text']);
+
+        $this->assertDatabaseHas('settings', ['key' => 'services.facebook.client_id', 'name' => 'App ID', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.facebook.client_secret', 'name' => 'App Secret', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.facebook.redirect', 'name' => 'Redirect', 'format' => 'text']);
+
+        $this->assertDatabaseHas('settings', ['key' => 'services.github.client_id', 'name' => 'Client ID', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.github.redirect', 'name' => 'Redirect', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.github.client_secret', 'name' => 'Client Secret', 'format' => 'text']);
+
+        $this->assertDatabaseHas('settings', ['key' => 'services.google.redirect', 'name' => 'Redirect', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.google.client_id', 'name' => 'Client ID', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.google.client_secret', 'name' => 'Client Secret', 'format' => 'text']);
+
+        $this->assertDatabaseHas('settings', ['key' => 'services.keycloak.base_url', 'name' => 'Base URL', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.keycloak.client_secret', 'name' => 'Client Secret', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.keycloak.realms', 'name' => 'Realm', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.keycloak.client_id', 'name' => 'Client ID', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.keycloak.redirect', 'name' => 'Redirect', 'format' => 'text']);
+
+        $this->assertDatabaseHas('settings', ['key' => 'services.microsoft.redirect', 'name' => 'Redirect', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.microsoft.client_id', 'name' => 'Client ID', 'format' => 'text']);
+        $this->assertDatabaseHas('settings', ['key' => 'services.microsoft.client_secret', 'name' => 'Client Secret', 'format' => 'text']);
+
+        $this->assertDatabaseCount('security_logs', 0);
+    }
+
+    public function testUpdateSsoSettings()
+    {
+        \Artisan::call('db:seed', ['--class' => AuthSeeder::class, '--force' => true]);
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'SSO', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(4, $response['data']);
+
+        $allowStandardLogin = $response['data'][0];
+        $this->assertEquals('Allow Standard Login', $allowStandardLogin['name']);
+        $this->assertEquals(1, $allowStandardLogin['config']);
+
+        $automaticRegistration = $response['data'][1];
+        $this->assertEquals('Automatic Registration', $automaticRegistration['name']);
+        $this->assertEquals(1, $automaticRegistration['config']);
+
+        $newUserDefaultConfig = $response['data'][2];
+        $this->assertEquals('New User Default Config', $newUserDefaultConfig['name']);
+        $this->assertEquals(['permissions' => [], 'groups' => []], $newUserDefaultConfig['config']);
+
+        $debugMode = $response['data'][3];
+        $this->assertEquals('Debug Mode', $debugMode['name']);
+        $this->assertEquals(0, $debugMode['config']);
+
+        $data = array_merge($allowStandardLogin, ['config' => 1]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $allowStandardLogin['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $allowStandardLogin['id'], 'config' => 1]);
+
+        $data = array_merge($automaticRegistration, ['config' => 0]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $automaticRegistration['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $automaticRegistration['id'], 'config' => 0]);
+
+        $data = array_merge($newUserDefaultConfig, ['config' => ['permissions' => ['view', 'edit'], 'groups' => ['admin', 'user']]]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $newUserDefaultConfig['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $newUserDefaultConfig['id'], 'config' => json_encode(['permissions' => ['view', 'edit'], 'groups' => ['admin', 'user']])]);
+
+        $data = array_merge($debugMode, ['config' => 1]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $debugMode['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $debugMode['id'], 'config' => 1]);
+
+        $this->assertDatabaseCount('security_logs', 4);
+    }
+}

--- a/tests/Feature/Api/SettingLogInOptionsTest.php
+++ b/tests/Feature/Api/SettingLogInOptionsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api;
 
-use ProcessMaker\Models\SecurityLog;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
@@ -35,9 +34,7 @@ class SettingLogInOptionsTest extends TestCase
         $response->assertJsonFragment(['name' => 'Require Two Step Authentication', 'key' => 'password-policies.2fa_enabled', 'format' => 'boolean']);
         $response->assertJsonFragment(['name' => 'Two Step Authentication Method', 'key' => 'password-policies.2fa_method', 'format' => 'checkboxes']);
 
-        $securityLogs = SecurityLog::where('event', 'SettingsUpdated')->count();
-
-        $this->assertEquals(0, $securityLogs);
+        $this->assertDatabaseCount('security_logs', 0);
     }
 
     public function testUpdatePasswordSetByUserSetting()

--- a/tests/Feature/Api/SettingLogInOptionsTest.php
+++ b/tests/Feature/Api/SettingLogInOptionsTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Feature\Api;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
 class SettingLogInOptionsTest extends TestCase
 {
     use RequestHelper;
+    use RefreshDatabase;
 
     private function upgrade()
     {

--- a/tests/Feature/Api/SettingLogInOptionsTest.php
+++ b/tests/Feature/Api/SettingLogInOptionsTest.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use ProcessMaker\Models\SecurityLog;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class SettingLogInOptionsTest extends TestCase
+{
+    use RequestHelper;
+
+    private function upgrade()
+    {
+        $this->artisan('migrate', [
+            '--path' => 'upgrades/2023_11_30_185738_add_password_policies_settings.php',
+        ])->run();
+    }
+
+    public function testDefaultLogInOptionsSettings()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $response->assertStatus(200);
+        $this->assertCount(10, $response['data']);
+        $response->assertJsonFragment(['name' => 'Password set by user', 'key' => 'password-policies.users_can_change', 'format' => 'boolean']);
+        $response->assertJsonFragment(['name' => 'Numeric characters', 'key' => 'password-policies.numbers', 'format' => 'boolean']);
+        $response->assertJsonFragment(['name' => 'Uppercase characters', 'key' => 'password-policies.uppercase', 'format' => 'boolean']);
+        $response->assertJsonFragment(['name' => 'Special characters', 'key' => 'password-policies.special', 'format' => 'boolean']);
+        $response->assertJsonFragment(['name' => 'Maximum length', 'key' => 'password-policies.maximum_length', 'format' => 'text']);
+        $response->assertJsonFragment(['name' => 'Minimum length', 'key' => 'password-policies.minimum_length', 'format' => 'text']);
+        $response->assertJsonFragment(['name' => 'Password expiration', 'key' => 'password-policies.expiration_days', 'format' => 'text']);
+        $response->assertJsonFragment(['name' => 'Login failed', 'key' => 'password-policies.login_attempts', 'format' => 'text']);
+        $response->assertJsonFragment(['name' => 'Require Two Step Authentication', 'key' => 'password-policies.2fa_enabled', 'format' => 'boolean']);
+        $response->assertJsonFragment(['name' => 'Two Step Authentication Method', 'key' => 'password-policies.2fa_method', 'format' => 'checkboxes']);
+
+        $securityLogs = SecurityLog::where('event', 'SettingsUpdated')->count();
+
+        $this->assertEquals(0, $securityLogs);
+    }
+
+    public function testUpdatePasswordSetByUserSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $passwordSetByUser = $response['data'][0];
+        $this->assertEquals('Password set by user', $passwordSetByUser['name']);
+        $this->assertEquals(true, $passwordSetByUser['config']);
+
+        $data = array_merge($passwordSetByUser, ['config' => false]);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $passwordSetByUser['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $passwordSetByUser['id'], 'config' => false]);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $passwordSetByUser['id']]);
+    }
+
+    public function testUpdateNumericCharactersSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $numericCharacters = $response['data'][1];
+        $this->assertEquals('Numeric characters', $numericCharacters['name']);
+        $this->assertEquals(true, $numericCharacters['config']);
+
+        $data = array_merge($numericCharacters, ['config' => false]);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $numericCharacters['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $numericCharacters['id'], 'config' => false]);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $numericCharacters['id']]);
+    }
+
+    public function testUpdateUppercaseCharactersSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $uppercaseCharacters = $response['data'][2];
+        $this->assertEquals('Uppercase characters', $uppercaseCharacters['name']);
+        $this->assertEquals(true, $uppercaseCharacters['config']);
+
+        $data = array_merge($uppercaseCharacters, ['config' => false]);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $uppercaseCharacters['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $uppercaseCharacters['id'], 'config' => false]);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $uppercaseCharacters['id']]);
+    }
+
+    public function testUpdateSpecialCharactersSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $specialCharacters = $response['data'][3];
+        $this->assertEquals('Special characters', $specialCharacters['name']);
+        $this->assertEquals(true, $specialCharacters['config']);
+
+        $data = array_merge($specialCharacters, ['config' => false]);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $specialCharacters['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $specialCharacters['id'], 'config' => false]);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $specialCharacters['id']]);
+    }
+
+    public function testUpdateMaximumLengthSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $maximumLength = $response['data'][4];
+        $this->assertEquals('Maximum length', $maximumLength['name']);
+        $this->assertNull($maximumLength['config']);
+
+        $data = array_merge($maximumLength, ['config' => '64']);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $maximumLength['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $maximumLength['id'], 'config' => '64']);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $maximumLength['id']]);
+    }
+
+    public function testUpdateMinimumLengthSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $minimumLength = $response['data'][5];
+        $this->assertEquals('Minimum length', $minimumLength['name']);
+        $this->assertEquals(8, $minimumLength['config']);
+
+        $data = array_merge($minimumLength, ['config' => '10']);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $minimumLength['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $minimumLength['id'], 'config' => '10']);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $minimumLength['id']]);
+    }
+
+    public function testUpdatePasswordExpirationSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $passwordExpiration = $response['data'][6];
+        $this->assertEquals('Password expiration', $passwordExpiration['name']);
+        $this->assertNull($passwordExpiration['config']);
+
+        $data = array_merge($passwordExpiration, ['config' => '30']);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $passwordExpiration['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $passwordExpiration['id'], 'config' => '30']);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $passwordExpiration['id']]);
+    }
+
+    public function testUpdateLoginFailedSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $loginFailed = $response['data'][7];
+        $this->assertEquals('Login failed', $loginFailed['name']);
+        $this->assertEquals(5, $loginFailed['config']);
+
+        $data = array_merge($loginFailed, ['config' => '3']);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $loginFailed['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $loginFailed['id'], 'config' => '3']);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $loginFailed['id']]);
+    }
+
+    public function testUpdateRequireTwoStepAuthenticationSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $requireTwoStepAuthentication = $response['data'][8];
+        $this->assertEquals('Require Two Step Authentication', $requireTwoStepAuthentication['name']);
+        $this->assertEquals(false, $requireTwoStepAuthentication['config']);
+
+        $data = array_merge($requireTwoStepAuthentication, ['config' => true]);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $requireTwoStepAuthentication['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $requireTwoStepAuthentication['id'], 'config' => true]);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $requireTwoStepAuthentication['id']]);
+    }
+
+    public function testUpdateTwoStepAuthenticationMethodSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Log-In Options', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(10, $response['data']);
+        $twoStepAuthenticationMethod = $response['data'][9];
+        $this->assertEquals('Two Step Authentication Method', $twoStepAuthenticationMethod['name']);
+        $this->assertEquals([], $twoStepAuthenticationMethod['config']);
+
+        $data = array_merge($twoStepAuthenticationMethod, ['config' => [['By email']]]);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $twoStepAuthenticationMethod['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $twoStepAuthenticationMethod['id'], 'config' => json_encode([['By email']])]);
+
+        $data = array_merge($twoStepAuthenticationMethod, ['config' => [['By message to phone number']]]);
+
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $twoStepAuthenticationMethod['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $twoStepAuthenticationMethod['id'], 'config' => json_encode([['By message to phone number']])]);
+
+        $data = array_merge($twoStepAuthenticationMethod, ['config' => [['Authenticator App']]]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $twoStepAuthenticationMethod['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $twoStepAuthenticationMethod['id'], 'config' => json_encode([['Authenticator App']])]);
+
+        $this->assertDatabaseCount('security_logs', 3);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $twoStepAuthenticationMethod['id']]);
+    }
+}

--- a/tests/Feature/Api/SettingSessionControlTest.php
+++ b/tests/Feature/Api/SettingSessionControlTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Feature\Api;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
 class SettingSessionControlTest extends TestCase
 {
     use RequestHelper;
+    use RefreshDatabase;
 
     private function upgrade()
     {
@@ -27,7 +29,7 @@ class SettingSessionControlTest extends TestCase
         $response->assertJsonFragment(['name' => 'Device restriction', 'key' => 'session-control.device_restriction', 'format' => 'choice']);
         $response->assertJsonFragment(['name' => 'Session Inactivity', 'key' => 'session.lifetime', 'format' => 'text']);
 
-        $this->assertDatabaseCount('settings', 3);
+        $this->assertDatabaseCount('settings', 21);
         $this->assertDatabaseCount('security_logs', 0);
     }
 

--- a/tests/Feature/Api/SettingSessionControlTest.php
+++ b/tests/Feature/Api/SettingSessionControlTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class SettingSessionControlTest extends TestCase
+{
+    use RequestHelper;
+
+    private function upgrade()
+    {
+        $this->artisan('migrate', [
+            '--path' => 'upgrades/2023_12_06_182508_add_session_control_settings.php',
+        ])->run();
+    }
+
+    public function testDefaultSessionControlSettings()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Session Control', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $response->assertStatus(200);
+        $this->assertCount(3, $response['data']);
+        $response->assertJsonFragment(['name' => 'IP restriction', 'key' => 'session-control.ip_restriction', 'format' => 'choice']);
+        $response->assertJsonFragment(['name' => 'Device restriction', 'key' => 'session-control.device_restriction', 'format' => 'choice']);
+        $response->assertJsonFragment(['name' => 'Session Inactivity', 'key' => 'session.lifetime', 'format' => 'text']);
+
+        $this->assertDatabaseCount('settings', 3);
+        $this->assertDatabaseCount('security_logs', 0);
+    }
+
+    public function testUpdateIPRestrictionSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Session Control', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(3, $response['data']);
+        $ipRestriction = $response['data'][0];
+        $this->assertEquals('IP restriction', $ipRestriction['name']);
+        $this->assertEquals(0, $ipRestriction['config']);
+
+        $data = array_merge($ipRestriction, ['config' => 1]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $ipRestriction['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $ipRestriction['id'], 'config' => 1]);
+
+        $data = array_merge($ipRestriction, ['config' => 2]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $ipRestriction['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $ipRestriction['id'], 'config' => 2]);
+
+        $data = array_merge($ipRestriction, ['config' => 0]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $ipRestriction['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $ipRestriction['id'], 'config' => 0]);
+
+        $this->assertDatabaseCount('security_logs', 3);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $ipRestriction['id']]);
+    }
+
+    public function testUpdateDeviceRestrictionSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Session Control', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(3, $response['data']);
+        $deviceRestriction = $response['data'][1];
+        $this->assertEquals('Device restriction', $deviceRestriction['name']);
+        $this->assertEquals(0, $deviceRestriction['config']);
+
+        $data = array_merge($deviceRestriction, ['config' => 1]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $deviceRestriction['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $deviceRestriction['id'], 'config' => 1]);
+
+        $data = array_merge($deviceRestriction, ['config' => 2]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $deviceRestriction['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $deviceRestriction['id'], 'config' => 2]);
+
+        $data = array_merge($deviceRestriction, ['config' => 0]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $deviceRestriction['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $deviceRestriction['id'], 'config' => 0]);
+
+        $this->assertDatabaseCount('security_logs', 3);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $deviceRestriction['id']]);
+    }
+
+    public function testUpdateSessionLifetimeSetting()
+    {
+        $this->upgrade();
+
+        $response = $this->apiCall('GET', route('api.settings.index', ['group' => 'Session Control', 'order_by' => 'name', 'order_direction' => 'ASC']));
+        $this->assertCount(3, $response['data']);
+        $sessionLifetime = $response['data'][2];
+        $this->assertEquals('Session Inactivity', $sessionLifetime['name']);
+        $this->assertEquals(120, $sessionLifetime['config']);
+
+        $data = array_merge($sessionLifetime, ['config' => 30]);
+        $response = $this->apiCall('PUT', route('api.settings.update', ['setting' => $sessionLifetime['id']]), $data);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('settings', ['id' => $sessionLifetime['id'], 'config' => 30]);
+
+        $this->assertDatabaseCount('security_logs', 1);
+        $this->assertDatabaseHas('security_logs', ['event' => 'SettingsUpdated', 'changes->setting_id' => $sessionLifetime['id']]);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Complete the Test coverage of Settings by adding at least the following one:

- Security Logging: Testing the security logging functionality when changing Settings
- Format Handling: Testing different data format support (could be saml or email,…)
- Validation: Fix, update or remove the skipped tests

## Solution
- Add missing tests for core settings
- Add missing tests for security logs when a setting is updated
- Add missing tests for setting formats

## How to Test
- Run `php artisan test --filter 'SettingLogInOptionsTest|SettingSessionControlTest|SettingAuthTest'`

## Related Tickets & Packages
[FOUR-20504](https://processmaker.atlassian.net/browse/FOUR-20504)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20504]: https://processmaker.atlassian.net/browse/FOUR-20504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ