### PR TITLE
Preview file is not visible in form in a request completed

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -472,6 +472,9 @@
   @foreach($managerModelerScripts as $script)
     <script src="{{ $script }}"></script>
   @endforeach
+  @foreach($manager->getScripts() as $script)
+        <script src="{{$script}}"></script>
+    @endforeach
   @if (hasPackage('package-files'))
     <!-- TODO: Replace with script injector like we do for modeler and screen builder -->
     <script src="{{ mix('js/manager.js', 'vendor/processmaker/packages/package-files') }}"></script>


### PR DESCRIPTION
## Issue & Reproduction Steps
Preview file is not visible in form in a request completed

## Solution
- load manager scripts

## How to Test

- Create process with upload, preview file | Import the process
- Create a case
- Upload a file
- Wait until this will be preview in preview file control
- Click on submit button
- Go to request complete
- Go to form 
- Check the screen completed
- Check the preview file control

## Related Tickets & Packages
- [FOUR-22096](https://processmaker.atlassian.net/browse/FOUR-22096)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22096]: https://processmaker.atlassian.net/browse/FOUR-22096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ