### PR TITLE
FOUR-23649: Updated JSON encoding to native array format for better data handling.

### DIFF
--- a/database/factories/ProcessMaker/Models/ProcessVersionFactory.php
+++ b/database/factories/ProcessMaker/Models/ProcessVersionFactory.php
@@ -43,7 +43,7 @@ class ProcessVersionFactory extends Factory
             'start_events' => function () use ($process) {
                 $process->save();
 
-                return json_encode($process->start_events);
+                return $process->start_events;
             },
         ];
     }

--- a/tests/Feature/Api/ScreenTest.php
+++ b/tests/Feature/Api/ScreenTest.php
@@ -267,8 +267,8 @@ class ScreenTest extends TestCase
         $response = $this->apiCall('PUT', $url, [
             'title' => 'ScreenTitleTest',
             'description' => $faker->sentence(5),
-            'config' => '{"foo":"bar"}',
-            'computed' => '[{"id": 2, "name": "test", "type": "expression", "formula": "test", "property": "test"}]',
+            'config' => [['items' => [['config' => ['foo' => 'bar']]]]],
+            'computed' => [['id' => 2, 'name' => 'test', 'type' => 'expression', 'formula' => 'test', 'property' => 'test']],
             'custom_css' => '.class { font-size: large; }',
             'watchers' => '[{"input_data":"{}","script_configuration":"{}","synchronous":false,"show_async_loading":false,"run_onload":false,"name":"Watchers","watching":"form_input_1","script":{"id":"script-4","uuid":"98a4376e-efb8-4c10-83fd-01199398eddc","key":null,"title":"Autosave","description":"Autosave","language":"php","code":"","timeout":60,"run_as_user_id":1,"status":"ACTIVE","script_category_id":"1","script_executor_id":3},"script_id":"4","script_key":null,"uid":"16794186944621"}]',
             'type' => $screen->type,
@@ -281,8 +281,8 @@ class ScreenTest extends TestCase
         // assert it creates a published screen version.
         $screen->refresh();
         $draft = $screen->versions()->draft()->first();
-        $this->assertEquals($draft->config, '{"foo":"bar"}');
-        $this->assertEquals($draft->computed, '[{"id": 2, "name": "test", "type": "expression", "formula": "test", "property": "test"}]');
+        $this->assertEquals($draft->config, [['items' => [['config' => ['foo' => 'bar']]]]]);
+        $this->assertEquals($draft->computed, [['id' => 2, 'name' => 'test', 'type' => 'expression', 'formula' => 'test', 'property' => 'test']]);
         $this->assertEquals($draft->custom_css, '.class { font-size: large; }');
         $this->assertEquals($draft->watchers, '[{"input_data":"{}","script_configuration":"{}","synchronous":false,"show_async_loading":false,"run_onload":false,"name":"Watchers","watching":"form_input_1","script":{"id":"script-4","uuid":"98a4376e-efb8-4c10-83fd-01199398eddc","key":null,"title":"Autosave","description":"Autosave","language":"php","code":"","timeout":60,"run_as_user_id":1,"status":"ACTIVE","script_category_id":"1","script_executor_id":3},"script_id":"4","script_key":null,"uid":"16794186944621"}]');
         $this->assertLessThan(3, $draft->updated_at->diffInSeconds($screen->updated_at));
@@ -335,7 +335,7 @@ class ScreenTest extends TestCase
     public function testDuplicateScreen()
     {
         $faker = Faker::create();
-        $config = '{"foo":"bar"}';
+        $config = [['items' => [['config' => ['foo' => 'bar']]]]];
         $screen = Screen::factory()->create([
             'config' => $config,
         ]);


### PR DESCRIPTION
## Issue & Reproduction Steps
Some tests are failing when var finder is parsing the assets.

## Solution
- Updated JSON encoding to native array format for better data handling.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23649

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-variable-finder:move-to-queued-job
.