### PR TITLE
FOUR-21957: Completed forms  in Cases do not show the data that was filled out in task

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -260,7 +260,7 @@ class RequestController extends Controller
         }
 
         $dataManager = new DataManager();
-        $data = $dataManager->getData($task);
+        $data = $dataManager->getData($task, true);
 
         $manager = app(ScreenBuilderManager::class);
         event(new ScreenBuilderStarting($manager, ($request->summary_screen) ? $request->summary_screen->type : 'FORM'));


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a screen with record list or any control to save data
2. Create a process with two task
3. Save the process 
4. Create a case
5. Fill the screen in the task 1
6. Route to the following task
7. Open the task 2
8. Fill another data in the task 2
9. Complete the request
10. Go to form completed in request 
11. In request this show data that was completed in each task
12. Go to case
13. Go to form completed
14. Check the forms in each task


## Current Behavior
Completed forms in Cases do not show the data that was filled out in tasks, always show the last data 

## Related Tickets & Packages

- https://processmaker.atlassian.net/browse/FOUR-5991

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

