### PR TITLE
FOUR-21718: When the previous element is a element without user the text  does not make sense

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -274,11 +274,11 @@ class TokenRepository implements TokenRepositoryInterface
         $taskName = $token->element_name ?? '';
         $emailData = [
             'firstname' => $user->firstname ?? '',
-            'assigned_by' => Auth::user()->fullname ?? '',
+            'assigned_by' => Auth::user()->fullname ?? __('System'),
             'element_name' => $taskName,
             'case_title' => $caseTitle, // Populate this if needed
             'due_date' => $token->due_at ?? '',
-            'link_review_task' => config('app.url') . 'tasks/' . $token->id . '/edit',
+            'link_review_task' => config('app.url') . '/' . 'tasks/' . $token->id . '/edit',
             'imgHeader' => config('app.url') . '/img/processmaker_login.png',
         ];
         // Get the screen


### PR DESCRIPTION
## Issue & Reproduction Steps
Create a process
Create a Send Email before the Form task
Make sure that the user assigned in the Form Task has enable the Email Task Notification
Create a CASE
Review the email

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21718
- https://processmaker.atlassian.net/browse/FOUR-21713

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
