### PR TITLE
FOUR-23657 Fix Error while uploading large File size 

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -24,6 +24,7 @@ use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Models\Media;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\TaskDraft;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileIsTooBig;
 
 class ProcessRequestFileController extends Controller
 {
@@ -282,7 +283,15 @@ class ProcessRequestFileController extends Controller
             // Perform a chunk upload
             return $this->chunk($receiver, $request, $laravel_request);
         } else {
-            return $this->saveUploadedFile($laravel_request->file, $request, $laravel_request);
+            try {
+                return $this->saveUploadedFile($laravel_request->file, $request, $laravel_request);
+            } catch (FileIsTooBig $e) {
+                return response()->json([
+                    'errors' => [
+                        'file' => ['file may not be greater than ' . (config('media-library.max_file_size') / 1024) . ' kilobytes']
+                    ]
+                ], 422);
+            }
         }
     }
 

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -12,7 +12,7 @@ return [
      * The maximum file size of an item in bytes.
      * Adding a larger file will result in an exception.
      */
-    'max_file_size' => 1024 * 1024 * 256, // 10MB
+    'max_file_size' => env('MEDIA_MAX_FILE_SIZE', 1024 * 1024 * 256), // 256MB default
 
     /*
      * This queue will be used to generate derived and responsive images.

--- a/tests/Feature/MediaConfigTest.php
+++ b/tests/Feature/MediaConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+use ProcessMaker\Models\ProcessRequest;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class MediaConfigTest extends TestCase
+{
+    use RequestHelper;
+
+    public function testMediaMaxFileSize()
+    {
+        // Set a small max file size for testing (1MB)
+        Config::set('media-library.max_file_size', 1024 * 1024); // 1MB
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $user = $processRequest->user;
+
+        // Test file within size limit (500KB)
+        $validFile = UploadedFile::fake()->create('valid.txt', 500);
+        file_put_contents($validFile->getPathname(), str_repeat('a', 500 * 1024));
+
+        $response = $this->actingAs($user)->apiCall('POST', '/requests/' . $processRequest->id . '/files', [
+            'file' => $validFile,
+            'data_name' => 'test_file',
+        ]);
+        $response->assertStatus(200);
+        $this->assertEquals(1, $processRequest->getMedia()->count());
+
+        // Test file exceeding size limit (2MB)
+        $oversizedFile = UploadedFile::fake()->create('oversized.txt', 2048);
+        file_put_contents($oversizedFile->getPathname(), str_repeat('a', 2048 * 1024));
+
+        $response = $this->apiCall('POST', '/requests/' . $processRequest->id . '/files', [
+            'file' => $oversizedFile,
+            'data_name' => 'test_file_2',
+        ]);
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['file']);
+
+        // Verify the error message mentions file size
+        $this->assertStringContainsString(
+            'file may not be greater than 1024 kilobytes',
+            $response->json()['errors']['file'][0]
+        );
+
+        // Verify no new media was added
+        $this->assertEquals(1, $processRequest->getMedia()->count());
+    }
+
+    public function testMediaMaxFileSizeFromEnv()
+    {
+        // Test that the config reads from environment variable
+        $maxSize = 5 * 1024 * 1024; // 5MB
+        Config::set('media-library.max_file_size', $maxSize);
+
+        $this->assertEquals(
+            $maxSize,
+            config('media-library.max_file_size'),
+            'Media max file size should match environment configuration'
+        );
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
`media-library.max_file_size` is hardcoded to 256mb

## Solution
- Add environment variable to configure the max file size.

## How to Test
- Create a process with a screen with upload file
- Run the process
- Try to upload a file larger than 256mb (e.g. 300mb)
- Setup the env variable MEDIA_MAX_FILE_SIZE to 500
- Try to upload a file larger than 256mb (e.g. 300mb)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23657

