### PR TITLE
FOUR-22377 SettingCache for null values

### DIFF
--- a/ProcessMaker/Cache/CacheManagerBase.php
+++ b/ProcessMaker/Cache/CacheManagerBase.php
@@ -98,7 +98,7 @@ abstract class CacheManagerBase
     public function keyExists(string $key, ?string $connection = null, ?string $prefix = null): bool
     {
         if (!$connection) {
-            $connection = config('cache.default');
+            $connection = config('cache.stores.cache_settings.connection');
         }
 
         if (!$this->checkAvailableConnections($connection)) {

--- a/ProcessMaker/Cache/CacheManagerBase.php
+++ b/ProcessMaker/Cache/CacheManagerBase.php
@@ -16,6 +16,36 @@ abstract class CacheManagerBase
     protected const AVAILABLE_CONNECTIONS = ['redis', 'cache_settings'];
 
     /**
+     * Check if a connection is available.
+     *
+     * @param string $connection The connection to check.
+     *
+     * @return bool True if the connection is available, false otherwise.
+     */
+    private function checkAvailableConnections(string $connection): bool
+    {
+        return in_array($connection, self::AVAILABLE_CONNECTIONS);
+    }
+
+    /**
+     * Get the prefix for a specific connection.
+     *
+     * @param string $connection The connection to get the prefix for.
+     *
+     * @return string The prefix for the connection.
+     */
+    private function getPrefix(string $connection): string
+    {
+        $prefix = config('cache.prefix');
+
+        if ($connection === 'cache_settings') {
+            $prefix = config('cache.stores.' . $connection . '.prefix');
+        }
+
+        return $prefix;
+    }
+
+    /**
      * Retrieve an array of cache keys that match a specific pattern.
      *
      * @param string $pattern The pattern to match.
@@ -23,18 +53,18 @@ abstract class CacheManagerBase
      *
      * @return array An array of cache keys that match the pattern.
      */
-    public function getKeysByPattern(string $pattern, string $connection = null, string $prefix = null): array
+    public function getKeysByPattern(string $pattern, ?string $connection = null, ?string $prefix = null): array
     {
         if (!$connection) {
             $connection = config('cache.default');
         }
 
-        if (!$prefix) {
-            $prefix = config('cache.prefix');
+        if (!$this->checkAvailableConnections($connection)) {
+            throw new CacheManagerException('`getKeysByPattern` method only supports Redis connections.');
         }
 
-        if (!in_array($connection, self::AVAILABLE_CONNECTIONS)) {
-            throw new CacheManagerException('`getKeysByPattern` method only supports Redis connections.');
+        if (!$prefix) {
+            $prefix = $this->getPrefix($connection);
         }
 
         try {
@@ -54,5 +84,37 @@ abstract class CacheManagerBase
         }
 
         return [];
+    }
+
+    /**
+     * Check if a key exists in the cache.
+     *
+     * @param string $key The key to check.
+     * @param string|null $connection The cache connection to use.
+     * @param string|null $prefix The cache prefix to use.
+     *
+     * @return bool True if the key exists, false otherwise.
+     */
+    public function keyExists(string $key, ?string $connection = null, ?string $prefix = null): bool
+    {
+        if (!$connection) {
+            $connection = config('cache.default');
+        }
+
+        if (!$this->checkAvailableConnections($connection)) {
+            return false;
+        }
+
+        if (!$prefix) {
+            $prefix = $this->getPrefix($connection);
+        }
+
+        try {
+            return Redis::connection($connection)->exists($prefix . $key);
+        } catch (Exception $e) {
+            Log::info('CacheManagerBase: ' . $e->getMessage());
+        }
+
+        return false;
     }
 }

--- a/ProcessMaker/Cache/Settings/SettingCacheManager.php
+++ b/ProcessMaker/Cache/Settings/SettingCacheManager.php
@@ -198,7 +198,7 @@ class SettingCacheManager extends CacheManagerBase implements CacheInterface
      */
     public function has(string $key): bool
     {
-        return $this->cacheManager->has($key);
+        return $this->keyExists($key);
     }
 
     /**

--- a/tests/Feature/Cache/CacheManagerBaseTest.php
+++ b/tests/Feature/Cache/CacheManagerBaseTest.php
@@ -109,40 +109,42 @@ class CacheManagerBaseTest extends TestCase
 
     public function testKeyExistsWithValidKey()
     {
-        config()->set('cache.default', 'cache_settings');
-
         $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
 
         $key = 'valid-key';
+        $connection = 'cache_settings';
+        $prefix = 'settings:';
 
         Redis::shouldReceive('connection')
+            ->with($connection)
             ->andReturnSelf();
 
         Redis::shouldReceive('exists')
-            ->with('settings:' . $key)
+            ->with($prefix . $key)
             ->andReturn(true);
 
-        $result = $this->cacheManagerBase->keyExists($key);
+        $result = $this->cacheManagerBase->keyExists($key, $connection, $prefix);
 
         $this->assertTrue($result);
     }
 
     public function testKeyExistsWithInvalidKey()
     {
-        config()->set('cache.default', 'cache_settings');
-
         $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
 
         $key = 'invalid-key';
+        $connection = 'cache_settings';
+        $prefix = 'settings:';
 
         Redis::shouldReceive('connection')
+            ->with($connection)
             ->andReturnSelf();
 
         Redis::shouldReceive('exists')
-            ->with('settings:' . $key)
+            ->with($prefix . $key)
             ->andReturn(false);
 
-        $result = $this->cacheManagerBase->keyExists($key);
+        $result = $this->cacheManagerBase->keyExists($key, $connection, $prefix);
 
         $this->assertFalse($result);
     }
@@ -161,24 +163,25 @@ class CacheManagerBaseTest extends TestCase
 
     public function testKeyExistsWithExceptionDuringRedisCall()
     {
-        config()->set('cache.default', 'cache_settings');
-
         $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
 
         $key = 'some-key';
+        $connection = 'cache_settings';
+        $prefix = 'settings:';
 
         Redis::shouldReceive('connection')
+            ->with($connection)
             ->andReturnSelf();
 
         Redis::shouldReceive('exists')
-            ->with('settings:' . $key)
+            ->with($prefix . $key)
             ->andThrow(new Exception('Redis error'));
 
         Log::shouldReceive('info')
             ->with('CacheManagerBase: Redis error')
             ->once();
 
-        $result = $this->cacheManagerBase->keyExists($key);
+        $result = $this->cacheManagerBase->keyExists($key, $connection, $prefix);
 
         $this->assertFalse($result);
     }

--- a/tests/Feature/Cache/CacheManagerBaseTest.php
+++ b/tests/Feature/Cache/CacheManagerBaseTest.php
@@ -106,4 +106,80 @@ class CacheManagerBaseTest extends TestCase
 
         $this->assertCount(0, $result);
     }
+
+    public function testKeyExistsWithValidKey()
+    {
+        $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
+
+        $key = 'valid-key';
+        $connection = 'cache_settings';
+
+        Redis::shouldReceive('connection')
+            ->with($connection)
+            ->andReturnSelf();
+
+        Redis::shouldReceive('exists')
+            ->with('settings:' . $key)
+            ->andReturn(true);
+
+        $result = $this->cacheManagerBase->keyExists($key, $connection);
+
+        $this->assertTrue($result);
+    }
+
+    public function testKeyExistsWithInvalidKey()
+    {
+        $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
+
+        $key = 'invalid-key';
+        $connection = 'cache_settings';
+
+        Redis::shouldReceive('connection')
+            ->with($connection)
+            ->andReturnSelf();
+
+        Redis::shouldReceive('exists')
+            ->with('settings:' . $key)
+            ->andReturn(false);
+
+        $result = $this->cacheManagerBase->keyExists($key, $connection);
+
+        $this->assertFalse($result);
+    }
+
+    public function testKeyExistsWithInvalidConnection()
+    {
+        $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
+
+        $key = 'some-key';
+        $connection = 'invalid-connection';
+
+        $result = $this->cacheManagerBase->keyExists($key, $connection);
+
+        $this->assertFalse($result);
+    }
+
+    public function testKeyExistsWithExceptionDuringRedisCall()
+    {
+        $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
+
+        $key = 'some-key';
+        $connection = 'cache_settings';
+
+        Redis::shouldReceive('connection')
+            ->with($connection)
+            ->andReturnSelf();
+
+        Redis::shouldReceive('exists')
+            ->with('settings:' . $key)
+            ->andThrow(new Exception('Redis error'));
+
+        Log::shouldReceive('info')
+            ->with('CacheManagerBase: Redis error')
+            ->once();
+
+        $result = $this->cacheManagerBase->keyExists($key, $connection);
+
+        $this->assertFalse($result);
+    }
 }

--- a/tests/Feature/Cache/CacheManagerBaseTest.php
+++ b/tests/Feature/Cache/CacheManagerBaseTest.php
@@ -109,40 +109,40 @@ class CacheManagerBaseTest extends TestCase
 
     public function testKeyExistsWithValidKey()
     {
+        config()->set('cache.default', 'cache_settings');
+
         $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
 
         $key = 'valid-key';
-        $connection = 'cache_settings';
 
         Redis::shouldReceive('connection')
-            ->with($connection)
             ->andReturnSelf();
 
         Redis::shouldReceive('exists')
             ->with('settings:' . $key)
             ->andReturn(true);
 
-        $result = $this->cacheManagerBase->keyExists($key, $connection);
+        $result = $this->cacheManagerBase->keyExists($key);
 
         $this->assertTrue($result);
     }
 
     public function testKeyExistsWithInvalidKey()
     {
+        config()->set('cache.default', 'cache_settings');
+
         $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
 
         $key = 'invalid-key';
-        $connection = 'cache_settings';
 
         Redis::shouldReceive('connection')
-            ->with($connection)
             ->andReturnSelf();
 
         Redis::shouldReceive('exists')
             ->with('settings:' . $key)
             ->andReturn(false);
 
-        $result = $this->cacheManagerBase->keyExists($key, $connection);
+        $result = $this->cacheManagerBase->keyExists($key);
 
         $this->assertFalse($result);
     }
@@ -161,13 +161,13 @@ class CacheManagerBaseTest extends TestCase
 
     public function testKeyExistsWithExceptionDuringRedisCall()
     {
+        config()->set('cache.default', 'cache_settings');
+
         $this->cacheManagerBase = Mockery::mock(CacheManagerBase::class)->makePartial();
 
         $key = 'some-key';
-        $connection = 'cache_settings';
 
         Redis::shouldReceive('connection')
-            ->with($connection)
             ->andReturnSelf();
 
         Redis::shouldReceive('exists')
@@ -178,7 +178,7 @@ class CacheManagerBaseTest extends TestCase
             ->with('CacheManagerBase: Redis error')
             ->once();
 
-        $result = $this->cacheManagerBase->keyExists($key, $connection);
+        $result = $this->cacheManagerBase->keyExists($key);
 
         $this->assertFalse($result);
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
SettingCache for null values is reading the database instead of the cache when reading the content.

## Solution
- Check if the setting key exists in the cache

## Related Tickets & Packages
[FOUR-22377](https://processmaker.atlassian.net/browse/FOUR-22377)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22377]: https://processmaker.atlassian.net/browse/FOUR-22377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ