### PR TITLE
FOUR-21657: Dynamic UI > Reset button does not work

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/CssOverrideController.php
+++ b/ProcessMaker/Http/Controllers/Api/CssOverrideController.php
@@ -87,7 +87,7 @@ class CssOverrideController extends Controller
         // Review the reset action
         $reset = false;
         if ($request->has('reset') && $request->input('reset')) {
-            Setting::destroy($setting->id);
+            $setting->delete();
             $reset = true;
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Go to server https://release-2025-winter-qa.processmaker.net/
2. Select Admin > Customize UI
3. upload new images and select different values in all fields
4. Press Save button
5. Press Reset button
6. Open the Customize UI page again

Current Behavior:
Some fields are not resetting

## Solution
- Changing from destroy to delete resolved the issue because it affected how the cache was managed in Redis.

## How to Test
- Follow the steps

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21657

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy