### PR TITLE
observation/FOUR-23662: `Add asset to Bundle` modal does not display the correct name for a Decision Table

### DIFF
--- a/resources/js/components/shared/AddToBundle.vue
+++ b/resources/js/components/shared/AddToBundle.vue
@@ -28,7 +28,12 @@ onMounted(() => {
     selected.value = null;
     error.value = null;
     assetId.value = data.id;
-    assetName.value = data.name || data.title;
+    assetName.value = data.title || data.name;
+    console.log({
+      assetName: assetName.value,
+      data: data,
+      id: data.id
+    });
     vue.$nextTick(() => {
       modal.value.show();
     });

--- a/resources/js/components/shared/AddToBundle.vue
+++ b/resources/js/components/shared/AddToBundle.vue
@@ -29,11 +29,6 @@ onMounted(() => {
     error.value = null;
     assetId.value = data.id;
     assetName.value = data.title || data.name;
-    console.log({
-      assetName: assetName.value,
-      data: data,
-      id: data.id
-    });
     vue.$nextTick(() => {
       modal.value.show();
     });


### PR DESCRIPTION

## How to Test
- Login PM4
- Go to designer->Decision Tables
- Open Decision Table list
- Click on ellipsis and Add To Bundle
- The name for decision Table should be correct

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23662

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
