### PR TITLE
FOUR-21803 Fix failing unit tests

### DIFF
--- a/tests/Feature/Api/ChangePasswordTest.php
+++ b/tests/Feature/Api/ChangePasswordTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
@@ -10,7 +9,7 @@ use Tests\TestCase;
 
 class ChangePasswordTest extends TestCase
 {
-    use RequestHelper, RefreshDatabase;
+    use RequestHelper;
 
     const API_TEST_URL = '/password/change';
 

--- a/tests/Feature/Api/ProcessRequestFileTest.php
+++ b/tests/Feature/Api/ProcessRequestFileTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Testing\File;
 use Illuminate\Support\Facades\Storage;

--- a/tests/Feature/Api/SettingAuthTest.php
+++ b/tests/Feature/Api/SettingAuthTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ScriptExecutor;
 use ProcessMaker\Package\Auth\Database\Seeds\AtlassianSeeder;
@@ -21,7 +20,6 @@ use Tests\TestCase;
 class SettingAuthTest extends TestCase
 {
     use RequestHelper;
-    use RefreshDatabase;
 
     private function seedLDAPSettings()
     {

--- a/tests/Feature/Api/SettingLogInOptionsTest.php
+++ b/tests/Feature/Api/SettingLogInOptionsTest.php
@@ -2,14 +2,12 @@
 
 namespace Tests\Feature\Api;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
 class SettingLogInOptionsTest extends TestCase
 {
     use RequestHelper;
-    use RefreshDatabase;
 
     private function upgrade()
     {

--- a/tests/Feature/Api/SettingSessionControlTest.php
+++ b/tests/Feature/Api/SettingSessionControlTest.php
@@ -2,14 +2,12 @@
 
 namespace Tests\Feature\Api;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
 class SettingSessionControlTest extends TestCase
 {
     use RequestHelper;
-    use RefreshDatabase;
 
     private function upgrade()
     {

--- a/tests/Feature/Api/SettingsTest.php
+++ b/tests/Feature/Api/SettingsTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Api;
 
 use DB;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\SettingsMenus;

--- a/tests/Feature/Api/SignalTest.php
+++ b/tests/Feature/Api/SignalTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Api;
 
 use Database\Seeders\SignalSeeder;
 use Faker\Factory as Faker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use ProcessMaker\Events\SignalCreated;
 use ProcessMaker\Managers\SignalManager;

--- a/tests/Feature/Api/V1_1/CaseControllerSearchTest.php
+++ b/tests/Feature/Api/V1_1/CaseControllerSearchTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api\V1_1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use ProcessMaker\Models\User;
 use ProcessMaker\Repositories\CaseUtils;
 use Tests\Feature\Shared\RequestHelper;
@@ -10,7 +9,7 @@ use Tests\TestCase;
 
 class CaseControllerSearchTest extends TestCase
 {
-    use RequestHelper, RefreshDatabase;
+    use RequestHelper;
 
     public function setUp(): void
     {

--- a/tests/Feature/Api/V1_1/CaseControllerTest.php
+++ b/tests/Feature/Api/V1_1/CaseControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api\V1_1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Constants\CaseStatusConstants;
 use ProcessMaker\Models\CaseParticipated;
@@ -15,7 +14,7 @@ use Tests\TestCase;
 
 class CaseControllerTest extends TestCase
 {
-    use RequestHelper, RefreshDatabase;
+    use RequestHelper;
 
     public static function createUser(string $username, string $password = 'secret', string $status = 'ACTIVE'): User
     {

--- a/tests/Feature/Cache/SettingCacheTest.php
+++ b/tests/Feature/Cache/SettingCacheTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Cache;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Redis;
@@ -15,7 +14,6 @@ use Tests\TestCase;
 class SettingCacheTest extends TestCase
 {
     use RequestHelper;
-    use RefreshDatabase;
 
     protected function setUp(): void
     {

--- a/tests/Feature/Cases/CaseExceptionTest.php
+++ b/tests/Feature/Cases/CaseExceptionTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Cases;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -12,8 +11,6 @@ use Tests\TestCase;
 
 class CaseExceptionTest extends TestCase
 {
-    use RefreshDatabase;
-
     protected $user;
 
     protected $process;

--- a/tests/Feature/CasesControllerTest.php
+++ b/tests/Feature/CasesControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -13,7 +12,6 @@ use Tests\TestCase;
 
 class CasesControllerTest extends TestCase
 {
-    use RefreshDatabase;
     use RequestHelper;
 
     const URL_CASES = '/cases/';

--- a/tests/Feature/CssOverrideTest.php
+++ b/tests/Feature/CssOverrideTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Models\User;

--- a/tests/Feature/Upgrade/PopulateCaseStartedTest.php
+++ b/tests/Feature/Upgrade/PopulateCaseStartedTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Upgrades;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use PopulateCaseStarted;
 use ProcessMaker\Models\Process;
@@ -13,8 +12,6 @@ use Tests\TestCase;
 
 class PopulateCaseStartedTest extends TestCase
 {
-    use RefreshDatabase;
-
     protected function setUp(): void
     {
         require_once base_path('upgrades/2024_10_09_032151_populate_case_started.php');

--- a/tests/Feature/Upgrade/PopulateCasesParticipatedTest.php
+++ b/tests/Feature/Upgrade/PopulateCasesParticipatedTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Upgrades;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use ProcessMaker\Models\CaseStarted;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
@@ -12,8 +11,6 @@ use Tests\TestCase;
 
 class PopulateCasesParticipatedTest extends TestCase
 {
-    use RefreshDatabase;
-
     protected $user;
 
     protected $user2;

--- a/tests/Feature/Upgrade/PopulateCommentsCaseNumberTest.php
+++ b/tests/Feature/Upgrade/PopulateCommentsCaseNumberTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Upgrade;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\ProcessRequest;
@@ -11,8 +10,6 @@ use Tests\TestCase;
 
 class PopulateCommentsCaseNumberTest extends TestCase
 {
-    use RefreshDatabase;
-
     /**
      * Test populateCommentsCaseNumber method.
      *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -97,8 +97,6 @@ if (env('TEST_TOKEN')) {
     Artisan::call('migrate:fresh', []);
     Artisan::call('db:seed', ['--class' => 'AnonymousUserSeeder']);
 
-    \Illuminate\Foundation\Testing\RefreshDatabaseState::$migrated = true;
-
     ScriptExecutor::firstOrCreate(
         ['language' => 'php'],
         ['title' => 'Test Executor']

--- a/tests/unit/ProcessMaker/MediaOrderColumnIndexTest.php
+++ b/tests/unit/ProcessMaker/MediaOrderColumnIndexTest.php
@@ -2,14 +2,11 @@
 
 namespace ProcessMaker;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 class MediaOrderColumnIndexTest extends TestCase
 {
-    use RefreshDatabase;
-
     /** @test */
     public function it_has_order_column_index_on_media_table()
     {


### PR DESCRIPTION
## Description
The code line: `\Illuminate\Foundation\Testing\RefreshDatabaseState::$migrated = true;` is no longer valid in Laravel 11.

## Solution
The `RefreshDatabase` trait is removed so that the migrations are not re-executed in each test.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21803

ci:connector-idp:feature/FOUR-20332
ci:package-actions-by-email:feature/FOUR-20332
ci:package-advanced-user-manager:feature/FOUR-20332
ci:package-ai:feature/FOUR-20332
ci:package-analytics-reporting:feature/FOUR-20332
ci:package-api-testing:feature/FOUR-20332
ci:package-auth:feature/FOUR-20332
ci:package-collections:feature/FOUR-20332
ci:package-data-sources:feature/FOUR-20332
ci:package-decision-engine:feature/FOUR-20332
ci:package-pm-blocks:feature/FOUR-20332
ci:package-projects:feature/FOUR-20332
ci:package-savedsearch:feature/FOUR-20332
ci:package-sentry:feature/FOUR-20332
ci:package-testing:feature/FOUR-20332
ci:package-translations:feature/FOUR-20332
ci:package-vocabularies:feature/FOUR-20332
ci:package-process-documenter:feature/FOUR-20332

ci:k8s-branch:fix-for-phpunit-10
...
