### PR TITLE
FOUR-22636: Cloned tasks with notifications have Assigned and due by default, even when these have been modified

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -279,8 +279,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
             return new HasMany($this->newQuery(), $this, '', '');
         }
 
-        return $this->belongsToMany(
-            'ProcessMaker\Package\Projects\Models\Project',
+        return $this->belongsToMany('ProcessMaker\Package\Projects\Models\Project',
             'project_assets',
             'asset_id',
             'project_id',
@@ -292,20 +291,15 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
     // Define the relationship with the ProjectAsset model
     public function projectAssets()
     {
-        return $this->belongsToMany(
-            'ProcessMaker\Package\Projects\Models\ProjectAsset',
-            'project_assets',
-            'asset_id',
-            'project_id'
-        )
+        return $this->belongsToMany('ProcessMaker\Package\Projects\Models\ProjectAsset',
+            'project_assets', 'asset_id', 'project_id')
             ->withPivot('asset_type')
             ->wherePivot('asset_type', static::class)->withTimestamps();
     }
 
     public function projectAsset()
     {
-        return $this->belongsToMany(
-            'ProcessMaker\Package\Projects\Models\ProjectAsset',
+        return $this->belongsToMany('ProcessMaker\Package\Projects\Models\ProjectAsset',
             'project_assets',
             'asset_id',
             'project_id',
@@ -717,7 +711,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
                 if ($escalateToManager) {
                     $user = WorkflowUserManager::escalateToManager($token, $user);
                 } else {
-                    $res = (new WorkflowManagerDefault())->runProcess($assignmentProcess, 'assign', [
+                    $res = (new WorkflowManagerDefault)->runProcess($assignmentProcess, 'assign', [
                         'user_id' => $user,
                         'process_id' => $this->id,
                         'request_id' => $token->getInstance()->getId(),
@@ -1662,7 +1656,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
             $schemaErrors = $document->getValidationErrors();
             $schemaErrors[] = $e->getMessage();
         }
-        $rulesValidation = new BPMNValidation();
+        $rulesValidation = new BPMNValidation;
         if (!$rulesValidation->passes('document', $document)) {
             $errors = $rulesValidation->errors('document', $document)->getMessages();
             $schemaErrors[] = [

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -226,6 +226,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         'assigned',
         'completed',
         'due',
+        'default'
     ];
 
     protected $appends = [
@@ -278,7 +279,8 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
             return new HasMany($this->newQuery(), $this, '', '');
         }
 
-        return $this->belongsToMany('ProcessMaker\Package\Projects\Models\Project',
+        return $this->belongsToMany(
+            'ProcessMaker\Package\Projects\Models\Project',
             'project_assets',
             'asset_id',
             'project_id',
@@ -290,15 +292,20 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
     // Define the relationship with the ProjectAsset model
     public function projectAssets()
     {
-        return $this->belongsToMany('ProcessMaker\Package\Projects\Models\ProjectAsset',
-            'project_assets', 'asset_id', 'project_id')
+        return $this->belongsToMany(
+            'ProcessMaker\Package\Projects\Models\ProjectAsset',
+            'project_assets',
+            'asset_id',
+            'project_id'
+        )
             ->withPivot('asset_type')
             ->wherePivot('asset_type', static::class)->withTimestamps();
     }
 
     public function projectAsset()
     {
-        return $this->belongsToMany('ProcessMaker\Package\Projects\Models\ProjectAsset',
+        return $this->belongsToMany(
+            'ProcessMaker\Package\Projects\Models\ProjectAsset',
             'project_assets',
             'asset_id',
             'project_id',
@@ -710,7 +717,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
                 if ($escalateToManager) {
                     $user = WorkflowUserManager::escalateToManager($token, $user);
                 } else {
-                    $res = (new WorkflowManagerDefault)->runProcess($assignmentProcess, 'assign', [
+                    $res = (new WorkflowManagerDefault())->runProcess($assignmentProcess, 'assign', [
                         'user_id' => $user,
                         'process_id' => $this->id,
                         'request_id' => $token->getInstance()->getId(),
@@ -1655,7 +1662,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
             $schemaErrors = $document->getValidationErrors();
             $schemaErrors[] = $e->getMessage();
         }
-        $rulesValidation = new BPMNValidation;
+        $rulesValidation = new BPMNValidation();
         if (!$rulesValidation->passes('document', $document)) {
             $errors = $rulesValidation->errors('document', $document)->getMessages();
             $schemaErrors[] = [

--- a/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
@@ -320,14 +320,11 @@ export default {
       this.managerDue = this.notifications?.manager.due;
     },
     updateNotifications() {
-      if (this.node.notifications === undefined) {
-        if (this.process.task_notifications[this.nodeId] === undefined) {
-          this.node.notifications = this.createNewNotification();
-        } else {
-          this.node.notifications = this.process.task_notifications[this.nodeId];
-        }
-      } else if (this.process.task_notifications[this.nodeId]) {
+      if (this.process.task_notifications[this.nodeId]) {
         this.node.notifications = this.process.task_notifications[this.nodeId];
+      } else if (this.node.notifications === undefined) {
+        const newNotifications = this.createNewNotification();
+        this.node.notifications = newNotifications;
       }
       this.notifications = this.node.notifications;
     },
@@ -335,7 +332,7 @@ export default {
       let type = "task";
       const cloneOf = this.getNode(this.node.cloneOf);
       if (this.node.cloneOf && cloneOf) {
-        return cloneOf.notifications;
+        return structuredClone(cloneOf.notifications);
       }
       if (this.node.type === "processmaker-modeler-manual-task") {
         type = "manual_task";

--- a/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
@@ -2,18 +2,6 @@
   <div>
     <div class="form-group">
       <div class="notification-settings-group">
-        <div class="custom-control custom-switch d-none">
-          <input
-            id="notify-default"
-            v-model="defaultNotification"
-            type="checkbox"
-            class="custom-control-input"
-          >
-          <label
-            class="custom-control-label"
-            for="notify-default"
-          >{{ $t('Default') }}</label>
-        </div>
         <div class="notification-settings-header">
           {{ $t('Requester') }}
         </div>

--- a/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
@@ -320,13 +320,9 @@ export default {
       this.managerDue = this.notifications?.manager.due;
     },
     updateNotifications() {
-      let type = "task";
       if (this.node.notifications === undefined) {
         if (this.process.task_notifications[this.nodeId] === undefined) {
-          if (this.node.type === "processmaker-modeler-manual-task") {
-            type = "manual_task";
-          }
-          this.node.notifications = new NotificationTemplate(type);
+          this.node.notifications = this.createNewNotification();
         } else {
           this.node.notifications = this.process.task_notifications[this.nodeId];
         }
@@ -334,6 +330,20 @@ export default {
         this.node.notifications = this.process.task_notifications[this.nodeId];
       }
       this.notifications = this.node.notifications;
+    },
+    createNewNotification() {
+      let type = "task";
+      const cloneOf = this.getNotification(this.node.cloneOf);
+      if (this.node.cloneOf && cloneOf) {
+        return cloneOf.notifications;
+      }
+      if (this.node.type === "processmaker-modeler-manual-task") {
+        type = "manual_task";
+      }
+      return new NotificationTemplate(type);
+    },
+    getNotification(nodeId) {
+      return this.$root.$children[0].$refs.modeler.nodes.find((node) => node.definition.id === nodeId);
     },
   },
 };

--- a/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
@@ -333,7 +333,7 @@ export default {
     },
     createNewNotification() {
       let type = "task";
-      const cloneOf = this.getNotification(this.node.cloneOf);
+      const cloneOf = this.getNode(this.node.cloneOf);
       if (this.node.cloneOf && cloneOf) {
         return cloneOf.notifications;
       }
@@ -342,7 +342,7 @@ export default {
       }
       return new NotificationTemplate(type);
     },
-    getNotification(nodeId) {
+    getNode(nodeId) {
       return this.$root.$children[0].$refs.modeler.nodes.find((node) => node.definition.id === nodeId);
     },
   },

--- a/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
@@ -2,6 +2,18 @@
   <div>
     <div class="form-group">
       <div class="notification-settings-group">
+        <div class="custom-control custom-switch d-none">
+          <input
+            id="notify-default"
+            v-model="defaultNotification"
+            type="checkbox"
+            class="custom-control-input"
+          >
+          <label
+            class="custom-control-label"
+            for="notify-default"
+          >{{ $t('Default') }}</label>
+        </div>
         <div class="notification-settings-header">
           {{ $t('Requester') }}
         </div>
@@ -182,6 +194,7 @@ class NotificationTemplate {
       assigned: type === "task",
       completed: false,
       due: type === "task",
+      default: false,
     };
     this.participants = {
       assigned: false,
@@ -215,6 +228,7 @@ export default {
       managerAssigned: false,
       managerCompleted: false,
       managerDue: false,
+      defaultNotification: false,
     };
   },
   computed: {
@@ -239,61 +253,73 @@ export default {
     requesterAssigned(value) {
       if (this.notifications) {
         this.notifications.requester.assigned = value;
+        this.verifyNotifications();
       }
     },
     requesterCompleted(value) {
       if (this.notifications) {
         this.notifications.requester.completed = value;
+        this.verifyNotifications();
       }
     },
     requesterDue(value) {
       if (this.notifications) {
         this.notifications.requester.due = value;
+        this.verifyNotifications();
       }
     },
     assigneeAssigned(value) {
       if (this.notifications) {
         this.notifications.assignee.assigned = value;
+        this.verifyNotifications();
       }
     },
     assigneeCompleted(value) {
       if (this.notifications) {
         this.notifications.assignee.completed = value;
+        this.verifyNotifications();
       }
     },
     assigneeDue(value) {
       if (this.notifications) {
         this.notifications.assignee.due = value;
+        this.verifyNotifications();
       }
     },
     participantsAssigned(value) {
       if (this.notifications) {
         this.notifications.participants.assigned = value;
+        this.verifyNotifications();
       }
     },
     participantsCompleted(value) {
       if (this.notifications) {
         this.notifications.participants.completed = value;
+        this.verifyNotifications();
       }
     },
     participantsDue(value) {
       if (this.notifications) {
         this.notifications.participants.due = value;
+        this.verifyNotifications();
       }
     },
     managerAssigned(value) {
       if (this.notifications) {
         this.notifications.manager.assigned = value;
+        this.verifyNotifications();
       }
     },
     managerCompleted(value) {
       if (this.notifications) {
         this.notifications.manager.completed = value;
+        this.verifyNotifications();
       }
     },
     managerDue(value) {
       if (this.notifications) {
         this.notifications.manager.due = value;
+        this.verifyNotifications();
       }
     },
     modelerId() {
@@ -318,6 +344,7 @@ export default {
       this.managerAssigned = this.notifications?.manager.assigned;
       this.managerCompleted = this.notifications?.manager.completed;
       this.managerDue = this.notifications?.manager.due;
+      this.defaultNotification = this.notifications?.assignee.default;
     },
     updateNotifications() {
       if (this.process.task_notifications[this.nodeId]) {
@@ -341,6 +368,21 @@ export default {
     },
     getNode(nodeId) {
       return this.$root.$children[0].$refs.modeler.nodes.find((node) => node.definition.id === nodeId);
+    },
+    /**
+     * Verify if there are any notifications enabled to set a default value in true
+     */
+    verifyNotifications() {
+      let flag = false;
+
+      for (const prop in this.notifications) {
+        if (this.notifications[prop].assigned || this.notifications[prop].completed || this.notifications[prop].due) {
+          flag = true;
+          break;
+        }
+      }
+
+      this.notifications.assignee.default = !flag;
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process 
2. Add task form 
3. Click on form task 
4. Click on Notifications 
5. Unchecked (Assigned and Due), Could select other 
6. Clone or copy the element
7. Check the notifications of the element cloned
8. Refresh and review the values

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22636

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
