### PR TITLE
FOUR-21495 default columns not being listed in the available columns

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
@@ -21,6 +21,7 @@ class ProcessVariableController extends Controller
 
     const CACHE_TTL = 60;
     private static bool $mockData = false;
+    private static bool $useVarFinder = true;
 
     /**
      * @OA\Schema(
@@ -203,11 +204,6 @@ class ProcessVariableController extends Controller
      */
     public function getProcessesVariables(array $processIds, $excludeSavedSearch, $page, $perPage, $request)
     {
-        // If the classes or tables do not exist, fallback to a saved search approach.
-        if (!class_exists(ProcessVariable::class) || !Schema::hasTable('process_variables')) {
-            return $this->getProcessesVariablesFrom($processIds);
-        }
-
         // Determine which columns to exclude based on the saved search
         $activeColumns = [];
         if ($excludeSavedSearch) {
@@ -215,6 +211,27 @@ class ProcessVariableController extends Controller
             if ($savedSearch && $savedSearch->current_columns) {
                 $activeColumns = $savedSearch->current_columns->pluck('field')->toArray();
             }
+        }
+
+        // If the classes or tables do not exist, fallback to a saved search approach.
+        if (
+            !class_exists(ProcessVariable::class)
+            || !Schema::hasTable('process_variables')
+            || !self::$useVarFinder
+        ) {
+            $paginator = $this->getProcessesVariablesFrom($processIds);
+            if ($request->has('onlyAvailable')) {
+                // Get the available columns from the saved search
+                $availableColumns = $savedSearch->available_columns;
+                // Merge the available columns with the paginated items
+                $availableColumns = $availableColumns->merge($paginator->items());
+                // Set the collection to the merged collection
+                $paginator->setCollection($availableColumns);
+
+                return $paginator;
+            }
+
+            return $paginator;
         }
 
         // Build a single query that joins process_variables, asset_variables, and var_finder_variables
@@ -266,6 +283,16 @@ class ProcessVariableController extends Controller
     public static function mock(bool $value = true)
     {
         static::$mockData = $value;
+    }
+
+    /**
+     * Change ProcessVariableController to not use VariableFinder
+     *
+     * @return void
+     */
+    public static function useVarFinder(bool $value = true)
+    {
+        static::$useVarFinder = $value;
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
@@ -230,7 +230,7 @@ class ProcessVariableController extends Controller
         }
 
         // Paginate the query result directly
-        return $query->select(
+        $query->select(
             'vfv.id',
             'pv.process_id',
             'vfv.data_type AS format',
@@ -239,7 +239,23 @@ class ProcessVariableController extends Controller
             DB::raw('NULL AS `default`'),
             'vfv.created_at',
             'vfv.updated_at',
-        )->paginate($perPage, ['*'], 'page', $page);
+        );
+
+        // Return the paginated result
+        $paginator = $query->paginate($perPage, ['*'], 'page', $page);
+
+        if ($request->has('onlyAvailable')) {
+            // Get the available columns from the saved search
+            $availableColumns = $savedSearch->available_columns;
+            // Merge the available columns with the paginated items
+            $availableColumns = $availableColumns->merge($paginator->items());
+            // Set the collection to the merged collection
+            $paginator->setCollection($availableColumns);
+
+            return $paginator;
+        }
+
+        return $query->paginate($perPage, ['*'], 'page', $page);
     }
 
     /**

--- a/tests/Feature/Api/V1_1/ProcessVariableControllerTest.php
+++ b/tests/Feature/Api/V1_1/ProcessVariableControllerTest.php
@@ -371,4 +371,144 @@ class ProcessVariableControllerTest extends TestCase
             ],
         ]);
     }
+
+    public function test_saved_search_with_all_available_columns(): void
+    {
+        // Create a saved search with specific columns
+        $savedSearch = SavedSearch::factory()->create([
+            'type' => 'request',
+            'meta' => [
+                "icon" => "bath",
+                "file" => null,
+                "collection_id" => null,
+                "columns" => [],
+            ],
+            'pmql' => '',
+        ]);
+
+        $response = $this->apiCall('GET', '/api/1.1/processes/variables?processIds=1&savedSearchId=' . $savedSearch->id . '&onlyAvailable=');
+
+        $responseData = $response->json();
+
+        $filteredFields = collect($responseData['data'])->pluck('field');
+
+        $this->assertTrue($filteredFields->contains('case_number'));
+        $this->assertTrue($filteredFields->contains('case_title'));
+        $this->assertTrue($filteredFields->contains('name'));
+        $this->assertTrue($filteredFields->contains('active_tasks'));
+        $this->assertTrue($filteredFields->contains('process_version_alternative'));
+        $this->assertTrue($filteredFields->contains('participants'));
+        $this->assertTrue($filteredFields->contains('status'));
+        $this->assertTrue($filteredFields->contains('initiated_at'));
+        $this->assertTrue($filteredFields->contains('completed_at'));
+    }
+
+    public function test_saved_search_with_remaining_available_columns(): void
+    {
+        // Create a saved search with specific columns
+        $savedSearch = SavedSearch::factory()->create([
+            'type' => 'request',
+            'meta' => [
+                "icon" => "bath",
+                "file" => null,
+                "collection_id" => null,
+                "columns" => [
+                    [
+                        "label" => "Case Number",
+                        "field" => "case_number",
+                    ],
+                    [
+                        "label" => "Case Title",
+                        "field" => "case_title",
+                    ],
+                ],
+            ],
+            'pmql' => '',
+        ]);
+
+        $response = $this->apiCall('GET', '/api/1.1/processes/variables?processIds=1&savedSearchId=' . $savedSearch->id . '&onlyAvailable=');
+
+        $responseData = $response->json();
+
+        $filteredFields = collect($responseData['data'])->pluck('field');
+
+        $this->assertFalse($filteredFields->contains('case_number'));
+        $this->assertFalse($filteredFields->contains('case_title'));
+
+        $this->assertTrue($filteredFields->contains('name'));
+        $this->assertTrue($filteredFields->contains('active_tasks'));
+        $this->assertTrue($filteredFields->contains('process_version_alternative'));
+        $this->assertTrue($filteredFields->contains('participants'));
+        $this->assertTrue($filteredFields->contains('status'));
+        $this->assertTrue($filteredFields->contains('initiated_at'));
+        $this->assertTrue($filteredFields->contains('completed_at'));
+    }
+
+    public function test_saved_search_with_no_available_columns(): void
+    {
+        // Create a saved search with specific columns
+        $savedSearch = SavedSearch::factory()->create([
+            'type' => 'request',
+            'meta' => [
+                "icon" => "bath",
+                "file" => null,
+                "collection_id" => null,
+                "columns" => [
+                    [
+                        "label" => "Case Number",
+                        "field" => "case_number",
+                    ],
+                    [
+                        "label" => "Case Title",
+                        "field" => "case_title",
+                    ],
+                    [
+                        "label" => "Name",
+                        "field" => "name",
+                    ],
+                    [
+                        'label' => 'Active Tasks',
+                        'field' => 'active_tasks',
+                    ],
+                    [
+                        'label' => 'Process Version Alternative',
+                        'field' => 'process_version_alternative',
+                    ],
+                    [
+                        'label' => 'Participants',
+                        'field' => 'participants',
+                    ],
+                    [
+                        'label' => 'Status',
+                        'field' => 'status',
+                    ],
+                    [
+                        'label' => 'Initiated At',
+                        'field' => 'initiated_at',
+                    ],
+                    [
+                        'label' => 'Completed At',
+                        'field' => 'completed_at',
+                    ],
+                ],
+            ],
+            'pmql' => '',
+        ]);
+
+        $response = $this->apiCall('GET', '/api/1.1/processes/variables?processIds=1&savedSearchId=' . $savedSearch->id . '&onlyAvailable=');
+
+        $responseData = $response->json();
+
+        $filteredFields = collect($responseData['data'])->pluck('field');
+
+        $this->assertFalse($filteredFields->contains('case_number'));
+        $this->assertFalse($filteredFields->contains('case_title'));
+        $this->assertFalse($filteredFields->contains('name'));
+        $this->assertFalse($filteredFields->contains('active_tasks'));
+        $this->assertFalse($filteredFields->contains('process_version_alternative'));
+        $this->assertFalse($filteredFields->contains('participants'));
+        $this->assertFalse($filteredFields->contains('status'));
+        $this->assertFalse($filteredFields->contains('initiated_at'));
+        $this->assertFalse($filteredFields->contains('completed_at'));
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Default Columns not being listed in the available columns

## Solution
- Get process variables including available columns

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
[FOUR-21495](https://processmaker.atlassian.net/browse/FOUR-21495)
https://github.com/ProcessMaker/package-savedsearch/pull/500

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-savedsearch:FOUR-21495
ci:package-variable-finder:epic/FOUR-20417


[FOUR-21495]: https://processmaker.atlassian.net/browse/FOUR-21495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ