### PR TITLE
FOUR-20909 invalidate cache on event

### DIFF
--- a/ProcessMaker/Cache/Settings/SettingCacheManager.php
+++ b/ProcessMaker/Cache/Settings/SettingCacheManager.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Cache\Settings;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
 use ProcessMaker\Cache\CacheInterface;
 
@@ -156,7 +157,7 @@ class SettingCacheManager implements CacheInterface
                 Redis::connection($connection)->del($matchedKeys);
             }
         } catch (\Exception $e) {
-            \Log::error('SettingCacheException' . $e->getMessage());
+            Log::error('SettingCacheException' . $e->getMessage());
 
             throw new SettingCacheException('Failed to delete keys.');
         }
@@ -184,5 +185,23 @@ class SettingCacheManager implements CacheInterface
     public function missing(string $key): bool
     {
         return !$this->has($key);
+    }
+
+    /**
+     * Invalidate a value in the settings cache.
+     *
+     * @param string $key
+     *
+     * @return void
+     */
+    public function invalidate(string $key): void
+    {
+        try {
+            $this->cacheManager->forget($key);
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+
+            throw new SettingCacheException('Failed to invalidate cache KEY:' . $key);
+        }
     }
 }

--- a/ProcessMaker/Observers/SettingObserver.php
+++ b/ProcessMaker/Observers/SettingObserver.php
@@ -65,5 +65,18 @@ class SettingObserver
                 $setting->config = $return;
                 break;
         }
+
+        \SettingCache::invalidate($setting->key);
+    }
+
+    /**
+     * Handle the setting "deleted" event.
+     *
+     * @param  \ProcessMaker\Models\Setting  $setting
+     * @return void
+     */
+    public function deleted(Setting $setting): void
+    {
+        \SettingCache::invalidate($setting->key);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Invalidate Cache on Event

## Solution
- Add `invalidate` method to `SettingCacheManager`

## Related Tickets & Packages
[FOUR-20909](https://processmaker.atlassian.net/browse/FOUR-20909)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20909]: https://processmaker.atlassian.net/browse/FOUR-20909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ