### PR TITLE
FOUR-22970 add Email Listener by default

### DIFF
--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -399,19 +399,22 @@ class Setting extends ProcessMakerModel implements HasMedia, PrometheusMetricInt
     public static function groupsByMenu($menuId)
     {
         $query = self::query()
-            ->select('group')
+            ->select([
+                \DB::raw('MAX(id) as id'),
+                'group',
+            ])
             ->groupBy('group')
             ->where('group_id', $menuId)
             ->orderBy('group', 'ASC')
             ->notHidden()
-            ->pluck('group');
-        $response = $query->toArray();
+            ->get();
+
         $result = [];
-        foreach ($response as &$value) {
-            // Technical debts: we need to add int key to identify a group, currently this is a label
+        foreach ($query as $setting) {
             $result[] = [
-                'id' => $value,
-                'name' => $value,
+                'id' => $setting->group,
+                'name' => $setting->group,
+                'setting_id' => $setting->id,
             ];
         }
 

--- a/resources/js/admin/settings/components/SettingChoice.vue
+++ b/resources/js/admin/settings/components/SettingChoice.vue
@@ -37,6 +37,7 @@
 </template>
 
 <script>
+import _ from "lodash";
 import settingMixin from "../mixins/setting";
 
 export default {

--- a/resources/js/admin/settings/components/SettingsMain.vue
+++ b/resources/js/admin/settings/components/SettingsMain.vue
@@ -11,12 +11,17 @@
     </div>
     <div class="setting-info pl-3">
       <settings-listing
-        v-if="selectedItem"
+        v-if="selectedItem && !emailListenerConfigurationComponent"
         :key="setListingKey"
         ref="listings"
         :group="group"
         @refresh="refresh"
         @refresh-all="refreshAll"
+      />
+      <component
+        :is="emailListenerConfigurationComponent"
+        ref="emailListenerConfiguration"
+        :setting-id="settingId"
       />
     </div>
   </div>
@@ -31,14 +36,28 @@ export default {
   data() {
     return {
       currentTab: 0,
+      settingId: null,
       group: "",
       setListingKey: 0,
       selectedItem: false,
     };
   },
+  computed: {
+    isEmailStartEventInstalled() {
+      return !!window.ProcessMaker.EmailStartEvent;
+    },
+    emailListenerConfigurationComponent() {
+      if (this.isEmailStartEventInstalled && this.group.startsWith('Email Listener')) {
+        return window.ProcessMaker.EmailStartEvent.EmailListenerConfiguration;
+      }
+
+      return null;
+    },
+  },
   methods: {
     selectGroup(item) {
       this.group = item.name;
+      this.settingId = item.setting_id;
       this.selectedItem = true;
       this.reRender();
     },

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -26,7 +26,12 @@
 @endsection
 
 @section('js')
+    @if (hasPackage('package-email-start-event'))
+    <script src="{{ mix('js/email-listener.js', 'vendor/processmaker/packages/package-email-start-event') }}"></script>
+    @endif
+
     <script src="{{mix('js/admin/settings/index.js')}}"></script>
+
     @if($errors->has('error'))
         <script>
             window.ProcessMaker.alert("{{ $errors->first('error') }}", 'danger');


### PR DESCRIPTION
## Issue & Reproduction Steps
Add Email Listener by default

## Solution
- Improve the settings management functionality in the application.
- The changes focus on enhancing the data retrieval process, adding new dependencies, and integrating additional components conditionally.
- Added a script tag to include the email listener JavaScript file if the `package-email-start-event` package is present.

## Related Tickets & Packages
[FOUR-22970](https://processmaker.atlassian.net/browse/FOUR-22970)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22970]: https://processmaker.atlassian.net/browse/FOUR-22970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ