### PR TITLE
FOUR-21803 Fix failing unit tests

### DIFF
--- a/tests/Feature/Api/PerformanceModelsTest.php
+++ b/tests/Feature/Api/PerformanceModelsTest.php
@@ -41,7 +41,7 @@ class PerformanceModelsTest extends TestCase
      *
      * @return array
      */
-    public function FactoryListProvider()
+    public static function FactoryListProvider()
     {
         $models = [];
         $factoriesPath = app_path('Models');

--- a/tests/Feature/Api/ProcessPatternsTest.php
+++ b/tests/Feature/Api/ProcessPatternsTest.php
@@ -25,7 +25,7 @@ class ProcessPatternsTest extends TestCase
     use RequestHelper;
     use ProcessTestingTrait;
 
-    private $basePath = __DIR__ . '/bpmnPatterns/';
+    public static $basePath = __DIR__ . '/bpmnPatterns/';
 
     /**
      * Make sure we have a personal access client set up
@@ -74,7 +74,7 @@ class ProcessPatternsTest extends TestCase
      */
     private static function prepareTestCases($bpmnFile, array $tests)
     {
-        $file = "{$this->basePath}{$bpmnFile}";
+        $file = self::$basePath . $bpmnFile;
         $name = basename($bpmnFile, '.bpmn');
         $jsonFile = substr($file, 0, -4) . 'json';
         if (file_exists($jsonFile)) {
@@ -107,7 +107,7 @@ class ProcessPatternsTest extends TestCase
     private function runProcessWithoutContext($bpmnFile)
     {
         $bpmnRepository = new BpmnDocument();
-        $bpmnRepository->load("{$this->basePath}{$bpmnFile}");
+        $bpmnRepository->load(self::$basePath . $bpmnFile);
         $startEvents = $bpmnRepository->getElementsByTagNameNS(BpmnDocument::BPMN_MODEL, 'startEvent');
         foreach ($startEvents as $startEvent) {
             $data = [];
@@ -132,7 +132,7 @@ class ProcessPatternsTest extends TestCase
             foreach ($context['requires'] as $index => $process) {
                 $this->createProcess([
                     'id' => $index + 1,
-                    'bpmn' => file_get_contents("{$this->basePath}{$process}"),
+                    'bpmn' => file_get_contents(self::$basePath . $process),
                 ]);
             }
         }
@@ -153,7 +153,7 @@ class ProcessPatternsTest extends TestCase
     private function runProcess($bpmnFile, $data, $startEvent, $expectedResult, $events, $output, $context)
     {
         Cache::store('global_variables')->flush();
-        $process = $this->createProcess(file_get_contents("{$this->basePath}{$bpmnFile}"));
+        $process = $this->createProcess(file_get_contents(self::$basePath . $bpmnFile));
         $definitions = $process->getDefinitions();
         $start = $definitions->getStartEvent($startEvent);
         if ($start->getEventDefinitions()->count() > 0) {

--- a/tests/Jobs/RunScriptTaskTest.php
+++ b/tests/Jobs/RunScriptTaskTest.php
@@ -83,7 +83,7 @@ class RunScriptTaskTest extends TestCase
         return $request->refresh();
     }
 
-    public function jobTypes()
+    public static function jobTypes()
     {
         return [
             [RunScriptTask::class],


### PR DESCRIPTION
## Description
The data provider specified for Tests\Feature\Api\ProcessPatternsTest::testProcessPatterns is invalid Using $this when not in object context

/opt/processmaker/tests/Feature/Api/ProcessPatternsTest.php:45

## Solution
PHPUnit advises that data providers should be static.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21803
