### PR TITLE
Fix Screen Template Owner Display

### DIFF
--- a/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
+++ b/resources/js/processes/screen-templates/components/PublicTemplatesListing.vue
@@ -285,6 +285,21 @@ export default {
           console.error(error);
         });
     },
+    transform(data) {
+      // Clean up fields for meta pagination so vue table pagination can understand
+      data.meta.last_page = data.meta.total_pages;
+      data.meta.from = (data.meta.current_page - 1) * data.meta.per_page;
+      data.meta.to = data.meta.from + data.meta.count;
+      data.data = this.jsonRows(data.data);
+
+      for (let record of data.data) {
+        //format Status
+        const usePmDefaultLabel = !record['user'];
+        record["owner"] = this.formatAvatar(record["user"], usePmDefaultLabel);
+        record["category_list"] = this.formatCategory(record["categories"]);
+      }
+      return data;
+    },
   },
 };
 </script>


### PR DESCRIPTION
## Issue & Reproduction Steps
Resolves an issue where screen templates without an owner displayed 'unclaimed' instead of the default 'ProcessMaker' text.
The screen template listing page was using the default **datatable.js** `transform` method which had `usePmDefaultLabel` set to `false`. This caused ownerless templates to display as 'unclaimed' instead of the desired default text 'ProcessMaker'.

## Solution
- Added a custom `transform` method in the screen template listing component
- Enabled `usePmDefaultLabel` property to ensure proper owner text formatting

## How to Test
1. Populate the 'Shared Templates' tab:
   ```
   php artisan processmaker:sync-screen-templates
   ```
2. Navigate to Designer > Screens > Shared Templates tab
3. Verify the 'Owner' column displays correctly

**Expected Results**
- Screen templates without an assigned owner should display 'ProcessMaker' in the Owner column
- Screen templates with assigned owners should display the owner's name

## Related Tickets & Packages
- [FOUR-21675](https://processmaker.atlassian.net/browse/FOUR-21675)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-21675]: https://processmaker.atlassian.net/browse/FOUR-21675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ