### PR TITLE
Observation/FOUR-23536: Chart configured in launchpad settings is lost after pressing Info button

### DIFF
--- a/resources/js/processes-catalogue/components/BaseChart.vue
+++ b/resources/js/processes-catalogue/components/BaseChart.vue
@@ -160,15 +160,11 @@ export default {
     this.setDefaults();
   },
   mounted() {
-    const unparseProperties = this.process.launchpad?.properties || null;
-    if (unparseProperties !== null) {
-      this.chartId = JSON.parse(unparseProperties)?.saved_chart_id || null;
-    }
-    this.fetchChart();
     ProcessMaker.EventBus.$on("getChartId", (newChartId) => {
       this.chartId = newChartId;
       this.fetchChart();
     });
+    this.fetchProcessConfigLaunchpad();
   },
   methods: {
     /**
@@ -282,6 +278,23 @@ export default {
         this.error = this.chart.chart_error;
         this.hint = this.chart.chart_hint;
       }
+    },
+    fetchProcessConfigLaunchpad() {
+      ProcessMaker.apiClient
+        .get(`process_launchpad/${this.process.id}`)
+        .then((response) => {
+          const firstResponse = response.data.shift();
+          const unparseProperties = firstResponse?.launchpad?.properties;
+          const launchpadProperties = unparseProperties
+            ? JSON.parse(unparseProperties)
+            : "";
+          this.chartId = launchpadProperties.saved_chart_id;
+          this.fetchChart();
+        })
+        .catch((error) => {
+          this.getDefaultData();
+          console.error("Error: ", error);
+        });
     },
   },
 };


### PR DESCRIPTION
## Solution
- Info button was fixed to show charts correctly

## How to Test
- Login PM4
- Go to Processes
- Open Process
- Go to Edit in Launchpad
- Select a Chart from dropdown list
- Save launchpad settings
- Click Info Button  several times to collapse and decollapse info section
- Chart selected should not change

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23536

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
