### PR TITLE
FOUR-21398: [42359] - Update a Process Request (PUT METHOD API)

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -211,19 +211,29 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     }
 
     /**
-     * Validation rules.
+     * Get the validation rules for process requests.
      *
-     * @param null $existing
+     * @param mixed|null $existing ID of existing process request to ignore in unique validation
      *
-     * @return array
+     * @return array Array of validation rules for the process request fields:
+     *               - name: Required string, max 100 chars, alpha spaces only, unique unless updating existing
+     *               - data: Required field
+     *               - status: Must be one of: ACTIVE, COMPLETED, ERROR, CANCELED
+     *               - process_id: Required and must exist in processes table
+     *               - process_collaboration_id: Optional but must exist in process_collaborations table if provided
+     *               - user_id: Must exist in users table
      */
     public static function rules($existing = null)
     {
         $self = new self();
         $unique = Rule::unique($self->getConnectionName() . '.process_requests')->ignore($existing);
+        $nameRules = ['required', 'string', 'max:100', 'alpha_spaces'];
+        if ($existing === null) {
+            $nameRules[] = $unique;
+        }
 
         return [
-            'name' => ['required', 'string', 'max:100', $unique, 'alpha_spaces'],
+            'name' => $nameRules,
             'data' => 'required',
             'status' => 'in:ACTIVE,COMPLETED,ERROR,CANCELED',
             'process_id' => 'required|exists:processes,id',
@@ -986,6 +996,7 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     {
         $array = $this->toArray();
         unset($array['process_version']['svg']);
+
         return $array;
     }
 

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -401,7 +401,8 @@ class ProcessRequestsTest extends TestCase
         ]);
         //Validate the header status code
         $response->assertStatus(422);
-        $response->assertSeeText('The Name has already been taken');
+        //assert that the response does not contain the error message
+        $response->assertDontSeeText('The Name has already been taken');
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
When attempting to change the status from "CANCELED" to "ACTIVE" or "ERROR" to "ACTIVE," the API returns a validation error:

"The Name has already been taken."

## Solution
- add a validation for existing request 

https://github.com/user-attachments/assets/16e27d78-c70c-4522-b5d6-1a98e0a61f9a


## How to Test
Described in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21398

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
