### PR TITLE
FOUR-22470: It is not possible to reopen a template that was created in base a process with launch pad

### DIFF
--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -80,6 +80,8 @@ class ProcessTemplate implements TemplateInterface
         // this ensures any updates to the template manifest will be reflected
         // in the editing process being shown in modeler.
         if ($process) {
+            // We need to remove the relations with other tables first
+            $process->notification_settings()->delete();
             $process->forceDelete();
         }
         // Otherwise we need to import the template and create a new process


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process 
2. Save the process with some element
3. Save the process launchpad configuration
4. Search the process
5. Create a template in base to the process
6. Search the template 
7. Edit the template
8. Do this exercise twice (Step 6, Step 7)

## Solution
- Solve the issue with `Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22470

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy