### PR TITLE
FOUR-21949 there are problems running tests in the SettingCacheTest file

### DIFF
--- a/tests/Feature/Cache/SettingCacheTest.php
+++ b/tests/Feature/Cache/SettingCacheTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Redis;
 use ProcessMaker\Cache\Settings\SettingCacheException;
+use ProcessMaker\Cache\Settings\SettingCacheFactory;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
@@ -260,38 +261,63 @@ class SettingCacheTest extends TestCase
 
     public function testInvalidateOnSaved()
     {
+        $settingKey = 'password-policies.users_can_change';
+
         $setting = Setting::factory()->create([
-            'key' => 'password-policies.users_can_change',
+            'key' => $settingKey,
             'config' => 1,
             'format' => 'boolean',
         ]);
 
-        \SettingCache::set($setting->key, $setting);
-        $settingCache = \SettingCache::get($setting->key);
+        // Set the setting in the cache
+        $settingCache = SettingCacheFactory::getSettingsCache();
+        $settingCacheKey = $settingCache->createKey([
+            'key' => $settingKey,
+        ]);
 
-        $this->assertEquals(1, $settingCache->config);
+        $settingCache->set($settingCacheKey, $setting);
 
+        // Get the setting from the cache
+        $settingFromCache = $settingCache->get($settingCacheKey);
+        // Check if the setting is in the cache
+        $this->assertEquals(1, $settingFromCache->config);
+
+        // Update the setting to invalidate the cache
         $setting->update(['config' => 0]);
-        $settingCache = \SettingCache::get($setting->key);
-        $this->assertNull($settingCache);
+        // Get the setting from the cache
+        $settingFromCache = $settingCache->get($settingCacheKey);
+        // Check if the setting is invalidated
+        $this->assertNull($settingFromCache);
     }
 
     public function testInvalidateOnDeleted()
     {
+        $settingKey = 'password-policies.users_can_change';
+
         $setting = Setting::factory()->create([
-            'key' => 'password-policies.users_can_change',
+            'key' => $settingKey,
             'config' => 1,
             'format' => 'boolean',
         ]);
 
-        \SettingCache::set($setting->key, $setting);
-        $settingCache = \SettingCache::get($setting->key);
+        // Set the setting in the cache
+        $settingCache = SettingCacheFactory::getSettingsCache();
+        $settingCacheKey = $settingCache->createKey([
+            'key' => $settingKey,
+        ]);
 
-        $this->assertEquals(1, $settingCache->config);
+        $settingCache->set($settingCacheKey, $setting);
+        // Get the setting from the cache
+        $settingFromCache = $settingCache->get($settingCacheKey);
+        // Check if the setting is in the cache
+        $this->assertEquals(1, $settingFromCache->config);
 
+        // Delete the setting to invalidate the cache
         $setting->delete();
-        $settingCache = \SettingCache::get($setting->key);
-        $this->assertNull($settingCache);
+        // Get the setting from the cache
+        $settingFromCache = $settingCache->get($settingCacheKey);
+        // Check if the setting is invalidated
+        $this->assertNull($settingFromCache);
     }
 
     public function testInvalidateWithException()


### PR DESCRIPTION
## Issue & Reproduction Steps
There are problems running tests in the SettingCacheTest file

## Solution
- Re-adapting Settings cache invalidation unit tests according to changes in the PR https://github.com/ProcessMaker/processmaker/pull/8008

## Related Tickets & Packages
[FOUR-21949](https://processmaker.atlassian.net/browse/FOUR-21949)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-21949]: https://processmaker.atlassian.net/browse/FOUR-21949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ