### PR TITLE
FOUR-23656: Element destination redirect to Home page should update the URL

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1279,12 +1279,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                 $elementDestination = route('tasks.index');
                 break;
             case 'homepageDashboard':
-                if (hasPackage('package-dynamic-ui')) {
-                    $user = auth()->user();
-                    $elementDestination = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::getHomePage($user);
-                } else {
-                    $elementDestination = route('inbox');
-                }
+                $elementDestination = route('home');
                 break;
             case 'processLaunchpad':
                 $elementDestination = route('process.browser.index', [

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1283,7 +1283,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                     $user = auth()->user();
                     $elementDestination = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::getHomePage($user);
                 } else {
-                    $elementDestination = route('home');
+                    $elementDestination = route('inbox');
                 }
                 break;
             case 'processLaunchpad':


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create/ update a process
2. Select a Task
3. Select the **Welcome Screen** as  Destination
![image](https://github.com/user-attachments/assets/e5e83377-52b2-415d-a4fa-89fe8a563657)

5. Start the Case

## Solution
- When the user select **Welcome screen** needs to redirect to **inbox**

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23656

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy