### PR TITLE
FOUR-21860: Requests created by signals in versions < 4.13, show an empty screen

### DIFF
--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -44,7 +44,9 @@ trait TaskResourceIncludes
         $user = $this->processRequest->user;
 
         // Exclude 'active_at' to prevent ETag inconsistencies.
-        $user->makeHidden(['active_at']);
+        if ($user) {
+            $user->makeHidden(['active_at']);
+        }
 
         return ['requestor' => new Users($user)];
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
- Using a PM < 4.13, Create a process with start signal 
image-20250129-152432.png
- Configure the start signal with create record in collection
- Go to Collection
- Create a new record 
- Go to Cases
- Switch to PM 4.13
- Open the process started by signal
- Open the task

* If it is not possible to switch PM versions, the request can be created in 4.13 and the request user can be set to null via API.

## Solution
- Validate is user exists to hide active_at

## How to Test
Follow the reproduction steps

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21860

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
