### PR TITLE
[42444] Coronation Registrar - Webentry Error

### DIFF
--- a/ProcessMaker/Traits/ForUserScope.php
+++ b/ProcessMaker/Traits/ForUserScope.php
@@ -21,7 +21,10 @@ trait ForUserScope
             return $query;
         }
 
-        $userParticipated = ProcessRequestToken::where('user_id', $user->id)->pluck('process_request_id')->toArray();
+        $userParticipated = [];
+        if ($user->username !== '_pm4_anon_user') {
+            $userParticipated = ProcessRequestToken::where('user_id', $user->id)->pluck('process_request_id')->toArray();
+        }
 
         $userHasSelfServiceTasks = ProcessRequestToken::where('is_self_service', true)
             ->whereJsonContains('self_service_groups->users', (string) $user->id)


### PR DESCRIPTION
## Issue & Reproduction Steps
The problem arises when you want to verify if a user has permission to view a Request.

In this specific case, it is when the anonymous user of Processmaker wants to see which ProcessRequestToken he has participated in.

## Solution
- Add validation so that ProcessRequest Tokens where the anonymous user has participated are not obtained.

## How to Test
You need to have a large number of ProcessRequestTokens where the anonymous user has participated for the error to occur.

`General error: 1390 Prepared statement contains too many placeholders (Connection: processmaker, SQL: select exists(select * from `process_requests` where (`user_id` = 1 or `id` in (4209, 29084, 29187, 21036, 7807, 26062, 14119, 17134, 24547, 16857, 27073, 33282, 35221, 1975, 1969, 1650, 1963, 1666, 1672, 2232, 158601, 156342, 156338, 158098, 159326, 159331, 159876, 159293, 158990, 159333, 158118, 158996, 158104,......`

## Related Tickets & Packages
- [FOUR-21558](https://processmaker.atlassian.net/browse/FOUR-21558)
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
