### PR TITLE
FOUR-21372:We can move the elements of the process in the Request - Overview

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/NewOverview.vue
+++ b/resources/jscomposition/cases/casesDetail/components/NewOverview.vue
@@ -138,6 +138,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   ProcessMaker.$modeler = null;
   modelerRef.value.reset({ readOnly: true });
+  modelerRef.value.reset({ panMode: true });
   modelerRef.value = null;
   tooltipRef.value = null;
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a case
2. Open the case
3. Go to overview
4. Select one element of the process
5. Go to Summary
6. Return to overview

**Current Behavior**
When we return to overview the second time is possible to move the elements

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21372

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
