### PR TITLE
FOUR-22984 Load settings configuration from the database during boot.

### DIFF
--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -62,6 +62,7 @@ class ProcessMakerServiceProvider extends ServiceProvider
         $this->app->singleton(Menu::class, function ($app) {
             return new MenuManager();
         });
+        app('config')->loadSettings();
 
         static::bootObservers();
 

--- a/ProcessMaker/Repositories/SettingsConfigRepository.php
+++ b/ProcessMaker/Repositories/SettingsConfigRepository.php
@@ -5,9 +5,11 @@ namespace ProcessMaker\Repositories;
 use Illuminate\Config\Repository;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Schema;
 use ProcessMaker\Models\Setting;
+use Throwable;
 
 class SettingsConfigRepository extends Repository
 {
@@ -133,5 +135,20 @@ class SettingsConfigRepository extends Repository
         }
 
         return $this->settingsTableExists;
+    }
+
+    public function loadSettings(): self
+    {
+        // Load settings from the database
+        try {
+            foreach (Setting::select('id', 'key', 'config', 'format')->get() as $setting) {
+                // Set the configuration value in the global app config
+                $this->set($setting->key, $setting->config);
+            }
+        } catch (Throwable $exception) {
+            Log::error('Error loading settings: ' . $exception->getMessage());
+        }
+
+        return $this;
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
LDAP settings were not loaded causing LDAP login to not work.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22984

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
