### PR TITLE
FOUR-21667 |  "Edit Template” Link for Screen Templates Does Not Redirect to Edit Page in Screen Builder

### DIFF
--- a/ProcessMaker/Http/Controllers/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/TemplateController.php
@@ -24,9 +24,13 @@ class TemplateController extends Controller
      *
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public function edit(string $type, Request $request)
+    public function editScreenTemplate(Request $request)
     {
-        new $this->types[$type][1]->edit($request);
+        $screenTemplate = new $this->types['screen'][1];
+
+        $response = $screenTemplate->show($request);
+
+        return view('processes.screen-builder.showTemplate')->with('id', $response['id']);
     }
 
     /**

--- a/resources/js/components/shared/ellipsisMenuActions.js
+++ b/resources/js/components/shared/ellipsisMenuActions.js
@@ -286,6 +286,8 @@ export default {
         {
           value: "edit-template",
           content: "Edit Template",
+          link: true,
+          href: "/screen-template/{{id}}/edit",
           permission: ["edit-screens"],
           icon: "fas fa-pen-square",
         },
@@ -322,6 +324,8 @@ export default {
         {
           value: "edit-template",
           content: "Edit Template",
+          link: true,
+          href: "/screen-template/{{id}}/edit",
           permission: ["edit-screens"],
           icon: "fas fa-pen-square",
           conditional: "if(is_owner and user_id, true, false)",

--- a/resources/js/processes/screen-templates/mixins/navigationMixin.js
+++ b/resources/js/processes/screen-templates/mixins/navigationMixin.js
@@ -2,9 +2,6 @@ export default {
   methods: {
     onTemplateNavigate(actionType, data) {
       switch (actionType?.value) {
-        case "edit-template":
-          this.goToScreenBuilder(data.id);
-          break;
         case "make-public":
           ProcessMaker.apiClient
             .put(`template/screen/${data.id}/update`, {
@@ -45,14 +42,6 @@ export default {
         default:
           break;
       }
-    },
-    goToScreenBuilder(data) {
-      ProcessMaker.apiClient.get(`/screen-builder/screen/${data}`)
-        .then((response) => {
-          window.location = `/designer/screen-builder/${response.data.id}/edit`;
-        }).catch((error) => {
-          ProcessMaker.alert(error.response?.data?.message, "danger");
-        });
     },
   },
 };

--- a/resources/views/processes/screen-builder/showTemplate.blade.php
+++ b/resources/views/processes/screen-builder/showTemplate.blade.php
@@ -1,0 +1,3 @@
+<script>
+    window.location.href = "/designer/screen-builder/{{ $id }}/edit";
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -181,6 +181,8 @@ Route::middleware('auth', 'session_kill', 'sanitize', 'force_change_password', '
     Route::get('modeler/templates/{id}', [TemplateController::class, 'show'])->name('modeler.template.show')->middleware('template-authorization', 'can:edit-process-templates');
     Route::get('screen-template/{screen}/export', [TemplateController::class, 'export'])->name('screens-template.export')->middleware('can:export-screens');
     Route::get('screen-template/import', [TemplateController::class, 'importScreen'])->name('screens-template.importScreen')->middleware('can:import-screens');
+    Route::get('screen-template/{id}/edit', [TemplateController::class, 'editScreenTemplate'])->name('screen-template.edit')->middleware('can:edit-screens');
+
     // Allows for a logged in user to see navigation on a 404 page
     Route::fallback(function () {
         return response()->view('errors.404', [], 404);


### PR DESCRIPTION
# Issue
Ticket: [FOUR-21667](https://processmaker.atlassian.net/browse/FOUR-21667)

When right-clicking on the "Edit Template" link within the Ellipsis Menu for Screen Templates (located on both "My Templates" and "Shared Templates" listing pages), the link incorrectly redirects to the Screens listing page instead of the Screen Builder. This prevents users from editing templates in a new browser tab.

# Solution
- Add `screen-template/{id}/edit` web route that opens a Screen Template in Screen Builder
- Add href link to the new route in `ellipsisMenuActions.js`
- Remove `goToScreenBuilder()` method used in `navigationMixin.js`
	
# How to Test
1. Go to branch `bugfix/FOUR-21667` in `processmaker`.
2. Ensure you have Screen Templates in your environment.
3. Go to Designer → Screens → My Templates.
	- Open the Ellipsis Menu and right-clik on Edit Template to 'Open link in new tab'.
	- Go to the new tab.
	- The new tab should be the Screen Builder page for the selected Screen Template.
4. Go to Designer → Screens → Shared Templates.
	- Open the Ellipsis Menu and right-clik on Edit Template to 'Open link in new tab'.
	- Go to the new tab.
	- The new tab should be the Screen Builder page for the selected Screen Template.

ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-21667]: https://processmaker.atlassian.net/browse/FOUR-21667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ