### PR TITLE
FOUR-22499 the searcher and pagination of the start new case are not working

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -944,8 +944,18 @@ class ProcessController extends Controller
             ->leftJoin('users as user', 'processes.user_id', '=', 'user.id')
             ->where('processes.status', 'ACTIVE')
             ->where('category.status', 'ACTIVE')
-            ->whereNull('warnings')
-            ->where($where);
+            ->whereNull('warnings');
+
+        $query = $query->where(function ($q) use ($where) {
+            foreach ($where as $condition) {
+                // Extract the condition
+                [$column, $operator, $value, $boolean] = $condition;
+                // Determine the method to use
+                $method = $boolean == 'or' ? 'orWhere' : 'where';
+                // Apply the condition
+                $q->{$method}($column, $operator, $value);
+            }
+        });
 
         // Add the order by columns
         foreach ($orderColumns as $key => $orderColumn) {

--- a/tests/Feature/Api/ProcessControllerTest.php
+++ b/tests/Feature/Api/ProcessControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace ProcessMaker\Api\Tests\Feature;
+
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessCategory;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class ProcessControllerTest extends TestCase
+{
+    use RequestHelper;
+
+    public function testStartProcessesReturnsActiveProcesses()
+    {
+        $file = Process::getProcessTemplatesPath() . '/SingleTask.bpmn';
+        $bpmn = file_get_contents($file);
+        // Create categories
+        $cat1 = ProcessCategory::factory()->create(['name' => 'A cat', 'status' => 'ACTIVE']);
+        $cat2 = ProcessCategory::factory()->create(['name' => 'B cat', 'status' => 'INACTIVE']);
+        // Create Processes
+        Process::factory()->count(1)->create(['process_category_id' => $cat1->id]);
+        Process::factory()->create([
+            'name' => 'AProcess',
+            'status' => 'ACTIVE',
+            'process_category_id' => $cat1->id,
+            'bpmn' => $bpmn,
+        ]);
+        Process::factory()->create([
+            'name' => 'BProcess',
+            'status' => 'ACTIVE',
+            'process_category_id' => $cat1->id,
+            'bpmn' => $bpmn,
+        ]);
+        Process::factory()->create([
+            'name' => 'CProcess',
+            'status' => 'INACTIVE',
+            'process_category_id' => $cat2->id,
+        ]);
+
+        $response = $this->apiCall('GET', route('api.processes.start'), ['order_by' => 'category.name,name']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonFragment(['name' => 'AProcess']);
+        $response->assertJsonFragment(['name' => 'BProcess']);
+        $response->assertJsonMissing(['name' => 'CProcess']);
+    }
+
+    public function testStartProcessesFiltersByName()
+    {
+        $file = Process::getProcessTemplatesPath() . '/SingleTask.bpmn';
+        $bpmn = file_get_contents($file);
+
+        // Create categories
+        $cat1 = ProcessCategory::factory()->create(['name' => 'A cat', 'status' => 'ACTIVE']);
+        // Create Processes
+        Process::factory()->create([
+            'name' => 'AProcess',
+            'status' => 'ACTIVE',
+            'process_category_id' => $cat1->id,
+            'bpmn' => $bpmn,
+        ]);
+        Process::factory()->create([
+            'name' => 'Test Process B',
+            'status' => 'ACTIVE',
+            'process_category_id' => $cat1->id,
+            'bpmn' => $bpmn,
+        ]);
+        Process::factory()->create([
+            'name' => 'Another Process',
+            'status' => 'ACTIVE',
+            'process_category_id' => $cat1->id,
+            'bpmn' => $bpmn,
+        ]);
+
+        $response = $this->apiCall('GET', route('api.processes.start'), ['order_by' => 'category.name,name']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(3, 'data');
+
+        // Filter by completed name
+        $response = $this->apiCall('GET', route('api.processes.start'), ['filter' => 'AProcess', 'order_by' => 'category.name,name']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment(['name' => 'AProcess']);
+
+        // Filter by partial name
+        $response = $this->apiCall('GET', route('api.processes.start'), ['filter' => 'Test', 'order_by' => 'category.name,name']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment(['name' => 'Test Process B']);
+
+        // Filter by partial name
+        $response = $this->apiCall('GET', route('api.processes.start'), ['filter' => 'Process', 'order_by' => 'category.name,name']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonFragment(['name' => 'AProcess']);
+        $response->assertJsonFragment(['name' => 'Test Process B']);
+        $response->assertJsonFragment(['name' => 'Another Process']);
+    }
+
+    public function testStartProcessesFiltersByCategory()
+    {
+        $file = Process::getProcessTemplatesPath() . '/SingleTask.bpmn';
+        $bpmn = file_get_contents($file);
+
+        // Create categories
+        $cat1 = ProcessCategory::factory()->create(['name' => 'Category A', 'status' => 'ACTIVE']);
+        $cat2 = ProcessCategory::factory()->create(['name' => 'Category B', 'status' => 'ACTIVE']);
+        // Create Processes
+        Process::factory()->create([
+            'name' => 'AProcess',
+            'status' => 'ACTIVE',
+            'process_category_id' => $cat1->id,
+            'bpmn' => $bpmn,
+        ]);
+        Process::factory()->create([
+            'name' => 'BProcess',
+            'status' => 'ACTIVE',
+            'process_category_id' => $cat1->id,
+            'bpmn' => $bpmn,
+        ]);
+        Process::factory()->create([
+            'name' => 'CProcess',
+            'status' => 'ACTIVE',
+            'process_category_id' => $cat2->id,
+            'bpmn' => $bpmn,
+        ]);
+
+        $response = $this->apiCall('GET', route('api.processes.start'), ['order_by' => 'category.name,name']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(3, 'data');
+
+        // Filter by category A
+        $response = $this->apiCall('GET', route('api.processes.start'), ['filter' => $cat1->name, 'order_by' => 'category.name,name']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonFragment(['name' => 'AProcess']);
+        $response->assertJsonFragment(['name' => 'BProcess']);
+
+        // Filter by category B
+        $response = $this->apiCall('GET', route('api.processes.start'), ['filter' => $cat2->name, 'order_by' => 'category.name,name']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment(['name' => 'CProcess']);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps

### Current behavior
The searcher of the process in the start case or start request is not working, This does not filter the process searched 

### Expected behavior
The searcher of the process in the start case should filter the process typed

## Solution
- Improve the where conditions according to the latest version of the framework 

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-22499](https://processmaker.atlassian.net/browse/FOUR-22499)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22499]: https://processmaker.atlassian.net/browse/FOUR-22499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

.