### PR TITLE
FOUR-21657: Dynamic UI > Reset button does not work

### DIFF
--- a/ProcessMaker/Observers/SettingObserver.php
+++ b/ProcessMaker/Observers/SettingObserver.php
@@ -68,7 +68,9 @@ class SettingObserver
         }
 
         $settingCache = SettingCacheFactory::getSettingsCache();
-        $settingCache->invalidate(['key' => $setting->key]);
+        // Invalidate the setting cache
+        $key = $settingCache->createKey(['key' => $setting->key]);
+        $settingCache->invalidate(['key' => $key]);
     }
 
     /**
@@ -80,7 +82,8 @@ class SettingObserver
     public function deleted(Setting $setting): void
     {
         $settingCache = SettingCacheFactory::getSettingsCache();
-        //invalidate the setting cache
-        $settingCache->invalidate(['key' => $setting->key]);
+        // Invalidate the setting cache
+        $key = $settingCache->createKey(['key' => $setting->key]);
+        $settingCache->invalidate(['key' => $key]);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Go to server https://release-2025-winter-qa.processmaker.net/
2. Select Admin > Customize UI
3. upload new images and select different values in all fields
4. Press Save button
5. Press Reset button
6. Open the Customize UI page again

## Solution
- Update the key for the cache to apply correctly the invalidate

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Lhttps://processmaker.atlassian.net/browse/FOUR-21657

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy