### PR TITLE
Observation/FOUR-22497: Processes list is not displayed in the home page

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
@@ -180,8 +180,7 @@ class ProcessLaunchpadController extends Controller
     {
         // Get the user
         $user = Auth::user();
-        $perPage = $this->getPerPage($request);
-        // Get the processes  active
+        // Get the processes active
         $processes = Process::nonSystem()->active();
         // Filter by category
         $category = $request->input('category', null);
@@ -208,16 +207,16 @@ class ProcessLaunchpadController extends Controller
         $userId = $user->id;
 
         $processes = Process::select('processes.*')
-        ->distinct()
-        ->whereHas('requests', function($query) use ($userId) {
-            $query->where('user_id', $userId)
-                ->orWhereHas('tokens', function($query) use ($userId) {
-                    $query->where('user_id', $userId);
-                });
-        })
-        ->where('asset_type', NULL)
-        ->orderBy('processes.name', 'asc')
-        ->paginate($perPage);
+            ->distinct()
+            ->whereHas('requests', function($query) use ($userId) {
+                $query->where('user_id', $userId)
+                    ->orWhereHas('tokens', function($query) use ($userId) {
+                        $query->where('user_id', $userId);
+                    });
+            })
+            ->where('asset_type', NULL)
+            ->orderBy('processes.name', 'asc')
+            ->get();
 
         foreach ($processes as $process) {
             // Get the id bookmark related

--- a/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\ProcessCollection;
@@ -47,8 +48,8 @@ class ProcessLaunchpadController extends Controller
         // Get the processes
         $processes = $processes
             ->select('processes.*')
-            ->orderBy('processes.name', 'asc')
-            ->paginate($perPage);
+        ->orderBy('processes.name', 'asc')
+        ->paginate($perPage);
 
         foreach ($processes as $process) {
             // Get the id bookmark related
@@ -173,5 +174,62 @@ class ProcessLaunchpadController extends Controller
         if ($embedUrl) {
             $embedUrl->delete();
         }
+    }
+
+    public function getProcessesMenu(Request $request)
+    {
+        // Get the user
+        $user = Auth::user();
+        $perPage = $this->getPerPage($request);
+        // Get the processes  active
+        $processes = Process::nonSystem()->active();
+        // Filter by category
+        $category = $request->input('category', null);
+        if ($category === 'recent') {
+            $processes->orderByRecentRequests();
+        } elseif (!empty($category)) {
+            $processes->processCategory($category);
+        }
+        // Filter pmql
+        $pmql = $request->input('pmql', '');
+        if (!empty($pmql)) {
+            try {
+                $processes->pmql($pmql);
+            } catch (\ProcessMaker\Query\SyntaxError $e) {
+                return response(['error' => 'PMQL error'], 400);
+            }
+        }
+
+        // Get with bookmark
+        $bookmark = $request->input('bookmark', false);
+        // Get with launchpad
+        $launchpad = $request->input('launchpad', false);
+
+        $userId = $user->id;
+
+        $processes = Process::select('processes.*')
+        ->distinct()
+        ->whereHas('requests', function($query) use ($userId) {
+            $query->where('user_id', $userId)
+                ->orWhereHas('tokens', function($query) use ($userId) {
+                    $query->where('user_id', $userId);
+                });
+        })
+        ->where('asset_type', NULL)
+        ->orderBy('processes.name', 'asc')
+        ->paginate($perPage);
+
+        foreach ($processes as $process) {
+            // Get the id bookmark related
+            $process->bookmark_id = Bookmark::getBookmarked($bookmark, $process->id, $user->id);
+            // Get the launchpad configuration
+            $process->launchpad = ProcessLaunchpad::getLaunchpad($launchpad, $process->id);
+        }
+
+        $process = $processes->map(function ($process) {
+            $process->counts = $process->getCounts();
+        });
+
+        return new ProcessCollection($processes);
     }
 }

--- a/resources/js/tasks/components/ProcessesDashboardsMenu.vue
+++ b/resources/js/tasks/components/ProcessesDashboardsMenu.vue
@@ -148,7 +148,7 @@ export default {
      * Build URL for Process Cards
      */
     buildURL() {
-      return `process_bookmarks/processes?
+      return `process_bookmarks/processes/menu?
         &pmql=${encodeURIComponent(this.pmql)}
         &bookmark=true
         &launchpad=true

--- a/routes/api.php
+++ b/routes/api.php
@@ -163,6 +163,8 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     )->name('processes.start.events')->middleware($middlewareCatalog);
     Route::get('process_bookmarks/processes', [ProcessLaunchpadController::class, 'getProcesses'])
         ->name('processes.launchpad.index')->middleware($middlewareCatalog);
+    Route::get('process_bookmarks/processes/menu', [ProcessLaunchpadController::class, 'getProcessesMenu'])
+        ->name('processes.launchpad.menu')->middleware($middlewareCatalog);
     Route::get('process_bookmarks/categories', [ProcessCategoryController::class, 'index'])
         ->name('bookmarks.categories.index')->middleware($middlewareCatalog);
     Route::get('process_bookmarks/{process_category}', [ProcessCategoryController::class, 'show'])


### PR DESCRIPTION
## Solution
- List was modified to show Participant's Processes

## How to Test
- Login with a Admin user
- Create a normal userA and assign Process Catalog permission
- Create a process with Admin process (start event - task - task - end event)
- Assign the userA in the first task
- Create a Case with Admin user
- Login with userA
- Go to Home page
Test Scenario 2
- Login with Admin
- Create more than 10 simple Processes and start one of them at least once
- Check List of Processes in Home page. All processes greater than 10 should be displayed.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-22497

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
