### PR TITLE
FOUR-22103: Oops! page not found appears when refreshing the browser in files cases

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
@@ -20,6 +20,8 @@ import ErrorsTab from "./ErrorsTab.vue";
 import { getRequestCount, getRequestStatus, isErrors } from "../variables/index";
 
 const translate = ProcessMaker.i18n;
+const Router = window.ProcessMaker.Router;
+const path = window.location.pathname;
 
 const urlTabs = [
   "errors",
@@ -35,6 +37,12 @@ const urlTabs = [
 const tabDefault = computed(() => {
   if (urlTabs.includes(window.location.hash.substring(1))) {
     return window.location.hash.substring(1);
+  }
+
+  // This section is for the package-files, the issue should be fixed in page with vue-router
+  const routeResolved = Router.resolve(path);
+  if (routeResolved.route?.name && routeResolved.route?.meta?.package === "package-files") {
+    return "file_manager";
   }
   if (isErrors()) {
     return "errors";

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -176,7 +176,7 @@
 
   @if (hasPackage('package-files'))
   <!-- TODO: Replace with script injector like we do for modeler and screen builder -->
-  <script src="{{ mix('js/manager.js', 'vendor/processmaker/packages/package-files') }}"></script>
+  <script src="{{ mix('js/manager-cases.js', 'vendor/processmaker/packages/package-files') }}"></script>
   @endif
 
   <script src="{{mix('js/composition/cases/casesDetail/edit.js')}}"></script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -151,6 +151,12 @@ Route::middleware('auth', 'session_kill', 'sanitize', 'force_change_password', '
         ->name('cases.show')
         ->middleware('no-cache');
 
+    Route::get('cases/{case_number}/files/{file}', [CasesController::class, 'show'])
+        ->where('case_number', '[0-9]+')
+        ->where('file', '.*')
+        ->name('cases.show')
+        ->middleware('no-cache');
+
     // Requests
     Route::get('requests', [RequestController::class, 'index'])
         ->name('requests.index')

--- a/routes/web.php
+++ b/routes/web.php
@@ -154,7 +154,7 @@ Route::middleware('auth', 'session_kill', 'sanitize', 'force_change_password', '
     Route::get('cases/{case_number}/files/{file}', [CasesController::class, 'show'])
         ->where('case_number', '[0-9]+')
         ->where('file', '.*')
-        ->name('cases.show')
+        ->name('cases.show-file')
         ->middleware('no-cache');
 
     // Requests


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process with upload files or pdf generator
2. Create a case
3. Upload a file or generated a pdf document
4. Complete the case
5. Open the case
6. Go to File manager
7. Open the file 
8. Refresh the page
9. Check the page


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22103

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:package-files:bugfix/FOUR-22103