### PR TITLE
bugfix/FOUR-21270: Added maximum file size limit for images and other documents

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -277,6 +277,28 @@ class ProcessRequestFileController extends Controller
      */
     public function store(Request $laravel_request, FileReceiver $receiver, ProcessRequest $request)
     {
+        // Get filetype and total size
+        $filetype = $laravel_request->file->getClientMimeType(); 
+        $filesize = $laravel_request->input('totalSize');
+
+        // Define image mime types
+        $imageMimeTypes = [
+            'image/jpeg',
+            'image/jpg', 
+            'image/png',
+            'image/gif'
+        ];
+
+        // Get appropriate size limit based on file type (values based on env variables)
+        $sizeLimit = in_array($filetype, $imageMimeTypes) 
+            ? config('app.settings.img_max_filesize_limit')
+            : config('app.settings.doc_max_filesize_limit');
+
+        // Check if file exceeds size limit
+        if ($filesize > $sizeLimit) {
+            throw new \Exception('File size exceeds limit');
+        }
+
         //delete it and upload the new one
         if ($laravel_request->input('chunk')) {
             // Perform a chunk upload

--- a/config/app.php
+++ b/config/app.php
@@ -153,6 +153,12 @@ return [
         // Path to site-wide favicon
         'favicon_path' => env('FAVICON_PATH', '/img/favicon.svg'),
 
+        // Maximum file size for images to be set as default (in bytes) (5MB)
+        'img_max_filesize_limit' => (int) env('IMG_MAX_FILESIZE_LIMIT', 5242880),
+        
+        // Maximum file size for documents to be set as default (in bytes) (10MB)
+        'doc_max_filesize_limit' => (int) env('DOC_MAX_FILESIZE_LIMIT', 10485760),
+
     ],
 
     // Turn on/off the recommendation engine


### PR DESCRIPTION
## Tickets solved by this PR:
- https://processmaker.atlassian.net/browse/FOUR-21270
- https://processmaker.atlassian.net/browse/FOUR-21210

## Solution
- Added a validation for the total file size before proceeding to upload chunks.
- Added two env variables to specify the max file size limit (the recommended sizes are 5MB for image files and 10MB for documents).

## How to Test
1. Go to Admin
2. Go to File Manager
3. Go to Public
4. Upload a file by clicking the "+ PUBLIC FILE"
5. Upload a .txt file bigger than 10MB 
6. Upload an image file (.jpg, .jpeg, .png) bigger than 5MB

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
