### PR TITLE
observation/FOUR-23694 when settings configurations were added without any asset in the bundle then reinstall or update are not working.

### DIFF
--- a/tests/Model/DevLinkTest.php
+++ b/tests/Model/DevLinkTest.php
@@ -92,7 +92,7 @@ class DevLinkTest extends TestCase
                 ]],
             ]),
             'http://remote-instance.test/api/1.0/devlink/export-local-bundle/123/settings-payloads' => Http::response([
-                'payloads' => [$exportsSettingsPayloads],
+                'payloads' => $exportsSettingsPayloads,
             ]),
             'http://remote-instance.test/api/1.0/devlink/local-bundles/123/add-bundle-instance' => Http::response([], 200),
         ]);


### PR DESCRIPTION
## Issue & Reproduction Steps
when settings configurations were added without any asset in the bundle then reinstall or update are not working.

## Solution
fix the reinstall bundle feature when the bundle only has settings

## How to Test
Create a bundle without assets and settings and publish
on the other instance install the bundle
after installing go to the bundle and reinstall the bundle

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23694
