### PR TITLE
bugfix/FOUR-19358: [40847] Bug: Sorting Functionality Not Working for Script Executors in Admin Panel

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
@@ -59,7 +59,15 @@ class ScriptExecutorController extends Controller
     {
         $this->checkAuth($request);
 
-        return new ApiCollection(ScriptExecutor::nonSystem()->get());
+        $query = ScriptExecutor::nonSystem();
+
+        if ($request->has('order_by')) {
+            $order_by = $request->input('order_by');
+            $order_direction = $request->input('order_direction', 'ASC');
+            $query->orderBy($order_by, $order_direction);
+        }
+
+        return new ApiCollection($query->get());
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- Sort Options in Script Executor Screen now works

## How to Test
- Go to Admin-> Script Executors
- Click on columns to sort rows

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19358

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
