### PR TITLE
FOUR-21901: Script Executor Microservices > double icons when a scrip…

### DIFF
--- a/tests/unit/ScriptMicroserviceServiceTest.php
+++ b/tests/unit/ScriptMicroserviceServiceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use ProcessMaker\Events\ScriptResponseEvent;
+use ProcessMaker\Jobs\CompleteActivity;
+use ProcessMaker\Models\Process as Definitions;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\Script;
+use ProcessMaker\Models\User;
+use ProcessMaker\Services\ScriptMicroserviceService;
+use Tests\TestCase;
+
+class ScriptMicroserviceServiceTest extends TestCase
+{
+    protected ScriptMicroserviceService $service;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ScriptMicroserviceService();
+        $this->user = User::factory()->create();
+    }
+
+    public function testHandlePreviewSuccess()
+    {
+        Event::fake();
+
+        $request = new Request();
+        $request->merge([
+            'status' => 'success',
+            'output' => ['result' => 'test output'],
+            'metadata' => [
+                'nonce' => 'test-nonce',
+                'current_user' => $this->user->id,
+            ],
+        ]);
+
+        $this->service->handle($request);
+
+        Event::assertDispatched(ScriptResponseEvent::class, function ($event) {
+            return $event->userId === $this->user->id
+                && $event->status === 200
+                && $event->response['output'] === ['result' => 'test output']
+                && $event->nonce === 'test-nonce';
+        });
+    }
+
+    public function testHandlePreviewError()
+    {
+        Event::fake();
+
+        $request = new Request();
+        $request->merge([
+            'status' => 'error',
+            'message' => 'Test error message',
+            'metadata' => [
+                'nonce' => 'test-nonce',
+                'current_user' => $this->user->id,
+            ],
+        ]);
+
+        $this->service->handle($request);
+
+        Event::assertDispatched(ScriptResponseEvent::class, function ($event) {
+            return $event->userId === $this->user->id
+                && $event->status === 500
+                && $event->response['exception'] === 'Test error message'
+                && $event->nonce === 'test-nonce';
+        });
+    }
+
+    public function testHandleScriptTaskSuccess()
+    {
+        Queue::fake();
+
+        $script = Script::factory()->create();
+        $definitions = Definitions::factory()->create();
+        $instance = ProcessRequest::factory()->create();
+        $token = ProcessRequestToken::factory()->create();
+
+        $request = new Request();
+        $request->merge([
+            'status' => 'success',
+            'output' => ['result' => 'task output'],
+            'metadata' => [
+                'script_task' => [
+                    'script_id' => $script->id,
+                    'definition_id' => $definitions->id,
+                    'instance_id' => $instance->id,
+                    'token_id' => $token->id,
+                ],
+            ],
+        ]);
+
+        $this->service->handle($request);
+
+        Queue::assertPushedOn('bpmn', CompleteActivity::class, function ($job) use ($definitions, $instance, $token) {
+            return $job->definitionsId === $definitions->id
+                && $job->instanceId === $instance->id
+                && $job->tokenId === $token->id
+                && $job->data === ['result' => 'task output'];
+        });
+    }
+
+    public function testHandleScriptTaskError()
+    {
+        Queue::fake();
+
+        $script = Script::factory()->create();
+        $definitions = Definitions::factory()->create();
+        $instance = ProcessRequest::factory()->create();
+        $token = ProcessRequestToken::factory()->create();
+
+        $request = new Request();
+        $request->merge([
+            'status' => 'error',
+            'output' => ['error' => 'Task failed'],
+            'metadata' => [
+                'script_task' => [
+                    'script_id' => $script->id,
+                    'definition_id' => $definitions->id,
+                    'instance_id' => $instance->id,
+                    'token_id' => $token->id,
+                ],
+            ],
+        ]);
+
+        $this->service->handle($request);
+
+        Queue::assertNotPushed(CompleteActivity::class);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Script Executor Microservices > double icons when a script is executed with errors
## Solution
- improve microservice response manager
![image](https://github.com/user-attachments/assets/10ef21e8-fb12-40bf-a02e-de772ae9a5d0)



## How to Test
Described in the related ticket
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21901

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

.