### PR TITLE
FOUR-21934: Oopss page when entering "Open Process Launchpad" in Docusign Authorization

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -346,7 +346,7 @@
                             <li class="list-group-item">
                               <p class="section-title">{{ __('Process') }}</p>
                               {{ $request->name }}
-                              <!-- This is the name defined in the installacion of connector-docusign 'DocuSignAuthentication' -->
+                              <!-- This is the name defined in the installation of connector-docusign 'DocuSignAuthentication' -->
                               @if ($request->process->name !== 'DocuSignAuthentication')
                                 <p class="launchpad-link">
                                   <a href="{{route('process.browser.index', [$request->process_id])}}">

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -309,11 +309,14 @@
                       <li class="list-group-item">
                         <p class="section-title">{{__('Case')}}</p>
                         @{{ caseTitle }}
-                        <p class="launchpad-link">
-                          <a href="{{route('process.browser.index', [$task->process->id])}}">
-                            {{ __('Open Process Launchpad') }}
-                          </a>
-                        </p>
+                        <!-- This is the name defined in the installacion of connector-docusign 'DocuSignAuthentication' -->
+                        @if ($request->process->name !== 'DocuSignAuthentication')
+                          <p class="launchpad-link">
+                            <a href="{{route('process.browser.index', [$task->process->id])}}">
+                              {{ __('Open Process Launchpad') }}
+                            </a>
+                          </p>
+                        @endif
                       </li>
                       <li class="list-group-item">
                         <p class="section-title">{{__('Request')}}</p>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -310,7 +310,7 @@
                         <p class="section-title">{{__('Case')}}</p>
                         @{{ caseTitle }}
                         <!-- This is the name defined in the installacion of connector-docusign 'DocuSignAuthentication' -->
-                        @if ($request->process->name !== 'DocuSignAuthentication')
+                        @if ($task->process->name !== 'DocuSignAuthentication')
                           <p class="launchpad-link">
                             <a href="{{route('process.browser.index', [$task->process->id])}}">
                               {{ __('Open Process Launchpad') }}

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -309,7 +309,7 @@
                       <li class="list-group-item">
                         <p class="section-title">{{__('Case')}}</p>
                         @{{ caseTitle }}
-                        <!-- This is the name defined in the installacion of connector-docusign 'DocuSignAuthentication' -->
+                        <!-- This is the name defined in the installation of connector-docusign 'DocuSignAuthentication' -->
                         @if ($task->process->name !== 'DocuSignAuthentication')
                           <p class="launchpad-link">
                             <a href="{{route('process.browser.index', [$task->process->id])}}">


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Log in 
2. Go to Admin
3. Clcik on Integrations
4. Click on Docusign
5. COnfigure docusign
6. Click on Grant Docusign Access
7. Click on Open Process launchpad 

## Solution
- When the process is related to the system the link to launchpad needs to hide in **Task view**

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21934

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy