### PR TITLE
FOUR-20687: Create the PHP Unit test

### DIFF
--- a/tests/Feature/TaskControllerTest.php
+++ b/tests/Feature/TaskControllerTest.php
@@ -4,7 +4,7 @@ namespace Tests\Feature;
 
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\Auth;
-use ProcessMaker\Models\AnonymousUser;
+use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessAbeRequestToken;
 use ProcessMaker\Models\ProcessRequest;
@@ -145,5 +145,34 @@ class TaskControllerTest extends TestCase
         );
         $response->assertSee('Token not found');
         $response->assertStatus(404);
+    }
+
+    /**
+     * Test email task notification
+     */
+    public function testEmailTaskNotificationInFormTask()
+    {
+        $user = User::factory()->create([
+            'email_task_notification' => 1,
+        ]);
+        Auth::login($user);
+        $process = Process::factory()->create([
+            'bpmn' => file_get_contents(__DIR__ . '/../Fixtures/email_task_notification_process.bpmn'),
+        ]);
+        // Start a request
+        $route = route('api.process_events.trigger', [$process->id, 'event' => 'node_1']);
+        $data = [];
+        $response = $this->apiCall('POST', $route, $data);
+        $response->assertStatus(201);
+        // Find the request
+        $instance = ProcessRequest::first();
+        $task = ProcessRequestToken::where('element_type', 'task')->where('process_id', $process->id)->where('status', 'ACTIVE')->first();
+        $this->assertEquals(0, $task->is_emailsent);
+        $user = User::where('id', $task->user_id)->first();
+        $user->email_task_notification = 1;
+        $user->save();
+        WorkflowManager::completeTask($process, $instance, $task, []);
+        $task = ProcessRequestToken::where('element_type', 'task')->where('process_id', $process->id)->where('status', 'ACTIVE')->first();
+        $this->assertEquals(0, $task->is_emailsent);
     }
 }

--- a/tests/Fixtures/email_task_notification_process.bpmn
+++ b/tests/Fixtures/email_task_notification_process.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="true" pm:interstitialScreenRef="1">
+      <bpmn:outgoing>node_24</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_2" name="Form Task A" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}">
+      <bpmn:incoming>node_24</bpmn:incoming>
+      <bpmn:outgoing>node_79</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_24" sourceRef="node_1" targetRef="node_2" />
+    <bpmn:task id="node_61" name="Form Task B" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}">
+      <bpmn:incoming>node_79</bpmn:incoming>
+      <bpmn:outgoing>node_83</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="node_71" name="End Event" pm:elementDestination="{&#34;type&#34;:&#34;summaryScreen&#34;,&#34;value&#34;:null}">
+      <bpmn:incoming>node_83</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_79" sourceRef="node_2" targetRef="node_61" />
+    <bpmn:sequenceFlow id="node_83" sourceRef="node_61" targetRef="node_71" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="391" y="142" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_24_di" bpmnElement="node_24">
+        <di:waypoint x="288" y="178" />
+        <di:waypoint x="449" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_61_di" bpmnElement="node_61">
+        <dc:Bounds x="584" y="144" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_71_di" bpmnElement="node_71">
+        <dc:Bounds x="760" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_79_di" bpmnElement="node_79">
+        <di:waypoint x="449" y="180" />
+        <di:waypoint x="642" y="182" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_83_di" bpmnElement="node_83">
+        <di:waypoint x="642" y="182" />
+        <di:waypoint x="778" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Issue & Reproduction Steps
Create the PHP Unit test

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20687

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:connector-docusign:release-2024-fall
ci:package-webentry:release-2024-fall