### PR TITLE
FOUR-20944: Implement ETag Caching for Task and Case Data

### DIFF
--- a/ProcessMaker/Http/Middleware/Etag/HandleEtag.php
+++ b/ProcessMaker/Http/Middleware/Etag/HandleEtag.php
@@ -21,38 +21,34 @@ class HandleEtag
             return $next($request);
         }
 
-        // Handle response.
-        $response = $next($request);
+        // Check if specific tables are defined for the route and calculate ETag.
+        $etag = $this->generateEtagFromTablesIfNeeded($request);
 
-        // Check if the response is cacheable.
-        if (!$this->isCacheableResponse($response)) {
-            return $response; // Skip ETag for non-cacheable responses.
+        // If the client has a matching ETag, return a 304 response.
+        // Otherwise, continue with the controller execution.
+        $response = $etag && $this->etagMatchesRequest($etag, $request)
+            ? $this->buildNotModifiedResponse($etag)
+            : $next($request);
+
+        // Add the pre-calculated ETag to the response if available.
+        if ($etag) {
+            $response = $this->setEtagOnResponse($response, $etag);
         }
 
-        // Generate ETag for the response.
-        $etag = EtagManager::getEtag($request, $response);
-        if ($etag) {
-            // Set the ETag header.
-            $response->setEtag($etag);
+        // If no ETag was calculated from tables, generate it based on the response.
+        if (!$etag && $this->isCacheableResponse($response)) {
+            $etag = EtagManager::getEtag($request, $response);
+            if ($etag) {
+                $response = $this->setEtagOnResponse($response, $etag);
 
-            // Get and strip weak ETags from request headers.
-            $noneMatch = array_map([$this, 'stripWeakTags'], $request->getETags());
-
-            // Compare ETags and set response as not modified if applicable.
-            if (in_array($etag, $noneMatch)) {
-                $response->setNotModified();
+                // If the client has a matching ETag, set the response to 304.
+                if ($this->etagMatchesRequest($etag, $request)) {
+                    $response = $this->buildNotModifiedResponse($etag);
+                }
             }
         }
 
         return $response;
-    }
-
-    /**
-     * Remove the weak indicator (W/) from an ETag.
-     */
-    private function stripWeakTags(string $etag): string
-    {
-        return str_replace('W/', '', $etag);
     }
 
     /**
@@ -66,5 +62,55 @@ class HandleEtag
         // Verify if the status code is cacheable and does not contain "no-store".
         return in_array($response->getStatusCode(), $cacheableStatusCodes)
             && !str_contains($cacheControl, 'no-store');
+    }
+
+    /**
+     * Generate an ETag based on the tables defined in the route, if applicable.
+     */
+    private function generateEtagFromTablesIfNeeded(Request $request): ?string
+    {
+        $tables = $request->route()->defaults['etag_tables'] ?? null;
+
+        return $tables ? EtagManager::generateEtagFromTables(explode(',', $tables)) : null;
+    }
+
+    /**
+     * Check if the ETag matches the request.
+     */
+    private function etagMatchesRequest(string $etag, Request $request): bool
+    {
+        $noneMatch = array_map([$this, 'stripWeakTags'], $request->getETags());
+
+        return in_array($etag, $noneMatch);
+    }
+
+    /**
+     * Build a 304 Not Modified response with the given ETag.
+     */
+    private function buildNotModifiedResponse(string $etag): Response
+    {
+        $response = new Response();
+        $response->setNotModified();
+        $response->setEtag($etag);
+
+        return $response;
+    }
+
+    /**
+     * Set the ETag on a given response.
+     */
+    private function setEtagOnResponse(Response $response, string $etag): Response
+    {
+        $response->setEtag($etag);
+
+        return $response;
+    }
+
+    /**
+     * Remove the weak indicator (W/) from an ETag.
+     */
+    private function stripWeakTags(string $etag): string
+    {
+        return str_replace('W/', '', $etag);
     }
 }

--- a/ProcessMaker/Http/Resources/Caching/EtagManager.php
+++ b/ProcessMaker/Http/Resources/Caching/EtagManager.php
@@ -4,6 +4,8 @@ namespace ProcessMaker\Http\Resources\Caching;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -40,5 +42,30 @@ class EtagManager
     private static function defaultGetEtag(Response $response): string
     {
         return md5(auth()->id() . $response->getContent());
+    }
+
+    /**
+     * Generate an ETag based on the latest update timestamps from multiple tables.
+     */
+    public static function generateEtagFromTables(array $tables, string $source = 'updated_at'): string
+    {
+        // Fetch the latest update timestamp from each table.
+        // If the source is 'etag_version', use a cached version key as the source of truth.
+        $lastUpdated = collect($tables)->map(function ($table) use ($source) {
+            if ($source === 'etag_version') {
+                // This is not currently implemented but serves as a placeholder for future flexibility.
+                // The idea is to use a cached version key (e.g., "etag_version_table_name") as the source of truth.
+                // This would allow us to version the ETag dynamically and invalidate it using model observers or other mechanisms.
+                // If implemented, observers can increment this version key whenever the corresponding table is updated.
+                return Cache::get("etag_version_{$table}", 0);
+            }
+
+            // Default to the updated_at column in the database.
+            return DB::table($table)->max('updated_at');
+        })->max();
+
+        $etag = md5(auth()->id() . $lastUpdated);
+
+        return (string) Str::of($etag)->start('"')->finish('"');
     }
 }

--- a/ProcessMaker/Http/Resources/Caching/EtagManager.php
+++ b/ProcessMaker/Http/Resources/Caching/EtagManager.php
@@ -23,26 +23,22 @@ class EtagManager
     }
 
     /**
-     * Get ETag value for this request and response.
+     * Get the ETag value for this request and response.
      */
-    public static function getEtag(Request $request, Response $response, bool $includeUser = false): string
+    public static function getEtag(Request $request, Response $response): string
     {
         $etag = static::$etagGenerateCallback
-            ? call_user_func(static::$etagGenerateCallback, $request, $response, $includeUser)
-            : static::defaultGetEtag($response, $includeUser);
+            ? call_user_func(static::$etagGenerateCallback, $request, $response)
+            : static::defaultGetEtag($response);
 
         return (string) Str::of($etag)->start('"')->finish('"');
     }
 
     /**
-     * Generate an ETag, optionally including user-specific data.
+     * Generate a default ETag, including user-specific data by default.
      */
-    private static function defaultGetEtag(Response $response, bool $includeUser = false): string
+    private static function defaultGetEtag(Response $response): string
     {
-        if ($includeUser) {
-            return md5(auth()->id() . $response->getContent());
-        }
-
-        return md5($response->getContent());
+        return md5(auth()->id() . $response->getContent());
     }
 }

--- a/ProcessMaker/Http/Resources/V1_1/TaskResource.php
+++ b/ProcessMaker/Http/Resources/V1_1/TaskResource.php
@@ -82,7 +82,6 @@ class TaskResource extends ApiResource
             'is_administrator',
             'expires_at',
             'loggedin_at',
-            'active_at',
             'created_at',
             'updated_at',
             'delegation_user_id',

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvi
 use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Facades;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Laravel\Dusk\DuskServiceProvider;
 use Laravel\Horizon\Horizon;
@@ -19,6 +20,7 @@ use ProcessMaker\Console\Migration\ExtendedMigrateCommand;
 use ProcessMaker\Events\ActivityAssigned;
 use ProcessMaker\Events\ScreenBuilderStarting;
 use ProcessMaker\Helpers\PmHash;
+use ProcessMaker\Http\Middleware\Etag\HandleEtag;
 use ProcessMaker\ImportExport\Extension;
 use ProcessMaker\ImportExport\SignalHelper;
 use ProcessMaker\Jobs\SmartInbox;
@@ -52,6 +54,8 @@ class ProcessMakerServiceProvider extends ServiceProvider
         $this->setupFactories();
 
         parent::boot();
+
+        Route::pushMiddlewareToGroup('api', HandleEtag::class);
     }
 
     public function register(): void

--- a/ProcessMaker/Providers/RouteServiceProvider.php
+++ b/ProcessMaker/Providers/RouteServiceProvider.php
@@ -89,7 +89,7 @@ class RouteServiceProvider extends ServiceProvider
     {
         Route::middleware('api')
             ->group(base_path('routes/api.php'));
-        Route::middleware('auth:api')
+        Route::middleware(['auth:api', 'etag'])
             ->group(base_path('routes/v1_1/api.php'));
     }
 

--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -41,7 +41,12 @@ trait TaskResourceIncludes
 
     private function includeRequestor()
     {
-        return ['requestor' => new Users($this->processRequest->user)];
+        $user = $this->processRequest->user;
+
+        // Exclude 'active_at' to prevent ETag inconsistencies.
+        $user->makeHidden(['active_at']);
+
+        return ['requestor' => new Users($user)];
     }
 
     private function includeProcessRequest()

--- a/routes/api.php
+++ b/routes/api.php
@@ -208,7 +208,9 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('tasks/{task}/setViewed', [TaskController::class, 'setViewed'])->name('tasks.set_viewed')->middleware('can:viewScreen,task,screen');
     Route::put('tasks/{task}/setPriority', [TaskController::class, 'setPriority'])->name('tasks.priority');
     Route::put('tasks/updateReassign', [TaskController::class, 'updateReassign'])->name('tasks.updateReassign');
-    Route::get('tasks/user-can-reassign', [TaskController::class, 'userCanReassign'])->name('tasks.user_can_reassign');
+    Route::get('tasks/user-can-reassign', [TaskController::class, 'userCanReassign'])
+        ->middleware('etag:user')
+        ->name('tasks.user_can_reassign');
 
     // TaskDrafts
     Route::put('drafts/{task}', [TaskDraftController::class, 'update'])->name('taskdraft.update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -208,9 +208,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::post('tasks/{task}/setViewed', [TaskController::class, 'setViewed'])->name('tasks.set_viewed')->middleware('can:viewScreen,task,screen');
     Route::put('tasks/{task}/setPriority', [TaskController::class, 'setPriority'])->name('tasks.priority');
     Route::put('tasks/updateReassign', [TaskController::class, 'updateReassign'])->name('tasks.updateReassign');
-    Route::get('tasks/user-can-reassign', [TaskController::class, 'userCanReassign'])
-        ->middleware('etag:user')
-        ->name('tasks.user_can_reassign');
+    Route::get('tasks/user-can-reassign', [TaskController::class, 'userCanReassign'])->name('tasks.user_can_reassign');
 
     // TaskDrafts
     Route::put('drafts/{task}', [TaskDraftController::class, 'update'])->name('taskdraft.update');

--- a/routes/engine.php
+++ b/routes/engine.php
@@ -8,7 +8,10 @@ use ProcessMaker\Http\Controllers\Api\TaskController;
 // Engine
 Route::prefix('api/1.0')->name('api.')->group(function () {
     // List of Processes that the user can start
-    Route::get('start_processes', [ProcessController::class, 'startProcesses'])->name('processes.start'); // Filtered in controller
+    Route::get('start_processes', [ProcessController::class, 'startProcesses'])
+        ->middleware('etag')
+        ->defaults('etag_tables', 'processes')
+        ->name('processes.start'); // Filtered in controller
 
     // Start a process
     Route::post('process_events/{process}', [ProcessController::class, 'triggerStartEvent'])->name('process_events.trigger')->middleware('can:start,process');

--- a/routes/v1_1/api.php
+++ b/routes/v1_1/api.php
@@ -22,6 +22,7 @@ Route::prefix('api/1.1')
 
             // Route to show the screen of a task
             Route::get('/{taskId}/screen', [TaskController::class, 'showScreen'])
+                ->defaults('etag_tables', 'screens,screen_versions')
                 ->name('show.screen');
 
             // Route to show the interstitial screen of a task

--- a/routes/v1_1/api.php
+++ b/routes/v1_1/api.php
@@ -18,11 +18,10 @@ Route::prefix('api/1.1')
             // Route to show a task
             Route::get('/{task}', [TaskController::class, 'show'])
                 ->name('show')
-                ->middleware(['bindings', 'can:view,task', 'etag:user']);
+                ->middleware(['bindings', 'can:view,task']);
 
             // Route to show the screen of a task
             Route::get('/{taskId}/screen', [TaskController::class, 'showScreen'])
-                ->middleware('etag')
                 ->name('show.screen');
 
             // Route to show the interstitial screen of a task

--- a/routes/v1_1/api.php
+++ b/routes/v1_1/api.php
@@ -18,7 +18,7 @@ Route::prefix('api/1.1')
             // Route to show a task
             Route::get('/{task}', [TaskController::class, 'show'])
                 ->name('show')
-                ->middleware(['bindings', 'can:view,task']);
+                ->middleware(['bindings', 'can:view,task', 'etag:user']);
 
             // Route to show the screen of a task
             Route::get('/{taskId}/screen', [TaskController::class, 'showScreen'])

--- a/tests/Feature/Etag/HandleEtagTest.php
+++ b/tests/Feature/Etag/HandleEtagTest.php
@@ -75,7 +75,7 @@ class HandleEtagTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        Route::middleware('etag:user')->any(self::TEST_ROUTE, function () {
+        Route::middleware('etag')->any(self::TEST_ROUTE, function () {
             return response($this->response, 200);
         });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR implements ETag caching for all GET and HEAD requests, enhancing performance and reducing bandwidth usage by leveraging HTTP conditional requests. The middleware is now applied globally, ensuring consistent ETag handling across endpoints.

## Solution
1. Global ETag Middleware:
- Applied the ETag middleware to all GET API requests to ensure consistency and avoid redundant implementation for individual routes.
- Middleware calculates and validates ETags based on the response or a configurable sources of truth (optional).

2. Exclude active_at Field:
- Removed the active_at field from TaskResource and requestor serialization to prevent ETag inconsistencies.

3. Introduce Configurable ETag Source:
- updated_at: Default method using database timestamps to determine the latest update for relevant tables.

## How to Test

1. Call any GET endpoint for the first time. A 200 OK response is returned and the content is fetched from the server and cached.
2. Refresh the page or call the endpoint again. A 304 Not Modified response is returned if the ETag matches.
3. Modify the relevant data (e.g., update the database). On subsequent requests:
	• If using updated_at as the source, a 200 OK response is returned with the updated content.
4. Validate that the updated content is cached and subsequent requests return 304 Not Modified.

## Related Tickets & Packages
- [FOUR-20944](https://processmaker.atlassian.net/browse/FOUR-20944)
- [FOUR-20939](https://processmaker.atlassian.net/browse/FOUR-20939)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20944]: https://processmaker.atlassian.net/browse/FOUR-20944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ