### PR TITLE
defect/FOUR-17640: Script execution is now halted when timeout is reached

### DIFF
--- a/ProcessMaker/Managers/DockerManager.php
+++ b/ProcessMaker/Managers/DockerManager.php
@@ -34,7 +34,7 @@ class DockerManager
     public function getDockerExecutable($timeout = 0)
     {
         return $timeout > 0 ?
-            config('app.processmaker_scripts_timeout') . " -s 9 $timeout " . config('app.processmaker_scripts_docker') :
+            config('app.processmaker_scripts_timeout') . " -k 1s $timeout " . config('app.processmaker_scripts_docker') :
             config('app.processmaker_scripts_docker');
     }
 

--- a/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
@@ -73,7 +73,7 @@ trait ScriptDockerBindingFilesTrait
 
         $line = exec($cmd, $output, $returnCode);
         if ($returnCode) {
-            if ($returnCode == 137 || $returnCode == 9) {
+            if ($returnCode == 137 || $returnCode == 9 || $returnCode == 124) {
                 Log::error('Script timed out');
                 $this->removeTemporalFiles();
                 throw new ScriptTimeoutException(

--- a/ProcessMaker/Models/ScriptDockerCopyingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerCopyingFilesTrait.php
@@ -143,7 +143,7 @@ trait ScriptDockerCopyingFilesTrait
 
         $line = exec($cmd, $output, $returnCode);
         if ($returnCode) {
-            if ($returnCode == 137) {
+            if ($returnCode == 137 || $returnCode == 124) {
                 Log::error('Script timed out');
                 throw new ScriptTimeoutException(implode("\n", $output));
             }


### PR DESCRIPTION
## Tickets Solved by this PR:
- https://processmaker.atlassian.net/browse/FOUR-17640

## Solution
- Changed the timeout effect to 'kill' whenever the timeout is reached.

## How to Test
1. Create a script
2. Use a sleep() function set to 20 seconds
3. Save the script
4. Edit the script settings so that the script timeout is 5 seconds
5. Open a terminal
6. Run the script and while it is running, use the command `docker ps` multiple times in the newly-opened terminal to verify that the execution is halted.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
