### PR TITLE
FOUR-21958: inbox rules does not show the filter selected from the requests save search.

### DIFF
--- a/resources/js/common/PMColumnFilterPopoverCommonMixin.js
+++ b/resources/js/common/PMColumnFilterPopoverCommonMixin.js
@@ -211,6 +211,18 @@ const PMColumnFilterCommonMixin = {
 
       return format;
     },
+    /**
+     * Returns the available alternatives for process version filtering
+     * Used by getFormatRange() to populate dropdown options
+     * 
+     * @returns {Array} Array of objects with value and text properties
+     */
+    getAlternatives() {
+      return [
+        { value: 'A', text: 'A' },
+        { value: 'B', text: 'B' },
+      ];
+    },
     getFormatRange(column) {
       let formatRange;
 


### PR DESCRIPTION

## Issue & Reproduction Steps
The tasks are not displayed and there are several error messages in the console.
## Solution
- add the missed method

<img width="1720" alt="image" src="https://github.com/user-attachments/assets/6a53d357-4498-4bb8-aaa2-37b69929222d" />

## How to Test
Described in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21958

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
