### PR TITLE
bugfix/FOUR-21980: Cancel button does not clear the data in Create user form

### DIFF
--- a/resources/js/admin/users/index.js
+++ b/resources/js/admin/users/index.js
@@ -24,12 +24,17 @@ new Vue({
       submitted: false,
       disabled: false,
     },
-    configCopy: "",
+    configCopy: null,
     focusErrors: "config.addError",
   },
   mounted() {
     this.$root.$on("bv::modal::hide", () => {
-      this.config = this.configCopy;
+      if (this.configCopy) {
+        const tempConfig = _.cloneDeep(this.configCopy);
+        this.configCopy = null;
+        this.config = tempConfig;
+      }
+      this.resetForm();
     });
 
     this.$root.$on("updateErrors", (val) => {
@@ -37,6 +42,21 @@ new Vue({
     });
   },
   methods: {
+    resetForm() {
+      this.config = {
+        username: "",
+        firstname: "",
+        lastname: "",
+        title: "",
+        status: "",
+        email: "",
+        password: "",
+        confpassword: "",
+        addError: {},
+        submitted: false,
+        disabled: false,
+      };
+    },
     reload() {
       this.$refs.listing.dataManager([{
         field: "updated_at",
@@ -63,10 +83,13 @@ new Vue({
     },
     hideModal() {
       this.$refs.addUserModal.hideAddUserModal();
+      this.configCopy = null;
+      this.resetForm();
     },
     onSubmit() {
       this.config.addError = {};
       if (this.validatePassword()) {
+        this.config.submitted = true;
         this.$refs.addUserModal.onSubmit(this.config);
       }
     },


### PR DESCRIPTION
## Solution
- Variables that store data from fields have been reset with empty values when modal window is hidden


## How to Test
- Go to user page
- Click on +User button
- Create an user existent
- Click on Save (User could not be saved because user already exists)
- Click on Cance
- Fill some data in some fields (enter new data) but leave at least one mandatory field empty
- Click on save (Validation should be displayed because some required fields are empty)
- Press Cancel button
- Click on +User button
- Check the Create user form SHOULD BE EMPTY.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21980

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
