### PR TITLE
FOUR-21382 Add boot timing to Server-Timing header

### DIFF
--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -29,7 +29,6 @@ class ServerTimingMiddleware
 
         // Start time for controller execution
         $startController = microtime(true);
-        $bootTiming = ($startController - \LARAVEL_START) * 1000; // Convert to ms
 
         // Process the request
         $response = $next($request);
@@ -42,11 +41,16 @@ class ServerTimingMiddleware
         $queryTime = ProcessMakerServiceProvider::getQueryTime() ?? 0;
 
         $serverTiming = [
-            "boot;dur={$bootTiming}",
             "provider;dur={$serviceProviderTime}",
             "controller;dur={$controllerTime}",
             "db;dur={$queryTime}",
         ];
+
+        $hasLaravelStart = defined('LARAVEL_START');
+        if ($hasLaravelStart) {
+            $bootTiming = ($startController - \LARAVEL_START) * 1000; // Convert to ms
+            array_unshift($serverTiming, "boot;dur={$bootTiming}");
+        }
 
         $packageTimes = ProcessMakerServiceProvider::getPackageBootTiming();
 

--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -29,6 +29,7 @@ class ServerTimingMiddleware
 
         // Start time for controller execution
         $startController = microtime(true);
+        $bootTiming = ($startController - LARAVEL_START) * 1000; // Convert to ms
 
         // Process the request
         $response = $next($request);
@@ -41,6 +42,7 @@ class ServerTimingMiddleware
         $queryTime = ProcessMakerServiceProvider::getQueryTime() ?? 0;
 
         $serverTiming = [
+            "boot;dur={$bootTiming}",
             "provider;dur={$serviceProviderTime}",
             "controller;dur={$controllerTime}",
             "db;dur={$queryTime}",

--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -29,7 +29,7 @@ class ServerTimingMiddleware
 
         // Start time for controller execution
         $startController = microtime(true);
-        $bootTiming = ($startController - LARAVEL_START) * 1000; // Convert to ms
+        $bootTiming = ($startController - \LARAVEL_START) * 1000; // Convert to ms
 
         // Process the request
         $response = $next($request);


### PR DESCRIPTION
## Issue & Reproduction Steps
Add boot timing to Server-Timing header

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21382

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
