### PR TITLE
FOUR-23140: Case title column does not have the Reset table option

### DIFF
--- a/resources/jscomposition/base/table/BaseTable.vue
+++ b/resources/jscomposition/base/table/BaseTable.vue
@@ -74,7 +74,7 @@
       <div
         v-show="placeholder"
         class="tw-flex tw-grow tw-w-full tw-h-full tw-pointer-events-none
-          tw-absolute tw-left-0 tw-top-0 tw-z-10 tw-justify-center tw-items-center">
+          tw-absolute tw-left-0 tw-top-0 tw-z-[3] tw-justify-center tw-items-center">
         <slot name="placeholder" />
       </div>
     </transition>

--- a/resources/jscomposition/cases/casesMain/config/columns.js
+++ b/resources/jscomposition/cases/casesMain/config/columns.js
@@ -61,6 +61,7 @@ export const caseTitleColumn = () => ({
   filter: {
     dataType: "string",
     operators: ["=", "in", "contains", "regex"],
+    resetTable: true,
   },
 });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Go to cases 
2. Click on Case Title
3. Look for “Reset Table“ option

#Current Behavior
Case title column does not have the Reset table option

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23140

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
