### PR TITLE
bugfix/FOUR-21511 Unable to reassign when Assignment rule is based on expressions

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -942,8 +942,12 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         }
 
         // Below is for rule_expression only
+        $instance = $this->getInstance();
+        if (!$instance) {
+            return $assignment;
+        }
 
-        $instanceData = $assignmentRules ? $this->getInstance()->getDataStore()->getData() : null;
+        $instanceData = $assignmentRules ? $instance->getDataStore()->getData() : null;
         if ($assignmentRules && $instanceData) {
             $list = json_decode($assignmentRules);
             $list = ($list === null) ? [] : $list;


### PR DESCRIPTION
## Issue & Reproduction Steps
Unable to reassign when Assignment rule is based on expressions

## Solution
 fix assignment rule when task instance is null

## How to Test
Create a Process:
Create a new process and add a form task.
Set the task's assignment rule to Regular Expression.

Configure Task Assignment:
Define the assignee based on the regular expression condition.
Specify a default task assignee.
Enable the options for Task Reassignment and Lock Assignment.

Test the Process:
Start a new case for the created process.
Navigate to the request and attempt to reassign the task.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21511

