### PR TITLE
FOUR-22425:Open launch pad remains stuck in alternatives even though Launch pad settings have already been configured

### DIFF
--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -396,6 +396,16 @@ export default {
     saveLaunchpadSettings(data) {
       if (window.ProcessMaker.modeler) {
         window.ProcessMaker.modeler.launchpad = data;
+        this.saveLaunchpadSettingsAlternatives(data);
+      }
+    },
+    /**
+     * Save Launchpad Settings in all alternatives
+     */
+    saveLaunchpadSettingsAlternatives(data) {
+      if (window.parent[0]?.ProcessMaker?.modeler && window.parent[1]?.ProcessMaker?.modeler) {
+        window.parent[0].ProcessMaker.modeler.launchpad = data;
+        window.parent[1].ProcessMaker.modeler.launchpad = data;
       }
     },
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Add some elements
3. Create an alternative B
4. Click on publish button 
5. Configure the Launch pad settings 
6. Go to alternative B 
7. Click on Open Launch pad 

**Current Behavior**
Open launch pad remains stuck in alternatives even though Launch pad settings have already been configured 

**Expected Behavior**
There should be possible to launch pad in alternatives after configure the launch pad


## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22425

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy