### PR TITLE
FOUR-23124 : Notification messages are not displayed correctly in different pages

### DIFF
--- a/resources/js/notifications/components/notification-item.vue
+++ b/resources/js/notifications/components/notification-item.vue
@@ -5,7 +5,7 @@
     :class="{ 'clickable': url }"
     @click="click"
   >
-    <b-container>
+    <div class="px-3">
       <b-row>
         <notification-user :notification="notification" />
         <notification-message
@@ -13,7 +13,7 @@
           :show-time="showTime"
         />
       </b-row>
-    </b-container>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
## Issue & Reproduction Steps
1. login in the server https://release-2025-spring-qa.processmaker.net/
2. ProcessMaker Platform Spring 2025 Version 4.14.0+beta-1 (Build #131e867d)
3. Create a simple process (start event - task - taks - end event)
4. Configure Notification accordion in both tasks 
5. Open this pages in the same browser
6. /modeler/{{id}}
7. /process-browser/?categoryId=recent
8. /cases
9. /tasks
10. /designer
11. /admin/users
12. /requests/199/files/Gemini_Generated_Image_5qgqwu5qgqwu5qgq.jpeg
13. /requests/199
14. /designer/screen-builder/518/edit
15. /tasks/644/edit
16. /file-manager
18. Create a Case
19. Wait until arrived notification
20. Open the notification in each page

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23124

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy