### PR TITLE
observation/FOUR-23373 Different message is displayed instead of `Added successfully to bundle`

### DIFF
--- a/resources/js/admin/auth-clients/components/AuthClientsListing.vue
+++ b/resources/js/admin/auth-clients/components/AuthClientsListing.vue
@@ -47,10 +47,6 @@
           {{ props.rowData.secret.substr(0, 10) }}...
         </template>
       </vuetable>
-      <add-to-bundle
-        asset-type="auth_clients"
-        :setting="true"
-      />
       <pagination
         :single="$t('Auth Client')"
         :plural="$t('Auth Clients')"
@@ -68,12 +64,11 @@
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
-import AddToBundle from "../../../components/shared/AddToBundle.vue";
 import { createUniqIdsMixin } from "vue-uniq-ids";
 const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
-  components: {EllipsisMenu, AddToBundle},
+  components: {EllipsisMenu},
   mixins: [datatableMixin, dataLoadingMixin, uniqIdsMixin],
   props: ["filter", "permission"],
   data() {
@@ -88,7 +83,6 @@ export default {
       ],
       actions: [
         { value: "edit-item", content: "Edit Auth Client", icon: "fas fa-pen-square", ariaDescribedBy: 'data.id'},
-        { value: "add-to-bundle", content: "Add to Bundle", icon: "fp-add-outlined", permission: "admin", emit_on_root: 'add-to-bundle'},
         { value: "delete-item", content: "Delete Auth Client", icon: "fas fa-trash-alt",  ariaDescribedBy: 'data.id'},
       ],
       fields: [

--- a/resources/js/components/shared/AddToBundle.vue
+++ b/resources/js/components/shared/AddToBundle.vue
@@ -41,7 +41,7 @@ const save = (event) => {
         type: props.settingType || null
       })
         .then(() => {
-          window.ProcessMaker.alert(vue.$t('Setting added to bundle'), 'success');
+          window.ProcessMaker.alert(vue.$t('Added successfully to bundle'), 'success');
         });
     } else {
       const asset = {
@@ -50,7 +50,7 @@ const save = (event) => {
       };
       window.ProcessMaker.apiClient.post(`devlink/local-bundles/${selected.value.id}/add-assets`, asset).then(() => {
         modal.value.hide();
-        window.ProcessMaker.alert(vue.$t('Asset added to bundle'), 'success');
+        window.ProcessMaker.alert(vue.$t('Added successfully to bundle'), 'success');
       }).catch(e => {
         error.value = e.response?.data?.error?.message || e.message;
       })
@@ -70,7 +70,7 @@ const save = (event) => {
       };
       window.ProcessMaker.apiClient.post(`devlink/local-bundles/add-setting-to-bundles`, setting).then(() => {
         modal.value.hide();
-        window.ProcessMaker.alert(vue.$t('Setting added to bundle'), 'success');
+        window.ProcessMaker.alert(vue.$t('Added successfully to bundle'), 'success');
       }).catch(e => {
         error.value = e.response?.data?.error?.message || e.message;
       });
@@ -82,7 +82,7 @@ const save = (event) => {
       };
       window.ProcessMaker.apiClient.post(`devlink/local-bundles/add-asset-to-bundles`, asset).then(() => {
         modal.value.hide();
-        window.ProcessMaker.alert(vue.$t('Asset added to bundle'), 'success');
+        window.ProcessMaker.alert(vue.$t('Added successfully to bundle'), 'success');
       }).catch(e => {
         error.value = e.response?.data?.error?.message || e.message;
       });


### PR DESCRIPTION
## Issue & Reproduction Steps
Different message is displayed instead of `Added successfully to bundle`

## Solution
Changed the add to bundle message displayed and removed the add to bundle from auth clients

## How to Test
Go to server
ProcessMaker Platform Spring 2025 version 4.14.0+beta-1 (Build #131e867d)
Go to Admin > devlink > local bundle
Create a bundle
Go to Admin/users page or any page where an asset can be added to a bundle
Select the bundle
Press Save button
Wait for the message

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23373

