### PR TITLE
FOUR-22703

### DIFF
--- a/resources/js/tasks/edit.js
+++ b/resources/js/tasks/edit.js
@@ -4,12 +4,14 @@ import TaskSavePanel from "./components/TaskSavePanel.vue";
 import autosaveMixins from "../modules/autosave/autosaveMixin";
 import draftFileUploadMixin from "../modules/autosave/draftFileUploadMixin";
 import reassignMixin from "../common/reassignMixin";
+import translator from "../modules/lang.js";
 
 Vue.mixin(autosaveMixins);
 Vue.mixin(draftFileUploadMixin);
 Vue.mixin(reassignMixin);
 Vue.component("DataTreeToggle", () => import("../components/common/data-tree-toggle.vue"));
 Vue.component("TreeView", () => import("../components/TreeView.vue"));
+window.__ = translator;
 
 const main = new Vue({
   el: "#task",


### PR DESCRIPTION
## Steps to Reproduce:
- Create an user with manager in USER configuration
- Create a process
- Add Start Event → Task → End Event
- Configure the task form with "Assignee manager escalation"
- Create a cases
- Route to the task open the task 
- Click on ESCALATE TO MANAGER button 

## Current Behavior:
It is not possible to Escalate to manager with "Assignee Manager Escalation"

## Caused by and the solution:
The way the script elements are loaded has changed, so the corresponding missing definition is added.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-22703