### PR TITLE
Fix retries and run microservice requests synchronously

### DIFF
--- a/ProcessMaker/Jobs/ErrorHandling.php
+++ b/ProcessMaker/Jobs/ErrorHandling.php
@@ -5,6 +5,8 @@ namespace ProcessMaker\Jobs;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
+use ProcessMaker\Exception\ScriptException;
+use ProcessMaker\Exception\ScriptTimeoutException;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -203,5 +205,15 @@ class ErrorHandling
             'retry_attempts' => Arr::get($endpointConfig, 'retry_attempts', 0),
             'retry_wait_time' => Arr::get($endpointConfig, 'retry_wait_time', 5),
         ];
+    }
+
+    public static function convertResponseToException($result)
+    {
+        if ($result['status'] === 'error') {
+            if (str_starts_with($result['message'], 'Command exceeded timeout of')) {
+                throw new ScriptTimeoutException($result['message']);
+            }
+            throw new ScriptException($result['message']);
+        }
     }
 }

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -108,7 +108,7 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
                     'attempts' => $this->attemptNum,
                 ],
             ];
-            $response = $script->runScript($data, $configuration, $token->getId(), $errorHandling->timeout(), 0, $metadata);
+            $response = $script->runScript($data, $configuration, $token->getId(), $errorHandling->timeout(), 1, $metadata);
 
             if (!config('script-runner-microservice.enabled') ||
                 ($scriptExecutor && $scriptExecutor->type === ScriptExecutorType::Custom)) {

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -110,10 +110,7 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
             ];
             $response = $script->runScript($data, $configuration, $token->getId(), $errorHandling->timeout(), 1, $metadata);
 
-            if (!config('script-runner-microservice.enabled') ||
-                ($scriptExecutor && $scriptExecutor->type === ScriptExecutorType::Custom)) {
-                $this->updateData($response);
-            }
+            $this->updateData($response);
         } catch (ConfigurationException $exception) {
             $this->unlock();
             $this->updateData(['output' => $exception->getMessageForData($token)]);

--- a/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
@@ -7,9 +7,8 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use ProcessMaker\Exception\ConfigurationException;
-use ProcessMaker\Exception\ScriptException;
-use ProcessMaker\Exception\ScriptTimeoutException;
 use ProcessMaker\GenerateAccessToken;
+use ProcessMaker\Jobs\ErrorHandling;
 use ProcessMaker\Models\EnvironmentVariable;
 use ProcessMaker\Models\Script;
 use ProcessMaker\Models\User;
@@ -98,11 +97,8 @@ class ScriptMicroserviceRunner
 
         $result = $response->json();
 
-        if ($sync && $result['status'] === 'error') {
-            if (str_starts_with($result['message'], 'Command exceeded timeout of')) {
-                throw new ScriptTimeoutException($result['message']);
-            }
-            throw new ScriptException($result['message']);
+        if ($sync) {
+            ErrorHandling::convertResponseToException($result);
         }
 
         return $result;

--- a/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use ProcessMaker\Exception\ConfigurationException;
 use ProcessMaker\Exception\ScriptException;
+use ProcessMaker\Exception\ScriptTimeoutException;
 use ProcessMaker\GenerateAccessToken;
 use ProcessMaker\Models\EnvironmentVariable;
 use ProcessMaker\Models\Script;
@@ -95,7 +96,16 @@ class ScriptMicroserviceRunner
 
         $response->throw();
 
-        return $response->json();
+        $result = $response->json();
+
+        if ($sync && $result['status'] === 'error') {
+            if (str_starts_with($result['message'], 'Command exceeded timeout of')) {
+                throw new ScriptTimeoutException($result['message']);
+            }
+            throw new ScriptException($result['message']);
+        }
+
+        return $result;
     }
 
     private function getEnvironmentVariables(User $user)

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -151,9 +151,13 @@ trait TaskControllerIndexMethods
         $nonSystem = filter_var($request->input('non_system'), FILTER_VALIDATE_BOOLEAN);
         $allTasks = filter_var($request->input('all_tasks'), FILTER_VALIDATE_BOOLEAN);
         $query->when(!$allTasks, function ($query) {
-            $query->where('element_type', '=', 'task');
-            $query->orWhere('element_type', '=', 'serviceTask');
-            $query->where('element_name', '=', 'AI Assistant');
+            $query->where(function ($query) {
+                $query->where('element_type', '=', 'task');
+                $query->orWhere(function ($query) {
+                    $query->where('element_type', '=', 'serviceTask');
+                    $query->where('element_name', '=', 'AI Assistant');
+                });
+            });
         })
             ->when($nonSystem, function ($query) {
                 $query->nonSystem();


### PR DESCRIPTION
See https://processmaker.atlassian.net/browse/FOUR-21497

Note this PR also fixes a unit test failure in core where the query [condition parentheses](https://github.com/ProcessMaker/processmaker/commit/9c4e5cd955ffb8be3dd56ce641ef08645a3aa3e4#diff-b5b31261a18689534ed57c3753fdb2dca3348d12d6ff51fbd3eb1a4fabb85a46R164-R168) were not correct. This did not surface as a failure until [a different change](https://github.com/ProcessMaker/processmaker/commit/9e9f638008e7aeade79801f70696d83c6283af3f#diff-ea22510c52122a86c40e9d839b6baeda845a03ffcb64d9c4d90afdbb428f1ec7R152-R153) was merged.