### PR TITLE
FOUR-22485: Open launchpad buttons appears templates edit

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -69,6 +69,7 @@ import CreateTemplateModal from "../../../components/templates/CreateTemplateMod
 import CreatePmBlockModal from "../../../components/pm-blocks/CreatePmBlockModal.vue";
 import autosaveMixins from "../../../modules/autosave/mixins";
 import AssetRedirectMixin from "../../../components/shared/AssetRedirectMixin";
+import LaunchpadButton from "./toprail/launchpad/LaunchpadButton.vue";
 
 export default {
   name: "ModelerApp",
@@ -88,7 +89,10 @@ export default {
   data() {
     return {
       self: this,
-      validationBar: [],
+      validationBar: [{
+        button: LaunchpadButton,
+        props: { isTemplate: !!window.ProcessMaker.modeler.process.is_template },
+      }],
       external: [],
       externalEmit: [],
       dataXmlSvg: {},

--- a/resources/js/processes/modeler/components/toprail/launchpad/LaunchpadButton.vue
+++ b/resources/js/processes/modeler/components/toprail/launchpad/LaunchpadButton.vue
@@ -1,0 +1,63 @@
+<template>
+  <div v-if="!isTemplate">
+    <button
+      v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
+      type="button"
+      class="btn btn-white"
+      :title="$t('Open Launchpad')"
+      data-cy="launchpad-button"
+      @mouseleave="handleMouseLeave"
+      @mouseover="handleMouseOver"
+      @click.prevent="handleOpenLaunchpad"
+    >
+      <i :class="iconOpen" />
+    </button>
+    <launchpad-modal
+      :show="showLaunchpadModal"
+      @closeModal="closeModal"
+    />
+  </div>
+</template>
+
+<script>
+import LaunchpadModal from "./LaunchpadModal.vue";
+
+export default {
+  components: {
+    LaunchpadModal,
+  },
+  props: {
+    isTemplate: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      iconOpen: "fas fa-play",
+      showLaunchpadModal: false,
+      openLaunchpad: false,
+    };
+  },
+  methods: {
+    handleMouseOver() {
+      this.iconOpen = "fas fa-external-link-alt";
+    },
+    handleMouseLeave() {
+      this.iconOpen = "fas fa-play";
+    },
+    handleOpenLaunchpad(value) {
+      this.openLaunchpad = value;
+      if (this.openLaunchpad) {
+        this.showLaunchpadModal = true;
+      } else {
+        this.openLaunchpad = false;
+        window.location.href = `/process-browser/${window.ProcessMaker.modeler.process.id}`;
+      }
+    },
+    closeModal() {
+      this.showLaunchpadModal = false;
+    },
+  },
+};
+</script>

--- a/resources/js/processes/modeler/components/toprail/launchpad/LaunchpadButton.vue
+++ b/resources/js/processes/modeler/components/toprail/launchpad/LaunchpadButton.vue
@@ -46,8 +46,8 @@ export default {
     handleMouseLeave() {
       this.iconOpen = "fas fa-play";
     },
-    handleOpenLaunchpad(value) {
-      this.openLaunchpad = value;
+    handleOpenLaunchpad() {
+      this.openLaunchpad = window.ProcessMaker.modeler.launchpad === null;
       if (this.openLaunchpad) {
         this.showLaunchpadModal = true;
       } else {

--- a/resources/js/processes/modeler/components/toprail/launchpad/LaunchpadModal.vue
+++ b/resources/js/processes/modeler/components/toprail/launchpad/LaunchpadModal.vue
@@ -1,0 +1,48 @@
+<template>
+  <b-modal
+    ref="launchpad-modal"
+    :title="$t('You have not publish your process')"
+    @hide="closeModal"
+  >
+    <p>
+      {{ $t('You have not published your process. Please publish your process to use the Launchpad.') }}
+    </p>
+    <template #modal-footer>
+      <b-button
+        variant="primary"
+        size="sm"
+        class="float-right"
+        @click="closeModal"
+      >
+        {{ $t('Cancel') }}
+      </b-button>
+    </template>
+  </b-modal>
+</template>
+
+<script>
+export default {
+  props: {
+    show: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  watch: {
+    show(value) {
+      if (value) {
+        this.$refs['launchpad-modal'].show();
+      }
+    },
+  },
+  methods: {
+    closeModal() {
+      this.$emit('closeModal');
+      this.$refs['launchpad-modal'].hide();
+    },
+  },
+  showModal() {
+    this.$refs['launchpad-modal'].show();
+  },
+};
+</script>

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2630,6 +2630,7 @@
   "You have made no requests of this process.": "You have made no requests of this process.",
   "You have no tasks from this process.": "You have no tasks from this process.",
   "You have to start a Case of this process.": "You have to start a Case of this process.",
+  "You have not published your process. Please publish your process to use the Launchpad.": "You have not published your process. Please publish your process to use the Launchpad.",
   "You haven't set up any Inbox Rules yet": "You haven't set up any Inbox Rules yet",
   "You must authorize your account before configuring folders": "You must authorize your account before configuring folders",
   "You must have your database credentials available in order to continue.": "You must have your database credentials available in order to continue.",


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process
2. Search the process
3. Create a template of the process
4. Search the template 
5. Edit the template 
6. Search “Open Launch Pad“ button

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22485

## PR packages
https://github.com/ProcessMaker/modeler/pull/1910

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
