### PR TITLE
FOUR-21522 Fix Get variable list without VarFinder package was not implemented

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
@@ -261,6 +261,12 @@ class ProcessVariableController extends Controller
      */
     private function getProcessesVariablesFrom(array $processIds)
     {
+        $perPage = request()->get('per_page', 20);
+        // Validate processIds input is required
+        if (empty($processIds)) {
+            return new LengthAwarePaginator([], 0, $perPage, 1);
+        }
+
         // Get screens used in the processes
         $processes = Process::whereIn('id', $processIds)->get();
         $ids = collect([]);
@@ -288,7 +294,6 @@ class ProcessVariableController extends Controller
 
         // Paginate the result
         $page = request()->get('page', 1);
-        $perPage = request()->get('per_page', 20);
         $total = $columns->count();
         $items = $columns->forPage($page, $perPage);
 


### PR DESCRIPTION
## Fix Get variable list without VarFinder package was not implemented

https://github.com/user-attachments/assets/767f75e3-e4d3-4432-8b99-c11635e91c5d

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21522

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-savedsearch:FOUR-21522
