### PR TITLE
FOUR-22068: After the conflict need review the seeders for create default-email-task-notification

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -281,8 +281,8 @@ class TokenRepository implements TokenRepositoryInterface
             'link_review_task' => config('app.url') . '/' . 'tasks/' . $token->id . '/edit',
             'imgHeader' => config('app.url') . '/img/processmaker_login.png',
         ];
-        // Get the screen
-        $screen = Screen::where('title', 'DEFAULT_EMAIL_TASK_NOTIFICATION')->first();
+        // Get the screen by key
+        $screen = Screen::getScreenByKey('default-email-task-notification');
         // Prepare the email configuration
         $configEmail = [
             'emailServer' => 0, // Use the default email server

--- a/database/processes/screens/default-email-task-notification.json
+++ b/database/processes/screens/default-email-task-notification.json
@@ -1,427 +1,448 @@
-[
-   {
-       "name": "DEFAULT_EMAIL_TASK_NOTIFICATION",
-       "items": [
-           {
-               "uuid": "c331f828-3b0f-47a3-bf6e-9037717a7690",
-               "label": "Rich Text",
-               "config": {
-                   "icon": "fas fa-pencil-ruler",
-                   "label": null,
-                   "content": "<p><img style=\"width: 224px; height: 56px;\" src=\"{{imgHeader}}\" /></p>",
-                   "interactive": true,
-                   "renderVarHtml": false
-               },
-               "component": "FormHtmlViewer",
-               "inspector": [
-                   {
-                       "type": "FormTextArea",
-                       "field": "content",
-                       "config": {
-                           "rows": 5,
-                           "label": "Content",
-                           "value": null,
-                           "helper": "The HTML text to display"
-                       }
-                   },
-                   {
-                       "type": "FormCheckbox",
-                       "field": "renderVarHtml",
-                       "config": {
-                           "label": "Render HTML from a Variable",
-                           "value": null,
-                           "helper": null
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "conditionalHide",
-                       "config": {
-                           "label": "Visibility Rule",
-                           "helper": "This control is hidden until this expression is true"
-                       }
-                   },
-                   {
-                       "type": "DeviceVisibility",
-                       "field": "deviceVisibility",
-                       "config": {
-                           "label": "Device Visibility",
-                           "helper": "This control is hidden until this expression is true"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "customFormatter",
-                       "config": {
-                           "label": "Custom Format String",
-                           "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
-                           "validation": null
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "customCssSelector",
-                       "config": {
-                           "label": "CSS Selector Name",
-                           "helper": "Use this in your custom css rules",
-                           "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "ariaLabel",
-                       "config": {
-                           "label": "Aria Label",
-                           "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "tabindex",
-                       "config": {
-                           "label": "Tab Order",
-                           "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
-                           "validation": "regex: [0-9]*"
-                       }
-                   },
-                   {
-                       "type": "EncryptedConfig",
-                       "field": "encryptedConfig",
-                       "config": {
-                           "label": "Encrypted",
-                           "helper": null
-                       }
-                   }
-               ],
-               "editor-control": "FormHtmlEditor",
-               "editor-component": "FormHtmlEditor"
-           },
-           {
-               "uuid": "64801c0f-3b96-4261-a1ab-76f521a537ba",
-               "label": "Rich Text",
-               "config": {
-                   "icon": "fas fa-pencil-ruler",
-                   "label": null,
-                   "content": "<p style=\"font-size:36px\"><strong>Hello {{ _firstname }}</strong> You just been assigned in a task by {{assigned_by}}.</p>",
-                   "interactive": true,
-                   "renderVarHtml": false
-               },
-               "component": "FormHtmlViewer",
-               "inspector": [
-                   {
-                       "type": "FormTextArea",
-                       "field": "content",
-                       "config": {
-                           "rows": 5,
-                           "label": "Content",
-                           "value": null,
-                           "helper": "The HTML text to display"
-                       }
-                   },
-                   {
-                       "type": "FormCheckbox",
-                       "field": "renderVarHtml",
-                       "config": {
-                           "label": "Render HTML from a Variable",
-                           "value": null,
-                           "helper": null
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "conditionalHide",
-                       "config": {
-                           "label": "Visibility Rule",
-                           "helper": "This control is hidden until this expression is true"
-                       }
-                   },
-                   {
-                       "type": "DeviceVisibility",
-                       "field": "deviceVisibility",
-                       "config": {
-                           "label": "Device Visibility",
-                           "helper": "This control is hidden until this expression is true"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "customFormatter",
-                       "config": {
-                           "label": "Custom Format String",
-                           "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
-                           "validation": null
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "customCssSelector",
-                       "config": {
-                           "label": "CSS Selector Name",
-                           "helper": "Use this in your custom css rules",
-                           "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "ariaLabel",
-                       "config": {
-                           "label": "Aria Label",
-                           "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "tabindex",
-                       "config": {
-                           "label": "Tab Order",
-                           "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
-                           "validation": "regex: [0-9]*"
-                       }
-                   },
-                   {
-                       "type": "EncryptedConfig",
-                       "field": "encryptedConfig",
-                       "config": {
-                           "label": "Encrypted",
-                           "helper": null
-                       }
-                   }
-               ],
-               "editor-control": "FormHtmlEditor",
-               "editor-component": "FormHtmlEditor"
-           },
-           {
-               "uuid": "1329abf7-3427-49cf-98f8-31f64fcbdd1b",
-               "label": "Link URL",
-               "config": {
-                   "icon": "fas fa-link",
-                   "event": "link",
-                   "label": "REVIEW TASK",
-                   "linkUrl": "{{link_review_task}}",
-                   "variant": "primary"
-               },
-               "component": "LinkButton",
-               "inspector": [
-                   {
-                       "type": "FormInput",
-                       "field": "label",
-                       "config": {
-                           "label": "Label",
-                           "helper": "The label describes the button's text"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "linkUrl",
-                       "config": {
-                           "label": "Link URL",
-                           "helper": "Type here the URL link. Mustache syntax is supported."
-                       }
-                   },
-                   {
-                       "type": "FormMultiselect",
-                       "field": "variant",
-                       "config": {
-                           "label": "Button Variant Style",
-                           "helper": "The variant determines the appearance of the button",
-                           "options": [
-                               {
-                                   "value": "primary",
-                                   "content": "Primary"
-                               },
-                               {
-                                   "value": "secondary",
-                                   "content": "Secondary"
-                               },
-                               {
-                                   "value": "success",
-                                   "content": "Success"
-                               },
-                               {
-                                   "value": "danger",
-                                   "content": "Danger"
-                               },
-                               {
-                                   "value": "warning",
-                                   "content": "Warning"
-                               },
-                               {
-                                   "value": "info",
-                                   "content": "Info"
-                               },
-                               {
-                                   "value": "light",
-                                   "content": "Light"
-                               },
-                               {
-                                   "value": "dark",
-                                   "content": "Dark"
-                               },
-                               {
-                                   "value": "link",
-                                   "content": "Link"
-                               }
-                           ]
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "conditionalHide",
-                       "config": {
-                           "label": "Visibility Rule",
-                           "helper": "This control is hidden until this expression is true"
-                       }
-                   },
-                   {
-                       "type": "DeviceVisibility",
-                       "field": "deviceVisibility",
-                       "config": {
-                           "label": "Device Visibility",
-                           "helper": "This control is hidden until this expression is true"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "customFormatter",
-                       "config": {
-                           "label": "Custom Format String",
-                           "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
-                           "validation": null
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "customCssSelector",
-                       "config": {
-                           "label": "CSS Selector Name",
-                           "helper": "Use this in your custom css rules",
-                           "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "ariaLabel",
-                       "config": {
-                           "label": "Aria Label",
-                           "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "tabindex",
-                       "config": {
-                           "label": "Tab Order",
-                           "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
-                           "validation": "regex: [0-9]*"
-                       }
-                   },
-                   {
-                       "type": "EncryptedConfig",
-                       "field": "encryptedConfig",
-                       "config": {
-                           "label": "Encrypted",
-                           "helper": null
-                       }
-                   }
-               ],
-               "editor-control": "LinkButton",
-               "editor-component": "LinkButton"
-           },
-           {
-               "uuid": "1c520abd-b1ef-4d42-9b69-887c70bb94b6",
-               "label": "Rich Text",
-               "config": {
-                   "icon": "fas fa-pencil-ruler",
-                   "label": null,
-                   "content": "<table style=\"width: 100%; border-collapse: collapse; border-radius: 10px; border: 1px solid var(--Color-Grey-200, #E9ECF1); background: var(--Color-Primary-50, #F8FBFF); overflow: hidden;\">\n<thead style=\"background: var(--Color-Primary-50, #F8FBFF);\">\n<tr>\n<th style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; text-align: left; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 14px; font-style: normal; font-weight: 400; line-height: 20px; letter-spacing: -0.14px;\">Task</th>\n<th style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; text-align: left; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 14px; font-style: normal; font-weight: 400; line-height: 20px; letter-spacing: -0.14px;\">Case</th>\n<th style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; text-align: left; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 14px; font-style: normal; font-weight: 400; line-height: 20px; letter-spacing: -0.14px;\">Due Date</th>\n<th style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; text-align: left; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 14px; font-style: normal; font-weight: 400; line-height: 20px; letter-spacing: -0.14px;\">Assigned By</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 16px; font-style: normal; font-weight: 600; line-height: 22px; letter-spacing: -0.16px;\">{{element_name}}</td>\n<td style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 16px; font-style: normal; font-weight: 600; line-height: 22px; letter-spacing: -0.16px;\">{{case_title}}</td>\n<td style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 16px; font-style: normal; font-weight: 600; line-height: 22px; letter-spacing: -0.16px;\">{{due_date}}</td>\n<td style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 16px; font-style: normal; font-weight: 600; line-height: 22px; letter-spacing: -0.16px;\">{{assigned_by}}</td>\n</tr>\n</tbody>\n</table>",
-                   "interactive": true,
-                   "renderVarHtml": false
-               },
-               "component": "FormHtmlViewer",
-               "inspector": [
-                   {
-                       "type": "FormTextArea",
-                       "field": "content",
-                       "config": {
-                           "rows": 5,
-                           "label": "Content",
-                           "value": null,
-                           "helper": "The HTML text to display"
-                       }
-                   },
-                   {
-                       "type": "FormCheckbox",
-                       "field": "renderVarHtml",
-                       "config": {
-                           "label": "Render HTML from a Variable",
-                           "value": null,
-                           "helper": null
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "conditionalHide",
-                       "config": {
-                           "label": "Visibility Rule",
-                           "helper": "This control is hidden until this expression is true"
-                       }
-                   },
-                   {
-                       "type": "DeviceVisibility",
-                       "field": "deviceVisibility",
-                       "config": {
-                           "label": "Device Visibility",
-                           "helper": "This control is hidden until this expression is true"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "customFormatter",
-                       "config": {
-                           "label": "Custom Format String",
-                           "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
-                           "validation": null
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "customCssSelector",
-                       "config": {
-                           "label": "CSS Selector Name",
-                           "helper": "Use this in your custom css rules",
-                           "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "ariaLabel",
-                       "config": {
-                           "label": "Aria Label",
-                           "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
-                       }
-                   },
-                   {
-                       "type": "FormInput",
-                       "field": "tabindex",
-                       "config": {
-                           "label": "Tab Order",
-                           "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
-                           "validation": "regex: [0-9]*"
-                       }
-                   },
-                   {
-                       "type": "EncryptedConfig",
-                       "field": "encryptedConfig",
-                       "config": {
-                           "label": "Encrypted",
-                           "helper": null
-                       }
-                   }
-               ],
-               "editor-control": "FormHtmlEditor",
-               "editor-component": "FormHtmlEditor"
-           }
-       ],
-       "order": 1
-   }
-]
+{
+    "type": "screen_package",
+    "version": "2",
+    "screens": [
+        {
+            "screen_category_id": null,
+            "title": "DEFAULT_EMAIL_TASK_NOTIFICATION",
+            "description": "Screen for the email task notification",
+            "type": "EMAIL",
+            "config": [
+                {
+                    "name": "DEFAULT_EMAIL_TASK_NOTIFICATION",
+                    "items": [
+                        {
+                            "uuid": "c331f828-3b0f-47a3-bf6e-9037717a7690",
+                            "label": "Rich Text",
+                            "config": {
+                                "icon": "fas fa-pencil-ruler",
+                                "label": null,
+                                "content": "<p><img style=\"width: 224px; height: 56px;\" src=\"{{imgHeader}}\" /></p>",
+                                "interactive": true,
+                                "renderVarHtml": false
+                            },
+                            "component": "FormHtmlViewer",
+                            "inspector": [
+                                {
+                                    "type": "FormTextArea",
+                                    "field": "content",
+                                    "config": {
+                                        "rows": 5,
+                                        "label": "Content",
+                                        "value": null,
+                                        "helper": "The HTML text to display"
+                                    }
+                                },
+                                {
+                                    "type": "FormCheckbox",
+                                    "field": "renderVarHtml",
+                                    "config": {
+                                        "label": "Render HTML from a Variable",
+                                        "value": null,
+                                        "helper": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "DeviceVisibility",
+                                    "field": "deviceVisibility",
+                                    "config": {
+                                        "label": "Device Visibility",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                },
+                                {
+                                    "type": "EncryptedConfig",
+                                    "field": "encryptedConfig",
+                                    "config": {
+                                        "label": "Encrypted",
+                                        "helper": null
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormHtmlEditor",
+                            "editor-component": "FormHtmlEditor"
+                        },
+                        {
+                            "uuid": "64801c0f-3b96-4261-a1ab-76f521a537ba",
+                            "label": "Rich Text",
+                            "config": {
+                                "icon": "fas fa-pencil-ruler",
+                                "label": null,
+                                "content": "<p style=\"font-size:36px\"><strong>Hello {{ _firstname }}</strong> You just been assigned in a task by {{assigned_by}}.</p>",
+                                "interactive": true,
+                                "renderVarHtml": false
+                            },
+                            "component": "FormHtmlViewer",
+                            "inspector": [
+                                {
+                                    "type": "FormTextArea",
+                                    "field": "content",
+                                    "config": {
+                                        "rows": 5,
+                                        "label": "Content",
+                                        "value": null,
+                                        "helper": "The HTML text to display"
+                                    }
+                                },
+                                {
+                                    "type": "FormCheckbox",
+                                    "field": "renderVarHtml",
+                                    "config": {
+                                        "label": "Render HTML from a Variable",
+                                        "value": null,
+                                        "helper": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "DeviceVisibility",
+                                    "field": "deviceVisibility",
+                                    "config": {
+                                        "label": "Device Visibility",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                },
+                                {
+                                    "type": "EncryptedConfig",
+                                    "field": "encryptedConfig",
+                                    "config": {
+                                        "label": "Encrypted",
+                                        "helper": null
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormHtmlEditor",
+                            "editor-component": "FormHtmlEditor"
+                        },
+                        {
+                            "uuid": "1329abf7-3427-49cf-98f8-31f64fcbdd1b",
+                            "label": "Link URL",
+                            "config": {
+                                "icon": "fas fa-link",
+                                "event": "link",
+                                "label": "REVIEW TASK",
+                                "linkUrl": "{{link_review_task}}",
+                                "variant": "primary"
+                            },
+                            "component": "LinkButton",
+                            "inspector": [
+                                {
+                                    "type": "FormInput",
+                                    "field": "label",
+                                    "config": {
+                                        "label": "Label",
+                                        "helper": "The label describes the button's text"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "linkUrl",
+                                    "config": {
+                                        "label": "Link URL",
+                                        "helper": "Type here the URL link. Mustache syntax is supported."
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "variant",
+                                    "config": {
+                                        "label": "Button Variant Style",
+                                        "helper": "The variant determines the appearance of the button",
+                                        "options": [
+                                            {
+                                                "value": "primary",
+                                                "content": "Primary"
+                                            },
+                                            {
+                                                "value": "secondary",
+                                                "content": "Secondary"
+                                            },
+                                            {
+                                                "value": "success",
+                                                "content": "Success"
+                                            },
+                                            {
+                                                "value": "danger",
+                                                "content": "Danger"
+                                            },
+                                            {
+                                                "value": "warning",
+                                                "content": "Warning"
+                                            },
+                                            {
+                                                "value": "info",
+                                                "content": "Info"
+                                            },
+                                            {
+                                                "value": "light",
+                                                "content": "Light"
+                                            },
+                                            {
+                                                "value": "dark",
+                                                "content": "Dark"
+                                            },
+                                            {
+                                                "value": "link",
+                                                "content": "Link"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "DeviceVisibility",
+                                    "field": "deviceVisibility",
+                                    "config": {
+                                        "label": "Device Visibility",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                },
+                                {
+                                    "type": "EncryptedConfig",
+                                    "field": "encryptedConfig",
+                                    "config": {
+                                        "label": "Encrypted",
+                                        "helper": null
+                                    }
+                                }
+                            ],
+                            "editor-control": "LinkButton",
+                            "editor-component": "LinkButton"
+                        },
+                        {
+                            "uuid": "1c520abd-b1ef-4d42-9b69-887c70bb94b6",
+                            "label": "Rich Text",
+                            "config": {
+                                "icon": "fas fa-pencil-ruler",
+                                "label": null,
+                                "content": "<table style=\"width: 100%; border-collapse: collapse; border-radius: 10px; border: 1px solid var(--Color-Grey-200, #E9ECF1); background: var(--Color-Primary-50, #F8FBFF); overflow: hidden;\">\n<thead style=\"background: var(--Color-Primary-50, #F8FBFF);\">\n<tr>\n<th style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; text-align: left; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 14px; font-style: normal; font-weight: 400; line-height: 20px; letter-spacing: -0.14px;\">Task</th>\n<th style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; text-align: left; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 14px; font-style: normal; font-weight: 400; line-height: 20px; letter-spacing: -0.14px;\">Case</th>\n<th style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; text-align: left; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 14px; font-style: normal; font-weight: 400; line-height: 20px; letter-spacing: -0.14px;\">Due Date</th>\n<th style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; text-align: left; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 14px; font-style: normal; font-weight: 400; line-height: 20px; letter-spacing: -0.14px;\">Assigned By</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 16px; font-style: normal; font-weight: 600; line-height: 22px; letter-spacing: -0.16px;\">{{element_name}}</td>\n<td style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 16px; font-style: normal; font-weight: 600; line-height: 22px; letter-spacing: -0.16px;\">{{case_title}}</td>\n<td style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 16px; font-style: normal; font-weight: 600; line-height: 22px; letter-spacing: -0.16px;\">{{due_date}}</td>\n<td style=\"border: 1px solid var(--Color-Grey-200, #E9ECF1); padding: 8px; color: var(--black-black, var(--color-black-black, #20242a)); font-size: 16px; font-style: normal; font-weight: 600; line-height: 22px; letter-spacing: -0.16px;\">{{assigned_by}}</td>\n</tr>\n</tbody>\n</table>",
+                                "interactive": true,
+                                "renderVarHtml": false
+                            },
+                            "component": "FormHtmlViewer",
+                            "inspector": [
+                                {
+                                    "type": "FormTextArea",
+                                    "field": "content",
+                                    "config": {
+                                        "rows": 5,
+                                        "label": "Content",
+                                        "value": null,
+                                        "helper": "The HTML text to display"
+                                    }
+                                },
+                                {
+                                    "type": "FormCheckbox",
+                                    "field": "renderVarHtml",
+                                    "config": {
+                                        "label": "Render HTML from a Variable",
+                                        "value": null,
+                                        "helper": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "DeviceVisibility",
+                                    "field": "deviceVisibility",
+                                    "config": {
+                                        "label": "Device Visibility",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                },
+                                {
+                                    "type": "EncryptedConfig",
+                                    "field": "encryptedConfig",
+                                    "config": {
+                                        "label": "Encrypted",
+                                        "helper": null
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormHtmlEditor",
+                            "editor-component": "FormHtmlEditor"
+                        }
+                    ]
+                }
+            ],
+            "computed": [],
+            "custom_css": "",
+            "status": "ACTIVE",
+            "key": "default-email-task-notification",
+            "watchers": [],
+            "translations": null,
+            "is_template": 0,
+            "categories": null
+        }
+    ],
+    "screen_categories": [],
+    "scripts": []
+  }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -29,6 +29,7 @@ class DatabaseSeeder extends Seeder
             // ScriptExecutorSeeder::class,
             SignalSeeder::class,
             SettingsMenusSeeder::class,
+            ScreenEmailSeeder::class,
         ]);
         $this->callPluginSeeders();
     }

--- a/database/seeders/ScreenEmailSeeder.php
+++ b/database/seeders/ScreenEmailSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use ProcessMaker\Models\Screen;
+
+class ScreenEmailSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        return Screen::getScreenByKey('default-email-task-notification');
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
After solved the conflicts in the database/seeders/ScreenSystemSeeder.php we need todo:
Create other seeder and use the new function getScreenByKey
Use the key default-email-task-notification to get the screen related
The Default Email is marked with system in this way this will not listed in the Screens List

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22068

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy