### PR TITLE
FOUR-22407: Collection record control not updating when editing from launchpad preview

### DIFF
--- a/resources/js/tasks/api/index.js
+++ b/resources/js/tasks/api/index.js
@@ -1,0 +1,11 @@
+import { api } from "../variables/index";
+
+export const updateCollection = async ({ collectionId, recordId, data }) => {
+  const response = await api.put(`collections/${collectionId}/records/${recordId}`, data);
+
+  return response.data;
+};
+
+export default {
+  updateCollection,
+};

--- a/resources/js/tasks/loaderPreview.js
+++ b/resources/js/tasks/loaderPreview.js
@@ -1,6 +1,9 @@
+import Mustache from "mustache";
 import vueFormElements from "../next/libraries/vueFormElements";
 import screenBuilder from "../next/screenBuilder";
 import { setupMain } from "../next/setupMain";
+
+window.Mustache = Mustache;
 
 setupMain();
 screenBuilder();

--- a/resources/js/tasks/preview.js
+++ b/resources/js/tasks/preview.js
@@ -1,3 +1,4 @@
+import { submitCollectionData } from "./utils/index";
 // const store = new Vuex.Store();
 const main = new Vue({
   // store: store,
@@ -293,6 +294,10 @@ const main = new Vue({
         if (this.submitting) {
           return;
         }
+
+        // Save collection data
+        // This code is copied from tasks/edit.js, we should improve it
+        submitCollectionData(task, this.formData);
 
         const message = this.$t("Task Completed Successfully");
         const taskId = task.id;

--- a/resources/js/tasks/utils/index.js
+++ b/resources/js/tasks/utils/index.js
@@ -1,0 +1,77 @@
+import { i18n, alert, Mustache } from "../variables/index";
+import { updateCollection } from "../api/index";
+
+export default {};
+
+export const isMustache = (record) => /\{\{.*\}\}/.test(record);
+
+// Get data in FormCollectionRecordControl components
+export const getCollectionDataFromTask = (task, formData) => {
+  const results = [];
+  // Verify if object "screen" exists
+  if (task.screen) {
+    // Verify if "config" array exists and it has at least one element
+    if (Array.isArray(task.screen.config) && task.screen.config.length > 0) {
+      // Iteration on "config" array
+      for (const configItem of task.screen.config) {
+        // Verify if "items" array exists
+        if (Array.isArray(configItem.items)) {
+          // Iteration over each "items" element
+          for (const item of configItem.items) {
+            // Verify if component "FormCollectionRecordControl" is inside the screen
+            if (item.component === "FormCollectionRecordControl") {
+              // Access to FormCollectionRecordControl "config" object
+              const { config } = item;
+
+              // Saving values into variables
+              const collectionFields = config.collection.data[0];
+              const submitCollectionChecked = config.collectionmode.submitCollectionCheck;
+              let recordId = "";
+              const { record } = config;
+
+              if (isMustache(record)) {
+                recordId = Mustache.render(record, formData);
+              } else {
+                recordId = parseInt(record, 10);
+              }
+              const { collectionId } = config.collection;
+              // Save the values into the results array
+              results.push({
+                submitCollectionChecked, recordId, collectionId, collectionFields,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+  return results.length > 0 ? results : null;
+};
+
+// Submit collection data
+export const submitCollectionData = async (task, formData) => {
+  // If screen has CollectionControl components saves collection data (if submit check is true)
+  const resultCollectionComponent = getCollectionDataFromTask(task, formData);
+
+  if (resultCollectionComponent && resultCollectionComponent.length > 0) {
+    resultCollectionComponent.forEach(async (result) => {
+      if (result.submitCollectionChecked) {
+        const collectionKeys = Object.keys(result.collectionFields);
+        const matchingKeys = _.intersection(Object.keys(formData), collectionKeys);
+        const collectionsData = _.pick(formData, matchingKeys);
+
+        updateCollection({
+          collectionId: result.collectionId,
+          recordId: result.recordId,
+          data: {
+            data: collectionsData,
+            uploads: [],
+          },
+        }).then(() => {
+          alert(i18n.t("Collection data was updated"), "success", 5, true);
+        });
+      }
+    });
+  }
+  return null;
+};

--- a/resources/js/tasks/variables/index.js
+++ b/resources/js/tasks/variables/index.js
@@ -1,0 +1,9 @@
+export default {};
+
+export const api = window.ProcessMaker?.apiClient;
+
+export const i18n = window.ProcessMaker?.i18n;
+
+export const alert = window.ProcessMaker?.alert;
+
+export const Mustache = window.Mustache || {};


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Log in 
2. Have a process with collection record control
3. start a new case 
4. edit collection record control 
5. Go to collections 
6. open collections 
7. open the collection and see the record number
8. the collection was edited correctly
9. go to Processes
10. Search for the process
11. open it from launchpad
12. go to the started case
13. click on preview
14. edit the collection
15. go to designer/ collections


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22407

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
