### PR TITLE
FOUR-21555 Performance backend improvements

### DIFF
--- a/database/migrations/2025_01_29_205842_add_index_process_id_status_user_id_to_process_requests_table.php
+++ b/database/migrations/2025_01_29_205842_add_index_process_id_status_user_id_to_process_requests_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('process_requests', function (Blueprint $table) {
+            $table->index(['process_id', 'status', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('process_requests', function (Blueprint $table) {
+            $table->dropIndex(['process_id', 'status', 'user_id']);
+        });
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
When the table "process_requests" have more than 100,000 records, the endpoints that returns the totals takes more than 2 seconds to respond.

## Solution
Added a new index for "process_requests" for the fields: 'process_id', 'status', 'user_id', with this new index the response takes 300-400 ms in my local server

## How to Test
Go to "My Requests" lists and check the server timing for endpoint: `https://127.0.0.1/api/1.0/requests?total=true&pmql=(status%20=%20%22In%20Progress%22)%20AND%20(requester%20=%20%22admin%22)`

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21555

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
