### PR TITLE
observation/FOUR-21138 devLink > Server error message is displayed when a Collection is downloaded

### DIFF
--- a/ProcessMaker/Enums/ExporterMap.php
+++ b/ProcessMaker/Enums/ExporterMap.php
@@ -13,6 +13,7 @@ enum ExporterMap
         'process_templates' => [\ProcessMaker\Models\ProcessTemplates::class, \ProcessMaker\ImportExport\Exporters\TemplateExporter::class],
         'data_source' => [\ProcessMaker\Packages\Connectors\DataSources\Models\DataSource::class, \ProcessMaker\Packages\Connectors\DataSources\ImportExport\DataSourceExporter::class],
         'decision_table' => [\ProcessMaker\Package\PackageDecisionEngine\Models\DecisionTable::class, \ProcessMaker\Package\PackageDecisionEngine\ImportExport\DecisionTableExporter::class],
+        'collection' => [\ProcessMaker\Plugins\Collections\Models\Collection::class, \ProcessMaker\Plugins\Collections\ImportExport\CollectionExporter::class],
         'flow_genie' => [
             \ProcessMaker\Package\PackageAi\Models\FlowGenie::class,
             \ProcessMaker\Package\PackageAi\ImportExport\FlowGenieExporter::class,


### PR DESCRIPTION
## Issue & Reproduction Steps
devLink > Server error message is displayed when a Collection is downloaded

## Solution
Added the collection model to the exporterMap

## How to Test
The two servers must have the solution
Go to server A
Create Collection
Go to admin > devlink > Shared Assets
check collection option

Go to server B 
Go to Admin > devlink > linked instances
Press Add instance button and connect with the server A
Select the instances
Select Assets tab
Press View button in the Collection
Select a collection
Press cloud download icon
Press ok button

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21138

