### PR TITLE
Update monaco AMD with async loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
                 "lodash": "^4.17.21",
                 "luxon": "^1.25.0",
                 "monaco-editor": "^0.34.0",
-                "monaco-editor-webpack-plugin": "^7.0.1",
                 "mustache": "3.2.1",
                 "npm-font-open-sans": "^1.1.0",
                 "oslllo-svg-fixer": "^5.0.0",
@@ -16225,31 +16224,6 @@
             "version": "0.34.1",
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
             "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
-        },
-        "node_modules/monaco-editor-webpack-plugin": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz",
-            "integrity": "sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==",
-            "dependencies": {
-                "loader-utils": "^2.0.2"
-            },
-            "peerDependencies": {
-                "monaco-editor": ">= 0.31.0",
-                "webpack": "^4.5.0 || 5.x"
-            }
-        },
-        "node_modules/monaco-editor-webpack-plugin/node_modules/loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
         },
         "node_modules/move-file": {
             "version": "2.1.0",
@@ -35178,26 +35152,6 @@
             "version": "0.34.1",
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
             "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
-        },
-        "monaco-editor-webpack-plugin": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz",
-            "integrity": "sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==",
-            "requires": {
-                "loader-utils": "^2.0.2"
-            },
-            "dependencies": {
-                "loader-utils": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-                    "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                }
-            }
         },
         "move-file": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
         "lodash": "^4.17.21",
         "luxon": "^1.25.0",
         "monaco-editor": "^0.34.0",
-        "monaco-editor-webpack-plugin": "^7.0.1",
         "mustache": "3.2.1",
         "npm-font-open-sans": "^1.1.0",
         "oslllo-svg-fixer": "^5.0.0",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,5 +1,6 @@
 const mix = require("laravel-mix");
 const path = require("path");
+const fs = require('fs');
 require("laravel-mix-polyfill");
 // const packageJson = require("./package.json");
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
@@ -21,7 +22,7 @@ mix.webpackConfig({
       analyzerMode: process.env.STATS ? "server" : "disabled",
     }),
   ],
-  externals: ["SharedComponents", "ModelerInspector"],
+  externals: ["monaco-editor", "SharedComponents", "ModelerInspector"],
   resolve: {
     extensions: [".*", ".js", ".ts", ".mjs", ".vue", ".json"],
     symlinks: false,
@@ -168,27 +169,6 @@ mix
 //   targets: "> 0.25%, not dead"
 // });
 
-// Monaco AMD modules. Copy only the files we need to make the build faster.
-const monacoSource = "node_modules/monaco-editor/min/vs/";
-const monacoDestination = "public/vendor/monaco-editor/min/vs/";
-const monacoLanguages = ["php", "css", "lua", "javascript", "csharp", "java", "python", "r", "html", "xml", "typescript", "sql"];
-const monacoFiles = [
-  "loader.js",
-  "editor/editor.main.js",
-  "editor/editor.main.css",
-  "editor/editor.main.nls.js",
-  "base/browser/ui/codicons/codicon/codicon.ttf",
-  "base/worker/workerMain.js",
-  "base/common/worker/simpleWorker.nls.js",
-];
-monacoFiles.forEach((file) => {
-  mix.copy(monacoSource + file, monacoDestination + file);
-});
-monacoLanguages.forEach((lang) => {
-  const path = `basic-languages/${lang}/${lang}.js`;
-  mix.copy(monacoSource + path, monacoDestination + path);
-});
-mix.copyDirectory(`${monacoSource}language`, `${monacoDestination}language`);
 
 mix
   .sass("resources/sass/sidebar/sidebar.scss", "public/css")
@@ -201,3 +181,10 @@ mix
   .version();
 
 mix.vue({ version: 2 });
+
+mix.then(() => {
+  // Use monaco AMD top keep it out of the build and manifest
+  const monacoSource = "node_modules/monaco-editor/min/vs/";
+  const monacoDestination = "public/vendor/monaco-editor/min/vs/";
+  fs.cpSync(monacoSource, monacoDestination, { recursive: true });
+});


### PR DESCRIPTION
Use Monaco's AMD loader so it can handle importing whatever dependencies are needed based on the file type. This speeds up the front end for pages that use monaco.

This also keeps it out of the build and mix manifest, making builds faster.