### PR TITLE
FOUR-21709 create index for table process_request_tokens

### DIFF
--- a/database/migrations/2025_02_05_141451_add_index_process_request_id_status_to_process_request_tokens_table.php
+++ b/database/migrations/2025_02_05_141451_add_index_process_request_id_status_to_process_request_tokens_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            $table->index(['process_request_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            $table->dropIndex(['process_request_id', 'status']);
+        });
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
The suggested new index is as follows:

`alter table process_request_tokens add index process_request_tokens_procid_status(process_request_id,status);`

## Solution
- Add the suggested index by DBA

## Related Tickets & Packages
[FOUR-21709](https://processmaker.atlassian.net/browse/FOUR-21709)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-21709]: https://processmaker.atlassian.net/browse/FOUR-21709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ