### PR TITLE
Observation/FOUR-23564: Dashboards with Saved Search Charts are not displaying in the Dashboards sections of Home page

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -58,6 +58,10 @@ class TaskController extends Controller
             return view('tasks.mobile', compact('title'));
         }
 
+        $manager = new ScreenBuilderManager();
+        event(new ScreenBuilderStarting($manager, 'FORM'));
+        event(new ScreenBuilderStarting($manager, 'DISPLAY'));
+
         $userFilter = SaveSession::getConfigFilter('taskFilter', Auth::user());
 
         $defaultColumns = DefaultColumns::get('tasks');
@@ -70,7 +74,7 @@ class TaskController extends Controller
 
         $defaultSavedSearchId = $this->getDefaultSavedSearchId();
 
-        return view('tasks.index', compact('title', 'userFilter', 'defaultColumns', 'taskDraftsEnabled', 'userConfiguration', 'showOldTaskScreen', 'currentUser', 'selectedProcess', 'defaultSavedSearchId'));
+        return view('tasks.index', compact('title', 'userFilter', 'defaultColumns', 'taskDraftsEnabled', 'userConfiguration', 'showOldTaskScreen', 'currentUser', 'selectedProcess', 'defaultSavedSearchId', 'manager'));
     }
 
     public function edit(ProcessRequestToken $task, string $preview = '')

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -162,6 +162,9 @@
         window.Processmaker.selectedProcess = @json($selectedProcess);
         window.Processmaker.defaultSavedSearchId = @json($defaultSavedSearchId);
     </script>
+    @foreach($manager->getScripts() as $script)
+        <script src="{{$script}}"></script>
+    @endforeach
     <script>
         window.ProcessMaker.ellipsisPermission = {{
           Js::from(\Auth::user()->hasPermissionsFor('processes', 'process-templates', 'pm-blocks', 'projects', 'documentation'))


### PR DESCRIPTION
## Solution
- Required packages from SavedSearch where registered.

## How to Test
- Login PM
- Create a Screen with Saved Search Chart control
- Create new Dashboard and assign previos screen
- Go to Groups and select dashboard in Select Home Dashboard dropdown
- Go to Home and click on Dashboard
- Dashboard should be display normally.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23564

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
