### PR TITLE
FOUR-21276: Allow the tasks API endpoint to show all tasks, not just user tasks Winter25

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -90,6 +90,15 @@ class TaskController extends Controller
      *           type="integer",
      *         )
      *     ),
+     *     @OA\Parameter(
+     *         description="Return all task types. Not just user tasks.",
+     *         in="query",
+     *         name="all_tasks",
+     *         required=false,
+     *         @OA\Schema(
+     *           type="boolean",
+     *         )
+     *     ),
      *     @OA\Parameter(ref="#/components/parameters/filter"),
      *     @OA\Parameter(ref="#/components/parameters/order_by"),
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -149,7 +149,8 @@ trait TaskControllerIndexMethods
     private function excludeNonVisibleTasks($query, $request)
     {
         $nonSystem = filter_var($request->input('non_system'), FILTER_VALIDATE_BOOLEAN);
-        $query->where(function ($query) {
+        $allTasks = filter_var($request->input('all_tasks'), FILTER_VALIDATE_BOOLEAN);
+        $query->when(!$allTasks, function ($query) {
             $query->where('element_type', '=', 'task');
             $query->orWhere('element_type', '=', 'serviceTask');
             $query->where('element_name', '=', 'AI Assistant');

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -6140,6 +6140,15 @@
                         }
                     },
                     {
+                        "name": "all_tasks",
+                        "in": "query",
+                        "description": "Return all task types. Not just user tasks.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "$ref": "#/components/parameters/filter"
                     },
                     {


### PR DESCRIPTION
## Issue & Reproduction Steps
Allow the tasks API endpoint to show all tasks, not just user tasks Winter25

## Solution
- Cherry picks the commits relate to the [FOUR-18842](https://processmaker.atlassian.net/browse/FOUR-18842)

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-21276

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy