### PR TITLE
FOUR-20590: Create a new Api to save, update and delete the configurations per user

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -895,7 +895,6 @@ class UserController extends Controller
      */
     public function storeFilterConfiguration(String $name, Request $request)
     {
-        $request->json()->all();
         $filter = SaveSession::setConfigFilter($name, $request->user(), $request->json()->all());
 
         return response(['data' => $filter], 200);

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -10,8 +10,6 @@ use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
-use ProcessMaker\Models\ProcessTaskAssignment;
-use ProcessMaker\Models\Recommendation;
 use ProcessMaker\Models\RecommendationUser;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
@@ -884,5 +882,58 @@ class UsersTest extends TestCase
 
         // Assert the list of users now contains the admin user
         $this->assertContains($admin->id, collect($users)->pluck('id')->toArray());
+    }
+
+    /**
+     * Test save and get filters per user saved in cache
+     */
+    public function testGetDefaultUserConfiguration()
+    {
+        // Define an example of filters to save
+        $values = [
+            'filters' => [
+                [
+                    'subject' => [
+                        'type' => 'Field',
+                        'value' => 'case_number',
+                    ],
+                    'operator' => '=',
+                    'value' => '885',
+                ],
+                [
+                    'subject' => [
+                        'type' => 'Field',
+                        'value' => 'case_title',
+                    ],
+                    'operator' => '=',
+                    'value' => 'TCP4_Case_title',
+                ],
+            ],
+            'order' => [
+                'by' => 'id',
+                'dir' => 'ASC',
+            ],
+        ];
+        // Define the page filter to save
+        $pagesSaveFilters = [
+            'casesFilter',
+            'casesFilter|in_progress',
+            'casesFilter|completed',
+            'casesFilter|all',
+        ];
+        $randomKey = array_rand($pagesSaveFilters);
+        $name = $pagesSaveFilters[$randomKey];
+        // Call the api PUT
+        $response = $this->apiCall('PUT', '/users/store_filter_configuration/' . $name, $values);
+        // Validate the header status code
+        $response->assertStatus(200);
+        $this->assertNotEmpty($response);
+
+        // Call the api GET
+        $response = $this->apiCall('GET', '/users/get_filter_configuration/' . $name);
+        // Validate the header status code
+        $response->assertStatus(200);
+        $this->assertNotEmpty($response);
+        $response->assertJson(['data' => $values]);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Create a new Api to save, update and delete the configurations per user

## Solution
- We will use the following API to Save and Get filters for the cases lists:
```
users/store_filter_configuration/casesFilter
users/store_filter_configuration/casesFilter|in_progress
users/store_filter_configuration/casesFilter|completed
users/store_filter_configuration/casesFilter|all
```
```
GET users/get_filter_configuration/{name}
PUT users/store_filter_configuration/{name}
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20590

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
