### PR TITLE
observation/FOUR-23376 `Add to bundle` option is not displayed in the Dashboards and Menus tabs

### DIFF
--- a/resources/js/components/shared/AddToBundle.vue
+++ b/resources/js/components/shared/AddToBundle.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { getCurrentInstance, onMounted, ref, defineProps } from 'vue';
+import { getCurrentInstance, onMounted, ref, defineProps, onBeforeUnmount } from 'vue';
 import BackendSelect from './BackendSelect.vue';
 
 const props = defineProps({
@@ -23,12 +23,20 @@ const selected = ref(null);
 const assetId = ref(null);
 const error = ref(null);
 const assetName = ref(null);
-vue.$root.$on('add-to-bundle', (data) => {
-  selected.value = null;
-  error.value = null;
-  assetId.value = data.id;
-  assetName.value = data.name || data.title;
-  modal.value.show();
+onMounted(() => {
+  vue.$root.$on('add-to-bundle', (data) => {
+    selected.value = null;
+    error.value = null;
+    assetId.value = data.id;
+    assetName.value = data.name || data.title;
+    vue.$nextTick(() => {
+      modal.value.show();
+    });
+  });
+});
+
+onBeforeUnmount(() => {
+  vue.$root.$off('add-to-bundle');
 });
 
 const save = (event) => {


### PR DESCRIPTION
## Issue & Reproduction Steps
`Add to bundle` option is not displayed in the Dashboards and Menus tabs

## Solution
Added the add-to-bundle listener on mounted

## How to Test
Go to server 
ProcessMaker Platform Spring 2025 version 4.14.0+beta-2 (Build #dfc96dcd)
Go to Admin > Customize UI > Dashboards or Admin > Customize UI > Menus
Open the ellipsis

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23376
