### PR TITLE
FOUR-20596:Show the modal if the process was not publish

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -21,6 +21,7 @@ use ProcessMaker\Package\PackagePmBlocks\Http\Controllers\Api\PmBlockController;
 use ProcessMaker\PackageHelper;
 use ProcessMaker\Traits\HasControllerAddons;
 use ProcessMaker\Traits\ProcessMapTrait;
+use ProcessMaker\Models\ProcessLaunchpad;
 
 class ModelerController extends Controller
 {
@@ -124,7 +125,7 @@ class ModelerController extends Controller
         if (class_exists('ProcessMaker\Package\PackageABTesting\Models\Alternative')) {
             $process->load('alternativeInfo');
         }
-
+// dd(ProcessLaunchpad::getLaunchpad(true, $process->id));
         return [
             'process' => $process,
             'manager' => $manager,
@@ -146,6 +147,7 @@ class ModelerController extends Controller
             'runAsUserDefault' => $runAsUserDefault,
             'alternative' => $alternative,
             'abPublish' => PackageHelper::isPackageInstalled('ProcessMaker\Package\PackageABTesting\PackageServiceProvider'),
+            'launchpad' => ProcessLaunchpad::getLaunchpad(true, $process->id),
         ];
     }
 

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -99,6 +99,7 @@ a {
     abPublish: @json($abPublish),
     alternative: @json($alternative),
     draftAlternative: @json($draftAlternative),
+    launchpad: @json($launchpad),
   }
   const warnings = @json($process->warnings);
 


### PR DESCRIPTION

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20596

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:modeler:feature/FOUR-20596