### PR TITLE
FOUR-23418 - Update "retry_after" for redis queue

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -66,7 +66,7 @@ return [
             'driver' => 'redis',
             'connection' => 'default',
             'queue' => env('REDIS_QUEUE', 'default'),
-            'retry_after' => 630,
+            'retry_after' => 86400,
             'block_for' => null,
             'after_commit' => false,
         ],


### PR DESCRIPTION
## Issue & Reproduction Steps
Long running scripts are re-running clobbering each other even though the timeout was set high (or unlimited)

From the laravel docs

> The --timeout value should always be at least several seconds shorter than your retry_after configuration value. This will ensure that a worker processing a frozen job is always terminated before the job is retried. If your --timeout option is longer than your retry_after configuration value, your jobs may be processed twice.

Our timeouts are variable and there's no documentation on what happens if retry_after is set to null or 0 so I set it to a reasonable maximum of 1 day.

## Solution
- Increase the redis retry_after setting to 1 day

## How to Test
Run a script with a 700 second sleep and a 900 second timeout. Look at the logs. Make sure it doesn't re-run after 630 seconds like it did before.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23418

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
