### PR TITLE
FOUR-21669: Assigned field in case detail has an empty avatar in self service

### DIFF
--- a/resources/jscomposition/cases/casesDetail/config/columns.js
+++ b/resources/jscomposition/cases/casesDetail/config/columns.js
@@ -57,7 +57,9 @@ const assignedColumn = () => ({
       click: (row, column, columns) => {
         window.document.location = `/profile/${row.user?.id}`;
       },
-      formatter: (row, column, columns) => row.user?.fullname,
+      formatter: (row, column, columns) => {
+        return row.user ? row.user.fullname : 'Self Service';
+      },
       initials: (row, column, columns) => row.user?.fullname[0],
       src: (row, column, columns) => row.user?.avatar,
     },


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process with self service
2. Start a case
3. Route to the task with self service
4. Open by case
5. Check the assigned field

Current Behavior
The assigned field in case page has an undefined avatar with self service which if we click on the avatar it redirects to an erroneous screen

## Solution
- Show label SelfService

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21669

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy