### PR TITLE
Add simple feature flag config

### DIFF
--- a/config/features.php
+++ b/config/features.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Add your feature flags here and set them to true.
+ *
+ * The Environment Variable name should be FEATURE_<name>
+ *
+ * Make sure to add the feature flag to the release checklist so CloudOps
+ * can disable it until it's ready.
+ *
+ * Use feature flags to control the visibility of new features. For example
+ *
+ *   if (config('features.dms')) {
+ *     // This is the new feature
+ *   }
+ */
+
+return [
+    'dms' => (bool) env('FEATURE_DMS', true),
+];


### PR DESCRIPTION
Idea for a simple feature flag system using configs.

Notes:
- Maybe we should have 2 new columns in the Release Checklist: "New Feature Flags" and "Features To Enable"
  - New Feature Flags are added to `.env` on release with the value set to `false`
  - QA environments will not have the entries in `.env` because they should have access to in-progress features
  - When the feature is ready for release, the developer can add the feature to the "Features To Enable" column

Flow
1. Developer stats a feature and hides it with a config, for example ` if (config('features.dms')) { ... }`
2. Developer adds the env var to the release checklist `FEATURE_DMS=false`
3. CloudOps adds it to `.env` on release
4. When ready, CloudOps can delete the entry and clear the cache.
