### PR TITLE
FOUR-23518 timeout issue in script microservice fails after 30 seconds

### DIFF
--- a/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
@@ -90,7 +90,8 @@ class ScriptMicroserviceRunner
 
         Log::debug('Payload: ' . print_r($payload, true));
 
-        $response = Http::withToken($this->getAccessToken())
+        $response = Http::timeout($timeout)
+            ->withToken($this->getAccessToken())
             ->post(config('script-runner-microservice.base_url') . '/requests/create', $payload);
 
         $response->throw();


### PR DESCRIPTION
## Issue & Reproduction Steps
I identified an issue with the script microservice’s timeout behavior during testing. It appears that the service fails if the execution time exceeds 30 seconds, rather than waiting for a longer period. This issue may impact processes that require extended execution times.

## Solution
- The `timeout` must be set on the HTTP client according to the [documentation](https://laravel.com/docs/11.x/http-client#timeout).

## How to Test
See the ticket

https://github.com/user-attachments/assets/d3dbd644-47cd-42bf-8dd2-3c11710866e9

## Related Tickets & Packages
[FOUR-23518](https://processmaker.atlassian.net/browse/FOUR-23518)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-23518]: https://processmaker.atlassian.net/browse/FOUR-23518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ