### PR TITLE
observation/FOUR-22090: Fix for TaskAssignmentExecutionTest

### DIFF
--- a/tests/Feature/Api/TaskAssignmentExecutionTest.php
+++ b/tests/Feature/Api/TaskAssignmentExecutionTest.php
@@ -155,7 +155,7 @@ class TaskAssignmentExecutionTest extends TestCase
         // Verify status
         $response->assertStatus(201);
         // Get the ProcessRequest
-        $expectedDueDate = Carbon::now()->addHours(24);
+        $expectedDueDate = Carbon::now()->addHours(72);
         $task = ProcessRequestToken::where([
             'process_request_id' => $response['id'],
             'status' => 'ACTIVE',

--- a/tests/Feature/Api/processes/TaskConfiguredCustomDueIn.bpmn
+++ b/tests/Feature/Api/processes/TaskConfiguredCustomDueIn.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="true" pm:interstitialScreenRef="46" pm:config="{&#34;web_entry&#34;:null}">
       <bpmn:outgoing>node_29</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:task id="node_2" name="Form Task" pm:allowInterstitial="false" pm:dueInVariable="{{var_due_date}}" pm:isDueInVariable="true" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
+    <bpmn:task id="node_2" name="Form Task" pm:allowInterstitial="false" pm:dueInVariable="var_due_date" pm:isDueInVariable="true" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}">
       <bpmn:incoming>node_29</bpmn:incoming>
       <bpmn:outgoing>node_38</bpmn:outgoing>
     </bpmn:task>


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- Double bracket was removed form BPMN file since Laravel 11 is more strict with XML notation.

## How to Test
- Run TEST with Laravel 11:  tests/Feature/Api/TaskAssignmentExecutionTest.php

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-22090

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
