### PR TITLE
FOUR-21803 Fix failing unit tests

### DIFF
--- a/database/migrations/2024_03_19_210114_change_int_to_uuid_on_screen_templates.php
+++ b/database/migrations/2024_03_19_210114_change_int_to_uuid_on_screen_templates.php
@@ -11,7 +11,8 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('screen_templates', function (Blueprint $table) {
-            $table->uuid('editing_screen_uuid')->change();
+            //In Laravel 11, you must explicitly specify if a value is nullable.
+            $table->uuid('editing_screen_uuid')->nullable()->change();
         });
     }
 


### PR DESCRIPTION
## Description
Screen Template (Tests\Feature\Templates\Api\ScreenTemplate)
 ✘ Create screen template
   │
   │ Expected response status code [200] but received 500.
   │ Failed asserting that 500 is identical to 200.
   │
   │ The following exception occurred during the last request:
   │
   │ PDOException: SQLSTATE[HY000]: General error: 1364 Field 'editing_screen_uuid' doesn't have a default value in /opt/processmaker/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:53

## Solution
In Laravel 11, you must explicitly specify if a value is nullable.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21803

ci:connector-idp:feature/FOUR-20332
ci:package-actions-by-email:feature/FOUR-20332
ci:package-advanced-user-manager:feature/FOUR-20332
ci:package-ai:feature/FOUR-20332
ci:package-analytics-reporting:feature/FOUR-20332
ci:package-api-testing:feature/FOUR-20332
ci:package-auth:feature/FOUR-20332
ci:package-collections:feature/FOUR-20332
ci:package-data-sources:feature/FOUR-20332
ci:package-decision-engine:feature/FOUR-20332
ci:package-pm-blocks:feature/FOUR-20332
ci:package-projects:feature/FOUR-20332
ci:package-savedsearch:feature/FOUR-20332
ci:package-sentry:feature/FOUR-20332
ci:package-testing:feature/FOUR-20332
ci:package-translations:feature/FOUR-20332
ci:package-vocabularies:feature/FOUR-20332
ci:package-process-documenter:feature/FOUR-20332

ci:k8s-branch:fix-for-phpunit-10
