### PR TITLE
Reload the data tab when the task changes

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -470,6 +470,9 @@
                 this.lastAutosave = "-";
                 this.lastAutosaveNav = "-"
               }
+              if (task.id !== oldTask.id) {
+                this.editJsonData();
+              }
             }
           },
           formData: {


### PR DESCRIPTION
## Issue & Reproduction Steps
Data tab was not updating when a task changed

## Solution
- Call the function that initializes data after the task changes

## How to Test
See Jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21203

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
