### PR TITLE
bugfix/FOUR-21978 update the counter when the process info is collapsed

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
@@ -12,6 +12,7 @@
         :hide-header-options="true"
         :icon-wizard-template="createdFromWizardTemplate"
         @goBack="goBack()"
+        @onProcessInfoCollapsed="onProcessInfoCollapsed"
       />
       <div
         id="collapseProcessInfo"
@@ -26,7 +27,10 @@
               />
             </b-col>
             <b-col class="process-options col-12">
-              <process-options :process="process" />
+              <process-options
+                :process="process"
+                :collapsed="collapsed"
+              />
             </b-col>
           </b-row>
         </div>
@@ -109,7 +113,8 @@ export default {
   },
   data() {
     return {
-      mobileApp: window.ProcessMaker.mobileApp
+      mobileApp: window.ProcessMaker.mobileApp,
+      collapsed: true,
     };
   },
   methods: {
@@ -129,6 +134,9 @@ export default {
     },
     getHelperProcess() {
       this.$refs.wizardHelperProcessModal.getHelperProcessStartEvent();
+    },
+    onProcessInfoCollapsed(collapsed) {
+      this.collapsed = collapsed;
     },
   },
 };

--- a/resources/js/processes-catalogue/components/ProcessHeader.vue
+++ b/resources/js/processes-catalogue/components/ProcessHeader.vue
@@ -169,6 +169,7 @@ export default {
     },
     toggleInfoCollapsed() {
       this.infoCollapsed = !this.infoCollapsed;
+      this.$emit("onProcessInfoCollapsed", this.infoCollapsed);
     },
     /**
      * get start events for dropdown Menu

--- a/resources/js/processes-catalogue/components/ProcessOptions.vue
+++ b/resources/js/processes-catalogue/components/ProcessOptions.vue
@@ -2,7 +2,7 @@
   <div class="section-options">
     <div class="left-column">
       <process-description :process="process" />
-      <process-counter :process="process" />
+      <process-counter v-if="collapsed" :process="process" />
     </div>
     <chart-save-search class="section-chart" :process="process" />
   </div>
@@ -15,7 +15,7 @@ import ProcessDescription from "./optionsMenu/ProcessDescription.vue";
 
 export default {
   components: { ProcessCounter, ChartSaveSearch, ProcessDescription },
-  props: ["process"],
+  props: ["process", "collapsed"],
 };
 </script>
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The counter is not update when the Process info collapses


## Solution
update the counter when the process info is collapsed

## How to Test
Create a process 
Open the process by launchpad
Start a case
Collapse the process info
Check the counter in the collapsible process info and the counter 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21978

