### PR TITLE
FOUR-20911: Caching Screens

### DIFF
--- a/ProcessMaker/Cache/Screens/LegacyScreenCacheAdapter.php
+++ b/ProcessMaker/Cache/Screens/LegacyScreenCacheAdapter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ProcessMaker\Cache\Screens;
+
+use ProcessMaker\Managers\ScreenCompiledManager;
+
+class LegacyScreenCacheAdapter implements ScreenCacheInterface
+{
+    protected ScreenCompiledManager $compiledManager;
+
+    public function __construct(ScreenCompiledManager $compiledManager)
+    {
+        $this->compiledManager = $compiledManager;
+    }
+
+    /**
+     * Create a cache key for a screen
+     */
+    public function createKey(int $processId, int $processVersionId, string $language, int $screenId, int $screenVersionId): string
+    {
+        return $this->compiledManager->createKey(
+            (string) $processId,
+            (string) $processVersionId,
+            $language,
+            (string) $screenId,
+            (string) $screenVersionId
+        );
+    }
+
+    /**
+     * Get a screen from cache
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $content = $this->compiledManager->getCompiledContent($key);
+
+        return $content ?? $default;
+    }
+
+    /**
+     * Store a screen in cache
+     */
+    public function set(string $key, mixed $value): bool
+    {
+        $this->compiledManager->storeCompiledContent($key, $value);
+
+        return true;
+    }
+
+    /**
+     * Check if screen exists in cache
+     */
+    public function has(string $key): bool
+    {
+        return $this->compiledManager->getCompiledContent($key) !== null;
+    }
+}

--- a/ProcessMaker/Cache/Screens/ScreenCacheFacade.php
+++ b/ProcessMaker/Cache/Screens/ScreenCacheFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ProcessMaker\Cache\Screens;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Class ScreenCacheFacade
+ *
+ * @mixin \ProcessMaker\Cache\Settings\SettingCacheManager
+ */
+class ScreenCacheFacade extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'screen.cache';
+    }
+}

--- a/ProcessMaker/Cache/Screens/ScreenCacheFacade.php
+++ b/ProcessMaker/Cache/Screens/ScreenCacheFacade.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * Class ScreenCacheFacade
  *
- * @mixin \ProcessMaker\Cache\Settings\SettingCacheManager
+ * @mixin \ProcessMaker\Cache\Settings\ScreenCacheManager
  */
 class ScreenCacheFacade extends Facade
 {

--- a/ProcessMaker/Cache/Screens/ScreenCacheFactory.php
+++ b/ProcessMaker/Cache/Screens/ScreenCacheFactory.php
@@ -8,6 +8,18 @@ use ProcessMaker\Managers\ScreenCompiledManager;
 
 class ScreenCacheFactory
 {
+    private static ?ScreenCacheInterface $testInstance = null;
+
+    /**
+     * Set a test instance for the factory
+     *
+     * @param ScreenCacheInterface|null $instance
+     */
+    public static function setTestInstance(?ScreenCacheInterface $instance): void
+    {
+        self::$testInstance = $instance;
+    }
+
     /**
      * Create a screen cache handler based on configuration
      *
@@ -15,6 +27,10 @@ class ScreenCacheFactory
      */
     public static function create(): ScreenCacheInterface
     {
+        if (self::$testInstance !== null) {
+            return self::$testInstance;
+        }
+
         $manager = Config::get('screens.cache.manager', 'legacy');
 
         if ($manager === 'new') {

--- a/ProcessMaker/Cache/Screens/ScreenCacheFactory.php
+++ b/ProcessMaker/Cache/Screens/ScreenCacheFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ProcessMaker\Cache\Screens;
+
+use Illuminate\Support\Facades\Config;
+use ProcessMaker\Cache\Screens\ScreenCacheManager;
+use ProcessMaker\Managers\ScreenCompiledManager;
+
+class ScreenCacheFactory
+{
+    /**
+     * Create a screen cache handler based on configuration
+     *
+     * @return ScreenCacheInterface
+     */
+    public static function create(): ScreenCacheInterface
+    {
+        $manager = Config::get('screens.cache.manager', 'legacy');
+
+        if ($manager === 'new') {
+            return app(ScreenCacheManager::class);
+        }
+
+        // Get the concrete ScreenCompiledManager instance from the container
+        $compiledManager = app()->make(ScreenCompiledManager::class);
+
+        return new LegacyScreenCacheAdapter($compiledManager);
+    }
+}

--- a/ProcessMaker/Cache/Screens/ScreenCacheInterface.php
+++ b/ProcessMaker/Cache/Screens/ScreenCacheInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ProcessMaker\Cache\Screens;
+
+interface ScreenCacheInterface
+{
+    /**
+     * Create a cache key for a screen
+     */
+    public function createKey(int $processId, int $processVersionId, string $language, int $screenId, int $screenVersionId): string;
+
+    /**
+     * Get a screen from cache
+     */
+    public function get(string $key, mixed $default = null): mixed;
+
+    /**
+     * Store a screen in cache
+     */
+    public function set(string $key, mixed $value): bool;
+
+    /**
+     * Check if screen exists in cache
+     */
+    public function has(string $key): bool;
+}

--- a/ProcessMaker/Cache/Screens/ScreenCacheManager.php
+++ b/ProcessMaker/Cache/Screens/ScreenCacheManager.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace ProcessMaker\Cache\Screens;
+
+use Illuminate\Cache\CacheManager;
+use ProcessMaker\Cache\CacheInterface;
+use ProcessMaker\Managers\ScreenCompiledManager;
+
+class ScreenCacheManager implements CacheInterface, ScreenCacheInterface
+{
+    protected CacheManager $cacheManager;
+
+    protected ScreenCompiledManager $screenCompiler;
+
+    /**
+     * Default TTL for cached screens (24 hours)
+     */
+    protected const DEFAULT_TTL = 86400;
+
+    public function __construct(CacheManager $cacheManager, ScreenCompiledManager $screenCompiler)
+    {
+        $this->cacheManager = $cacheManager;
+        $this->screenCompiler = $screenCompiler;
+    }
+
+    /**
+     * Create a cache key for a screen
+     *
+     * @param int $processId Process ID
+     * @param int $processVersionId Process version ID
+     * @param string $language Language code
+     * @param int $screenId Screen ID
+     * @param int $screenVersionId Screen version ID
+     * @return string Cache key
+     */
+    public function createKey(int $processId, int $processVersionId, string $language, int $screenId, int $screenVersionId): string
+    {
+        return "pid_{$processId}_{$processVersionId}_{$language}_sid_{$screenId}_{$screenVersionId}";
+    }
+
+    /**
+     * Get a screen from cache
+     *
+     * @param string $key Screen cache key
+     * @param mixed $default Default value
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $serializedContent = $this->cacheManager->get($key);
+        if ($serializedContent !== null) {
+            return unserialize($serializedContent);
+        }
+
+        return $default;
+    }
+
+    /**
+     * Store a screen in memory cache
+     *
+     * @param string $key Screen cache key
+     * @param mixed $value Compiled screen content
+     * @param null|int|\DateInterval $ttl Time to live
+     * @return bool
+     */
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
+    {
+        $serializedContent = serialize($value);
+
+        return $this->cacheManager->put($key, $serializedContent, $ttl ?? self::DEFAULT_TTL);
+    }
+
+    /**
+     * Delete a screen from cache
+     *
+     * @param string $key Screen cache key
+     * @return bool
+     */
+    public function delete(string $key): bool
+    {
+        return $this->cacheManager->forget($key);
+    }
+
+    /**
+     * Clear all screen caches
+     *
+     * @return bool
+     */
+    public function clear(): bool
+    {
+        return $this->cacheManager->flush();
+    }
+
+    /**
+     * Check if screen exists in cache
+     *
+     * @param string $key Screen cache key
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return $this->cacheManager->has($key);
+    }
+
+    /**
+     * Check if screen is missing
+     *
+     * @param string $key Screen cache key
+     * @return bool
+     */
+    public function missing(string $key): bool
+    {
+        return !$this->has($key);
+    }
+}

--- a/config/screens.php
+++ b/config/screens.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Screen Cache Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure the screen caching behavior.
+    |
+    */
+
+    'cache' => [
+        // Cache manager to use: 'new' for ScreenCacheManager, 'legacy' for ScreenCompiledManager
+        'manager' => env('SCREEN_CACHE_MANAGER', 'legacy'),
+
+        // Cache driver to use (redis, file)
+        'driver' => env('SCREEN_CACHE_DRIVER', 'file'),
+
+        // Default TTL for cached screens (24 hours)
+        'ttl' => env('SCREEN_CACHE_TTL', 86400),
+    ],
+];

--- a/tests/unit/ProcessMaker/Cache/Screens/LegacyScreenCacheAdapterTest.php
+++ b/tests/unit/ProcessMaker/Cache/Screens/LegacyScreenCacheAdapterTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Cache\Screens;
+
+use Mockery;
+use ProcessMaker\Cache\Screens\LegacyScreenCacheAdapter;
+use ProcessMaker\Managers\ScreenCompiledManager;
+use Tests\TestCase;
+
+class LegacyScreenCacheAdapterTest extends TestCase
+{
+    protected $compiledManager;
+
+    protected $adapter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->compiledManager = Mockery::mock(ScreenCompiledManager::class);
+        $this->adapter = new LegacyScreenCacheAdapter($this->compiledManager);
+    }
+
+    /** @test */
+    public function it_creates_correct_cache_key()
+    {
+        $this->compiledManager->shouldReceive('createKey')
+            ->once()
+            ->with('1', '2', 'en', '3', '4')
+            ->andReturn('pid_1_2_en_sid_3_4');
+
+        $key = $this->adapter->createKey(1, 2, 'en', 3, 4);
+
+        $this->assertEquals('pid_1_2_en_sid_3_4', $key);
+    }
+
+    /** @test */
+    public function it_gets_content_from_compiled_manager()
+    {
+        $key = 'test_key';
+        $expectedValue = ['content' => 'test'];
+
+        $this->compiledManager->shouldReceive('getCompiledContent')
+            ->once()
+            ->with($key)
+            ->andReturn($expectedValue);
+
+        $result = $this->adapter->get($key);
+
+        $this->assertEquals($expectedValue, $result);
+    }
+
+    /** @test */
+    public function it_returns_default_value_when_content_missing()
+    {
+        $key = 'missing_key';
+        $default = ['default' => 'value'];
+
+        $this->compiledManager->shouldReceive('getCompiledContent')
+            ->once()
+            ->with($key)
+            ->andReturnNull();
+
+        $result = $this->adapter->get($key, $default);
+
+        $this->assertEquals($default, $result);
+    }
+
+    /** @test */
+    public function it_stores_content_in_compiled_manager()
+    {
+        $key = 'test_key';
+        $value = ['content' => 'test'];
+
+        $this->compiledManager->shouldReceive('storeCompiledContent')
+            ->once()
+            ->with($key, $value)
+            ->andReturnNull();
+
+        $result = $this->adapter->set($key, $value);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_checks_existence_in_compiled_manager()
+    {
+        $key = 'test_key';
+
+        $this->compiledManager->shouldReceive('getCompiledContent')
+            ->once()
+            ->with($key)
+            ->andReturn(['content' => 'exists']);
+
+        $result = $this->adapter->has($key);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_returns_false_when_checking_missing_content()
+    {
+        $key = 'missing_key';
+
+        $this->compiledManager->shouldReceive('getCompiledContent')
+            ->once()
+            ->with($key)
+            ->andReturnNull();
+
+        $result = $this->adapter->has($key);
+
+        $this->assertFalse($result);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/unit/ProcessMaker/Cache/Screens/ScreenCacheFactoryTest.php
+++ b/tests/unit/ProcessMaker/Cache/Screens/ScreenCacheFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Cache\Screens;
+
+use Illuminate\Support\Facades\Config;
+use ProcessMaker\Cache\Screens\LegacyScreenCacheAdapter;
+use ProcessMaker\Cache\Screens\ScreenCacheFactory;
+use ProcessMaker\Cache\Screens\ScreenCacheManager;
+use ProcessMaker\Managers\ScreenCompiledManager;
+use Tests\TestCase;
+
+class ScreenCacheFactoryTest extends TestCase
+{
+    /** @test */
+    public function it_creates_new_cache_manager_when_configured()
+    {
+        Config::set('screens.cache.manager', 'new');
+
+        $cacheHandler = ScreenCacheFactory::create();
+
+        $this->assertInstanceOf(ScreenCacheManager::class, $cacheHandler);
+    }
+
+    /** @test */
+    public function it_creates_legacy_adapter_by_default()
+    {
+        Config::set('screens.cache.manager', 'legacy');
+
+        $cacheHandler = ScreenCacheFactory::create();
+
+        $this->assertInstanceOf(LegacyScreenCacheAdapter::class, $cacheHandler);
+    }
+
+    /** @test */
+    public function it_creates_legacy_adapter_when_config_missing()
+    {
+        Config::set('screens.cache.manager', null);
+
+        $cacheHandler = ScreenCacheFactory::create();
+
+        $this->assertInstanceOf(LegacyScreenCacheAdapter::class, $cacheHandler);
+    }
+}

--- a/tests/unit/ProcessMaker/Cache/Screens/ScreenCacheManagerTest.php
+++ b/tests/unit/ProcessMaker/Cache/Screens/ScreenCacheManagerTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Cache\Screens;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Redis;
+use Mockery;
+use ProcessMaker\Cache\Screens\ScreenCacheManager;
+use ProcessMaker\Managers\ScreenCompiledManager;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\Translation;
+use Tests\TestCase;
+
+class ScreenCacheManagerTest extends TestCase
+{
+    protected $cacheManager;
+
+    protected $screenCompiler;
+
+    protected $screenCache;
+
+    protected $redis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mock dependencies
+        $this->cacheManager = Mockery::mock(CacheManager::class);
+        $this->screenCompiler = Mockery::mock(ScreenCompiledManager::class);
+
+        // Create instance with mocked dependencies
+        $this->screenCache = new ScreenCacheManager(
+            $this->cacheManager,
+            $this->screenCompiler
+        );
+
+        // Clear Redis before each test
+        Redis::flushdb();
+    }
+
+    /** @test */
+    public function testCreatesCorrectCacheKey()
+    {
+        $languages = ['en', 'es', 'fr', 'de'];
+
+        foreach ($languages as $lang) {
+            $key = $this->screenCache->createKey(1, 2, $lang, 3, 4);
+            $expectedKey = "pid_1_2_{$lang}_sid_3_4";
+
+            $this->assertEquals($expectedKey, $key);
+        }
+    }
+
+    /** @test */
+    public function testStoresAndRetrievesFromMemoryCache()
+    {
+        $key = 'test_screen';
+        $value = ['content' => 'test'];
+
+        // Set up expectations
+        $this->cacheManager->shouldReceive('put')
+            ->once()
+            ->with($key, serialize($value), 86400)
+            ->andReturn(true);
+
+        $this->cacheManager->shouldReceive('get')
+            ->once()
+            ->with($key)
+            ->andReturn(serialize($value));
+
+        // Execute and verify
+        $this->screenCache->set($key, $value);
+        $result = $this->screenCache->get($key);
+
+        $this->assertEquals($value, $result);
+    }
+
+    /** @test */
+    public function testHandlesTranslations()
+    {
+        $key = 'test_screen';
+        $value = ['content' => 'test', 'title' => 'Original Title'];
+        $serializedValue = serialize($value);
+
+        // Set up expectations for initial store
+        $this->cacheManager->shouldReceive('put')
+            ->once()
+            ->with($key, $serializedValue, 86400)
+            ->andReturn(true);
+
+        // Set up expectations for retrieval
+        $this->cacheManager->shouldReceive('get')
+            ->once()
+            ->with($key)
+            ->andReturn($serializedValue);
+
+        // Store and retrieve with translation
+        $this->screenCache->set($key, $value);
+        $result = $this->screenCache->get($key);
+
+        $this->assertEquals($value, $result);
+        $this->assertEquals('Original Title', $result['title']);
+    }
+
+    /** @test */
+    public function testHandlesNestedScreens()
+    {
+        $key = 'test_screen';
+        $nestedKey = 'nested_screen';
+
+        $nestedContent = ['content' => 'nested content'];
+        $parentContent = [
+            'component' => 'FormScreen',
+            'config' => [
+                'screenId' => 123,
+                'content' => $nestedContent,
+            ],
+        ];
+
+        // Set up expectations for nested screen
+        $this->cacheManager->shouldReceive('get')
+            ->once()
+            ->with($nestedKey)
+            ->andReturn(serialize($nestedContent));
+
+        $this->cacheManager->shouldReceive('put')
+            ->once()
+            ->with($key, serialize($parentContent), 86400)
+            ->andReturn(true);
+
+        $this->cacheManager->shouldReceive('get')
+            ->once()
+            ->with($key)
+            ->andReturn(serialize($parentContent));
+
+        // Store and retrieve parent screen
+        $this->screenCache->set($key, $parentContent);
+        $result = $this->screenCache->get($key);
+        $this->screenCache->get($nestedKey);
+
+        // Verify parent and nested content
+        $this->assertEquals($parentContent, $result);
+        $this->assertEquals($nestedContent, $result['config']['content']);
+    }
+
+    /** @test */
+    public function testTracksCacheStatistics()
+    {
+        $key = 'test_stats';
+        $value = ['data' => 'test'];
+        $serializedValue = serialize($value);
+
+        // Initialize Redis counters
+        Redis::set('screen_cache:stats:hits', 0);
+        Redis::set('screen_cache:stats:misses', 0);
+        Redis::set('screen_cache:stats:size', 0);
+
+        // Test cache hit
+        $this->cacheManager->shouldReceive('get')
+            ->once()
+            ->with($key)
+            ->andReturn($serializedValue);
+
+        $this->screenCache->get($key);
+        Redis::incr('screen_cache:stats:hits');
+        $this->assertEquals(1, Redis::get('screen_cache:stats:hits'));
+
+        // Test cache miss
+        $this->cacheManager->shouldReceive('get')
+            ->once()
+            ->with('missing_key')
+            ->andReturnNull();
+
+        $this->screenCache->get('missing_key');
+        Redis::incr('screen_cache:stats:misses');
+        $this->assertEquals(1, Redis::get('screen_cache:stats:misses'));
+
+        // Test cache size tracking
+        $this->cacheManager->shouldReceive('put')
+            ->once()
+            ->with($key, $serializedValue, 86400)
+            ->andReturn(true);
+
+        $this->screenCache->set($key, $value);
+        Redis::incrBy('screen_cache:stats:size', strlen($serializedValue));
+        $this->assertGreaterThan(0, Redis::get('screen_cache:stats:size'));
+    }
+
+    /** @test */
+    public function testDeletesFromCache()
+    {
+        $key = 'test_delete';
+
+        // Set up expectations
+        $this->cacheManager->shouldReceive('forget')
+            ->once()
+            ->with($key)
+            ->andReturn(true);
+
+        // Execute delete and verify return value
+        $result = $this->screenCache->delete($key);
+        $this->assertTrue($result);
+
+        // Verify forget was called
+        $this->cacheManager->shouldHaveReceived('forget')
+            ->once()
+            ->with($key);
+    }
+
+    /** @test */
+    public function testClearsEntireCache()
+    {
+        // Set up expectations
+        $this->cacheManager->shouldReceive('flush')
+            ->once()
+            ->andReturn(true);
+
+        $result = $this->screenCache->clear();
+
+        // Verify the clear operation was successful
+        $this->assertTrue($result);
+
+        // Verify flush was called
+        $this->cacheManager->shouldHaveReceived('flush')
+            ->once();
+    }
+
+    /** @test */
+    public function testChecksIfKeyExists()
+    {
+        $key = 'test_exists';
+
+        // Test when key exists
+        $this->cacheManager->shouldReceive('has')
+            ->once()
+            ->with($key)
+            ->andReturn(true);
+
+        $this->assertTrue($this->screenCache->has($key));
+
+        // Test when key doesn't exist
+        $this->cacheManager->shouldReceive('has')
+            ->once()
+            ->with($key)
+            ->andReturn(false);
+
+        $this->assertFalse($this->screenCache->has($key));
+    }
+
+    /** @test */
+    public function testChecksIfKeyIsMissing()
+    {
+        $key = 'test_missing';
+
+        // Test when key exists
+        $this->cacheManager->shouldReceive('has')
+            ->once()
+            ->with($key)
+            ->andReturn(true);
+
+        $this->assertFalse($this->screenCache->missing($key));
+
+        // Test when key doesn't exist
+        $this->cacheManager->shouldReceive('has')
+            ->once()
+            ->with($key)
+            ->andReturn(false);
+
+        $this->assertTrue($this->screenCache->missing($key));
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        Redis::flushdb();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- Create screen cache manage
- Create screen cache factory
- add screen cache facade
- create legacy screen adapter
## How to Test
- run 
`php artisan test`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20911

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
