### PR TITLE
FOUR-21290: Fix Unable to Create Processes from Guided Templates

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -311,7 +311,7 @@ class TemplateController extends Controller
 
     protected function createProcess(Request $request)
     {
-        $request->validate(Process::rules($request->id));
+        $request->validate(Template::rules($request->id, $this->types['process'][4]));
         $postOptions = $this->checkIfAssetsExist($request);
 
         if (!empty($postOptions)) {

--- a/ProcessMaker/Models/Template.php
+++ b/ProcessMaker/Models/Template.php
@@ -138,7 +138,7 @@ class Template extends ProcessMakerModel
 
         return [
             'name' => ['required', $unique, 'alpha_spaces', 'max:255'],
-            'description' => ['required', 'string', 'max:100'],
+            'description' => ['required', 'string'],
             'version' => ['required', 'regex:/^[0-9.]+$/'],
         ];
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
Users are unable to create processes from guided templates. Upon selecting a template, the process creation flow fails. This issue is observed in version 4.12.0 and did not occur in previous versions.

## Steps to Reproduce:

- Navigate to the Designer/Processes.
- Select Guide Template from the available options.
- Attempt to create a new process using any of the available guided templates.

## Solution
- Restore the Template::rules

- Expand the description field to allow more than 100 characters to ensure that  [FOUR-20102](https://processmaker.atlassian.net/browse/FOUR-20102) is also resolved.

## How to Test
Please follow the Steps to Reproduce and ensure that the Guided Template is fully generated and functioning as expected.

## Related Tickets & Packages
- Ticket: https://processmaker.atlassian.net/browse/FOUR-21290

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-20102]: https://processmaker.atlassian.net/browse/FOUR-20102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ