### PR TITLE
bugfix/FOUR-23723 added an new param for redirectListener

### DIFF
--- a/ProcessMaker/Listeners/HandleRedirectListener.php
+++ b/ProcessMaker/Listeners/HandleRedirectListener.php
@@ -31,11 +31,11 @@ class HandleRedirectListener
             $params['activeTokens'] = ProcessRequest::getActiveTokens($processRequest);
             $event = new RedirectToEvent($processRequest, $method, $params);
             event($event);
-        }
 
-        // Clean params to prevent sending the same redirect multiple times
-        self::$redirectionParams = [];
-        self::$redirectionMethod = '';
-        self::$processRequest = null;
+            // Clean params to prevent sending the same redirect multiple times
+            self::$redirectionParams = [];
+            self::$redirectionMethod = '';
+            self::$processRequest = null;
+        }
     }
 }

--- a/ProcessMaker/Listeners/HandleRedirectListener.php
+++ b/ProcessMaker/Listeners/HandleRedirectListener.php
@@ -25,16 +25,17 @@ class HandleRedirectListener
         $method = self::$redirectionMethod;
         $params = self::$redirectionParams;
         $processRequest = self::$processRequest;
-        $params['activeTokens'] = ProcessRequest::getActiveTokens($processRequest);
 
+        // Only get active tokens if there is a valid process request
         if ($processRequest !== null) {
+            $params['activeTokens'] = ProcessRequest::getActiveTokens($processRequest);
             $event = new RedirectToEvent($processRequest, $method, $params);
             event($event);
-            // clean params to prevent send the same redirect multiple times
-            self::$redirectionParams = [];
-            self::$redirectionMethod = '';
-            self::$processRequest = null;
         }
-    }
 
+        // Clean params to prevent sending the same redirect multiple times
+        self::$redirectionParams = [];
+        self::$redirectionMethod = '';
+        self::$processRequest = null;
+    }
 }

--- a/ProcessMaker/Listeners/HandleRedirectListener.php
+++ b/ProcessMaker/Listeners/HandleRedirectListener.php
@@ -25,6 +25,7 @@ class HandleRedirectListener
         $method = self::$redirectionMethod;
         $params = self::$redirectionParams;
         $processRequest = self::$processRequest;
+        $params['activeTokens'] = ProcessRequest::getActiveTokens($processRequest);
 
         if ($processRequest !== null) {
             $event = new RedirectToEvent($processRequest, $method, $params);
@@ -35,4 +36,5 @@ class HandleRedirectListener
             self::$processRequest = null;
         }
     }
+
 }

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -1132,4 +1132,19 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
 
         return $query->where('case_number', $caseNumber);
     }
+
+    /**
+     * Get the IDs of the active tokens for a process request
+     *
+     * @param ProcessRequest $processRequest
+     * @return array Array of active tokens IDs
+     */
+    public static function getActiveTokens(self $processRequest)
+    {
+        return $processRequest->tokens()
+            ->select('id')
+            ->where('status', 'ACTIVE')
+            ->pluck('id')
+            ->toArray();
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
added an new param for redirectListener with active tokes to validate the redirection

## How to Test
Steps to Reproduce: 

# [step1] 
import the attached process
# [step2]  
Assign the users per each task
# [step3] 
create a new case for the new process
# [step4] 
run the case in parallel thread in the same time (with different users and browsers)
# [step5] 
submit the first task
h5. Current Behavior: 

We have two scenarios: 

The task is set to "Task Source (Default)" in the Task Destination. Submitting one thread reloads the other and redirects to the request page (see the attached video on the parallel problem).

The task is set to "Show Next Assigned Task" in the Task Destination. Submitting one thread reloads the other and redirects to the next task in the submitted thread, thus bypassing permissions to view tasks (see the attached video on the parallel problem with interstitials).

Expected Behavior: 
The submission of tasks should be independent. Other threads should not reload automatically.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23723

