### PR TITLE
bugfix/FOUR-17745: Smart Inbox> filters are not changing when different saved searches are selected

### DIFF
--- a/resources/js/inbox-rules/components/InboxRuleButtons.vue
+++ b/resources/js/inbox-rules/components/InboxRuleButtons.vue
@@ -3,7 +3,7 @@
     <b-button size="sm"
               variant="light"
               class="inbox-rule-buttons-border inbox-rule-buttons-font"
-              @click="$emit('reset-filters')">
+              @click="callResetFilters">
       <img src="/img/eraser-fill.svg" :alt="$t('Clear unsaved filters')"/>
       {{ $t('Clear unsaved filters') }}
     </b-button>
@@ -106,8 +106,12 @@
       });
     },
     methods: {
+      callResetFilters() {
+        this.$emit('reset-filters');
+      },
       onSelect(option) {
         this.selectedOption = option;
+        this.callResetFilters();
         this.$emit('saved-search-id-changed', option.value);
         this.showMenu(false);
       },

--- a/resources/js/inbox-rules/components/InboxRuleButtons.vue
+++ b/resources/js/inbox-rules/components/InboxRuleButtons.vue
@@ -3,7 +3,7 @@
     <b-button size="sm"
               variant="light"
               class="inbox-rule-buttons-border inbox-rule-buttons-font"
-              @click="callResetFilters">
+              @click="$emit('reset-filters')">
       <img src="/img/eraser-fill.svg" :alt="$t('Clear unsaved filters')"/>
       {{ $t('Clear unsaved filters') }}
     </b-button>
@@ -106,12 +106,8 @@
       });
     },
     methods: {
-      callResetFilters() {
-        this.$emit('reset-filters');
-      },
       onSelect(option) {
         this.selectedOption = option;
-        this.callResetFilters();
         this.$emit('saved-search-id-changed', option.value);
         this.showMenu(false);
       },

--- a/resources/js/inbox-rules/components/InboxRuleFilters.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFilters.vue
@@ -144,6 +144,9 @@
       resetFilters() {
         this.savedSearchAdvancedFilter = _.cloneDeep(this.originalSavedSearchAdvancedFilter);
       },
+      resetSavedSearch() {
+        this.loadSavedSearch();
+      },
       defaultTaskFilters() {
         return {
           order: {by: 'id', direction: 'desc'},
@@ -199,6 +202,7 @@
         } else {
           filter.filters = [this.userIdFilter()];
         }
+
         return filter;
       },
       userIdFilter() {
@@ -238,12 +242,15 @@
                     this.columns = _.cloneDeep(cols);
                     this.defaultColumns = _.cloneDeep(cols);
                   }
-
+                  
+                  const advancedFilter = response.data.advanced_filter ?? this.defaultSavedSearchFilters();
+                  const processedFilter = this.addRequiredSavedSearchFilters(advancedFilter);
+                  
                   if (this.savedSearchAdvancedFilter === null) {
-                    const advancedFilter = response.data.advanced_filter ?? this.defaultSavedSearchFilters();
-                    this.originalSavedSearchAdvancedFilter = _.cloneDeep(this.savedSearchAdvancedFilter);
-                    this.savedSearchAdvancedFilter = this.addRequiredSavedSearchFilters(advancedFilter);
+                    this.originalSavedSearchAdvancedFilter = _.cloneDeep(processedFilter);
                   }
+                  
+                  this.savedSearchAdvancedFilter = processedFilter;
 
                   this.ready = true;
                 });

--- a/resources/js/inbox-rules/components/InboxRuleFilters.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFilters.vue
@@ -241,8 +241,8 @@
 
                   if (this.savedSearchAdvancedFilter === null) {
                     const advancedFilter = response.data.advanced_filter ?? this.defaultSavedSearchFilters();
-                    this.savedSearchAdvancedFilter = this.addRequiredSavedSearchFilters(advancedFilter);
                     this.originalSavedSearchAdvancedFilter = _.cloneDeep(this.savedSearchAdvancedFilter);
+                    this.savedSearchAdvancedFilter = this.addRequiredSavedSearchFilters(advancedFilter);
                   }
 
                   this.ready = true;

--- a/resources/js/inbox-rules/components/InboxRuleFilters.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFilters.vue
@@ -231,26 +231,24 @@
       loadSavedSearch() {
         this.ready = false;
         return ProcessMaker.apiClient.get("saved-searches/" + this.savedSearchId)
-                .then(response => {
-                  this.savedSearch = response.data;
+          .then(response => {
+            this.savedSearch = response.data;
 
-                  if (this.columns.length === 0) {
-                    const cols = response.data._adjusted_columns?.filter(this.columnFilter);
-                    this.columns = _.cloneDeep(cols);
-                    this.defaultColumns = _.cloneDeep(cols);
-                  }
-                  
-                  const advancedFilter = response.data.advanced_filter ?? this.defaultSavedSearchFilters();
-                  const processedFilter = this.addRequiredSavedSearchFilters(advancedFilter);
-                  
-                  if (this.savedSearchAdvancedFilter === null) {
-                    this.originalSavedSearchAdvancedFilter = _.cloneDeep(processedFilter);
-                  }
-                  
-                  this.savedSearchAdvancedFilter = processedFilter;
+            if (this.columns.length === 0) {
+              const cols = response.data._adjusted_columns?.filter(this.columnFilter);
+              this.columns = _.cloneDeep(cols);
+              this.defaultColumns = _.cloneDeep(cols);
+            }
+          
+            const advancedFilter = response.data.advanced_filter ?? this.defaultSavedSearchFilters();
+            const processedFilter = this.addRequiredSavedSearchFilters(advancedFilter);
+            
+            // saves the original filter and current filter
+            this.originalSavedSearchAdvancedFilter = _.cloneDeep(processedFilter);
+            this.savedSearchAdvancedFilter = processedFilter;
 
-                  this.ready = true;
-                });
+            this.ready = true;
+          });
       },
       // Only used when creating inbox rules.
       // Existing inbox rules always have a saved search.

--- a/resources/js/inbox-rules/components/InboxRuleFilters.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFilters.vue
@@ -144,9 +144,6 @@
       resetFilters() {
         this.savedSearchAdvancedFilter = _.cloneDeep(this.originalSavedSearchAdvancedFilter);
       },
-      resetSavedSearch() {
-        this.loadSavedSearch();
-      },
       defaultTaskFilters() {
         return {
           order: {by: 'id', direction: 'desc'},


### PR DESCRIPTION
## How to Test
1. Go to server
2. Go to tasks page
3. use the filters and create a saved search
4. Go to Tasks page
5. Press inbox rules button
6. Press +create rule button
7. Select the new saved search in the load a saved search field
8. Select  `to do` option in the load a saved search field

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17745

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
