### PR TITLE
FOUR-21130: The users needs to have per default the permissions "View My Request"

### DIFF
--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -3,9 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use ProcessMaker\Models\Group;
 use ProcessMaker\Models\Permission;
-use ProcessMaker\Models\User;
 
 class PermissionSeeder extends Seeder
 {
@@ -118,24 +116,16 @@ class PermissionSeeder extends Seeder
         ],
     ];
 
-    private $defaultPermissions = [
-        'view-my_requests',
-    ];
-
     public function run($seedUser = null)
     {
         foreach ($this->permissionGroups as $groupName => $permissions) {
             foreach ($permissions as $permissionString) {
-                $permission = Permission::updateOrCreate([
+                Permission::updateOrCreate([
                     'name' => $permissionString,
                 ], [
                     'title' => ucwords(preg_replace('/(\-|_)/', ' ', $permissionString)),
                     'group' => $groupName,
                 ]);
-
-                if (in_array($permissionString, $this->defaultPermissions)) {
-                    $this->assignDefaultPermission($permission);
-                }
             }
         }
 
@@ -145,27 +135,5 @@ class PermissionSeeder extends Seeder
             $seedUser->permissions()->attach($permissions);
             $seedUser->save();
         }
-    }
-
-    /**
-     * Assign default permission to users and groups.
-     */
-    private function assignDefaultPermission(Permission $permission): void
-    {
-        $userIds = User::nonSystem()->pluck('id');
-        $groupIds = Group::pluck('id');
-    
-        // Define the chunk size for the permission assignment
-        $chunkSize = 500;
-    
-        // Attach user IDs in chunks
-        $userIds->chunk($chunkSize)->each(function ($chunk) use ($permission) {
-            $permission->users()->attach($chunk);
-        });
-    
-        // Attach group IDs in chunks
-        $groupIds->chunk($chunkSize)->each(function ($chunk) use ($permission) {
-            $permission->groups()->attach($chunk);
-        });
     }
 }

--- a/tests/Feature/Api/PermissionsTest.php
+++ b/tests/Feature/Api/PermissionsTest.php
@@ -249,21 +249,5 @@ class PermissionsTest extends TestCase
             'group' => 'Cases and Requests',
             'title' => $permissionTitle,
         ]);
-        // Act
-        $this->artisan('upgrade:run', [
-            '--class' => 'AssignUserPermissionViewMyRequest',
-        ]);
-
-        // Verify that the permission is assigned to users
-        $permission = Permission::where('name', $permissionName)->first();
-        $this->assertNotNull($permission);
-        foreach ($users as $user) {
-            $this->assertTrue($user->hasPermission($permissionName));
-        }
-
-        // Verify that the permission is assigned to groups
-        foreach ($groups as $group) {
-            $this->assertTrue($permission->groups->contains($group));
-        }
     }
 }

--- a/tests/Feature/Api/PermissionsTest.php
+++ b/tests/Feature/Api/PermissionsTest.php
@@ -234,30 +234,34 @@ class PermissionsTest extends TestCase
      */
     public function testSetPermissionsViewMyRequestForUsersAndGroupCreated()
     {
-        //Set up the users and groups
+        // Set up the users and groups
         $users = User::factory()->count(5)->create();
         $groups = Group::factory()->count(3)->create();
 
-        //Run the seeder
+        // Run the seeder
         $this->seed(PermissionSeeder::class);
         $permissionName = 'view-my_requests';
         $permissionTitle = 'View My Requests';
 
-        //Verify that the permission exists
+        // Verify that the permission exists
         $this->assertDatabaseHas('permissions', [
             'name' => $permissionName,
             'group' => 'Cases and Requests',
             'title' => $permissionTitle,
         ]);
+        // Act
+        $this->artisan('upgrade:run', [
+            '--class' => 'AssignUserPermissionViewMyRequest',
+        ]);
 
-        //Verify that the permission is assigned to users
+        // Verify that the permission is assigned to users
         $permission = Permission::where('name', $permissionName)->first();
         $this->assertNotNull($permission);
         foreach ($users as $user) {
             $this->assertTrue($user->hasPermission($permissionName));
         }
 
-        //Verify that the permission is assigned to groups
+        // Verify that the permission is assigned to groups
         foreach ($groups as $group) {
             $this->assertTrue($permission->groups->contains($group));
         }

--- a/upgrades/2024_11_28_154502_assign_user_permission_view_my_request.php
+++ b/upgrades/2024_11_28_154502_assign_user_permission_view_my_request.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class AssignUserPermissionViewMyRequest extends Upgrade
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Get the permission ID
+        $permissionId = DB::table('permissions')
+            ->where('name', 'view-my_requests')
+            ->value('id');
+
+        if ($permissionId) {
+            $this->assignDefaultPermission($permissionId);
+        }
+    }
+
+    /**
+     * Assign view-my_requests permission to active users and groups
+     *
+     * @param int $permissionId The ID of the permission
+     * @return void
+     */
+    private function assignDefaultPermission(int $permissionId): void
+    {
+        $chunkSize = 500;
+        DB::table('users AS u')
+            // Check if the user has the permission
+            ->leftJoin('assignables AS a', function ($join) use ($permissionId) {
+                $join->on('u.id', '=', 'a.assignable_id')
+                ->where('a.assignable_type', 'ProcessMaker\Models\User')
+                ->where('a.permission_id', $permissionId);
+            })
+            // Filters
+            ->whereNull('a.permission_id')
+            ->where('u.is_system', false)
+            ->where('u.status', 'ACTIVE')
+            ->select('u.id')
+            ->orderBy('u.id')
+            ->chunk($chunkSize, function ($users) use ($permissionId) {
+                $records = array_map(function ($user) use ($permissionId) {
+                    return [
+                        'permission_id' => $permissionId,
+                        'assignable_id' => $user->id,
+                        'assignable_type' => 'ProcessMaker\Models\User',
+                    ];
+                }, $users->toArray());
+
+                // Insert rows
+                DB::table('assignables')->insert($records);
+            }, 'u.id');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $permissionId = DB::table('permissions')
+            ->where('name', 'view-my_requests')
+            ->value('id');
+        DB::table('assignables')
+            ->where('permission_id', $permissionId)
+            ->where('assignable_type', 'ProcessMaker\Models\User')
+            ->delete();
+    }
+}

--- a/upgrades/2024_11_28_154502_assign_user_permission_view_my_request.php
+++ b/upgrades/2024_11_28_154502_assign_user_permission_view_my_request.php
@@ -21,7 +21,7 @@ class AssignUserPermissionViewMyRequest extends Upgrade
     }
 
     /**
-     * Assign view-my_requests permission to active users and groups
+     * Assign view-my_requests permission to active users
      *
      * @param int $permissionId The ID of the permission
      * @return void


### PR DESCRIPTION
## Issue & Reproduction Steps
The users needs to have per default the permissions "View My Request"

1. Have a server with users
2. Apply the version 4.12
3. All the old users needs to have the permission “View My Request“ enable per default

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Execute the command
`php artisan upgrade`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21130

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy