### PR TITLE
FOUR-23139 - Fix SAML configuration

### DIFF
--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -59,8 +59,6 @@ class ProcessMakerServiceProvider extends ServiceProvider
         // Track the start time for service providers boot
         self::$bootStart = microtime(true);
 
-        config()->setApplicationBooted();
-
         $this->app->singleton(Menu::class, function ($app) {
             return new MenuManager();
         });


### PR DESCRIPTION
## Issue & Reproduction Steps
See jira issue. Package auth provider was checking if it was enabled by looking at the Settings DB table but the config proxy wasn't allowing Settings DB calls until the application was fully booted.

## Solution
- Only need to wait for DB instead of full app booted

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23139
- Others too

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
