### PR TITLE
Observation/FOUR-23548: Edit Task Column form grows in length when a screen is set to launchpad

### DIFF
--- a/resources/js/components/shared/ColumnChooser.vue
+++ b/resources/js/components/shared/ColumnChooser.vue
@@ -16,7 +16,7 @@
                     </div>                                    
                 </div>
             </div>
-            <div class="column-container d-flex flex-row align-content-stretch custom-height" ref="columnContainer">
+            <div class="column-container d-flex flex-row align-content-stretch" ref="columnContainer">
                 <div class="w-50 mr-3">
                     <draggable group="columns" class="border bg-muted px-3 draggable-list draggable-current" :list="currentColumns">
                         <column v-for="(element, index) in currentColumns" 

--- a/resources/js/components/shared/ColumnChooser.vue
+++ b/resources/js/components/shared/ColumnChooser.vue
@@ -16,7 +16,7 @@
                     </div>                                    
                 </div>
             </div>
-            <div class="column-container d-flex flex-row align-content-stretch" ref="columnContainer">
+            <div class="column-container d-flex flex-row align-content-stretch custom-height" ref="columnContainer">
                 <div class="w-50 mr-3">
                     <draggable group="columns" class="border bg-muted px-3 draggable-list draggable-current" :list="currentColumns">
                         <column v-for="(element, index) in currentColumns" 
@@ -224,11 +224,12 @@ export default {
             return;
           }
           
+          let adjustHeight = 10;
           let containerHeight = tabContent.offsetHeight;
           let beforeHeight = this.$refs.columnBefore.offsetHeight;
           let afterHeight = this.$refs.columnAfter.offsetHeight;
           
-          let height = (containerHeight - (beforeHeight + afterHeight));
+          let height = (containerHeight - (beforeHeight + afterHeight) - adjustHeight);
           this.$refs.columnContainer.style.height = `${height}px`;
           this.$refs.columnContainer.style.maxHeight = `${height}px`;
         },
@@ -361,6 +362,6 @@ export default {
 
 <style lang="scss">
     .column-container {
-        min-height: 100px;
+        min-height: 150px;
     }
 </style>


### PR DESCRIPTION
## Solution
- Adjusting Height to fit better Column Modal in Edit Task Column (Launchpad Option)

## How to Test
- Create a process
- Open the process by launchpad
- Edit launchpad settings
- Click on Edit task columns (The form It is a normal size)
- Return to launchpad settings
- Set a screen in Launch Screen
- Save the changes
- Click on Edit task columns
- Check the form 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23548

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
