### PR TITLE
Update readme and add namespace config

### DIFF
--- a/ProcessMaker/Services/MetricsService.php
+++ b/ProcessMaker/Services/MetricsService.php
@@ -3,7 +3,9 @@
 namespace ProcessMaker\Services;
 
 use Exception;
-use Illuminate\Support\Facades\Cache;
+use Prometheus\Counter;
+use Prometheus\Gauge;
+use Prometheus\Histogram;
 use Prometheus\CollectorRegistry;
 use Prometheus\RenderTextFormat;
 use Prometheus\Storage\Redis;
@@ -19,17 +21,20 @@ class MetricsService
     private $collectionRegistry;
 
     /**
+     * The namespace used by the MetricsService.
+     *
+     * @var string
+     */
+    private $namespace;
+
+    /**
      * Initializes the MetricsService with a CollectorRegistry using the provided storage adapter.
-     * Example:
-     * $metricsService = new MetricsService(new Redis([
-     *     'host' => config('database.redis.default.host'),
-     *     'port' => config('database.redis.default.port'),
-     * ]));
      *
      * @param mixed $adapter The storage adapter to use (e.g., Redis).
      */
     public function __construct($adapter = null)
     {
+        $this->namespace = config('app.prometheus_namespace', 'app');
         try {
             // Set up Redis as the adapter if none is provided
             if ($adapter === null) {
@@ -45,105 +50,66 @@ class MetricsService
     }
 
     /**
-     * Sets the CollectorRegistry used by the MetricsService.
-     * Example:
-     * $metricsService->setRegistry(new CollectorRegistry(new Redis([
-     *     'host' => config('database.redis.default.host'),
-     *     'port' => config('database.redis.default.port'),
-     * ])));
-     *
-     * @param CollectorRegistry $collectionRegistry The CollectorRegistry to set.
-     */
-    public function setRegistry(CollectorRegistry $collectionRegistry): void
-    {
-        $this->collectionRegistry = $collectionRegistry;
-    }
-
-    /**
-     * Returns the CollectorRegistry used by the MetricsService.
-     *
-     * @return CollectorRegistry The CollectorRegistry used by the MetricsService.
-     */
-    public function getMetrics(): CollectorRegistry
-    {
-        return $this->collectionRegistry;
-    }
-
-    /**
-     * Retrieves a metric by its name. The app_ prefix is added to the name of the metric.
-     * Example:
-     * $metricsService->getMetricByName('app_http_requests_total');
-     *
-     * @param string $name The name of the metric to retrieve.
-     * @return \Prometheus\MetricFamilySamples|null The metric with the specified name, or null if not found.
-     */
-    public function getMetricByName(string $name)
-    {
-        $metrics = $this->collectionRegistry->getMetricFamilySamples();
-        foreach ($metrics as $metric) {
-            if ($metric->getName() === $name) {
-                return $metric;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Registers a new counter metric.
-     * Example:
-     * $metricsService->registerCounter('app_http_requests_total', 'Total HTTP requests', ['method', 'endpoint', 'status']);
+     * Registers or retrieves a counter metric.
      *
      * @param string $name The name of the counter.
-     * @param string $help The help text of the counter.
+     * @param string|null $help The help text of the counter.
      * @param array $labels The labels of the counter.
-     * @return \Prometheus\Counter The registered counter.
-     * @throws RuntimeException If a metric with the same name already exists.
+     * @return Counter The registered or retrieved counter.
      */
-    public function registerCounter(string $name, string $help, array $labels = []): \Prometheus\Counter
+    public function counter(string $name, string $help = null, array $labels = []): Counter
     {
-        if ($this->getMetricByName($name) !== null) {
-            throw new RuntimeException("A metric with this name already exists. '{$name}'.");
-        }
-
-        return $this->collectionRegistry->registerCounter($this->namespace, $name, $help, $labels);
+        $help = $help ?? $name;
+        return $this->collectionRegistry->getOrRegisterCounter(
+                $this->namespace,
+                $name,
+                $help,
+                $labels
+            );
     }
 
     /**
-     * Registers a new histogram metric.
-     * Example:
-     * $metricsService->registerHistogram('app_http_request_duration_seconds', 'HTTP request duration in seconds', ['method', 'endpoint'], [0.1, 0.5, 1, 5, 10]);
-     *
-     * @param string $name The name of the histogram.
-     * @param string $help The help text of the histogram.
-     * @param array $labels The labels of the histogram.
-     * @param array $buckets The buckets of the histogram.
-     * @return \Prometheus\Histogram The registered histogram.
-     */
-    public function registerHistogram(string $name, string $help, array $labels = [], array $buckets = [0.1, 1, 5, 10]): \Prometheus\Histogram
-    {
-        return $this->collectionRegistry->registerHistogram($this->namespace, $name, $help, $labels, $buckets);
-    }
-
-    /**
-     * Registers a new gauge metric.
-     * Example:
-     * $metricsService->registerGauge('app_active_jobs', 'Number of active jobs in the queue', ['queue']);
+     * Registers or retrieves a gauge metric.
      *
      * @param string $name The name of the gauge.
-     * @param string $help The help text of the gauge.
+     * @param string|null $help The help text of the gauge.
      * @param array $labels The labels of the gauge.
-     * @return \Prometheus\Gauge The registered gauge.
+     * @return Gauge The registered or retrieved gauge.
      */
-    public function registerGauge(string $name, string $help, array $labels = []): \Prometheus\Gauge
+    public function gauge(string $name, string $help = null, array $labels = []): Gauge
     {
-        return $this->collectionRegistry->registerGauge($this->namespace, $name, $help, $labels);
+        $help = $help ?? $name;
+        return $this->collectionRegistry->getOrRegisterGauge(
+                $this->namespace,
+                $name,
+                $help,
+                $labels
+            );
+    }
+
+    /**
+     * Registers or retrieves a histogram metric.
+     *
+     * @param string $name The name of the histogram.
+     * @param string|null $help The help text of the histogram.
+     * @param array $labels The labels of the histogram.
+     * @param array $buckets The buckets of the histogram.
+     * @return Histogram The registered or retrieved histogram.
+     */
+    public function histogram(string $name, string $help = null, array $labels = [], array $buckets = [0.1, 1, 5, 10]): Histogram
+    {
+        $help = $help ?? $name;
+        return $this->collectionRegistry->getOrRegisterHistogram(
+                $this->namespace,
+                $name,
+                $help,
+                $labels,
+                $buckets
+            );
     }
 
     /**
      * Sets a gauge metric to a specific value.
-     * Example:
-     * $metricsService->setGauge('app_active_jobs', 10, ['queue1']);
      *
      * @param string $name The name of the gauge.
      * @param float $value The value to set the gauge to.
@@ -156,74 +122,14 @@ class MetricsService
     }
 
     /**
-     * Increments a counter metric by 1.
-     * Example:
-     * $metricsService->incrementCounter('app_http_requests_total', ['GET', '/api/v1/users', '200']);
-     *
-     * @param string $name The name of the counter.
-     * @param array $labelValues The values of the labels for the counter.
-     * @throws RuntimeException If the counter could not be incremented.
-     */
-    public function incrementCounter(string $name, array $labelValues = []): void
-    {
-        try {
-            $counter = $this->collectionRegistry->getCounter($this->namespace, $name);
-            $counter->inc($labelValues);
-        } catch (Exception $e) {
-            throw new RuntimeException("The counter could not be incremented '{$name}': " . $e->getMessage());
-        }
-    }
-
-    /**
-     * Observes a value for a histogram metric.
-     * Example:
-     * $metricsService->observeHistogram('app_http_request_duration_seconds', 0.3, ['GET', '/api/v1/users']);
-     *
-     * @param string $name The name of the histogram.
-     * @param float $value The value to observe.
-     * @param array $labelValues The values of the labels for the histogram.
-     */
-    public function observeHistogram(string $name, float $value, array $labelValues = []): void
-    {
-        $histogram = $this->collectionRegistry->getHistogram($this->namespace, $name);
-        $histogram->observe($value, $labelValues);
-    }
-
-    /**
-     * Retrieves or increments a value stored in the cache and sets it to a Prometheus gauge.
-     * Example: This is useful to monitor the number of active jobs in the queue.
-     * $metricsService->cacheToGauge('app_active_jobs', 'app_active_jobs', 'Number of active jobs in the queue', ['queue'], 1);
-     *
-     * @param string $key The cache key.
-     * @param string $metricName The Prometheus metric name.
-     * @param string $help The help text for the gauge.
-     * @param array $labels The labels for the gauge.
-     * @param float $increment The value to increment.
-     */
-    public function cacheToGauge(string $key, string $metricName, string $help, array $labels = [], float $increment = 0): void
-    {
-        // Retrieve and update the cache
-        $currentValue = Cache::increment($key, $increment);
-
-        // Register the gauge if it doesn't exist
-        if ($this->getMetricByName($metricName) === null) {
-            $this->registerGauge($metricName, $help, $labels);
-        }
-
-        // Update the gauge with the cached value
-        $this->setGauge($metricName, $currentValue, []);
-    }
-
-    /**
      * Renders the metrics in the Prometheus text format.
      *
      * @return string The rendered metrics.
      */
-    public function renderMetrics()
+    public function renderMetrics(): string
     {
         $renderer = new RenderTextFormat();
         $metrics = $this->collectionRegistry->getMetricFamilySamples();
-
         return $renderer->render($metrics);
     }
 }

--- a/ProcessMaker/Services/MetricsService.php
+++ b/ProcessMaker/Services/MetricsService.php
@@ -14,16 +14,9 @@ class MetricsService
     /**
      * The CollectorRegistry instance used by the MetricsService.
      *
-     * @var \Prometheus\CollectorRegistry
+     * @var CollectorRegistry
      */
     private $collectionRegistry;
-
-    /**
-     * The namespace used by the MetricsService.
-     *
-     * @var string
-     */
-    private $namespace = 'app';
 
     /**
      * Initializes the MetricsService with a CollectorRegistry using the provided storage adapter.
@@ -52,26 +45,6 @@ class MetricsService
     }
 
     /**
-     * Returns the namespace used by the MetricsService.
-     *
-     * @return string The namespace used by the MetricsService.
-     */
-    public function getNamespace(): string
-    {
-        return $this->namespace;
-    }
-
-    /**
-     * Sets the namespace used by the MetricsService.
-     *
-     * @param string $namespace The namespace to set.
-     */
-    public function setNamespace(string $namespace): void
-    {
-        $this->namespace = $namespace;
-    }
-
-    /**
      * Sets the CollectorRegistry used by the MetricsService.
      * Example:
      * $metricsService->setRegistry(new CollectorRegistry(new Redis([
@@ -79,7 +52,7 @@ class MetricsService
      *     'port' => config('database.redis.default.port'),
      * ])));
      *
-     * @param \Prometheus\CollectorRegistry $collectionRegistry The CollectorRegistry to set.
+     * @param CollectorRegistry $collectionRegistry The CollectorRegistry to set.
      */
     public function setRegistry(CollectorRegistry $collectionRegistry): void
     {
@@ -89,7 +62,7 @@ class MetricsService
     /**
      * Returns the CollectorRegistry used by the MetricsService.
      *
-     * @return \Prometheus\CollectorRegistry The CollectorRegistry used by the MetricsService.
+     * @return CollectorRegistry The CollectorRegistry used by the MetricsService.
      */
     public function getMetrics(): CollectorRegistry
     {
@@ -112,6 +85,7 @@ class MetricsService
                 return $metric;
             }
         }
+
         return null;
     }
 
@@ -124,13 +98,14 @@ class MetricsService
      * @param string $help The help text of the counter.
      * @param array $labels The labels of the counter.
      * @return \Prometheus\Counter The registered counter.
-     * @throws \RuntimeException If a metric with the same name already exists.
+     * @throws RuntimeException If a metric with the same name already exists.
      */
     public function registerCounter(string $name, string $help, array $labels = []): \Prometheus\Counter
     {
         if ($this->getMetricByName($name) !== null) {
             throw new RuntimeException("A metric with this name already exists. '{$name}'.");
         }
+
         return $this->collectionRegistry->registerCounter($this->namespace, $name, $help, $labels);
     }
 
@@ -187,7 +162,7 @@ class MetricsService
      *
      * @param string $name The name of the counter.
      * @param array $labelValues The values of the labels for the counter.
-     * @throws \RuntimeException If the counter could not be incremented.
+     * @throws RuntimeException If the counter could not be incremented.
      */
     public function incrementCounter(string $name, array $labelValues = []): void
     {
@@ -248,17 +223,7 @@ class MetricsService
     {
         $renderer = new RenderTextFormat();
         $metrics = $this->collectionRegistry->getMetricFamilySamples();
-        return $renderer->render($metrics);
-    }
 
-    /**
-     * Helper to register a default set of metrics for common Laravel use cases.
-     */
-    public function registerDefaultMetrics(): void
-    {
-        $this->registerCounter('http_requests_total', 'Total HTTP requests', ['method', 'endpoint', 'status']);
-        $this->registerHistogram('http_request_duration_seconds', 'HTTP request duration in seconds', ['method', 'endpoint'], [0.1, 0.5, 1, 5, 10]);
-        $this->registerGauge('active_jobs', 'Number of active jobs in the queue', ['queue']);
-        $this->registerCounter('job_failures_total', 'Total number of failed jobs', ['queue']);
+        return $renderer->render($metrics);
     }
 }

--- a/README.md
+++ b/README.md
@@ -439,75 +439,28 @@ npm run dev-font
 ```
 
 
-# Install Prometheus and Grafana with Docker
+# Prometheus and Grafana
 
 This guide explains how to install and run **Prometheus** and **Grafana** using Docker. Both tools complement each other: Prometheus collects and monitors metrics, while Grafana visualizes them with interactive dashboards.
 
-## Compose sample
+## Local Development with docker compose
 ### Prometheus & Grafana
 Go to the metrics directory
 ```text
 cd metrics
 ```
-Project structure:
-```
-.
-├── compose.yaml
-├── grafana
-│   └── datasource.yml
-├── prometheus
-│   └── prometheus.yml
-```
 
-[_compose.yaml_](compose.yaml)
-```
-services:
-  prometheus:
-    image: prom/prometheus
-    ...
-    ports:
-      - 9090:9090
-  grafana:
-    image: grafana/grafana
-    ...
-    ports:
-      - 3000:3000
-```
-The compose file defines a stack with two services `prometheus` and `grafana`.
-When deploying the stack, docker compose maps port the default ports for each service to the equivalent ports on the host in order to inspect easier the web interface of each service.
 Make sure the ports 9090 and 3000 on the host are not already in use.
 
-## Deploy with docker compose
+Edit `prometheus.yml` and update the target hostname with your local processmaker instance. You might also need to change the scheme if you are using https.
 
-```
-$ docker compose up -d
-Creating network "prometheus-grafana_default" with the default driver
-Creating volume "prometheus-grafana_prom_data" with default driver
-...
-Creating grafana    ... done
-Creating prometheus ... done
-Attaching to prometheus, grafana
+Run `docker compose up`
 
-```
+Check that prometheus can connect to your local instance at http://localhost:9090/targets
 
-## Expected result
+Go to Grafana at http://localhost:3000/
 
-Listing containers must show two containers running and the port mapping as below:
-```
-$ docker ps
-CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                    NAMES
-dbdec637814f        prom/prometheus     "/bin/prometheus --c…"   8 minutes ago       Up 8 minutes        0.0.0.0:9090->9090/tcp   prometheus
-79f667cb7dc2        grafana/grafana     "/run.sh"                8 minutes ago       Up 8 minutes        0.0.0.0:3000->3000/tcp   grafana
-```
-
-Navigate to `http://localhost:3000` in your web browser and use the login credentials specified in the compose file to access Grafana. It is already configured with prometheus as the default datasource.
-
-Navigate to `http://localhost:9090` in your web browser to access directly the web interface of prometheus.
-
-Stop and remove the containers. Use `-v` to remove the volumes if looking to erase all data.
-```
-$ docker compose down -v
-```
+When you are finished, run `docker compose down`. To delete all data, run `docker compose down -v`
 
 ### **Use the Facade in Your Application**
 
@@ -535,6 +488,10 @@ class ExampleController extends Controller
     }
 }
 ```
+
+To make things even easier, you can run `Metrics::counter('cases')->inc();` or `Metrics::gauge('active_tasks')->set($activeTasks)` anywhere in the code.
+
+You can provide an optional description, for example `Metrics::gauge('active_tasks', 'Total Active Tasks')->...`
 
 #### **Example: Registering and Using a Histogram**
 

--- a/config/app.php
+++ b/config/app.php
@@ -247,7 +247,7 @@ return [
     // Process Request security log rate limit: 1 per day (86400 seconds)
     'process_request_errors_rate_limit' => env('PROCESS_REQUEST_ERRORS_RATE_LIMIT', 1),
     'process_request_errors_rate_limit_duration' => env('PROCESS_REQUEST_ERRORS_RATE_LIMIT_DURATION', 86400),
-    
+
     'default_colors' => [
         'primary' => '#2773F3',
         'secondary' => '#728092',
@@ -267,4 +267,6 @@ return [
         'vault_token' => env('ENCRYPTED_DATA_VAULT_TOKEN', ''),
         'vault_transit_key' => env('ENCRYPTED_DATA_VAULT_TRANSIT_KEY', ''),
     ],
+
+    'prometheus_namespace' => env('PROMETHEUS_NAMESPACE', 'processmaker'),
 ];

--- a/metrics/compose.yaml
+++ b/metrics/compose.yaml
@@ -17,8 +17,8 @@ services:
       - 3000:3000
     restart: unless-stopped
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     volumes:
       - ./grafana:/etc/grafana/provisioning/datasources
 volumes:

--- a/metrics/prometheus/prometheus.yml
+++ b/metrics/prometheus/prometheus.yml
@@ -15,26 +15,6 @@ scrape_configs:
     scheme: http
     static_configs:
       - targets:
-          - localhost:9090
-          
-  # For ProcessMaker https://127.0.0.5:8092/metrics
-  - job_name: processmaker
-    honor_timestamps: true
-    scrape_interval: 15s
-    scrape_timeout: 10s
-    metrics_path: /metrics
-    scheme: https
-    tls_config:
-      insecure_skip_verify: true # Ignore the certificate validation (for development only, remove for production).
-    static_configs:
-      - targets:
-          - 127.0.0.5:8092 # Replace with the address of your application.
+          # Replace this with your local processmaker instance
+          - processmaker-b.test
 
-# Alerting configuration for Prometheus. 
-#alerting:
-#  alertmanagers:
-#    - static_configs:
-#        - targets: []
-#      scheme: http
-#      timeout: 10s
-#      api_version: v1

--- a/metrics/prometheus/prometheus.yml
+++ b/metrics/prometheus/prometheus.yml
@@ -1,13 +1,10 @@
-# Global configuration settings for Prometheus
 global:
   scrape_interval: 15s
   scrape_timeout: 10s
   evaluation_interval: 15s
 
-# Scrape configurations
 scrape_configs:
-  # For Prometheus
-  - job_name: prometheus
+  - job_name: processmaker
     honor_timestamps: true
     scrape_interval: 15s
     scrape_timeout: 10s
@@ -15,6 +12,5 @@ scrape_configs:
     scheme: http
     static_configs:
       - targets:
-          # Replace this with your local processmaker instance
+          # Replace this with your local processmaker instance (add port if needed)
           - processmaker-b.test
-

--- a/metrics/prometheus/prometheus.yml
+++ b/metrics/prometheus/prometheus.yml
@@ -13,4 +13,4 @@ scrape_configs:
     static_configs:
       - targets:
           # Replace this with your local processmaker instance (add port if needed)
-          - processmaker-b.test
+          - processmaker.test


### PR DESCRIPTION
## Descripción

I already
- Set the namespace in the config (needed by cloudops)
- removed unused code
- updated the readme
- made grafana development docker compose anonymous (no username/password needed)

We need to
- Add the logic to MetricService to support Metrics::counter and Metrics::guage (and histogram the same way)
- Use the metric name (first argument) as the 2nd argument (description) if not provided
- Use config('app.prometheus_namespace') to set the namespace
- use the library’s getOrRegister*** methods
- Remove any additional unused code

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21074
