### PR TITLE
FOUR-23512 Data in 'Available columns' is saved without 'data.' in Saved search by default

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
@@ -253,7 +253,7 @@ class ProcessVariableController extends Controller
             'pv.process_id',
             'vfv.data_type AS format',
             'vfv.label',
-            'vfv.field',
+            DB::raw("CONCAT('data.', vfv.field) as field"),
             DB::raw('NULL AS `default`'),
             'vfv.created_at',
             'vfv.updated_at',


### PR DESCRIPTION
## Issue & Reproduction Steps
"data." is not set by default in variables of process in columns of saved search. So the value of the variables is not visible in the list.

## Solution
Change the query used when the package "variable-finder" is enabled.

## How to Test
1. Create a process
2. Create some cases
3. Create a saved search of the process 
4. Go to saved search configuration 
5. Click on columns 
6. Add values of the process like dataA that belong to variable of the process 
7. Check the value of the column (It is is without data.) So the value is not show in the list 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23512

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
