### PR TITLE
FOUR-21508:When I publish the process the launchpad button is showing the modal

### DIFF
--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -296,6 +296,14 @@ export default {
       this.isSecondaryColor = false;
     },
     /**
+     * Save Launchpad Settings if this modal is open in Modeler
+     */
+    saveLaunchpadSettings(data) {
+      if (window.ProcessMaker.modeler) {
+        window.ProcessMaker.modeler.launchpad = data;
+      }
+    },
+    /**
      * Save description field in Process
      */
     saveProcessDescription() {
@@ -330,6 +338,7 @@ export default {
           ProcessMaker.EventBus.$emit("getLaunchpadImagesEvent", params);
           ProcessMaker.EventBus.$emit("getChartId", this.selectedSavedChart.id);
           this.customModalButtons[1].disabled = false;
+          this.saveLaunchpadSettings(response.data);
           this.hideModal();
         })
         .catch((error) => {


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create process
2. Go to Launchpad button
3. See the modal
4. Publish the process
5. Click again in the Launchpad button

**Current Behavior**
After publish the process the Launchpad button needs to redirect to launchpad

## Related Tickets & Packages
- [Link to any related FOUR tickets, PRDs, or packages](https://processmaker.atlassian.net/browse/FOUR-21508)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:modeler:bugfix/FOUR-21508