### PR TITLE
FOUR-21469 - Upgrade to php 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "babenkoivan/elastic-scout-driver": "^3.0",
         "bacon/bacon-qr-code": "^2.0",
         "codegreencreative/laravel-samlidp": "^5.2",


### PR DESCRIPTION
For local development on mac, you may need to:
- `valet use 8.3` or the herd equivalent
- `brew install librdkafka`
- `sudo pecl install rdkafka`
  - Specify the library path from the brew install command. In my case it was `/opt/homebrew/Cellar/librdkafka/2.8.0`
- `sudo pecl install redis` You can use all default options
- `brew tap kabel/php-ext && brew install php@8.3-imap`
- Finally, `valet restart` and restart horizon

ci:k8s-branch:fall-php83
...