### PR TITLE
FOUR-22048 floating buttons have a strange behavior when the cursor is over them

### DIFF
--- a/resources/js/tasks/components/TaskListRowButtons.vue
+++ b/resources/js/tasks/components/TaskListRowButtons.vue
@@ -10,7 +10,7 @@
                       @click="onClick(button)"
                       variant="light"
                       size="sm">
-              <i v-if="button.icon" 
+              <i v-if="button.icon"
                  :class="button.icon"
                  class="task-row-icon"
               />
@@ -23,11 +23,11 @@
               :title="button.title"
               custom-class="task-hover-tooltip"
               placement="bottom"
-              :delay="0"
+              :delay="1"
               boundary="viewport"
               :no-fade="true"
               />
-            <div v-if="index < buttons.length - 1 && button.show" 
+            <div v-if="index < buttons.length - 1 && button.show"
                  class="task-vertical-separator">
             </div>
           </span>
@@ -65,7 +65,7 @@
         });
       },
       setMargin(size) {
-        this.$refs.pmFloatingButtons.$el.style.marginRight = size + "px";
+        this.$refs.pmFloatingButtons.$el.style.marginRight = `${size}px`;
       },
       disableFloatingButtons(state) {
         this.$root["inbox-rule-row-button-floating-disable"] = state;
@@ -87,7 +87,8 @@
 <style scoped>
   .pm-task-row-buttons {
     position: relative;
-    display: math;
+    display: inline-block;
+    height: 30px;
   }
   .task-vertical-separator {
     display: inline;

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -906,7 +906,7 @@ export default {
     taskListRowButtonsShow(row, index) {
       const container = this.$refs.filterTable.$el;
       const scrolledWidth = container.scrollWidth - container.clientWidth - container.scrollLeft;
-      const widthTd = this.$refs[`taskListRowButtons-${index}`][0].$el.parentNode.offsetWidth - 24;
+      const widthTd = this.$refs[`taskListRowButtons-${index}`][0].$el.parentNode.getBoundingClientRect().width - 24;
       this.$refs[`taskListRowButtons-${index}`][0].show();
       this.$refs[`taskListRowButtons-${index}`][0].setMargin(scrolledWidth - widthTd);
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
Floating buttons have a strange behavior when the cursor is over them in Firefox

## Solution
- Use `display: inline-block` instead of `math` since it's not compatible with Firefox
- Use `getBoundingClientRect` instead of `offsetWidth` to get a more accurate width of the parent node

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-22048](https://processmaker.atlassian.net/browse/FOUR-22048)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22048]: https://processmaker.atlassian.net/browse/FOUR-22048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ