### PR TITLE
FOUR-20487: Display "Screen Interstitial" Option

### DIFF
--- a/resources/js/processes/modeler/components/inspector/TaskInterstitial.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskInterstitial.vue
@@ -91,7 +91,6 @@ export default {
      * @param {Object} { nodeId, isDisabled }
      */
     handleInterstitial({ nodeId, show }) {
-      console.log("handleInterstitial", nodeId, show);
       if (nodeId !== this.node.id) {
         return;
       }

--- a/resources/js/processes/modeler/components/inspector/TaskInterstitial.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskInterstitial.vue
@@ -1,0 +1,106 @@
+<template>
+  <div>
+    <screen-select
+      v-if="allowInterstitial"
+      v-model="screen"
+      :label="$t('Screen Interstitial')"
+      :required="true"
+      :helper="$t('What Screen Should Be Used For Rendering This Interstitial')"
+      :params="parameters"
+      default-key="interstitial"
+    />
+  </div>
+</template>
+
+<script>
+import { get } from "lodash";
+import ScreenSelect from "./ScreenSelect.vue";
+
+export default {
+  components: { ScreenSelect },
+  props: {
+    label: {
+      type: String,
+      default: "",
+    },
+    helper: {
+      type: String,
+      default: "",
+    },
+    enabledByDefault: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      screen: null,
+      loading: false,
+      error: "",
+      parameters: {
+        type: "DISPLAY",
+      },
+      isDisabled: false,
+    };
+  },
+  computed: {
+    /**
+     * Get the value of the edited property
+     */
+    allowInterstitial: {
+      get() {
+        const { node } = this;
+        // Get the value of allowInterstitial or set it to true if it hasn't been defined yet.
+        const value = get(node, "allowInterstitial", this.enabledByDefault);
+
+        this.screen = get(node, "interstitialScreenRef");
+        return value;
+      },
+      /**
+       * Update allowInterstitial property
+       */
+      set(value) {
+        this.$set(this.node, "allowInterstitial", value);
+      },
+    },
+
+    node() {
+      return this.$root.$children[0].$refs.modeler.highlightedNode.definition;
+    },
+  },
+  watch: {
+    screen: {
+      handler(value) {
+        this.$set(this.node, "interstitialScreenRef", value);
+      },
+    },
+  },
+  created() {
+    // Listen for elementDestination interstitial event
+    this.$root.$on("handle-task-interstitial", this.handleInterstitial);
+  },
+  mounted() {
+    if (!("allowInterstitial" in this.node)) {
+      this.$set(this.node, "allowInterstitial", this.enabledByDefault);
+    }
+  },
+  methods: {
+    /**
+     * Handle interstitial event
+     *
+     * @param {Object} { nodeId, isDisabled }
+     */
+    handleInterstitial({ nodeId, show }) {
+      console.log("handleInterstitial", nodeId, show);
+      if (nodeId !== this.node.id) {
+        return;
+      }
+      if (show) {
+        this.$set(this.node, "allowInterstitial", true);
+      } else {
+        this.$set(this.node, "allowInterstitial", false);
+      }
+    },
+  },
+};
+</script>

--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -43,6 +43,7 @@ import SignalPayload from "./components/inspector/SignalPayload";
 import ScriptSelect from "./components/inspector/ScriptSelect";
 import StartPermission from "./components/inspector/StartPermission";
 import Interstitial from "./components/inspector/Interstitial";
+import TaskInterstitial from "./components/inspector/TaskInterstitial";
 import SelectUserGroup from "../../components/SelectUserGroup";
 import validateScreenRef from "./validateScreenRef";
 import validateFlowGenieRef from "./validateFlowGenieRef";
@@ -65,6 +66,7 @@ Vue.component("SignalPayload", SignalPayload);
 Vue.component("ScriptSelect", ScriptSelect);
 Vue.component("StartPermission", StartPermission);
 Vue.component("Interstitial", Interstitial);
+Vue.component("TaskInterstitial", TaskInterstitial);
 Vue.component("SelectUserGroup", SelectUserGroup);
 Vue.component("NodeIdentifierInput", NodeIdentifierInput);
 Vue.component("ErrorHandlingTimeout", ErrorHandlingTimeout);
@@ -205,11 +207,11 @@ ProcessMaker.EventBus.$on(
     });
 
     registerInspectorExtension(task, {
-      component: "Interstitial",
+      component: "TaskInterstitial",
       config: {
         label: "Display Next Assigned Task to Task Assignee",
         helper: "Directs Task assignee to the next assigned Task",
-        name: "interstitial",
+        name: "taskInterstitial",
       },
     });
 
@@ -357,11 +359,11 @@ ProcessMaker.EventBus.$on(
       ],
     });
     registerInspectorExtension(manualTask, {
-      component: "Interstitial",
+      component: "TaskInterstitial",
       config: {
         label: "Enable Interstitial",
         helper: "redirected to my next assigned task",
-        name: "interstitial",
+        name: "TaskInterstitial",
       },
     });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
When "Next Assigned Task" is selected, the "Screen Interstitial" option appears.

## Solution
- Add the Next Assigned Task  option to element destination


https://github.com/user-attachments/assets/5e7ccf8d-8a12-4ea5-9cf0-62de3032e63c

## How to Test
- create a new process
- add a task or manual task
- select the task
- open the inspector
- go to element destination
- Select Next AssignedTask


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20487
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
