### PR TITLE
FOUR-21893: Overview does not show the correct version of proccess

### DIFF
--- a/ProcessMaker/Traits/ProcessMapTrait.php
+++ b/ProcessMaker/Traits/ProcessMapTrait.php
@@ -116,7 +116,11 @@ trait ProcessMapTrait
     private function loadProcessMap(ProcessRequest $request): array
     {
         $processRequest = ProcessRequest::find($request->id);
-        $bpmn = $request->process->bpmn;
+        // Get the bpmn related to the version
+        $bpmn = $request->process->versions()
+            ->where('id', $request->process_version_id)
+            ->firstOrFail()
+            ->bpmn;
         $filteredCompletedNodes = [];
         $requestInProgressNodes = [];
         $requestIdleNodes = [];

--- a/ProcessMaker/Traits/ProcessMapTrait.php
+++ b/ProcessMaker/Traits/ProcessMapTrait.php
@@ -119,6 +119,7 @@ trait ProcessMapTrait
         // Get the bpmn related to the version
         $bpmn = $request->process->versions()
             ->where('id', $request->process_version_id)
+            ->select('bpmn')
             ->firstOrFail()
             ->bpmn;
         $filteredCompletedNodes = [];

--- a/tests/Feature/CasesControllerTest.php
+++ b/tests/Feature/CasesControllerTest.php
@@ -85,6 +85,49 @@ class CasesControllerTest extends TestCase
         $response->assertStatus(200);
     }
 
+    public function testShowCaseWithProcessVersion()
+    {
+        // Create user admin
+        $user = User::factory()->create([
+            'is_administrator' => true,
+        ]);
+        $this->actingAs($user);
+
+        // Create a process
+        $bpmnTemplate = Process::getProcessTemplate('OnlyStartElement.bpmn');
+        $process = Process::factory()->create([
+            'bpmn' => $bpmnTemplate,
+        ]);
+        $request1 = ProcessRequest::factory()->create([
+            'parent_request_id' => null,
+            'process_id' => $process->id,
+        ]);
+        // Update the process
+        $newBpmn = trim(Process::getProcessTemplate('SingleTask.bpmn'));
+        $route = route('api.' . 'processes' . '.update', [$process->id]);
+        $response = $this->apiCall('PUT', $route, [
+            'name' => 'test name',
+            'description' => 'test description',
+            'bpmn' => $newBpmn,
+        ]);
+        $response->assertStatus(200);
+        // Create a request with the new process
+        $request2 = ProcessRequest::factory()->create([
+            'parent_request_id' => null,
+            'process_id' => $process->id,
+        ]);
+        // Validate the request1
+        $response = $this->get(route('cases.show', ['case_number' => $request1->case_number]));
+        $response->assertStatus(200);
+        $response->assertViewHas('bpmn');
+        $this->assertEquals($bpmnTemplate, $response->viewData('bpmn'));
+        // Validaet the request2
+        $response = $this->get(route('cases.show', ['case_number' => $request2->case_number]));
+        $response->assertStatus(200);
+        $response->assertViewHas('bpmn');
+        $this->assertEquals($newBpmn, $response->viewData('bpmn'));
+    }
+
     public function testShowCaseWithParticipateUser()
     {
         // Create user


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process with a single task 
2. Start a CASE
3. Review the overview
4. Update the process Adding more task
5. Open the CASE created with version 1

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21893

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy