### PR TITLE
FOUR-23643 Fix migration issue

### DIFF
--- a/database/migrations/2025_02_26_194048_modify_client_secret_in_dev_links_table.php
+++ b/database/migrations/2025_02_26_194048_modify_client_secret_in_dev_links_table.php
@@ -11,7 +11,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('dev_links', function (Blueprint $table) {
-            $table->text('client_secret')->change();
+            $table->text('client_secret')->nullable()->change();
         });
     }
 
@@ -21,7 +21,7 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::table('dev_links', function (Blueprint $table) {
-            $table->string('client_secret')->change();
+            $table->string('client_secret')->nullable()->change();
         });
     }
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
When the migration ran, there was a record in  dev_links with client_secret in null.

![image](https://github.com/user-attachments/assets/00bc6d1e-76f5-4f30-ac28-2ae195fd2460)


## Solution
- Fix the migration that convert the column to text.

![image](https://github.com/user-attachments/assets/67fce9e0-e5b2-4ef9-9791-f372980c0140)


## How to Test
Migrate an environment with a dev link configured without client_secret (null).

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23643

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
