### PR TITLE
FOUR-21966 Do not log error case log when system like processes without case are updated

### DIFF
--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -85,7 +85,6 @@ class CaseRepository implements CaseRepositoryInterface
     public function update(ExecutionInstanceInterface $instance, TokenInterface $token): void
     {
         if (!$this->checkIfCaseStartedExist($instance->case_number)) {
-            Log::error('case started not found, method=update, instance=' . $instance->getKey());
 
             return;
         }
@@ -119,7 +118,6 @@ class CaseRepository implements CaseRepositoryInterface
     public function updateStatus(ExecutionInstanceInterface $instance): void
     {
         if (is_null($instance->case_number)) {
-            Log::error('case started not found, method=updateStatus, instance=' . $instance->getKey());
 
             return;
         }

--- a/tests/Feature/Cases/CaseExceptionTest.php
+++ b/tests/Feature/Cases/CaseExceptionTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Cases;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
 use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\User;
@@ -123,13 +125,31 @@ class CaseExceptionTest extends TestCase
 
         $this->assertDatabaseCount('cases_started', 0);
 
-        try {
-            $repo->update($this->instance, $this->token);
-        } catch (\Exception $e) {
-            $this->assertEquals(
-                'case started not found, method=update, instance=' . $this->instance->getKey(), $e->getMessage()
-            );
-        }
+        $repo->update($this->instance, $this->token);
+    }
+
+    public function test_update_case_system_process(): void
+    {
+        $this->withoutExceptionHandling();
+        $process = Process::factory()->create([
+            'process_category_id' => ProcessCategory::factory()->create(['is_system' => true])->id,
+        ]);
+        $instance = ProcessRequest::factory()->create([
+            'user_id' => $this->user->id,
+            'process_id' => $process->id,
+        ]);
+
+        $instance->case_title = null;
+        $repo = new CaseRepository();
+        $repo->create($instance);
+
+        $this->assertDatabaseCount('cases_started', 0);
+
+        Log::shouldReceive('error')->never()->withAnyArgs();
+        $repo->update($instance, $this->token);
+
+        Log::shouldReceive('error')->never()->withAnyArgs();
+        $repo->updateStatus($instance, $this->token);
     }
 
     public function test_artisan_sync_command_missing_ids(): void


### PR DESCRIPTION
## Do not log error case log when system like processes without case are updated

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21966

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
