### PR TITLE
Task/FOUR-21198: Create command to revoke specified API tokens

### DIFF
--- a/ProcessMaker/Console/Commands/RevokeOauthAccessTokens.php
+++ b/ProcessMaker/Console/Commands/RevokeOauthAccessTokens.php
@@ -14,7 +14,7 @@ class RevokeOauthAccessTokens extends Command
      *
      * @var string
      */
-    protected $signature = 'processmaker:revoke-oauth-access-tokens {--name=} {--after=} {--client_id=}';
+    protected $signature = 'processmaker:revoke-oauth-access-tokens {--name=} {--after=} {--client_id=} {--no-interaction|n}';
 
     /**
      * The console command description.
@@ -33,9 +33,15 @@ class RevokeOauthAccessTokens extends Command
         $name = $this->option('name');
         $after = $this->option('after');
         $clientId = $this->option('client_id');
+        $noInteraction = $this->option('no-interaction');
 
         if (!$name && !$after && !$clientId) {
             $this->error('At least one of --name, --after, or --client_id must be specified.');
+            return;
+        }
+
+        if (!$noInteraction && !$this->confirm('Are you sure you want to revoke this certificate?')) {
+            $this->info('Certificate revocation cancelled.');
             return;
         }
 

--- a/ProcessMaker/Console/Commands/RevokeOauthAccessTokens.php
+++ b/ProcessMaker/Console/Commands/RevokeOauthAccessTokens.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class RevokeOauthAccessTokens extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'processmaker:revoke-oauth-access-tokens {--name=} {--after=} {--client_id=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Revoke oauth access tokens for a given token name, client_id, or after a given date';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->option('name');
+        $after = $this->option('after');
+        $clientId = $this->option('client_id');
+
+        if (!$name && !$after && !$clientId) {
+            $this->error('At least one of --name, --after, or --client_id must be specified.');
+            return;
+        }
+
+        $query = DB::table('oauth_access_tokens')->where('revoked', false);
+
+        if ($name) {
+            $names = explode(',', $name);
+            $query->whereIn('name', $names);
+        }
+
+        if ($after) {
+            $date = Carbon::createFromFormat('Y-m-d', $after);
+            $query->where('created_at', '>', $date);
+        }
+
+        if ($clientId) {
+            $clientIds = explode(',', $clientId);
+            $query->whereIn('client_id', $clientIds);
+        }
+
+        $revokedCount = $query->update(['revoked' => true]);
+
+        $this->info("Revoked $revokedCount tokens.");
+    }
+}


### PR DESCRIPTION
# Description
Please see the description in the ticket: https://processmaker.atlassian.net/browse/FOUR-21198



# RevokeOauthAccessTokens Command

This pull request introduces a new console command `RevokeOauthAccessTokens` to the ProcessMaker application. The command is designed to revoke OAuth access tokens based on specified criteria.

## Command Signature
`php artisan processmaker:revoke-oauth-access-tokens {--name=} {--after=} {--client_id=} {--no-interaction|-n}`

## Options

- `--name=`: Specify the name(s) of the token(s) to revoke. Multiple names can be separated by commas.
- `--after=`: Revoke tokens created after a specified date. The date should be in `Y-m-d` format.
- `--client_id=`: Specify the client ID(s) associated with the tokens to revoke. Multiple client IDs can be separated by commas.
- `--no-interaction|-n`: Run the command without any interactive prompts.

## Description

The `RevokeOauthAccessTokens` command allows administrators to revoke OAuth access tokens based on the token name, client ID, or creation date. This is useful for managing access and ensuring that only valid tokens are active.

## Usage Examples

1. **Revoke tokens by name:**
   ```bash
   php artisan processmaker:revoke-oauth-access-tokens --name=token1,token2
   ```

2. **Revoke tokens created after a specific date:**
   ```bash
   php artisan processmaker:revoke-oauth-access-tokens --after=2023-01-01
   ```

3. **Revoke tokens by client ID:**
   ```bash
   php artisan processmaker:revoke-oauth-access-tokens --client_id=123,456
   ```

4. **Run the command without interaction:**
   ```bash
   php artisan processmaker:revoke-oauth-access-tokens --name=token1 --no-interaction
   ```

## Notes

- At least one of the options `--name`, `--after`, or `--client_id` must be specified.
- If `--no-interaction` is not used, the command will prompt for confirmation before revoking tokens.



