### PR TITLE
FOUR-21624 There is not Clear draft in task detail

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -433,6 +433,7 @@
     const userConfiguration = @json($userConfiguration);
 
     window.Processmaker.user = @json($currentUser);
+    window.ProcessMaker.taskDraftsEnabled = @json($taskDraftsEnabled);
   </script>
 
   @foreach(GlobalScripts::getScripts() as $script)


### PR DESCRIPTION
## Issue
The value for "window.ProcessMaker.taskDraftsEnabled" by default "false", the template is not setting this value according to the configuration in the ".env" file


## Solution
Set the correct value for variable "window.ProcessMaker.taskDraftsEnabled" when the template "tasks/edit" is loaded

## How to Test
Create process
Create a case
Open the task
Search for clear draft in task details
Ensure that the environment variable "TASK_DRAFTS_ENABLED" is set to "TRUE"

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21624

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
