### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,7 @@
         ],
         "processmaker": {
             "build": "4ee84764",
-            "cicd-enabled": true,
+            "cicd-enabled": false,
             "custom": {
                 "package-ellucian-ethos": "1.16.0",
                 "package-plaid": "1.6.0",


### PR DESCRIPTION
## Issue & Reproduction Steps
It was discussed and decided that we will be doing nightly release builds for releases up to 1 year. Now that we are developing for 2025-spring, we can remove the release-2024-spring nightly builds.

## Solution
- set cicd_enabled: false

## How to Test
- Should no longer show up during the nightly release builds here: https://github.com/ProcessMaker/pm4-k8s-distribution/actions

## Related Tickets & Packages
- none

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
