### PR TITLE
FOUR-23699 Fix User/groups > Home Page field does not works correctly when URL Redirect is selected

### DIFF
--- a/ProcessMaker/Http/Controllers/HomeController.php
+++ b/ProcessMaker/Http/Controllers/HomeController.php
@@ -22,7 +22,7 @@ class HomeController extends Controller
                 }
 
                 // Check if there is at least one custom dashboard per user
-                $customDashboardExists = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::where('type', 'DASHBOARD')
+                $customDashboardExists = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::whereIn('type', ['DASHBOARD', 'URL'])
                     ->where('assignable_id', $user->id)
                     ->where('assignable_type', 'ProcessMaker\Models\User')
                     ->count() > 0;
@@ -30,7 +30,7 @@ class HomeController extends Controller
                 // Check if there is at least one custom dashboard per group only first match is selected
                 if (!$customDashboardExists) {
                     $customDashboardExists = collect($groups)->some(function ($groupId) {
-                        return \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::where('type', 'DASHBOARD')
+                        return \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::whereIn('type', ['DASHBOARD', 'URL'])
                             ->where('assignable_type', 'ProcessMaker\Models\Group')
                             ->where('assignable_id', $groupId)
                             ->exists();

--- a/tests/Feature/HomeControllerTest.php
+++ b/tests/Feature/HomeControllerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use ProcessMaker\Models\User;
+use ProcessMaker\Models\Group;
+use ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI;
+use Tests\Feature\Shared\RequestHelper;
+
+class HomeControllerTest extends TestCase
+{
+    use RequestHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // skip if package-dynamic-ui is not installed
+        if (!hasPackage('package-dynamic-ui')) {
+            $this->markTestSkipped('package-dynamic-ui is not installed');
+        }
+    }
+
+    /** @test */
+    public function testRedirectsToLoginWhenNotAuthenticated()
+    {
+        $response = $this->get('/');
+        $response->assertRedirect('/login');
+    }
+
+    /** @test */
+    public function testRedirectsToCustomDashboardWhenUserHasDashboard()
+    {
+        $user = User::factory()->create();
+        
+        // Create a custom dashboard for the user
+        DynamicUI::create([
+            'type' => 'DASHBOARD',
+            'assignable_id' => $user->id,
+            'assignable_type' => User::class,
+            'homepage' => '/custom-dashboard',
+        ]);
+
+        $response = $this->actingAs($user)->get('/');
+        $response->assertRedirect('/custom-dashboard');
+    }
+
+    /** @test */
+    public function testRedirectsToCustomDashboardWhenGroupHasDashboard()
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create();
+        $user->groups()->attach($group->id);
+
+        // Create a custom dashboard for the group
+        DynamicUI::create([
+            'type' => 'DASHBOARD',
+            'assignable_id' => $group->id,
+            'assignable_type' => Group::class,
+            'homepage' => '/group-dashboard',
+        ]);
+
+        $response = $this->actingAs($user)->get('/');
+        $response->assertRedirect('/group-dashboard');
+    }
+
+    /** @test */
+    public function testRedirectsToTasksOnMobileWithoutCustomDashboard()
+    {
+        $user = User::factory()->create();
+        
+        // Mock MobileHelper to return true
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1';
+        $_COOKIE['isMobile'] = 'true';
+
+        $response = $this->actingAs($user)->get('/');
+        $response->assertRedirect('/tasks');
+
+        unset($_SERVER['HTTP_USER_AGENT']);
+        unset($_COOKIE['isMobile']);
+    }
+
+    /** @test */
+    public function testRedirectsToInboxOnDesktopWithoutCustomDashboard()
+    {
+        $user = User::factory()->create();
+        
+        // Mock MobileHelper to return false
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36';
+        $_COOKIE['isMobile'] = 'false';
+
+        $response = $this->actingAs($user)->get('/');
+        $response->assertRedirect('/inbox');
+
+        unset($_SERVER['HTTP_USER_AGENT']);
+        unset($_COOKIE['isMobile']);
+    }
+
+    /** @test */
+    public function testRedirectsToUserUrlRedirect()
+    {
+        $user = User::factory()->create();
+
+        // Create a custom dashboard for the user
+        DynamicUI::create([
+            'type' => 'URL',
+            'assignable_id' => $user->id,
+            'assignable_type' => User::class,
+            'homepage' => 'https://processmaker.com/home',
+        ]);
+
+        $response = $this->actingAs($user)->get('/');
+        $response->assertRedirect('https://processmaker.com/home');
+    }
+
+    /** @test */
+    public function testRedirectsToGroupUrlRedirect()
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create();
+        $user->groups()->attach($group->id);
+
+        // Create a custom dashboard for the group
+        DynamicUI::create([
+            'type' => 'URL',
+            'assignable_id' => $group->id,
+            'assignable_type' => Group::class,
+            'homepage' => 'https://processmaker.com/home',
+        ]);
+
+        $response = $this->actingAs($user)->get('/');
+        $response->assertRedirect('https://processmaker.com/home');
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
User/groups > Home Page field does not works correctly when URL Redirect is selected

## Solution
- Consider DASHBOARD AND URL REDIRECT in login redirect.

https://github.com/user-attachments/assets/92d46836-29d5-45e3-a52b-deb9ac4533cd


## How to Test
- Setup User Home Page to REDIRECT URL
- Set a URL
- Save config
- Logout
- Login with the configured User

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23699

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
