### PR TITLE
FOUR-16704: Session Token Not Invalidated on Logout (for version 4.11.6)

### DIFF
--- a/ProcessMaker/Events/SessionStarted.php
+++ b/ProcessMaker/Events/SessionStarted.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Events;
 
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\PrivateChannel;
@@ -59,6 +60,13 @@ class SessionStarted implements ShouldBroadcastNow
         $lifetime = Session::has('rememberme') && Session::get('rememberme')
                         ? 'Number.MAX_SAFE_INTEGER'
                         : config('session.lifetime');
+
+                              // Initialize the session activity control
+        Cache::put(
+            'user_' . $this->user->id . '_active_session_' . RequestDevice::getId(),
+            ['active' => true, 'updated_at' => now()],
+            now()->addMinutes(config('session.lifetime'))
+        );
 
         return [
             'lifetime' => $lifetime,

--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -249,6 +249,11 @@ class LoginController extends Controller
             $userId = Auth::user()->id;
             Cache::forget("user_{$userId}_permissions");
             Cache::forget("user_{$userId}_project_assets");
+            Cache::put(
+                'user_' . $userId . '_active_session_' . $request->cookie('device_id'),
+                ['active' => false, 'updated_at' => now()],
+                now()->addMinutes(config('session.lifetime'))
+            );
 
             // Clear the user session
             $this->forgetUserSession();

--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -81,6 +81,7 @@ class Kernel extends HttpKernel
         'session_block' => \ProcessMaker\Http\Middleware\SessionControlBlock::class,
         'session_kill' => \ProcessMaker\Http\Middleware\SessionControlKill::class,
         'no-cache' => \ProcessMaker\Http\Middleware\NoCache::class,
+        'verify_active_session' => Middleware\VerifyActiveSession::class,
     ];
 
     /**

--- a/ProcessMaker/Http/Middleware/VerifyActiveSession.php
+++ b/ProcessMaker/Http/Middleware/VerifyActiveSession.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use ProcessMaker\Models\UserSession;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Crypt;
+
+class VerifyActiveSession
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // if the authorization is via token in cookie 
+        if (!$request->hasHeader('Authorization') && $request->hasCookie('laravel_token')) {
+            $user = \Auth::user();
+
+            $cacheKey = 'user_' . $user->id . '_active_session_' . $request->cookie('device_id');
+            $activeSession = Cache::get($cacheKey);
+            $isActive = $activeSession ? $activeSession['active'] : false;
+            if (!$isActive) {
+                return response()->json(['error' => 'Unauthorized'], 401);
+            }
+            else {
+                $lastActivity = $activeSession ? $activeSession['updated_at'] : now();
+                // refresh the cache entry's lifetime
+                if (now()->diffInMinutes($lastActivity) > config('session.lifetime') / 2) {
+                    Cache::put(
+                        $cacheKey,
+                        ['active' => true, 'updated_at' => now()],
+                        now()->addMinutes(config('session.lifetime'))
+                    );
+                }
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,7 +41,7 @@ use ProcessMaker\Http\Controllers\Api\WizardTemplateController;
 use ProcessMaker\Http\Controllers\Auth\TwoFactorAuthController;
 use ProcessMaker\Http\Controllers\TestStatusController;
 
-Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/1.0')->name('api.')->group(function () {
+Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize', 'verify_active_session')->prefix('api/1.0')->name('api.')->group(function () {
     // Users
     Route::get('users', [UserController::class, 'index'])->name('users.index'); // Permissions handled in the controller
     Route::get('users/{user}', [UserController::class, 'show'])->name('users.show'); // Permissions handled in the controller


### PR DESCRIPTION
## Issue & Reproduction Steps
Follow the instructions in the video "Screen Recording on 2024-12-03 at 12-00-33.mp4" of the ticket https://processmaker.atlassian.net/browse/FOUR-16704

## Solution
- Cache de status of logged in/logged out of a user
![Peek 2024-12-06 16-17](https://github.com/user-attachments/assets/01ed1a32-c8b4-4901-bd9e-f01891187e8a)


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16704

## Tests done:
- Login/logout in one device --> OK
- Login/logout in multiple devices --> OK
- Socialite authentication (used SAML) --> OK
- Endpoint called using Postman or similar -> OK

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy