### PR TITLE
FOUR-21670: Screen is empty if the request was started by start signals

### DIFF
--- a/ProcessMaker/Repositories/ExecutionInstanceRepository.php
+++ b/ProcessMaker/Repositories/ExecutionInstanceRepository.php
@@ -5,8 +5,10 @@ namespace ProcessMaker\Repositories;
 use Carbon\Carbon;
 use ProcessMaker\Jobs\CaseStore;
 use ProcessMaker\Jobs\CaseUpdateStatus;
+use ProcessMaker\Models\AnonymousUser;
 use ProcessMaker\Models\ProcessCollaboration;
 use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\User;
 use ProcessMaker\Nayra\Contracts\Bpmn\ParticipantInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 use ProcessMaker\Nayra\Contracts\Repositories\ExecutionInstanceRepositoryInterface;
@@ -175,7 +177,7 @@ class ExecutionInstanceRepository implements ExecutionInstanceRepositoryInterfac
                 $instance->process_collaboration_id = $collaboration->id;
             }
         }
-        $instance->user_id = pmUser() ? pmUser()->getKey() : null;
+        $instance->user_id = pmUser() ? pmUser()->getKey() : app(AnonymousUser::class)->id;
         $instance->name = $definition->name;
         $instance->status = 'ACTIVE';
         $instance->initiated_at = Carbon::now();


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to Reproduce**

- Create a process with start signal 
- Configure the start signal with create record in collection
- Go to Collection
- Create a new record 
- Go to Cases
- Open the process started by signal
- Open the task

**Current Behavior**
The screen of the task is empty if the process was start by start signal event


## Solution
- Signal start events were started so that the request user_id column was set to null. Now, if no authenticated user exists in the context, the Anonymous user is used.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21670

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
