### PR TITLE
observation/FOUR-22387: Route [package.savedsearch.defaults.edit] not defined

### DIFF
--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -140,12 +140,12 @@
                     'isAdministrator' => Auth::user()->is_administrator,
                     'canEditScreens' => Auth::user()->hasPermission('edit-screens'),
                 ]) }}"
-                :savedsearch-defaults-edit-route="{{ json_encode(
+                :savedsearch-defaults-edit-route="{{ Route::has('package.savedsearch.defaults.edit') ? json_encode(
                     route('package.savedsearch.defaults.edit', [
                         'type' => 'task',
                         'key' => 'tasks',
-                    ]),
-                ) }}"></participant-home-screen>
+                    ])
+                ) : 'null' }}"></participant-home-screen>
         </div>
     </div>
 @endsection


### PR DESCRIPTION
## Solution
- Validation for package-savedsearch was added

## How to Test
- In Spring version Login to PM4
- No error message should be displayed

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22387

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
