### PR TITLE
FOUR-20462 add support for server timing headers

### DIFF
--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Http;
 
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use ProcessMaker\Http\Middleware\ServerTimingMiddleware;
 
 class Kernel extends HttpKernel
 {
@@ -20,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         Middleware\TrustProxies::class,
         Middleware\BrowserCache::class,
+        ServerTimingMiddleware::class,
     ];
 
     /**

--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -17,16 +17,6 @@ class ServerTimingMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
-        // Start time for the entire request
-        $startEndpoint = microtime(true);
-        // Track total query execution time
-        $queryTime = 0;
-
-        // Listen to query events and accumulate query execution time
-        DB::listen(function ($query) use (&$queryTime) {
-            $queryTime += $query->time; // Query time in milliseconds
-        });
-
         // Start time for controller execution
         $startController = microtime(true);
 
@@ -35,14 +25,13 @@ class ServerTimingMiddleware
 
         // Calculate execution times
         $controllerTime = (microtime(true) - $startController) * 1000; // Convert to ms
-        $endpointTime = (microtime(true) - $startEndpoint) * 1000; // Convert to ms
-
         // Fetch service provider boot time
         $serviceProviderTime = ProcessMakerServiceProvider::getBootTime() ?? 0;
+        // Fetch query time
+        $queryTime = ProcessMakerServiceProvider::getQueryTime() ?? 0;
 
         $serverTiming = [
-            "providers;dur={$serviceProviderTime}",
-            "endpoint;dur={$endpointTime}",
+            "provider;dur={$serviceProviderTime}",
             "controller;dur={$controllerTime}",
             "db;dur={$queryTime}",
         ];

--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -40,13 +40,23 @@ class ServerTimingMiddleware
         // Fetch service provider boot time
         $serviceProviderTime = ProcessMakerServiceProvider::getBootTime() ?? 0;
 
-        // Add Server-Timing headers
-        $response->headers->set('Server-Timing', [
+        $serverTiming = [
             "providers;dur={$serviceProviderTime}",
             "endpoint;dur={$endpointTime}",
             "controller;dur={$controllerTime}",
             "db;dur={$queryTime}",
-        ]);
+        ];
+
+        $packageTimes = ProcessMakerServiceProvider::getPackageBootTiming();
+
+        foreach ($packageTimes as $package => $timing) {
+            $time = ($timing['end'] - $timing['start']) * 1000;
+
+            $serverTiming[] = "{$package};dur={$time}";
+        }
+
+        // Add Server-Timing headers
+        $response->headers->set('Server-Timing', $serverTiming);
 
         return $response;
     }

--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use ProcessMaker\Providers\ProcessMakerServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 
 class ServerTimingMiddleware
@@ -36,11 +37,15 @@ class ServerTimingMiddleware
         $controllerTime = (microtime(true) - $startController) * 1000; // Convert to ms
         $endpointTime = (microtime(true) - $startEndpoint) * 1000; // Convert to ms
 
-        // Add Server-Timing header
+        // Fetch service provider boot time
+        $serviceProviderTime = ProcessMakerServiceProvider::getBootTime() ?? 0;
+
+        // Add Server-Timing headers
         $response->headers->set('Server-Timing', [
+            "providers;dur={$serviceProviderTime}",
             "endpoint;dur={$endpointTime}",
             "controller;dur={$controllerTime}",
-            "db;dur={$queryTime}"
+            "db;dur={$queryTime}",
         ]);
 
         return $response;

--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ServerTimingMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $start = microtime(true);
+
+        // Process the request
+        $response = $next($request);
+
+        // Calculate elapsed time
+        $duration = (microtime(true) - $start) * 1000; // Convert to milliseconds
+
+        // Add Server-Timing header
+        $response->headers->set('Server-Timing', "controller;dur={$duration}");
+
+        return $response;
+    }
+}

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -39,9 +39,14 @@ class ProcessMakerServiceProvider extends ServiceProvider
     private static $bootStart;
     // Track the boot time for service providers
     private static $bootTime;
+    // Track the boot time for each package
+    private static $packageBootTiming = [];
 
     public function boot(): void
     {
+        // Track the start time for service providers boot
+        self::$bootStart = microtime(true);
+
         $this->app->singleton(Menu::class, function ($app) {
             return new MenuManager();
         });
@@ -64,9 +69,6 @@ class ProcessMakerServiceProvider extends ServiceProvider
 
     public function register(): void
     {
-        // Track the start time for service providers boot
-        self::$bootStart = microtime(true);
-
         // Dusk, if env is appropriate
         // TODO Remove Dusk references and remove from composer dependencies
         if (!$this->app->environment('production')) {
@@ -378,5 +380,42 @@ class ProcessMakerServiceProvider extends ServiceProvider
     public static function getBootTime(): ?float
     {
         return self::$bootTime;
+    }
+
+    /**
+     * Set the boot time for service providers.
+     *
+     * @param float $time
+     */
+    public static function setPackageBootStart(string $package, $time): void
+    {
+        $package = ucfirst(\Str::camel(str_replace(['ProcessMaker\Packages\\', '\\'], '', $package)));
+
+        self::$packageBootTiming[$package] = [
+            'start' => $time,
+            'end' => null,
+        ];
+    }
+
+    /**
+     * Set the boot time for service providers.
+     *
+     * @param float $time
+     */
+    public static function setPackageBootedTime(string $package, $time): void
+    {
+        $package = ucfirst(\Str::camel(str_replace(['ProcessMaker\Packages\\', '\\'], '', $package)));
+
+        self::$packageBootTiming[$package]['end'] = $time;
+    }
+
+    /**
+     * Get the boot time for service providers.
+     *
+     * @return array
+     */
+    public static function getPackageBootTiming(): array
+    {
+        return self::$packageBootTiming;
     }
 }

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -35,6 +35,11 @@ use ProcessMaker\PolicyExtension;
  */
 class ProcessMakerServiceProvider extends ServiceProvider
 {
+    // Track the start time for service providers boot
+    private static $bootStart;
+    // Track the boot time for service providers
+    private static $bootTime;
+
     public function boot(): void
     {
         $this->app->singleton(Menu::class, function ($app) {
@@ -52,10 +57,16 @@ class ProcessMakerServiceProvider extends ServiceProvider
         $this->setupFactories();
 
         parent::boot();
+
+        // Hook after service providers boot
+        self::$bootTime = (microtime(true) - self::$bootStart) * 1000; // Convert to milliseconds
     }
 
     public function register(): void
     {
+        // Track the start time for service providers boot
+        self::$bootStart = microtime(true);
+
         // Dusk, if env is appropriate
         // TODO Remove Dusk references and remove from composer dependencies
         if (!$this->app->environment('production')) {
@@ -357,5 +368,15 @@ class ProcessMakerServiceProvider extends ServiceProvider
         if (config('app.force_https')) {
             URL::forceScheme('https');
         }
+    }
+
+    /**
+     * Get the boot time for service providers.
+     *
+     * @return float|null
+     */
+    public static function getBootTime(): ?float
+    {
+        return self::$bootTime;
     }
 }

--- a/ProcessMaker/Traits/PluginServiceProviderTrait.php
+++ b/ProcessMaker/Traits/PluginServiceProviderTrait.php
@@ -11,6 +11,7 @@ use ProcessMaker\Events\ScriptBuilderStarting;
 use ProcessMaker\Managers\IndexManager;
 use ProcessMaker\Managers\LoginManager;
 use ProcessMaker\Managers\PackageManager;
+use ProcessMaker\Providers\ProcessMakerServiceProvider;
 
 /**
  * Add functionality to control a PM plug-in
@@ -20,6 +21,32 @@ trait PluginServiceProviderTrait
     private $modelerScripts = [];
 
     private $scriptBuilderScripts = [];
+
+    private static $bootStart = null;
+
+    private static $bootTime;
+
+    public function __construct($app)
+    {
+        parent::__construct($app);
+
+        $this->booting(function () {
+            self::$bootStart = microtime(true);
+
+            $package = defined('static::name') ? static::name : $this::class;
+
+            ProcessMakerServiceProvider::setPackageBootStart($package, self::$bootStart);
+        });
+
+        $this->booted(function () {
+            self::$bootTime = microtime(true);
+
+            $package = defined('static::name') ? static::name : $this::class;
+
+            ProcessMakerServiceProvider::setPackageBootedTime($package, self::$bootTime);
+        });
+
+    }
 
     /**
      * Boot the PM plug-in.

--- a/tests/Feature/ServerTimingMiddlewareTest.php
+++ b/tests/Feature/ServerTimingMiddlewareTest.php
@@ -35,10 +35,9 @@ class ServerTimingMiddlewareTest extends TestCase
         $response->assertHeader('Server-Timing');
 
         $serverTiming = $this->getHeader($response, 'server-timing');
-        $this->assertStringContainsString('providers;dur=', $serverTiming[0]);
-        $this->assertStringContainsString('endpoint;dur=', $serverTiming[1]);
-        $this->assertStringContainsString('controller;dur=', $serverTiming[2]);
-        $this->assertStringContainsString('db;dur=', $serverTiming[3]);
+        $this->assertStringContainsString('provider;dur=', $serverTiming[0]);
+        $this->assertStringContainsString('controller;dur=', $serverTiming[1]);
+        $this->assertStringContainsString('db;dur=', $serverTiming[2]);
     }
 
     public function testQueryTimeIsMeasured()
@@ -54,7 +53,7 @@ class ServerTimingMiddlewareTest extends TestCase
         // Extract the Server-Timing header
         $serverTiming = $this->getHeader($response, 'server-timing');
         // Assert the db timing is greater than 200ms (SLEEP simulates query time)
-        preg_match('/db;dur=([\d.]+)/', $serverTiming[3], $matches);
+        preg_match('/db;dur=([\d.]+)/', $serverTiming[2], $matches);
         $dbTime = $matches[1] ?? 0;
 
         $this->assertGreaterThanOrEqual(200, (float)$dbTime);
@@ -73,31 +72,11 @@ class ServerTimingMiddlewareTest extends TestCase
         $serverTiming = $this->getHeader($response, 'server-timing');
 
         // Assert the providers timing is present and greater than or equal to 0
-        preg_match('/providers;dur=([\d.]+)/', $serverTiming[0], $matches);
+        preg_match('/provider;dur=([\d.]+)/', $serverTiming[0], $matches);
         $providersTime = $matches[1] ?? null;
 
         $this->assertNotNull($providersTime);
         $this->assertGreaterThanOrEqual(0, (float)$providersTime);
-    }
-
-    public function testEndpointTimingIsMeasuredCorrectly()
-    {
-        // Mock a route
-        Route::middleware(ServerTimingMiddleware::class)->get('/endpoint-test', function () {
-            usleep(500000); // Simulate 500ms delay
-            return response()->json(['message' => 'Endpoint timing test']);
-        });
-
-        // Send a GET request
-        $response = $this->get('/endpoint-test');
-        // Extract the Server-Timing header
-        $serverTiming = $this->getHeader($response, 'server-timing');
-
-        // Assert the endpoint timing is greater than 500ms
-        preg_match('/endpoint;dur=([\d.]+)/', $serverTiming[1], $matches);
-        $endpointTime = $matches[1] ?? 0;
-
-        $this->assertGreaterThanOrEqual(500, (float)$endpointTime);
     }
 
     public function testControllerTimingIsMeasuredCorrectly()
@@ -114,7 +93,7 @@ class ServerTimingMiddlewareTest extends TestCase
         $serverTiming = $this->getHeader($response, 'server-timing');
 
         // Assert the controller timing is greater than 300ms
-        preg_match('/controller;dur=([\d.]+)/', $serverTiming[2], $matches);
+        preg_match('/controller;dur=([\d.]+)/', $serverTiming[1], $matches);
         $controllerTime = $matches[1] ?? 0;
 
         $this->assertGreaterThanOrEqual(300, (float)$controllerTime);
@@ -133,7 +112,7 @@ class ServerTimingMiddlewareTest extends TestCase
         $serverTiming = $this->getHeader($response, 'server-timing');
 
         // Assert the providers timing is present and greater than or equal to 0
-        preg_match('/providers;dur=([\d.]+)/', $serverTiming[0], $matches);
+        preg_match('/provider;dur=([\d.]+)/', $serverTiming[0], $matches);
         $providersTime = $matches[1] ?? null;
 
         $this->assertNotNull($providersTime);
@@ -151,9 +130,8 @@ class ServerTimingMiddlewareTest extends TestCase
         $response->assertHeader('Server-Timing');
 
         $serverTiming = $this->getHeader($response, 'server-timing');
-        $this->assertStringContainsString('providers;dur=', $serverTiming[0]);
-        $this->assertStringContainsString('endpoint;dur=', $serverTiming[1]);
-        $this->assertStringContainsString('controller;dur=', $serverTiming[2]);
-        $this->assertStringContainsString('db;dur=', $serverTiming[3]);
+        $this->assertStringContainsString('provider;dur=', $serverTiming[0]);
+        $this->assertStringContainsString('controller;dur=', $serverTiming[1]);
+        $this->assertStringContainsString('db;dur=', $serverTiming[2]);
     }
 }

--- a/tests/Feature/ServerTimingMiddlewareTest.php
+++ b/tests/Feature/ServerTimingMiddlewareTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use ProcessMaker\Http\Middleware\ServerTimingMiddleware;
+use ProcessMaker\Models\User;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class ServerTimingMiddlewareTest extends TestCase
+{
+    use RequestHelper;
+
+    private function getHeader($response, $header)
+    {
+        $headers = $response->headers->all();
+        return $headers[$header];
+    }
+
+    public function testServerTimingHeaderIncludesAllMetrics()
+    {
+        Route::middleware(ServerTimingMiddleware::class)->get('/test', function () {
+            // Simulate a query
+            DB::select('SELECT SLEEP(1)');
+
+            return response()->json(['message' => 'Test endpoint']);
+        });
+
+        // Send a GET request
+        $response = $this->get('/test');
+        $response->assertStatus(200);
+        // Assert the response has the Server-Timing header
+        $response->assertHeader('Server-Timing');
+
+        $serverTiming = $this->getHeader($response, 'server-timing');
+        $this->assertStringContainsString('providers;dur=', $serverTiming[0]);
+        $this->assertStringContainsString('endpoint;dur=', $serverTiming[1]);
+        $this->assertStringContainsString('controller;dur=', $serverTiming[2]);
+        $this->assertStringContainsString('db;dur=', $serverTiming[3]);
+    }
+
+    public function testQueryTimeIsMeasured()
+    {
+        // Mock a route with a query
+        Route::middleware(ServerTimingMiddleware::class)->get('/query-test', function () {
+            DB::select('SELECT SLEEP(0.2)');
+            return response()->json(['message' => 'Query test']);
+        });
+
+        // Send a GET request
+        $response = $this->get('/query-test');
+        // Extract the Server-Timing header
+        $serverTiming = $this->getHeader($response, 'server-timing');
+        // Assert the db timing is greater than 200ms (SLEEP simulates query time)
+        preg_match('/db;dur=([\d.]+)/', $serverTiming[3], $matches);
+        $dbTime = $matches[1] ?? 0;
+
+        $this->assertGreaterThanOrEqual(200, (float)$dbTime);
+    }
+
+    public function testServiceProviderTimeIsMeasured()
+    {
+        // Mock a route
+        Route::middleware(ServerTimingMiddleware::class)->get('/providers-test', function () {
+            return response()->json(['message' => 'Providers test']);
+        });
+
+        // Send a GET request
+        $response = $this->get('/providers-test');
+        // Extract the Server-Timing header
+        $serverTiming = $this->getHeader($response, 'server-timing');
+
+        // Assert the providers timing is present and greater than or equal to 0
+        preg_match('/providers;dur=([\d.]+)/', $serverTiming[0], $matches);
+        $providersTime = $matches[1] ?? null;
+
+        $this->assertNotNull($providersTime);
+        $this->assertGreaterThanOrEqual(0, (float)$providersTime);
+    }
+
+    public function testEndpointTimingIsMeasuredCorrectly()
+    {
+        // Mock a route
+        Route::middleware(ServerTimingMiddleware::class)->get('/endpoint-test', function () {
+            usleep(500000); // Simulate 500ms delay
+            return response()->json(['message' => 'Endpoint timing test']);
+        });
+
+        // Send a GET request
+        $response = $this->get('/endpoint-test');
+        // Extract the Server-Timing header
+        $serverTiming = $this->getHeader($response, 'server-timing');
+
+        // Assert the endpoint timing is greater than 500ms
+        preg_match('/endpoint;dur=([\d.]+)/', $serverTiming[1], $matches);
+        $endpointTime = $matches[1] ?? 0;
+
+        $this->assertGreaterThanOrEqual(500, (float)$endpointTime);
+    }
+
+    public function testControllerTimingIsMeasuredCorrectly()
+    {
+        // Mock a route
+        Route::middleware(ServerTimingMiddleware::class)->get('/controller-test', function () {
+            usleep(300000); // Simulate 300ms delay in the controller
+            return response()->json(['message' => 'Controller timing test']);
+        });
+
+        // Send a GET request
+        $response = $this->get('/controller-test');
+        // Extract the Server-Timing header
+        $serverTiming = $this->getHeader($response, 'server-timing');
+
+        // Assert the controller timing is greater than 300ms
+        preg_match('/controller;dur=([\d.]+)/', $serverTiming[2], $matches);
+        $controllerTime = $matches[1] ?? 0;
+
+        $this->assertGreaterThanOrEqual(300, (float)$controllerTime);
+    }
+
+    public function testProvidersTimingIsMeasuredCorrectly()
+    {
+        // Mock a route
+        Route::middleware(ServerTimingMiddleware::class)->get('/providers-test', function () {
+            return response()->json(['message' => 'Providers timing test']);
+        });
+
+        // Send a GET request
+        $response = $this->get('/providers-test');
+        // Extract the Server-Timing header
+        $serverTiming = $this->getHeader($response, 'server-timing');
+
+        // Assert the providers timing is present and greater than or equal to 0
+        preg_match('/providers;dur=([\d.]+)/', $serverTiming[0], $matches);
+        $providersTime = $matches[1] ?? null;
+
+        $this->assertNotNull($providersTime);
+        $this->assertGreaterThanOrEqual(0, (float)$providersTime);
+    }
+
+    public function testServerTimingOnLogin()
+    {
+        $user = User::factory()->create([
+            'username' =>'john',
+        ]);
+        $this->actingAs($user, 'web');
+
+        $response = $this->get('/login');
+        $response->assertHeader('Server-Timing');
+
+        $serverTiming = $this->getHeader($response, 'server-timing');
+        $this->assertStringContainsString('providers;dur=', $serverTiming[0]);
+        $this->assertStringContainsString('endpoint;dur=', $serverTiming[1]);
+        $this->assertStringContainsString('controller;dur=', $serverTiming[2]);
+        $this->assertStringContainsString('db;dur=', $serverTiming[3]);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
As a developer, I want to add support for Server Timing headers in the API responses so that we can collect and view detailed timing information for requests directly in the browser and in LogRocket.

## Solution
- Add Service Provider timing execution
- Add DB query timing execution
- Add Controller timing execution
- Add Package Service Provider timing execution

## Related Tickets & Packages
[FOUR-20462](https://processmaker.atlassian.net/browse/FOUR-20462)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20462]: https://processmaker.atlassian.net/browse/FOUR-20462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ