### PR TITLE
Include timestamps when adding a user to a group

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -293,7 +293,7 @@ class User extends Authenticatable implements HasMedia
 
     public function groups()
     {
-        return $this->morphToMany('ProcessMaker\Models\Group', 'member', 'group_members');
+        return $this->morphToMany('ProcessMaker\Models\Group', 'member', 'group_members')->withTimestamps();
     }
 
     public function projectMembers()


### PR DESCRIPTION
## Issue & Reproduction Steps
There were 2 problems here
- When a user was added to a group using the Admin interface, timestamps were not saved in the group_members table. These group associations were getting cleared every time LDAP ran because it looks for a null `created_at` to know if the association was created with LDAP
- The auth package was attempting to sync (and clearing the associations) even if the connection to the LDAP server was invalid

## Solution
- Core: Fix timestamps when adding a user to a group in the User settings
- package-auth: Test the connection before attempting to sync

## How to Test
See reproduction steps in the jira ticket

## Related Tickets & Packages
- Requires https://github.com/ProcessMaker/package-auth/pull/123
- See https://processmaker.atlassian.net/browse/FOUR-17912

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
