### PR TITLE
Resolve Process Creation Error for Templates with Signal Events

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TemplateController.php
+++ b/ProcessMaker/Http/Controllers/Api/TemplateController.php
@@ -288,8 +288,10 @@ class TemplateController extends Controller
                 continue;
             }
 
-            if ($payload['root'] === $asset['attributes']['uuid']
-                || Str::contains($asset['type'], 'Category')
+            $skipTypes = ['Category', 'Signal'];
+
+            if ($payload['root'] === ($asset['attributes']['uuid'] ?? null)
+                || Str::contains($asset['type'], $skipTypes)
                 || !$asset['model']::where('uuid', $key)->exists()
             ) {
                 continue;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves an issue where creating a process from a template containing a signal event resulted in errors.
The errors occurred due to:

- Attempting to check for existing assets using a UUID on a BPMN signal, which it did not contain.
- Running a `where` query on a Signal model that doesn't exist.


## Solution
Signals are now treated as assets to skip during the validation process. This bypasses unnecessary checks, allowing the process creation to proceed without errors.


## How to Test
Describe how to test that this solution works.

1. Import the provided process template.
2. Create a process using the imported template.
3. Verify that no errors occur during the process creation.
4. Confirm that the process is created successfully and behaves as expected.


[process_script_b.json.txt](https://github.com/user-attachments/files/19372958/process_script_b.json.txt)


## Related Tickets & Packages
[FOUR-23372](https://processmaker.atlassian.net/browse/FOUR-23372)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-23372]: https://processmaker.atlassian.net/browse/FOUR-23372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ