### PR TITLE
FOUR-21936: Error 404 when importing old processes with sub processes

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -257,7 +257,7 @@ class ProcessController extends Controller
      *         @OA\JsonContent(ref="#/components/schemas/Process")
      *     ),
      *     @OA\Response(
-     *         response=404,
+     *         response=204,
      *         description="Process not found",
      *         @OA\JsonContent(
      *             type="object",
@@ -272,7 +272,7 @@ class ProcessController extends Controller
         if ($process === null) {
             return response()->json([
                 'message' => __('The requested process was not found'),
-            ], 404);
+            ], 204);
         }
 
         return new Resource($process);


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently, when the API returns a 404 Not Found response for a process that does not exist, a popup message is displayed in the UI. However, this issue is part of a deeper problem where the Modeler component is being mounted twice, leading to duplicate API calls.

1. Open the Modeler and select a sub-process.
2. Observe that the API call to GET /api/1.0/processes/{processId} is made twice.
3. If the process does not exist, a 404 response is returned twice, triggering an error popup in the UI.

## Solution
- Modified the show(int $processId) method in ProcessController.php to return a 204 response without a message, preventing the UI from displaying an error popup.
- The core issue of the Modeler mounting twice and causing duplicate API calls remains unresolved and requires further investigation and work.

## How to Test
Follow the reproduction steps from the JIRA ticket.

## Related Tickets & Packages
- [FOUR-21936](https://processmaker.atlassian.net/browse/FOUR-21936)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-21936]: https://processmaker.atlassian.net/browse/FOUR-21936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ