### PR TITLE
FOUR-21490 - Hide Lua and R Script Executors

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
@@ -347,6 +347,9 @@ class ScriptExecutorController extends Controller
     {
         $languages = [];
         foreach (Script::scriptFormats() as $key => $config) {
+            if (in_array($key, Script::deprecatedLanguages)) {
+                continue;
+            }
             if (!array_key_exists('system', $config) || (array_key_exists('system', $config) && !$config['system'])) {
                 $languages[] = [
                     'value' => $key,

--- a/ProcessMaker/Models/Script.php
+++ b/ProcessMaker/Models/Script.php
@@ -73,6 +73,8 @@ class Script extends ProcessMakerModel implements ScriptInterface
 
     const categoryClass = ScriptCategory::class;
 
+    const deprecatedLanguages = ['lua', 'r'];
+
     protected $connection = 'processmaker';
 
     protected $guarded = [

--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -147,11 +147,19 @@ class ScriptExecutor extends ProcessMakerModel
 
     public static function rules($existing = null)
     {
+        if ($existing) {
+            $allowedLanguages = Script::scriptFormatValues();
+        } else {
+            $allowedLanguages = array_filter(Script::scriptFormatValues(), function ($language) {
+                return !in_array($language, Script::deprecatedLanguages);
+            });
+        }
+
         return [
             'title' => 'required',
             'language' => [
                 'required',
-                Rule::in(Script::scriptFormatValues()),
+                Rule::in($allowedLanguages),
             ],
         ];
     }

--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -59,6 +59,13 @@ class ScriptExecutor extends ProcessMakerModel
         'title', 'description', 'language', 'config', 'is_system',
     ];
 
+    // Lua and R are deprecated. This scope can be removed
+    // when they are removed permanently.
+    public function scopeActive($query)
+    {
+        return $query->whereNotIn('language', Script::deprecatedLanguages);
+    }
+
     public static function install($params)
     {
         $language = $params['language'];
@@ -153,7 +160,7 @@ class ScriptExecutor extends ProcessMakerModel
     {
         $list = [];
         $executors =
-            self::where('is_system', false)->orderBy('language', 'asc')
+            self::active()->where('is_system', false)->orderBy('language', 'asc')
             ->orderBy('created_at', 'asc');
 
         if ($language) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Hide deprecated languages and prevent saving new scripts and executors

## How to Test
- Ensure R and LUA are not available in lists of available languages
- Ensure you can not save new scripts or executors that attempt to use them

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21490

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
