### PR TITLE
Do not filter by user for self-serve Processes I Manager

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -136,13 +136,13 @@ class TaskController extends Controller
 
         $this->applyAdvancedFilter($query, $request);
 
-        $this->applyForCurrentUser($query, $user);
-
         // Apply filter overdue
         $query->overdue($request->input('overdue'));
 
         if ($request->input('processesIManage') === 'true') {
             $this->applyProcessManager($query, $user);
+        } else {
+            $this->applyForCurrentUser($query, $user);
         }
 
         // If only the total is being requested (by a Saved Search), send it now

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -743,13 +743,15 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
 
         $value = mb_strtolower($value);
 
-        return function ($query) use ($value, $statusMap, $expression, $user) {
+        $processesIManage = request()->input('processesIManage') === 'true';
+
+        return function ($query) use ($value, $statusMap, $expression, $user, $processesIManage) {
             if ($value === 'self service') {
                 if (!$user) {
                     $user = auth()->user();
                 }
 
-                if ($user) {
+                if ($user && !$processesIManage) {
                     $taskIds = $user->availableSelfServiceTaskIds();
                     $query->whereIn('id', $taskIds);
                 } else {

--- a/database/factories/ProcessMaker/Models/ProcessRequestTokenFactory.php
+++ b/database/factories/ProcessMaker/Models/ProcessRequestTokenFactory.php
@@ -19,7 +19,7 @@ class ProcessRequestTokenFactory extends Factory
     public function definition(): array
     {
         return [
-            'element_type' => 'TASK',
+            'element_type' => 'task',
             'element_id' => $this->faker->randomDigit(),
             'element_name' => $this->faker->name(),
             'status' => $this->faker->randomElement(['ACTIVE', 'FAILING', 'COMPLETED', 'CLOSED', 'EVENT_CATCH']),

--- a/tests/Feature/Api/TaskControllerTest.php
+++ b/tests/Feature/Api/TaskControllerTest.php
@@ -196,4 +196,61 @@ class TaskControllerTest extends TestCase
             'meta',
         ]);
     }
+
+    public function testProcessesIManage()
+    {
+        $managerUser = User::factory()->create();
+        $taskUser = User::factory()->create();
+        Auth::login($managerUser);
+
+        $process = Process::factory()->create([
+            'properties' => [
+                'manager_id' => $managerUser->id,
+            ],
+        ]);
+
+        $processRequest = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+        ]);
+
+        $selfServiceTask = ProcessRequestToken::factory()->create([
+            'process_request_id' => $processRequest->id,
+            'process_id' => $process->id,
+            'user_id' => null,
+            'status' => 'ACTIVE',
+            'is_self_service' => true,
+        ]);
+
+        $regularTask = ProcessRequestToken::factory()->create([
+            'process_request_id' => $processRequest->id,
+            'process_id' => $process->id,
+            'user_id' => $taskUser->id,
+            'status' => 'ACTIVE',
+        ]);
+
+        $this->user = $managerUser;
+        $params = [
+            'processesIManage' => 'true',
+            'pmql' => '(status = "Self Service" or status = "In Progress")',
+        ];
+        $response = $this->apiCall('GET', '/tasks', $params);
+        $this->assertCount(2, $response->json()['data']);
+        $this->assertEquals($selfServiceTask->id, $response->json()['data'][0]['id']);
+        $this->assertEquals($regularTask->id, $response->json()['data'][1]['id']);
+
+        // Add the advanced filter to only show the self service task
+        $params['advanced_filter'] = [
+            [
+                'subject' => [
+                    'type' => 'Status',
+                    'value' => 'status',
+                ],
+                'operator' => '=',
+                'value' => 'Self Service',
+            ],
+        ];
+        $response = $this->apiCall('GET', '/tasks', $params);
+        $this->assertCount(1, $response->json()['data']);
+        $this->assertEquals($selfServiceTask->id, $response->json()['data'][0]['id']);
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The self-serve value alias was forcing filtering by the current logged in user

## Solution
- Check for the parameter and skip the user when showing processes I Manage

## How to Test
See jira ticket

## Related Tickets & Packages
- Requires https://github.com/ProcessMaker/package-savedsearch/pull/501
- Jira: https://processmaker.atlassian.net/browse/FOUR-19940

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
