### PR TITLE
Cache routes before running tests

### DIFF
--- a/tests/Feature/LicenseCommandsTest.php
+++ b/tests/Feature/LicenseCommandsTest.php
@@ -35,6 +35,8 @@ class LicenseCommandsTest extends TestCase
 
     public function testLicenseUpdateFromLocalPath()
     {
+        $this->markTestSkipped('Artisan optimize resets the storage driver and that deletes the license file for some reason.');
+        
         // Create a sample license file for testing.
         $sampleLicense = '{"expires_at": "2023-12-31", "packages": ["package-translations", "package-projects"]}';
         $licenseFilePath = tempnam(sys_get_temp_dir(), 'license_');

--- a/tests/Feature/LicenseCommandsTest.php
+++ b/tests/Feature/LicenseCommandsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use ProcessMaker\LicensedPackageManifest;
@@ -35,8 +36,12 @@ class LicenseCommandsTest extends TestCase
 
     public function testLicenseUpdateFromLocalPath()
     {
-        $this->markTestSkipped('Artisan optimize resets the storage driver and that deletes the license file for some reason.');
-        
+        // See https://laracasts.com/discuss/channels/testing/this-partialmock-doesnt-call-the-constructor
+        $mock = Artisan::partialMock();
+        $mock->shouldReceive('call')->with('optimize')->andReturn(0);
+        $mock->__construct(app(), app('events'));
+        Artisan::swap($mock);
+
         // Create a sample license file for testing.
         $sampleLicense = '{"expires_at": "2023-12-31", "packages": ["package-translations", "package-projects"]}';
         $licenseFilePath = tempnam(sys_get_temp_dir(), 'license_');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,9 @@ use ProcessMaker\ScriptRunners\Base;
 // Bootstrap laravel
 app()->make(Kernel::class)->bootstrap();
 
+// Cache all routes
+Artisan::call('optimize');
+
 // Cache with new config so we don't overwrite our local development database
 Artisan::call('config:cache', ['--env' => 'testing']);
 


### PR DESCRIPTION
Ensure we are building the latest cache before running the unit tests
https://processmaker.atlassian.net/browse/FOUR-21932

ci:k8s-branch:debug-phpunit