### PR TITLE
FOUR-23520: Mobile view - Headers are not displayed in the first login

### DIFF
--- a/ProcessMaker/Http/Controllers/HomeController.php
+++ b/ProcessMaker/Http/Controllers/HomeController.php
@@ -3,7 +3,6 @@
 namespace ProcessMaker\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Helpers\MobileHelper;
 use ProcessMaker\Http\Controllers\Controller;
@@ -28,7 +27,7 @@ class HomeController extends Controller
                     ->where('assignable_type', 'ProcessMaker\Models\User')
                     ->count() > 0;
 
-                //Check if there is at least one custom dashboard per group only first match is selected
+                // Check if there is at least one custom dashboard per group only first match is selected
                 if (!$customDashboardExists) {
                     $customDashboardExists = collect($groups)->some(function ($groupId) {
                         return \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::where('type', 'DASHBOARD')
@@ -37,12 +36,16 @@ class HomeController extends Controller
                             ->exists();
                     });
                 }
-
+                // Redirect to the custom Dashboard
                 if ($customDashboardExists) {
                     $homePage = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::getHomePage($user);
 
                     return redirect($homePage);
                 }
+            }
+            // If does not have a custom dashboard and is a mobile needs to redirect tasks instead of inbox
+            if (MobileHelper::detectMobile()) {
+                return redirect('/tasks');
             }
 
             // Redirect to the default view


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Login using mobile

## Solution
- The mobile needs to redirect task instead  inbox because there are not a INBOX version for mobile

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23520

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy