### PR TITLE
The "Create your missing assets with AI" message is not displayed when a process is generated with AI Assistant from a project.

### DIFF
--- a/resources/js/processes/components/CreateProcessModal.vue
+++ b/resources/js/processes/components/CreateProcessModal.vue
@@ -323,19 +323,21 @@ export default {
     getRedirectUrlForAi(processId) {
       let redirectUrl = `/modeler/${processId}`;
 
-      if (this.isAiGenerated) {
-        redirectUrl += "?ai=true";
-      }
-
-      return redirectUrl;
+      return this.redirectUrlWithAi(redirectUrl);
     },
     handleRedirection(url, data) {
       if (this.callFromAiModeler) {
-        const redirectUrl = `/package-ai/processes/create/${data.id}`;
+        const redirectUrl = this.redirectUrlWithAi(`/package-ai/processes/create/${data.id}`);
         this.$emit("process-created-from-modeler", redirectUrl, data.id, data.name);
       } else {
-        window.location.href = url;
+        window.location.href = this.redirectUrlWithAi(url);
       }
+    },
+    redirectUrlWithAi(url) {
+      if (this.isAiGenerated) {
+        url += "?ai=true";
+      }
+      return url;
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
The menu to generate assets is not displayed because the ai=true flag is not present in the URL.

## Solution
- Validate parameter ai Generated

## How to Test
steps in the ticket

## Related Tickets & Packages
- [FOUR-22817](https://processmaker.atlassian.net/browse/FOUR-22817)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22817]: https://processmaker.atlassian.net/browse/FOUR-22817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ