### PR TITLE
FOUR-21704: When we open a case the following error is showing 'Screen nBuilder is not defined'

### DIFF
--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -46,8 +46,18 @@ class CasesController extends Controller
         $manager = app(ScreenBuilderManager::class);
         event(new ScreenBuilderStarting($manager, 'FORM'));
          // Load event ModelerStarting
-         $managerModeler = app(ModelerManager::class);
-         event(new ModelerStarting($managerModeler));
+        $managerModeler = app(ModelerManager::class);
+        event(new ModelerStarting($managerModeler));
+
+        $scriptsEnabled = ['package-slideshow','package-process-optimization','package-ab-testing','package-testing'];
+        $managerModelerScripts = array_filter($managerModeler->getScripts(), function($script) use ($scriptsEnabled) {
+            foreach ($scriptsEnabled as $enabledScript) {
+                if (strpos($script, $enabledScript) !== false) {
+                    return false;
+                }
+            }
+            return true;
+        });
 
         // Get all the request related to this case number
         $allRequests = ProcessRequest::where('case_number', $case_number)->get();
@@ -105,7 +115,7 @@ class CasesController extends Controller
             'canPrintScreens',
             'isProcessManager',
             'manager',
-            'managerModeler',
+            'managerModelerScripts',
             'bpmn',
             'inflightData',
             'pmBlockList'

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -167,11 +167,20 @@
   @foreach(GlobalScripts::getScripts() as $script)
     <script src="{{$script}}"></script>
   @endforeach
-
-  @foreach($managerModeler->getScripts() as $script)
-    @if (!str_contains($script, 'slideshow'))
-      <script src="{{ $script }}"></script>
-    @endif
+  
+  @php
+    $blacklist = ['package-slideshow','package-process-optimization','package-ab-testing','package-testing'];
+    $filteredScripts = array_filter($managerModeler->getScripts(), function($script) use ($blacklist) {
+      foreach ($blacklist as $term) {
+        if (str_contains($script, $term)) {
+          return false;
+        }
+      }
+      return true;
+    });
+  @endphp
+  @foreach($filteredScripts as $script)
+    <script src="{{ $script }}"></script>
   @endforeach
 
   @if (hasPackage('package-files'))

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -168,18 +168,7 @@
     <script src="{{$script}}"></script>
   @endforeach
   
-  @php
-    $blacklist = ['package-slideshow','package-process-optimization','package-ab-testing','package-testing'];
-    $filteredScripts = array_filter($managerModeler->getScripts(), function($script) use ($blacklist) {
-      foreach ($blacklist as $term) {
-        if (str_contains($script, $term)) {
-          return false;
-        }
-      }
-      return true;
-    });
-  @endphp
-  @foreach($filteredScripts as $script)
+  @foreach($managerModelerScripts as $script)
     <script src="{{ $script }}"></script>
   @endforeach
 


### PR DESCRIPTION
## Steps to Reproduce
1. Login in a winter version
2. Go to cases
3. Open a case
4. Per default the Task is open

## Current  Behavior

The following console log error is showing
modeler.js?id=5436ca…0fb712a5993379b27:1 Uncaught ReferenceError: ScreenBuilder is not defined at modeler.js?id=5436ca…a5993379b27:1:18249 at modeler.js?id=5436ca…a5993379b27:1:45230 at modeler.js?id=5436ca…a5993379b27:1:45234

## Expected Behavior

Avoid error in the console

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21704

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:connector-pdf-print:bugfix/FOUR-21706