### PR TITLE
Bugfix/FOUR-21700: When filling any field from . web entry , we see an error in the console

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -432,7 +432,7 @@
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
     const userIsProcessManager = {{ Auth::user()->id === $task->process?->manager_id ? "true": "false" }};
     const userConfiguration = @json($userConfiguration);
-
+    var screenFields = @json($screenFields);
     window.Processmaker.user = @json($currentUser);
     window.ProcessMaker.taskDraftsEnabled = @json($taskDraftsEnabled);
   </script>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -432,7 +432,7 @@
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
     const userIsProcessManager = {{ Auth::user()->id === $task->process?->manager_id ? "true": "false" }};
     const userConfiguration = @json($userConfiguration);
-    var screenFields = @json($screenFields);
+    let screenFields = @json($screenFields);
     window.Processmaker.user = @json($currentUser);
     window.ProcessMaker.taskDraftsEnabled = @json($taskDraftsEnabled);
   </script>


### PR DESCRIPTION
## Solution
- Fix was applied to edit.blade.php creating global variable for screenFields.

## How to Test
- Log in PM4
- Have o create a process with web entry  or without web entry
- Make test by copying WebEntry URL and with simple Case run
- Open devTools in new browser. 
- Fill fields in some form. The error with screenFields should no longer appear

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21700

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
