### PR TITLE
FOUR-21631 select list does not show the field assigned to its data in web entry

### DIFF
--- a/resources/js/processes/screen-builder/typeForm.js
+++ b/resources/js/processes/screen-builder/typeForm.js
@@ -1,3 +1,7 @@
+import { Multiselect } from "@processmaker/vue-multiselect";
+
+Vue.component("Multiselect", Multiselect);
+
 ProcessMaker.EventBus.$on("screen-builder-init", (manager) => {
   const { FormBuilderControls, globalProperties } = window.ScreenBuilder;
   const initialControls = FormBuilderControls;


### PR DESCRIPTION
## Issue & Reproduction Steps
The field assigned to display the data of the select list is not shown from the web entry.

## Solution
- Register the `multiselect` component in screen builder

## How to Test
1. Create a screen with a select list
2. Create a simple process
3. Enable web entry
4. Assign the screen created with the select list to the web entry
5. Save the process
6. Copy the URL and paste it into another window

## Related Tickets & Packages
[FOUR-21631](https://processmaker.atlassian.net/browse/FOUR-21631)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-21631]: https://processmaker.atlassian.net/browse/FOUR-21631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ