### PR TITLE
Bugfix/FOUR-23621: Error in console when clicking on the Cases tab; no cases displayed

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
@@ -42,8 +42,12 @@ class UserConfigurationController extends Controller
                 'user_id' => $user->id,
                 'ui_configuration' => json_encode(self::DEFAULT_USER_CONFIGURATION),
             ]; // return default
+        } else {
+            $uiConfiguration = json_decode($response->ui_configuration, true);
+            $configuration = array_replace_recursive(self::DEFAULT_USER_CONFIGURATION, $uiConfiguration);
+            $response->ui_configuration = json_encode($configuration);
         }
-
+        
         return new ApiResource($response);
     }
 

--- a/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserConfigurationController.php
@@ -47,7 +47,7 @@ class UserConfigurationController extends Controller
             $configuration = array_replace_recursive(self::DEFAULT_USER_CONFIGURATION, $uiConfiguration);
             $response->ui_configuration = json_encode($configuration);
         }
-        
+
         return new ApiResource($response);
     }
 

--- a/resources/jscomposition/cases/casesMain/CasesDataSection.vue
+++ b/resources/jscomposition/cases/casesMain/CasesDataSection.vue
@@ -222,7 +222,7 @@ const onStopResize = (column) => {
 };
 
 const updateColumnWithUserConfiguration = (columnsDefault) => {
-  const casesColumns = store.getters["core:cases/getCasesColumns"];
+  const casesColumns = store.getters["core:cases/getCasesColumns"] || {};
 
   columnsDefault.forEach((column) => {
     if (casesColumns[column.field]) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

- Log in  → https://release-2025-spring-qa.processmaker.net/
- Click on CASES tab 
- Click on My Cases, In progress, Completed, All Cases 

Additional Test:
- In the table of user_configuration, remove some indexes in ui_configuration like tasks_inbox.

**Current Behavior:**
As we see in the attached video, when we click on Cases, we get an error in the console, and we can't see the list of cad in one of the columns of cases.

## Solution
- Merge default configuration with user configuration when some key is missing
- When columns is null return an empty object in frontend

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-23621](https://processmaker.atlassian.net/browse/FOUR-23621)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-23621]: https://processmaker.atlassian.net/browse/FOUR-23621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ