### PR TITLE
FOUR-23123:The "Pan Tool" disappears when you press the keyboard "space" in the overview.

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/NewOverview.vue
+++ b/resources/jscomposition/cases/casesDetail/components/NewOverview.vue
@@ -29,6 +29,7 @@
         :request-in-progress-nodes="inflightData.requestInProgressNodes"
         :request-idle-nodes="inflightData.requestIdleNodes"
         :read-only="true"
+        :preview="true"
         @set-xml-manager="xmlManager = $event"
         @click="handleClick"
       />


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Steps to reproduced:
2. Go to requests page
3. Open any completed request
4. Click Overview tab
5. Click the space key

**Current Behavior:**
If the request has scrolling, it will scroll to the bottom of the screen, and the "Pan Tool" is no longer displayed when you return to the paper with the mouse.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23123

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:modeler:bugfix/FOUR-23123