### PR TITLE
FOUR-21690 An error is displayed when a script is executed

### DIFF
--- a/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
@@ -31,7 +31,7 @@ class ScriptMicroserviceRunner
             return Cache::get('keycloak.access_token');
         }
 
-        $response = Http::asForm()->post(config('script-runner-microservice.keycloak.base_url'), [
+        $response = Http::asForm()->post(config('script-runner-microservice.keycloak.base_url') ?? '', [
             'grant_type' => 'password',
             'client_id' => config('script-runner-microservice.keycloak.client_id'),
             'client_secret' => config('script-runner-microservice.keycloak.client_secret'),


### PR DESCRIPTION
## Descripción
Argument #1 ($url) must be of type string, null given, called in processmaker/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php on line 34

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21690
