### PR TITLE
FOUR-22097: download file is not displayed in form completed cases

### DIFF
--- a/resources/jscomposition/system/table/cell/CollapseFormCell.vue
+++ b/resources/jscomposition/system/table/cell/CollapseFormCell.vue
@@ -40,6 +40,10 @@ const props = defineProps({
 const viewScreen = ref(false);
 
 const showScreen = () => {
+  const requestIdNode = document.head.querySelector('meta[name="request-id"]');
+  if (requestIdNode) {
+    requestIdNode.setAttribute('content', props.row.process_request_id);
+  }
   viewScreen.value = !viewScreen.value;
   emit("collapseContainer", viewScreen.value);
 };

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -15,6 +15,10 @@
   ]])
 @endsection
 
+@section('meta')
+  <meta name="request-id" content="">
+@endsection
+
 @section('content')
 <div
   id="case-detail"


### PR DESCRIPTION
## Issue & Reproduction Steps
Download file is not displayed in form completed cases

## Solution
- add request-id to head html tag because is required for file download file field


<img width="1368" alt="image" src="https://github.com/user-attachments/assets/71cbe4a6-f464-482f-b6fa-46b07119cc92" />

## How to Test
- described in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22097

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
