### PR TITLE
FOUR-18935 Ecobank - ERROR 404 ON SECURITY LOGS SWAGGER

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
+++ b/ProcessMaker/Http/Controllers/Api/SecurityLogController.php
@@ -81,9 +81,16 @@ class SecurityLogController extends Controller
             $query->pmql($pmql);
         }
 
+        // Get total
+        $totalCount = $query->count();
+
+        // Always paginate using query object instead "ApiCollection" class
+        $query->paginate($request->input('per_page', 10));
+
+        // Get records
         $response = $query->get();
 
-        return new ApiCollection($response);
+        return new ApiCollection($response, $totalCount);
     }
 
     /**

--- a/tests/Feature/Api/SecurityLogControllerTest.php
+++ b/tests/Feature/Api/SecurityLogControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use ProcessMaker\Models\SecurityLog;
+use ProcessMaker\Models\User;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class SecurityLogControllerTest extends TestCase
+{
+    use RequestHelper;
+
+    public function test_index(): void
+    {
+        $user = User::factory()->create([
+            'status' => 'ACTIVE',
+            'is_administrator' => true,
+        ]);
+
+        // Create 20 records
+        SecurityLog::factory()->count(20)->create([
+            'event' => 'login',
+            'user_id' => $user->id,
+            'meta' => [
+                'os' => [
+                    'name' => 'OS X',
+                ],
+                'browser' => [
+                    'name' => 'Firefox',
+                ],
+            ],
+        ]);
+
+        // Get 10 items (default per page)
+        $response = $this->apiCall('GET', route('api.security-logs.index'));
+        $response->assertStatus(200);
+        $response->assertJsonCount(10, 'data');
+
+        // Get 2 items, page 1
+        $response = $this->apiCall('GET', route('api.security-logs.index'), ['per_page' => 2]);
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonFragment(['total_pages' => 10]);
+        $response->assertJsonFragment(['current_page' => 1]);
+
+        // Get 2 items, page 2
+        $response = $this->apiCall('GET', route('api.security-logs.index'), ['per_page' => 2, 'page' => 2]);
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonFragment(['total_pages' => 10]);
+        $response->assertJsonFragment(['current_page' => 2]);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
ApiCollection class is getting all records in order to count the records.

## Solution
The count is made using the query object instead the ApiCollection class.

## How to Test
1. Go to API SWAGER: https:/<server>/api/documentation#/Security%20Logs/getSecurityLogs 
2. Go to Authorize and paste the Bearer Token attached.
3. Select SecurityLogs
4. Select GET /security-logs  Returns all security logs
5. Set the parameters per_page to 100 or 10
6. Or use postman and test the same API

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-18935

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
