### PR TITLE
FOUR-20465 ensure out-of-the-box server timing header support

### DIFF
--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -23,6 +23,10 @@ class ServerTimingMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
+        if (!config('app.server_timing.enabled')) {
+            return $next($request);
+        }
+
         // Start time for controller execution
         $startController = microtime(true);
 

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -73,10 +73,12 @@ class ProcessMakerServiceProvider extends ServiceProvider
 
     public function register(): void
     {
-        // Listen to query events and accumulate query execution time
-        DB::listen(function ($query) {
-            self::$queryTime += $query->time;
-        });
+        if (config('app.server_timing.enabled')) {
+            // Listen to query events and accumulate query execution time
+            DB::listen(function ($query) {
+                self::$queryTime += $query->time;
+            });
+        }
 
         // Dusk, if env is appropriate
         // TODO Remove Dusk references and remove from composer dependencies

--- a/ProcessMaker/Traits/PluginServiceProviderTrait.php
+++ b/ProcessMaker/Traits/PluginServiceProviderTrait.php
@@ -30,6 +30,21 @@ trait PluginServiceProviderTrait
     {
         parent::__construct($app);
 
+        $this->bootServerTiming();
+    }
+
+    /**
+     * The `bootServerTiming` function sets up timing measurements for the booting and booted events of the packages
+     *
+     * @return void If the condition `config('app.server_timing.enabled')` is false, nothing is being returned as the
+     * function will exit early.
+     */
+    protected function bootServerTiming(): void
+    {
+        if (!config('app.server_timing.enabled')) {
+            return;
+        }
+
         $package = $this->getPackageName();
 
         $this->booting(function () use ($package) {
@@ -43,7 +58,6 @@ trait PluginServiceProviderTrait
 
             ProcessMakerServiceProvider::setPackageBootedTime($package, self::$bootTime);
         });
-
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -268,6 +268,7 @@ return [
     ],
 
     'server_timing' => [
+        'enabled' => env('SERVER_TIMING_ENABLED', true),
         'min_package_time' => env('SERVER_TIMING_MIN_PACKAGE_TIME', 5), // Minimum time in milliseconds
     ],
 ];

--- a/tests/Feature/ServerTimingMiddlewareTest.php
+++ b/tests/Feature/ServerTimingMiddlewareTest.php
@@ -134,4 +134,22 @@ class ServerTimingMiddlewareTest extends TestCase
         $this->assertStringContainsString('controller;dur=', $serverTiming[1]);
         $this->assertStringContainsString('db;dur=', $serverTiming[2]);
     }
+
+    public function testServerTimingIfIsDisabled()
+    {
+        config(['app.server_timing.enabled' => false]);
+
+        Route::middleware(ServerTimingMiddleware::class)->get('/test', function () {
+            // Simulate a query
+            DB::select('SELECT SLEEP(1)');
+
+            return response()->json(['message' => 'Test endpoint']);
+        });
+
+        // Send a GET request
+        $response = $this->get('/test');
+        $response->assertStatus(200);
+        // Assert the response has not the Server-Timing header
+        $response->assertHeaderMissing('Server-Timing');
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
As a developer, I want to ensure that the integration of Server Timing headers is implemented out-of-the-box without additional custom configurations. We can start tracking and analyzing request timing data quickly and consistently.

## Solution
- Add configuration option to enable/disable server timing: `app.server_timing.enabled` with `true` as default value

## Related Tickets & Packages
[FOUR-20465](https://processmaker.atlassian.net/browse/FOUR-20465)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
