### PR TITLE
observation/FOUR-23561 DevLink > Search icon is overlapped by the word in the search field

### DIFF
--- a/resources/js/admin/devlink/components/AssetListing.vue
+++ b/resources/js/admin/devlink/components/AssetListing.vue
@@ -168,6 +168,7 @@ const handleFilterChange = () => {
   background-position: 7px 8px;
   background-size: 15px;
   border-radius: 8px;
+  padding-left: 30px;
 }
 
 @import "styles/components/table";


### PR DESCRIPTION
## Issue & Reproduction Steps
DevLink > Search icon is overlapped by the word in the search field

## Solution
add a left padding in the search input

## How to Test
Go to server
Go to Admin > devLink 
Connect to Instance
Open the instance
Select Assets tab
Press view button
Search a asset

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23561
