### PR TITLE
observation/FOUR-23761 Response error with API calls using Password Grant authentication

### DIFF
--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -59,6 +59,8 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
+        Passport::enablePasswordGrant();
+
         Passport::authorizationView('auth.oauth2.authorize');
 
         Gate::before(function ($user) {


### PR DESCRIPTION
…l passport

## Issue & Reproduction Steps
Response error with API calls using Password Grant authentication

## Solution
explicitly enable password grant is required in new version of laravel Passport

## How to Test
Log in  
Go to Admin
Click on Auth Clients 
Create an auth client
Enter a name and enable the "Enable Password Grant" option.
Save
Copy the generated client secret.
place. with your domain data, id password as follows. curl

curl -X "POST" "{server domain}/oauth/token" \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "client_id": "1",
  "username": "admin",
  "password": "admin",
  "client_secret": "{client_secret}",
  "grant_type": "password"
}'

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23761