### PR TITLE
FOUR-23563: When the user import a process or open and old processes the toogle Assigne and Due is enable per default

### DIFF
--- a/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskNotifications.vue
@@ -172,17 +172,16 @@
 <script>
 
 class NotificationTemplate {
-  constructor(type) {
+  constructor() {
     this.requester = {
       assigned: false,
       completed: false,
       due: false,
     };
     this.assignee = {
-      assigned: type === "task",
+      assigned: false,
       completed: false,
-      due: type === "task",
-      default: false,
+      due: false,
     };
     this.participants = {
       assigned: false,
@@ -216,7 +215,6 @@ export default {
       managerAssigned: false,
       managerCompleted: false,
       managerDue: false,
-      defaultNotification: false,
     };
   },
   computed: {
@@ -241,73 +239,61 @@ export default {
     requesterAssigned(value) {
       if (this.notifications) {
         this.notifications.requester.assigned = value;
-        this.verifyNotifications();
       }
     },
     requesterCompleted(value) {
       if (this.notifications) {
         this.notifications.requester.completed = value;
-        this.verifyNotifications();
       }
     },
     requesterDue(value) {
       if (this.notifications) {
         this.notifications.requester.due = value;
-        this.verifyNotifications();
       }
     },
     assigneeAssigned(value) {
       if (this.notifications) {
         this.notifications.assignee.assigned = value;
-        this.verifyNotifications();
       }
     },
     assigneeCompleted(value) {
       if (this.notifications) {
         this.notifications.assignee.completed = value;
-        this.verifyNotifications();
       }
     },
     assigneeDue(value) {
       if (this.notifications) {
         this.notifications.assignee.due = value;
-        this.verifyNotifications();
       }
     },
     participantsAssigned(value) {
       if (this.notifications) {
         this.notifications.participants.assigned = value;
-        this.verifyNotifications();
       }
     },
     participantsCompleted(value) {
       if (this.notifications) {
         this.notifications.participants.completed = value;
-        this.verifyNotifications();
       }
     },
     participantsDue(value) {
       if (this.notifications) {
         this.notifications.participants.due = value;
-        this.verifyNotifications();
       }
     },
     managerAssigned(value) {
       if (this.notifications) {
         this.notifications.manager.assigned = value;
-        this.verifyNotifications();
       }
     },
     managerCompleted(value) {
       if (this.notifications) {
         this.notifications.manager.completed = value;
-        this.verifyNotifications();
       }
     },
     managerDue(value) {
       if (this.notifications) {
         this.notifications.manager.due = value;
-        this.verifyNotifications();
       }
     },
     modelerId() {
@@ -332,7 +318,6 @@ export default {
       this.managerAssigned = this.notifications?.manager.assigned;
       this.managerCompleted = this.notifications?.manager.completed;
       this.managerDue = this.notifications?.manager.due;
-      this.defaultNotification = this.notifications?.assignee.default;
     },
     updateNotifications() {
       if (this.process.task_notifications[this.nodeId]) {
@@ -344,33 +329,14 @@ export default {
       this.notifications = this.node.notifications;
     },
     createNewNotification() {
-      let type = "task";
       const cloneOf = this.getNode(this.node.cloneOf);
       if (this.node.cloneOf && cloneOf) {
         return structuredClone(cloneOf.notifications);
       }
-      if (this.node.type === "processmaker-modeler-manual-task") {
-        type = "manual_task";
-      }
-      return new NotificationTemplate(type);
+      return new NotificationTemplate();
     },
     getNode(nodeId) {
       return this.$root.$children[0].$refs.modeler.nodes.find((node) => node.definition.id === nodeId);
-    },
-    /**
-     * Verify if there are any notifications enabled to set a default value in true
-     */
-    verifyNotifications() {
-      let flag = false;
-
-      for (const prop in this.notifications) {
-        if (this.notifications[prop].assigned || this.notifications[prop].completed || this.notifications[prop].due) {
-          flag = true;
-          break;
-        }
-      }
-
-      this.notifications.assignee.default = !flag;
     },
   },
 };

--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -51,6 +51,7 @@ import ErrorHandlingTimeout from "./components/inspector/ErrorHandlingTimeout";
 import ErrorHandlingRetryAttempts from "./components/inspector/ErrorHandlingRetryAttempts";
 import ErrorHandlingRetryWaitTime from "./components/inspector/ErrorHandlingRetryWaitTime";
 import NotifyProcessManager from "./components/inspector/NotifyProcessManager";
+import { onModelerInit } from "./modelerInit";
 
 Vue.component("UserSelect", UserSelect);
 Vue.component("UserById", UserById);
@@ -105,6 +106,10 @@ ProcessMaker.modelerExtensions = {
   loopCharacteristicsData,
   NodeIdentifierInput,
 };
+
+ProcessMaker.EventBus.$on("modeler-init", (options) => {
+  onModelerInit(options);
+});
 
 ProcessMaker.EventBus.$on("modeler-init", registerNodes);
 
@@ -472,24 +477,25 @@ ProcessMaker.EventBus.$on(
   "modeler-init",
   (event) => {
     event.registerPreview({
-      url: '/designer/screens/preview',
-      assetUrl: (nodeData) => nodeData.screenRef ? `/designer/screen-builder/${nodeData.screenRef}/edit` : null,
-      receivingParams: ['screenRef'],
-      matcher: (nodeData) => nodeData?.$type === 'bpmn:Task',
+      url: "/designer/screens/preview",
+      assetUrl: (nodeData) => (nodeData.screenRef ? `/designer/screen-builder/${nodeData.screenRef}/edit` : null),
+      receivingParams: ["screenRef"],
+      matcher: (nodeData) => nodeData?.$type === "bpmn:Task",
     });
     event.registerPreview({
-      url: '/designer/screens/preview',
-      assetUrl: (nodeData) => nodeData.screenRef ? `/designer/screen-builder/${nodeData.screenRef}/edit` : null,
-      receivingParams: ['screenRef'],
-      matcher: (nodeData) => nodeData?.$type === 'bpmn:ManualTask',
+      url: "/designer/screens/preview",
+      assetUrl: (nodeData) => (nodeData.screenRef ? `/designer/screen-builder/${nodeData.screenRef}/edit` : null),
+      receivingParams: ["screenRef"],
+      matcher: (nodeData) => nodeData?.$type === "bpmn:ManualTask",
     });
     event.registerPreview({
-      url: '/designer/scripts/preview',
-      assetUrl: (nodeData) => nodeData.scriptRef ? `/designer/scripts/${nodeData.scriptRef}/builder` : null,
-      receivingParams: ['scriptRef'],
-      matcher: (nodeData) => nodeData?.$type === 'bpmn:ScriptTask',
+      url: "/designer/scripts/preview",
+      assetUrl: (nodeData) => (nodeData.scriptRef ? `/designer/scripts/${nodeData.scriptRef}/builder` : null),
+      receivingParams: ["scriptRef"],
+      matcher: (nodeData) => nodeData?.$type === "bpmn:ScriptTask",
     });
-  });
+  },
+);
 
 validateScreenRef();
 validateFlowGenieRef();

--- a/resources/js/processes/modeler/modelerInit.js
+++ b/resources/js/processes/modeler/modelerInit.js
@@ -1,0 +1,18 @@
+export default {};
+
+export const configureTaskNotifications = ({ modeler }) => {
+  modeler.$on("node-added", (node) => {
+    if (node.type.includes("task") && node.notifications) {
+      node.notifications.assignee = {
+        assigned: true,
+        completed: false,
+        due: true,
+        default: false,
+      };
+    }
+  });
+};
+
+export const onModelerInit = (options) => {
+  configureTaskNotifications(options);
+};

--- a/resources/js/processes/modeler/modelerInit.js
+++ b/resources/js/processes/modeler/modelerInit.js
@@ -1,5 +1,10 @@
+import { nextTick } from "vue";
+
 export default {};
 
+// Highlight the node when it is added
+// TODO: This is a workaround to highlight the node when it is added
+// because the highlightNode method is not working when the node is added
 export const configureTaskNotifications = ({ modeler }) => {
   modeler.$on("node-added", (node) => {
     if (node.type.includes("task") && node.notifications) {
@@ -10,6 +15,10 @@ export const configureTaskNotifications = ({ modeler }) => {
         default: false,
       };
     }
+    modeler.clearSelection();
+    nextTick(() => {
+      modeler.highlightNode(node);
+    });
   });
 };
 


### PR DESCRIPTION

## Issue & Reproduction Steps
1. Import an old process or Open a old processes
2. When check the a Task Properties
3. The toogle Assigne and Due are enable

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23563

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy