### PR TITLE
FOUR-20464 view server timing data in LogRocket

### DIFF
--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -41,7 +41,10 @@ class ServerTimingMiddleware
         foreach ($packageTimes as $package => $timing) {
             $time = ($timing['end'] - $timing['start']) * 1000;
 
-            $serverTiming[] = "{$package};dur={$time}";
+            // Only include packages that took more than 5ms
+            if ($time > 5) {
+                $serverTiming[] = "{$package};dur={$time}";
+            }
         }
 
         // Add Server-Timing headers

--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -4,12 +4,18 @@ namespace ProcessMaker\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use ProcessMaker\Providers\ProcessMakerServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 
 class ServerTimingMiddleware
 {
+    // Minimum time in ms to include a package in the Server-Timing header
+    private static $minPackageTime;
+
+    public function __construct()
+    {
+        self::$minPackageTime = config('app.server_timing.min_package_time');
+    }
     /**
      * Handle an incoming request.
      *
@@ -41,8 +47,8 @@ class ServerTimingMiddleware
         foreach ($packageTimes as $package => $timing) {
             $time = ($timing['end'] - $timing['start']) * 1000;
 
-            // Only include packages that took more than 5ms
-            if ($time > 5) {
+            // Only include packages that took more than MIN_PACKAGE_TIME ms
+            if ($time > self::$minPackageTime) {
                 $serverTiming[] = "{$package};dur={$time}";
             }
         }

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -407,8 +407,6 @@ class ProcessMakerServiceProvider extends ServiceProvider
      */
     public static function setPackageBootStart(string $package, $time): void
     {
-        $package = ucfirst(\Str::camel(str_replace(['ProcessMaker\Packages\\', '\\'], '', $package)));
-
         self::$packageBootTiming[$package] = [
             'start' => $time,
             'end' => null,
@@ -422,8 +420,6 @@ class ProcessMakerServiceProvider extends ServiceProvider
      */
     public static function setPackageBootedTime(string $package, $time): void
     {
-        $package = ucfirst(\Str::camel(str_replace(['ProcessMaker\Packages\\', '\\'], '', $package)));
-
         self::$packageBootTiming[$package]['end'] = $time;
     }
 

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Facades;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Laravel\Dusk\DuskServiceProvider;
 use Laravel\Horizon\Horizon;
@@ -403,10 +404,17 @@ class ProcessMakerServiceProvider extends ServiceProvider
     /**
      * Set the boot time for service providers.
      *
+     * @param string $package
      * @param float $time
      */
-    public static function setPackageBootStart(string $package, $time): void
+    public static function setPackageBootStart(string $package, float $time): void
     {
+        if ($time < 0) {
+            Log::info("Server Timing: Invalid boot time for package: {$package}, time: {$time}");
+
+            $time = 0;
+        }
+
         self::$packageBootTiming[$package] = [
             'start' => $time,
             'end' => null,
@@ -416,10 +424,17 @@ class ProcessMakerServiceProvider extends ServiceProvider
     /**
      * Set the boot time for service providers.
      *
+     *
      * @param float $time
      */
     public static function setPackageBootedTime(string $package, $time): void
     {
+        if (!isset(self::$packageBootTiming[$package]) || $time < 0) {
+            Log::info("Server Timing: Invalid booted time for package: {$package}, time: {$time}");
+
+            return;
+        }
+
         self::$packageBootTiming[$package]['end'] = $time;
     }
 

--- a/ProcessMaker/Traits/PluginServiceProviderTrait.php
+++ b/ProcessMaker/Traits/PluginServiceProviderTrait.php
@@ -51,7 +51,7 @@ trait PluginServiceProviderTrait
      *
      * @return string
      */
-    protected function getPackageName()
+    protected function getPackageName(): string
     {
         if (defined('static::name')) {
             return ucfirst(\Str::camel(static::name));

--- a/ProcessMaker/Traits/PluginServiceProviderTrait.php
+++ b/ProcessMaker/Traits/PluginServiceProviderTrait.php
@@ -30,22 +30,34 @@ trait PluginServiceProviderTrait
     {
         parent::__construct($app);
 
-        $this->booting(function () {
-            self::$bootStart = microtime(true);
+        $package = $this->getPackageName();
 
-            $package = defined('static::name') ? static::name : $this::class;
+        $this->booting(function () use ($package) {
+            self::$bootStart = microtime(true);
 
             ProcessMakerServiceProvider::setPackageBootStart($package, self::$bootStart);
         });
 
-        $this->booted(function () {
+        $this->booted(function () use ($package) {
             self::$bootTime = microtime(true);
-
-            $package = defined('static::name') ? static::name : $this::class;
 
             ProcessMakerServiceProvider::setPackageBootedTime($package, self::$bootTime);
         });
 
+    }
+
+    /**
+     * Get the package name for the Server Timing header
+     *
+     * @return string
+     */
+    protected function getPackageName()
+    {
+        if (defined('static::name')) {
+            return ucfirst(\Str::camel(static::name));
+        }
+
+        return substr(static::class, strrpos(static::class, '\\') + 1);
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -246,7 +246,7 @@ return [
     // Process Request security log rate limit: 1 per day (86400 seconds)
     'process_request_errors_rate_limit' => env('PROCESS_REQUEST_ERRORS_RATE_LIMIT', 1),
     'process_request_errors_rate_limit_duration' => env('PROCESS_REQUEST_ERRORS_RATE_LIMIT_DURATION', 86400),
-    
+
     'default_colors' => [
         'primary' => '#2773F3',
         'secondary' => '#728092',
@@ -265,5 +265,9 @@ return [
         'vault_host' => env('ENCRYPTED_DATA_VAULT_HOST', ''),
         'vault_token' => env('ENCRYPTED_DATA_VAULT_TOKEN', ''),
         'vault_transit_key' => env('ENCRYPTED_DATA_VAULT_TRANSIT_KEY', ''),
+    ],
+
+    'server_timing' => [
+        'min_package_time' => env('SERVER_TIMING_MIN_PACKAGE_TIME', 5), // Minimum time in milliseconds
     ],
 ];


### PR DESCRIPTION
## Issue & Reproduction Steps
As a support agent, I want to view the Server Timing headers in LogRocket, So that I can analyze detailed timing information for API requests when investigating performance issues reported by users.

## Solution
- Improve the Server Timing headers
- Ensure the Server Timing headers are displayed in LogRocket
<img width="2672" alt="Screenshot 2024-12-13 at 10 30 16 AM" src="https://github.com/user-attachments/assets/8a87a87c-70a4-4e2c-a5e0-9675728e304a" />

## Related Tickets & Packages
[FOUR-20464](https://processmaker.atlassian.net/browse/FOUR-20464)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20464]: https://processmaker.atlassian.net/browse/FOUR-20464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ