### PR TITLE
FOUR-23556: VarFinder Panel Not Displaying on Cases and Analytics Pages

### DIFF
--- a/resources/views/layouts/layoutnext.blade.php
+++ b/resources/views/layouts/layoutnext.blade.php
@@ -144,5 +144,6 @@
 @if (hasPackage('package-accessibility'))
   @include('package-accessibility::userway')
 @endif
+@includeWhen(hasPackage('package-variable-finder'), 'package-variable-finder::index')
 </body>
 </html>


### PR DESCRIPTION
## Issue & Reproduction Steps
The VarFinder Panel does not open on the Cases or Analytics pages when using the shortcut **Shift + Space**.

**Steps to Reproduce:**
1. Navigate to the **Cases** or **Analytics** pages.
2. Attempt to open the **VarFinder Panel** using **Shift + Space**.

## Solution
- Added Blade directive, this ensures the view is included only when the package is available in the layout.

## How to Test
1. Navigate to the Cases or Analytics pages.
2. Press Shift + Space.
3. Confirm that the VarFinder Panel now opens correctly.
4. Ensure no errors are thrown if the package-variable-finder package is not installed.

🔎 **Note:** On the **/analytics/process-intelligence** page, most of the content is rendered inside an `<iframe>`, so keyboard shortcuts like **Shift + Space** will **not work inside that iframe**. 

## Related Tickets & Packages
- [FOUR-23556](https://processmaker.atlassian.net/browse/FOUR-23556)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-23556]: https://processmaker.atlassian.net/browse/FOUR-23556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ