### PR TITLE
Fix HTTP client timeout

### DIFF
--- a/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
@@ -90,7 +90,12 @@ class ScriptMicroserviceRunner
 
         Log::debug('Payload: ' . print_r($payload, true));
 
-        $response = Http::timeout($timeout)
+        // Set a theoretical maximum timeout of 1 day (86400 seconds)
+        // since the laravel client must have a timeout set.
+        // The actual script timeout will be handled by the microservice.
+        $clientTimeout = 86400;
+
+        $response = Http::timeout($clientTimeout)
             ->withToken($this->getAccessToken())
             ->post(config('script-runner-microservice.base_url') . '/requests/create', $payload);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The error was caused by https://github.com/ProcessMaker/processmaker/pull/8141

The fix was intended to solve a problem where the script was failing after 30 seconds even though the microservice had not yet finished running the script. This was because laravel's HTTP client had a default timeout of 30 seconds

The problem is that some scripts (like the one configured for the PDF generator) had a null timeout. This means unlimited and it worked fine with the docker engine. However, the laravel HTTP client can not take null and must have a value set for it's timeout.

## Solution
- Set a theoretical maximum of 1 day for the laravel client only. The actual timeout will be handled by the microservice, which correctly interprets `null` as unlimited.

## How to Test
Configure your environment to use the script microservice. Generate a PDF. The PDF Package uses a script task with a `null` timeout value (unlimited). It should correctly generate the PDF without errors.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23776

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
