### PR TITLE
FOUR-21880:Overview does not show the pmblocks in Cases

### DIFF
--- a/resources/jscomposition/cases/casesDetail/loader.js
+++ b/resources/jscomposition/cases/casesDetail/loader.js
@@ -3,6 +3,10 @@ import vueFormElements from "../../../js/next/libraries/vueFormElements";
 import modelerInspector from "../../../js/next/libraries/modelerInspector";
 import modeler from "../../../js/next/modeler";
 import screenBuilderNext from "../../../js/next/screenBuilder";
+// Load screen-builder for PMBLOCKs
+import * as ScreenBuilder from "@processmaker/screen-builder";
+
+window.ScreenBuilder = ScreenBuilder;
 
 setupMain();
 screenBuilderNext();

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -164,10 +164,12 @@
     window.ProcessMaker.PMBlockList = @json($pmBlockList);
   </script>
 
+  <!-- Load the screen scripts -->
   @foreach(GlobalScripts::getScripts() as $script)
     <script src="{{$script}}"></script>
   @endforeach
   
+  <!-- Load the modeler scripts -->
   @foreach($managerModelerScripts as $script)
     <script src="{{ $script }}"></script>
   @endforeach

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -458,9 +458,6 @@
 @endsection
 
 @section('js')
-  @foreach ($manager->getScripts() as $script)
-    <script src="{{ $script }}"></script>
-  @endforeach
   <script src="{{ mix('js/processes/modeler/initialLoad.js') }}"></script>
   <script>
     window.ProcessMaker.packages = @json(\App::make(ProcessMaker\Managers\PackageManager::class)->listPackages());
@@ -471,6 +468,10 @@
       apiTimeout: {{config('app.api_timeout')}}
     };
   </script>
+
+  @foreach($managerModelerScripts as $script)
+    <script src="{{ $script }}"></script>
+  @endforeach
   @if (hasPackage('package-files'))
     <!-- TODO: Replace with script injector like we do for modeler and screen builder -->
     <script src="{{ mix('js/manager.js', 'vendor/processmaker/packages/package-files') }}"></script>
@@ -902,6 +903,7 @@
     }) => {
       loadXML(window.ProcessMaker.modeler.xml);
     });
+    window.ProcessMaker.PMBlockList = @json($pmBlockList);
   </script>
 @endsection
 


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process 
2. Convert the process to pmblock 
3. Create another process
4. Add the pmblock in the process
5. Crate a case
6. Complete the request of the pmblock
7. Go to Case
8. Click on Overview
9. Check the pmbcok in the canvas modeler

**Current Behavior**
Overview does not show the pmblocks in Cases

**Expected Behavior**
PMblock should be displayed in Overview in Cases like  PM 4.12.2

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21880

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

...