### PR TITLE
FOUR-24658 - Fix css config overrides

### DIFF
--- a/ProcessMaker/Jobs/CompileSass.php
+++ b/ProcessMaker/Jobs/CompileSass.php
@@ -47,7 +47,7 @@ class CompileSass implements ShouldQueue
     public function handle()
     {
         chdir(app()->basePath());
-        $this->runCmd('node_modules/sass/sass.js --no-source-map '
+        $this->runCmd('node_modules/sass/sass.js --no-source-map --quiet '
             . $this->properties['origin'] . ' ' . $this->properties['target']);
 
         if (Str::contains($this->properties['tag'], 'app')) {
@@ -90,7 +90,7 @@ class CompileSass implements ShouldQueue
         $file = str_replace('public/css/precompiled/poppins/500.css', 'css/precompiled/poppins/500.css', $file);
         $file = str_replace('url("../webfonts/', 'url("/fonts/', $file);
         $file = str_replace('url("../fonts/', 'url("/fonts/', $file);
-        $file = str_replace('url("processmaker-font', 'url("/fonts/processmaker-font', $file);        
+        $file = str_replace('url("processmaker-font', 'url("/fonts/processmaker-font', $file);
         $file = str_replace('url("fonts/', 'url("/fonts/', $file);
         $file = str_replace('content: /; }', 'content: "/"; }', $file);
         $re = '/(content:\s)\\\\\"(\\\\[0-9abcdef]+)\\\\\"/m';

--- a/ProcessMaker/Repositories/SettingsConfigRepository.php
+++ b/ProcessMaker/Repositories/SettingsConfigRepository.php
@@ -84,7 +84,26 @@ class SettingsConfigRepository extends Repository
             return null;
         }
 
-        return Setting::byKey($key)?->config;
+        $setting = Setting::byKey($key);
+
+        if ($setting !== null) {
+            return $setting->config;
+        }
+
+        // If the key is a dot notation, we can try to get the first part
+        // and then use the dot notation to get the value if it's an array.
+        $parts = explode('.', $key);
+        if (count($parts) > 1) {
+            $firstKey = array_shift($parts);
+            $setting = Setting::byKey($firstKey);
+            if ($setting && $setting->format === 'array') {
+                $subPath = implode('.', $parts);
+
+                return Arr::get($setting->config, $subPath);
+            }
+        }
+
+        return null;
     }
 
     private function readyToUseSettingsDatabase()

--- a/helpers.php
+++ b/helpers.php
@@ -75,7 +75,7 @@ if (!function_exists('color')) {
      */
     function color($key)
     {
-        if ($colors = Arr::get(config('css-override'), 'variables')) {
+        if ($colors = config('css-override.variables')) {
             $colors = json_decode($colors);
             foreach ($colors as $color) {
                 if ($color->id === '$' . $key) {
@@ -96,7 +96,7 @@ if (!function_exists('sidebar_class')) {
      */
     function sidebar_class()
     {
-        if (Arr::get(config('css-override'), 'variables')) {
+        if (config('css-override.variables')) {
             $defaults = ['#0872C2', '#2773F3'];
             if (!in_array(color('primary'), $defaults)) {
                 return 'sidebar-custom';

--- a/helpers.php
+++ b/helpers.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Horizon\Repositories\RedisJobRepository;
 use ProcessMaker\Events\MarkArtisanCachesAsInvalid;

--- a/helpers.php
+++ b/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Horizon\Repositories\RedisJobRepository;
 use ProcessMaker\Events\MarkArtisanCachesAsInvalid;
@@ -39,8 +40,8 @@ if (!function_exists('settings')) {
      *
      * @param $key
      *
-     * @throws \Psr\Container\ContainerExceptionInterface
-     * @throws \Psr\Container\NotFoundExceptionInterface
+     * @throws Psr\Container\ContainerExceptionInterface
+     * @throws Psr\Container\NotFoundExceptionInterface
      *
      * @return array|mixed
      */
@@ -74,7 +75,7 @@ if (!function_exists('color')) {
      */
     function color($key)
     {
-        if ($colors = config('css-override.variables')) {
+        if ($colors = Arr::get(config('css-override'), 'variables')) {
             $colors = json_decode($colors);
             foreach ($colors as $color) {
                 if ($color->id === '$' . $key) {
@@ -82,7 +83,7 @@ if (!function_exists('color')) {
                 }
             }
         }
-        
+
         return default_color($key);
     }
 }
@@ -91,17 +92,17 @@ if (!function_exists('sidebar_class')) {
     /**
      * Returns the class for the sidebar based on admin settings.
      *
-     * @return boolean
+     * @return bool
      */
     function sidebar_class()
     {
-        if (config('css-override.variables')) {
+        if (Arr::get(config('css-override'), 'variables')) {
             $defaults = ['#0872C2', '#2773F3'];
-            if (! in_array(color('primary'), $defaults)) {
+            if (!in_array(color('primary'), $defaults)) {
                 return 'sidebar-custom';
             }
         }
-        
+
         return 'sidebar-default';
     }
 }
@@ -120,7 +121,7 @@ if (!function_exists('lavaryMenuArray')) {
     /**
      * Convert the Laravy menu into associative array.
      *
-     * @param \Lavary\Menu\Item $menu
+     * @param Lavary\Menu\Item $menu
      * @param mixed             $includeSubMenus
      *
      * @return array
@@ -150,7 +151,7 @@ if (!function_exists('lavaryMenuJson')) {
     /**
      * Convert the Laravy menu into json string.
      *
-     * @param \Lavary\Menu\Item $menu
+     * @param Lavary\Menu\Item $menu
      *
      * @return false|string
      */
@@ -166,7 +167,7 @@ if (!function_exists('hasPackage')) {
      *
      * @param $name
      *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws Illuminate\Contracts\Container\BindingResolutionException
      *
      * @return bool
      */
@@ -182,7 +183,7 @@ if (!function_exists('pmUser')) {
     /**
      * Check both the web and api middleware for an existing user.
      *
-     * @return null|\ProcessMaker\Models\User
+     * @return null|ProcessMaker\Models\User
      */
     function pmUser()
     {

--- a/tests/Repositories/SettingsConfigRepositoryTest.php
+++ b/tests/Repositories/SettingsConfigRepositoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Repositories;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Repository;
+use Illuminate\Support\Facades\Cache;
+use ProcessMaker\Models\Setting;
+use Tests\TestCase;
+
+class SettingsConfigRepositoryTest extends TestCase
+{
+    public function testDotNotation()
+    {
+        Setting::create([
+            'key' => 'test',
+            'config' => '{"dot":{"notation":"the value"}}',
+            'format' => 'array',
+        ]);
+
+        $this->assertEquals('the value', config('test.dot.notation'));
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
See jira issue

## Solution
- Make the refactored settings config repository work with dot notation for values stored in settings
- Also, add a `--quiet` flag to the sass compiler to get rid of the deprecation warnings that we can't fix because they are part of the bootstrap sass library

## How to Test
Change the primary color and make sure the sidebar background changes

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23658

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
