### PR TITLE
FOUR-23552: Checking some SSO options is not working correctly.

### DIFF
--- a/ProcessMaker/Cache/Settings/SettingCacheManager.php
+++ b/ProcessMaker/Cache/Settings/SettingCacheManager.php
@@ -13,6 +13,8 @@ class SettingCacheManager extends CacheManagerBase implements CacheInterface
 {
     const DEFAULT_CACHE_DRIVER = 'cache_settings';
 
+    const DEFAULT_CACHE_PREFIX = 'settings:';
+
     protected CacheManager $manager;
 
     protected Repository $cacheManager;
@@ -169,10 +171,10 @@ class SettingCacheManager extends CacheManagerBase implements CacheInterface
     public function clearBy(string $pattern): void
     {
         //get the default driver
-        $defaultDriver = config('cache.stores.cache_settings.connection') ?? 'redis';
+        $defaultDriver = config('cache.stores.cache_settings.connection') ?? self::DEFAULT_CACHE_DRIVER;
         try {
             //get the prefix
-            $prefix = config('cache.stores.cache_settings.prefix', 'settings:');
+            $prefix = config('cache.stores.cache_settings.prefix', self::DEFAULT_CACHE_PREFIX);
             // Filter keys by pattern
             $matchedKeys = $this->getKeysByPattern($pattern, $defaultDriver, $prefix);
 

--- a/ProcessMaker/Cache/Settings/SettingCacheManager.php
+++ b/ProcessMaker/Cache/Settings/SettingCacheManager.php
@@ -168,14 +168,11 @@ class SettingCacheManager extends CacheManagerBase implements CacheInterface
      */
     public function clearBy(string $pattern): void
     {
-        $defaultDriver = $this->manager->getDefaultDriver();
-
-        if ($defaultDriver !== 'cache_settings') {
-            throw new SettingCacheException('The cache driver must be Redis.');
-        }
-
+        //get the default driver
+        $defaultDriver = config('cache.stores.cache_settings.connection') ?? 'redis';
         try {
-            $prefix = $this->manager->getPrefix();
+            //get the prefix
+            $prefix = config('cache.stores.cache_settings.prefix', 'settings:');
             // Filter keys by pattern
             $matchedKeys = $this->getKeysByPattern($pattern, $defaultDriver, $prefix);
 

--- a/tests/Feature/Cache/SettingCacheTest.php
+++ b/tests/Feature/Cache/SettingCacheTest.php
@@ -213,16 +213,6 @@ class SettingCacheTest extends TestCase
         \SettingCache::clearBy($pattern);
     }
 
-    public function testTryClearByPatternWithNonRedisDriver()
-    {
-        config()->set('cache.default', 'array');
-
-        $this->expectException(SettingCacheException::class);
-        $this->expectExceptionMessage('The cache driver must be Redis.');
-
-        \SettingCache::clearBy('pattern');
-    }
-
     public function testClearByPatternWithRedisPrefix()
     {
         $defaultRedisPrefix = config('database.redis.options.prefix');


### PR DESCRIPTION
## Issue & Reproduction Steps
When we enable or disable the Git Hub tab, it is not lost. It is not currently enabled, and there is no way to lose it. Disabling the option

## Solution
- add Invalidates the cache for all service settings during the SSO enable/disable user actions


https://github.com/user-attachments/assets/dd7f1187-4709-46b9-8313-f10fdf9010bf



## How to Test
Detailed in the related ticket

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-23552

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:package-auth:bugfix/FOUR-23552

