### PR TITLE
FOUR-21803 Fix failing unit tests

### DIFF
--- a/tests/Feature/Api/PerformanceModelsTest.php
+++ b/tests/Feature/Api/PerformanceModelsTest.php
@@ -47,7 +47,7 @@ class PerformanceModelsTest extends TestCase
         $factoriesPath = app_path('Models');
         $modelFiles = glob($factoriesPath . '/*.php');
 
-        $baseTime = $this->calculateUnitTime();
+        $baseTime = self::calculateUnitTime();
 
         foreach ($modelFiles as $file) {
             $model = 'ProcessMaker\\Models\\' . basename($file, '.php');
@@ -66,7 +66,7 @@ class PerformanceModelsTest extends TestCase
      *
      * @return float
      */
-    private function calculateUnitTime($times = 100)
+    private static function calculateUnitTime($times = 100)
     {
         $model = Group::class;
         $t = microtime(true);


### PR DESCRIPTION
## Description
Access issue with a non-static method.

## Solution
The `static` signature is added to the method, and the access is modified.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21803

ci:connector-idp:feature/FOUR-20332
ci:package-actions-by-email:feature/FOUR-20332
ci:package-advanced-user-manager:feature/FOUR-20332
ci:package-ai:feature/FOUR-20332
ci:package-analytics-reporting:feature/FOUR-20332
ci:package-api-testing:feature/FOUR-20332
ci:package-auth:feature/FOUR-20332
ci:package-collections:feature/FOUR-20332
ci:package-data-sources:feature/FOUR-20332
ci:package-decision-engine:feature/FOUR-20332
ci:package-pm-blocks:feature/FOUR-20332
ci:package-projects:feature/FOUR-20332
ci:package-savedsearch:feature/FOUR-20332
ci:package-sentry:feature/FOUR-20332
ci:package-testing:feature/FOUR-20332
ci:package-translations:feature/FOUR-20332
ci:package-vocabularies:feature/FOUR-20332
ci:package-comments:feature/FOUR-20332
ci:package-process-documenter:feature/FOUR-20332
ci:package-versions:feature/FOUR-20332

ci:k8s-branch:fix-for-phpunit-10
