### PR TITLE
FOUR-21803 Fix failing unit tests

### DIFF
--- a/tests/Sdk/BuildSdkTest.php
+++ b/tests/Sdk/BuildSdkTest.php
@@ -9,8 +9,6 @@ class BuildSdkTest extends TestCase
 {
     public function setUpSuppressOutput() : void
     {
-        $this->setOutputCallback(function () {
-        });
     }
 
     private function jsonFile()


### PR DESCRIPTION
## Description
Build Sdk (Tests\Sdk\BuildSdk)
With unsupported language
Error: Call to undefined method Tests\Sdk\BuildSdkTest::setOutputCallback()   /opt/processmaker/tests/Sdk/BuildSdkTest.php:12
/opt/processmaker/tests/TestCase.php:40

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21803
