### PR TITLE
Delete draft after editing request data

### DIFF
--- a/resources/js/tasks/edit.js
+++ b/resources/js/tasks/edit.js
@@ -240,6 +240,9 @@ const main = new Vue({
           data,
           task_element_id: this.task.element_id,
         })
+        .then(response => {
+          return this.eraseDraft();
+        })
         .then((response) => {
           this.fieldsToUpdate.splice(0);
           ProcessMaker.alert(this.$t("The request data was saved."), "success");
@@ -446,7 +449,7 @@ const main = new Vue({
     },
     eraseDraft() {
       this.formDataWatcherActive = false;
-      ProcessMaker.apiClient
+      return ProcessMaker.apiClient
         .delete(`drafts/${this.task.id}`)
         .then((response) => {
           this.resetRequestFiles(response);


### PR DESCRIPTION
## Issue & Reproduction Steps
Edited request data was not reflected in the task, even after reload.

## Solution
- Erase the draft after manually editing request data

## How to Test
See video in the jira issue. Create a simple `start -> task -> task -> end` process to test with

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19108

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
...