### PR TITLE
FOUR-21607: SEC [42831] Cookie Does Not Contain The "HTTPOnly" Attribute

### DIFF
--- a/ProcessMaker/Http/Middleware/SessionStarted.php
+++ b/ProcessMaker/Http/Middleware/SessionStarted.php
@@ -3,7 +3,6 @@
 namespace ProcessMaker\Http\Middleware;
 
 use Auth;
-use Carbon\Carbon;
 use Closure;
 use Illuminate\Support\Facades\Cookie;
 use ProcessMaker\Events\SessionStarted as SessionStartedEvent;
@@ -16,7 +15,7 @@ class SessionStarted
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param  Closure  $next
      * @return mixed
      */
     public function handle($request, Closure $next)
@@ -34,7 +33,7 @@ class SessionStarted
             config('session.path'),
             config('session.domain'),
             config('session.secure'),
-            false
+            true
         );
 
         return $next($request);
@@ -48,11 +47,11 @@ class SessionStarted
      */
     private function userHasValidRememberMe($request)
     {
-        if (\Auth::user() === null) {
+        if (Auth::user() === null) {
             return false;
         }
 
-        $guard = \Auth::guard();
+        $guard = Auth::guard();
 
         // Remember me is validate only in user session guards
         if (!is_a($guard, \Illuminate\Auth\SessionGuard::class)) {
@@ -77,7 +76,7 @@ class SessionStarted
         }
 
         // Validate the cookie's remember me token with the one stored in the database
-        if (hash_equals(\Auth::user()->getRememberToken(), $token)) {
+        if (hash_equals(Auth::user()->getRememberToken(), $token)) {
             return true;
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
[42831] Cookie Does Not Contain The "HTTPOnly" Attribute

## Solution
-  Enable this attribute

## How to Test
All the plataform

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21607

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy