### PR TITLE
FOUR-21688 Wrong argument when starting a new case

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -242,10 +242,10 @@ class TokenRepository implements TokenRepositoryInterface
             $mustache = new Mustache_Engine();
             $mustacheDueVariable = $mustache->render($dueVariable, $instanceData);
 
-            return is_numeric($mustacheDueVariable) ? $mustacheDueVariable : '72';
+            return is_numeric($mustacheDueVariable) ? $mustacheDueVariable : 72;
         }
 
-        return $activity->getProperty('dueIn', '72');
+        return (int) $activity->getProperty('dueIn', '72');
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -13893,7 +13893,7 @@
             "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
             "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
@@ -15038,7 +15038,7 @@
                 "node": ">=16"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
@@ -23279,7 +23279,7 @@
                 "lib0": "^0.2.31"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "peerDependencies": {
@@ -23298,7 +23298,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "peerDependencies": {
@@ -23323,7 +23323,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "optionalDependencies": {
@@ -23561,7 +23561,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors ❤",
+                "type": "GitHub Sponsors \u2764",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13893,7 +13893,7 @@
             "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
             "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
@@ -15038,7 +15038,7 @@
                 "node": ">=16"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
@@ -23279,7 +23279,7 @@
                 "lib0": "^0.2.31"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "peerDependencies": {
@@ -23298,7 +23298,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "peerDependencies": {
@@ -23323,7 +23323,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             },
             "optionalDependencies": {
@@ -23561,7 +23561,7 @@
                 "npm": ">=8.0.0"
             },
             "funding": {
-                "type": "GitHub Sponsors \u2764",
+                "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
             }
         },


### PR DESCRIPTION
## Wrong argument when starting a new case
Errors when creating a new case in the branch feature/FOUR-20332:

Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given, called in /Users/user/srv/http/processmaker4/vendor/nesbot/carbon/src/Carbon/Traits/Units.php on line 356

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21688