### PR TITLE
Bugfix/FOUR-21504: Owner default name is not displayed in the Processes page

### DIFF
--- a/resources/js/components/AvatarImage.vue
+++ b/resources/js/components/AvatarImage.vue
@@ -45,7 +45,7 @@
               {{ limitCharacters(value.name) }}
             </template>
           </span> 
-          <span v-else-if="usePmDefaultLabel">{{ $t('ProcessMaker') }}</span>
+          <span v-else-if="usePmDefaultLabel || usePmDefaultLabelProcess">{{ $t('ProcessMaker') }}</span>
           <span v-else><b-badge class="status-alternative-a">{{ $t('Unclaimed') }}</b-badge></span>
       </span>
       </div>
@@ -96,6 +96,10 @@ export default {
       default: '',
     },
     usePmDefaultLabel: {
+      type: Boolean,
+      default: false,
+    },
+    usePmDefaultLabelProcess: {
       type: Boolean,
       default: false,
     }

--- a/resources/js/components/shared/FilterTableBodyMixin.js
+++ b/resources/js/components/shared/FilterTableBodyMixin.js
@@ -39,7 +39,8 @@ export default {
       this.perPage = value;
       this.fetch();
     },
-    formatAvatar(user, $usePmDefaultLabel = false) {
+    formatAvatar(user, $usePmDefaultLabel = false, $usePmDefaultLabelProcess = false) {
+      console.log("EN formatAvatar user",user, "usePmDefaultLabelProcess",$usePmDefaultLabelProcess);
       return {
         component: "AvatarImage",
         props: {
@@ -47,7 +48,8 @@ export default {
           "input-data": user,
           "hide-name": false,
           "name-clickable": true,
-          'use-pm-default-label': $usePmDefaultLabel
+          'use-pm-default-label': $usePmDefaultLabel,
+          'use-pm-default-label-process': $usePmDefaultLabelProcess
         },
       };
     },

--- a/resources/js/components/shared/FilterTableBodyMixin.js
+++ b/resources/js/components/shared/FilterTableBodyMixin.js
@@ -40,7 +40,6 @@ export default {
       this.fetch();
     },
     formatAvatar(user, $usePmDefaultLabel = false, $usePmDefaultLabelProcess = false) {
-      console.log("EN formatAvatar user",user, "usePmDefaultLabelProcess",$usePmDefaultLabelProcess);
       return {
         component: "AvatarImage",
         props: {

--- a/resources/js/processes/components/ProcessMixin.js
+++ b/resources/js/processes/components/ProcessMixin.js
@@ -9,7 +9,7 @@ export default {
 
       for (const record of data.data) {
         // format Status
-        record.owner = this.formatAvatar(record.user);
+        record.owner = this.formatAvatar(record.user, false, true);
         record.category_list = this.formatCategory(record.categories);
       }
       return data;

--- a/resources/js/processes/components/ProcessMixin.js
+++ b/resources/js/processes/components/ProcessMixin.js
@@ -9,7 +9,8 @@ export default {
 
       for (const record of data.data) {
         // format Status
-        record.owner = this.formatAvatar(record.user, false, true);
+        const usePmDefaultLabelProcess = record.user === null;
+        record.owner = this.formatAvatar(record.user, false, usePmDefaultLabelProcess);
         record.category_list = this.formatCategory(record.categories);
       }
       return data;


### PR DESCRIPTION
## Solution
- Fixed Column Owner in Processes List

## How to Test
-Go to server: https://release-2024-fall-qa.processmaker.net/
-ProcessMaker Platform Winter 2025 Version 4.12.2 (Build #2c11d2de)

Server A

-Create a new user (e.g. user_id = 123) (this user needs all permissions to create processes)
- login with new user and create a process
- Export a process

Server B (no user should exist with a user_id = 123)
- Go to Processes page
- Import the process
- Go to Process page
- Search the imported process
- Column Owner should show "ProcessMaker" instead of "Unclaimed"

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21504

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
