### PR TITLE
Implement eTag to the Modal for Cases

### DIFF
--- a/routes/engine.php
+++ b/routes/engine.php
@@ -6,7 +6,7 @@ use ProcessMaker\Http\Controllers\Api\ProcessRequestController;
 use ProcessMaker\Http\Controllers\Api\TaskController;
 
 // Engine
-Route::prefix('api/1.0')->name('api.')->group(function () {
+Route::middleware('etag')->prefix('api/1.0')->name('api.')->group(function () {
     // List of Processes that the user can start
     Route::get('start_processes', [ProcessController::class, 'startProcesses'])->name('processes.start'); // Filtered in controller
 

--- a/routes/engine.php
+++ b/routes/engine.php
@@ -6,9 +6,9 @@ use ProcessMaker\Http\Controllers\Api\ProcessRequestController;
 use ProcessMaker\Http\Controllers\Api\TaskController;
 
 // Engine
-Route::middleware('etag')->prefix('api/1.0')->name('api.')->group(function () {
+Route::prefix('api/1.0')->name('api.')->group(function () {
     // List of Processes that the user can start
-    Route::get('start_processes', [ProcessController::class, 'startProcesses'])->name('processes.start'); // Filtered in controller
+    Route::get('start_processes', [ProcessController::class, 'startProcesses'])->middleware('etag')->name('processes.start'); // Filtered in controller
 
     // Start a process
     Route::post('process_events/{process}', [ProcessController::class, 'triggerStartEvent'])->name('process_events.trigger')->middleware('can:start,process');


### PR DESCRIPTION
## Issue & Reproduction Steps

To improve performance and user experience, we need to preload all cases into the cache when the + Case button is clicked. This reduces load times and ensures a smoother interaction.

In this scenario, we utilize the **ETag implementation** to enhance the caching mechanism for the `start_processes` endpoint.

## Solution

- Implemented the **ETag middleware** for the `start_processes` endpoint to enable efficient response caching and validation.

## How to Test

1. Ensure the application has a substantial number of cases to work with.
2. Click the **+ Case** button to initiate the modal.
3. Verify that a `304 Not Modified` response is returned for cached data, confirming the ETag implementation is functioning correctly.

![Screenshot 2024-12-03 at 12 40 18 PM](https://github.com/user-attachments/assets/f61629b2-9066-475d-8c12-b1847c650ca8)

- ci:deploy




## Related Tickets & Packages
- Ticket: [FOUR-20920](https://processmaker.atlassian.net/browse/FOUR-20920)
- eTag: [FOUR-20929](https://processmaker.atlassian.net/browse/FOUR-20929)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20920]: https://processmaker.atlassian.net/browse/FOUR-20920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-20929]: https://processmaker.atlassian.net/browse/FOUR-20929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ