### PR TITLE
FOUR-23441: Errors occur when importing a process that has a select l…

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -371,9 +371,18 @@ abstract class ExporterBase implements ExporterInterface
             }
         } elseif ($model->translations && $model->language_code) {
             // Get the translations for the model translatable
-            $translatedLanguages[$model->language_code] = $availableLanguages->filter(function ($language) use ($model) {
-                return $language->code === $model->language_code;
-            })->first()->name;
+            \Log::info('--------------------------------');
+            \Log::info('model class', [get_class($model)]);
+            //\Log::info('model translations', [$model->translations]);
+            \Log::info('model language_code', [$model->language_code]);
+            \Log::info('--------------------------------');
+
+            if ($model::class !== \ProcessMaker\Package\Translations\Models\Translatable::class) {
+                // Get the translations for the model translatable
+                $translatedLanguages[$model->language_code] = $availableLanguages->filter(function ($language) use ($model) {
+                    return $language->code === $model->language_code;
+                })->first()->name;
+            }
         }
 
         return [

--- a/ProcessMaker/ImportExport/Exporters/ExporterBase.php
+++ b/ProcessMaker/ImportExport/Exporters/ExporterBase.php
@@ -371,18 +371,9 @@ abstract class ExporterBase implements ExporterInterface
             }
         } elseif ($model->translations && $model->language_code) {
             // Get the translations for the model translatable
-            \Log::info('--------------------------------');
-            \Log::info('model class', [get_class($model)]);
-            //\Log::info('model translations', [$model->translations]);
-            \Log::info('model language_code', [$model->language_code]);
-            \Log::info('--------------------------------');
-
-            if ($model::class !== \ProcessMaker\Package\Translations\Models\Translatable::class) {
-                // Get the translations for the model translatable
-                $translatedLanguages[$model->language_code] = $availableLanguages->filter(function ($language) use ($model) {
-                    return $language->code === $model->language_code;
-                })->first()->name;
-            }
+            $translatedLanguages[$model->language_code] = $availableLanguages->filter(function ($language) use ($model) {
+                return $language->code === $model->language_code;
+            })->first()->name;
         }
 
         return [

--- a/ProcessMaker/Observers/SettingObserver.php
+++ b/ProcessMaker/Observers/SettingObserver.php
@@ -107,14 +107,9 @@ class SettingObserver
      */
     private function updateConfigurationCache(Setting $setting): void
     {
-        if (app()->environment() === 'testing') {
-            return;
-        }
-
         if (app()->configurationIsCached() && $setting->config !== config([$setting->key])) {
             config([$setting->key => $setting->config]);
-
-            \Artisan::call('config:cache');
+            // \Artisan::call('config:cache');
         }
     }
 }


### PR DESCRIPTION

## Issue & Reproduction Steps
As we can see, when our screen has a select list with a data connector, the process cannot be imported and an error appears on the screen.



## Solution
- 

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
