### PR TITLE
FOUR-21445 email field cannot be updated for users imported from AD or SAML

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/UserController.php
+++ b/ProcessMaker/Http/Controllers/Admin/UserController.php
@@ -69,7 +69,13 @@ class UserController extends Controller
         );
         $ssoUser = false;
         if (class_exists(SsoUser::class)) {
+            // Check if the user is an SSO user (including SAML)
             $ssoUser = SsoUser::where('user_id', $user->id)->exists();
+        }
+
+        // Check if the user is an LDAP user
+        if (isset($user->meta?->authenticationType) && $user->meta->authenticationType === 'ldap') {
+            $ssoUser = true;
         }
 
         // Get global and valid 2FA preferences for the user

--- a/ProcessMaker/Http/Controllers/ProfileController.php
+++ b/ProcessMaker/Http/Controllers/ProfileController.php
@@ -46,7 +46,13 @@ class ProfileController extends Controller
 
         $ssoUser = false;
         if (class_exists(SsoUser::class)) {
+            // Check if the user is an SSO user (including SAML)
             $ssoUser = SsoUser::where('user_id', $currentUser->id)->exists();
+        }
+
+        // Check if the user is an LDAP user
+        if (isset($currentUser->meta?->authenticationType) && $currentUser->meta->authenticationType === 'ldap') {
+            $ssoUser = true;
         }
 
         // Get global and valid 2FA preferences for the user


### PR DESCRIPTION
## Issue & Reproduction Steps
A modal is displayed to validate the changes and save the email field by password confirmation. The issue is caused by the users synchronized by AD or SAML not having a known password.

## Solution
- Checks for SAML and LDAP users on email update

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-21445](https://processmaker.atlassian.net/browse/FOUR-21445)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-21445]: https://processmaker.atlassian.net/browse/FOUR-21445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ