### PR TITLE
FOUR-21125 When assigning two categories to screens/scripts/decision tables the category disappears

### DIFF
--- a/resources/js/components/shared/FilterTableBodyMixin.js
+++ b/resources/js/components/shared/FilterTableBodyMixin.js
@@ -52,10 +52,16 @@ export default {
       };
     },
     formatCategory(categories) {
-      return categories.map(item => item.name).join(', ');
+      return categories?.map(item => item.name).join(', ');
     },
     getNestedPropertyValue(obj, header) {
-      return this.format(get(obj, header.field), header);
+      const value = get(obj, header.field);
+
+      if (typeof header.cb === 'function') {
+        return header.cb(value, obj);
+      }
+
+      return this.format(value, header);
     },
     format(value, header) {
       let config = "";

--- a/resources/js/processes/screens/components/ScreenListing.vue
+++ b/resources/js/processes/screens/components/ScreenListing.vue
@@ -208,14 +208,12 @@ export default {
           title: () => this.$t("Category"),
           name: "categories",
           label: this.$t("Category"),
-          field: "category.name",
+          field: "categories",
           sortable: true,
           direction: "none",
           width: 150,
           sortField: "category.name",
-          callback(categories) {
-            return categories.map(item => item.name).join(', ');
-          },
+          cb: (categories) => this.formatCategory(categories),
         },
         {
           title: () => this.$t("Type"),

--- a/resources/js/processes/scripts/components/ScriptListing.vue
+++ b/resources/js/processes/scripts/components/ScriptListing.vue
@@ -185,13 +185,11 @@ export default {
           name: "categories",
           sortField: "category.name",
           label: this.$t("Category"),
-          field: "category.name",
+          field: "categories",
           sortable: true,
           direction: "none",
           width: 150,
-          callback(categories) {
-            return categories.map(item => item.name).join(', ');
-          },
+          cb: (categories) => this.formatCategory(categories),
         },
         {
           title: () => this.$t("Language"),


### PR DESCRIPTION
## Issue & Reproduction Steps
When assigning two categories to screens/scripts/decision tables the category disappears

## Solution
- Add a callback to display all assigned categories

https://github.com/user-attachments/assets/a767fef4-ee56-4d48-a5e9-178616822639

## Related Tickets & Packages
[FOUR-21125](https://processmaker.atlassian.net/browse/FOUR-21125)

https://github.com/ProcessMaker/package-decision-engine/pull/148
https://github.com/ProcessMaker/package-data-sources/pull/375

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-21125]: https://processmaker.atlassian.net/browse/FOUR-21125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ