### PR TITLE
FOUR-17551:Scrollbar Position Issue When Navigating to Next Page

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -1243,7 +1243,9 @@ export default {
       );
     },
     updatePage() {
-      this.$refs["preview-screen"].scrollTop = 0;
+      if (this.$refs["preview-screen"]) {
+        this.$refs["preview-screen"].scrollTop = 0;
+      }
     },
   },
 };

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -41,7 +41,10 @@
           id="preview"
           class="h-100 m-0"
         >
-          <b-col class="d-flex overflow-auto h-100">
+          <b-col
+            ref="preview-screen"
+            class="d-flex overflow-auto h-100"
+          >
             <vue-form-renderer
               v-if="renderComponent === 'task-screen'"
               ref="renderer"
@@ -56,6 +59,7 @@
               :show-errors="true"
               :mock-magic-variables="mockMagicVariables"
               :device-screen="deviceScreen"
+              @update-page-task="updatePage"
               @submit="previewSubmit"
               @update="onUpdate"
               @css-errors="cssErrors = $event"
@@ -77,6 +81,7 @@
                 :watchers="preview.watchers"
                 :data="previewData"
                 :type="screen.type"
+                @update-page-task="updatePage"
                 @update="onUpdate"
                 @submit="previewSubmit"
               />
@@ -1236,6 +1241,9 @@ export default {
         },
         4,
       );
+    },
+    updatePage() {
+      this.$refs["preview-screen"].scrollTop = 0;
     },
   },
 };

--- a/resources/js/tasks/edit.js
+++ b/resources/js/tasks/edit.js
@@ -392,6 +392,9 @@ const main = new Vue({
     taskUpdated(task) {
       this.task = task;
     },
+    updatePage() {
+      document.getElementById("tabContent").scrollTop = 0;
+    },
     updateScreenFields(taskId) {
       return ProcessMaker.apiClient
         .get(`tasks/${taskId}/screen_fields`)

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -36,7 +36,7 @@
     <div
       class="tw-flex tw-w-full tw-grow px-3">
       <div class="tw-flex tw-w-full tw-grow">
-        <div class="tw-flex tw-flex-col tw-grow">
+        <div class="tw-flex tw-flex-col tw-grow tw-overflow-hidden container-height">
           <div 
             v-if="isSelfService"
             class="alert alert-primary"
@@ -99,6 +99,7 @@
                   initial-loop-context="{{ $task->getLoopContext() }}"
                   :wait-loading-listeners="true"
                   @task-updated="taskUpdated"
+                  @updated-page-core="updatePage"
                   @submit="submit"
                   @completed="completed"
                   @@error="error"


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Import the attached screen file.
2. Preview the screen.
3. Navigate to the second page of the screen.

**Current Behavior:**
When the customer builds a button in a form that navigates to a new screen, the following page opens at the same point where the previous page was left off. This means the subsequent page opens about halfway down.

**Expected Behavior:**
The new page should open from the top, not at the same point where the previous page was left off.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17551

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:screen-builder:bugfix/FOUR-17551