### PR TITLE
FOUR-21806: The process title slides down across the screen in the request overview

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/NewOverview.vue
+++ b/resources/jscomposition/cases/casesDetail/components/NewOverview.vue
@@ -3,7 +3,7 @@
     class="tw-w-full tw-h-full tw-overflow-hidden tw-relative"
     data-test="body-container"
   >
-    <h4 class="tw-fixed tw-z-10 tw-p-4">
+    <h4 class="tw-absolute tw-z-10 tw-p-4">
       {{ processTitle }}
     </h4>
     <MapLegend />

--- a/resources/jscomposition/cases/casesDetail/components/NewOverview.vue
+++ b/resources/jscomposition/cases/casesDetail/components/NewOverview.vue
@@ -3,9 +3,6 @@
     class="tw-w-full tw-h-full tw-overflow-hidden tw-relative"
     data-test="body-container"
   >
-    <h4 class="tw-absolute tw-z-10 tw-p-4">
-      {{ processTitle }}
-    </h4>
     <MapLegend />
     <ProcessMapTooltip
       v-show="showTooltip"


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Import a process or create a process with big history
2. Create a case
3. Complete the case
4. Go to request complete
5. Click on Overview
6. Move the scroll bar of the browser screen
7. Check the title of the process

## Current Behavior

The process title slides down across the screen in the request overview 

## Solution
- use absolute instead of fixed


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21806

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy