### PR TITLE
observation/FOUR-23773 Unable to get any logs in ew58

### DIFF
--- a/ProcessMaker/Http/Middleware/TrustProxies.php
+++ b/ProcessMaker/Http/Middleware/TrustProxies.php
@@ -20,4 +20,11 @@ class TrustProxies extends Middleware
      * @var int
      */
     protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+
+    public function __construct()
+    {
+        if (env('TRUST_ALL_PROXIES', false)) {
+            $this->proxies = '*';
+        }
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Unable to get any logs in ew58

Steps to Reproduce

Make any change in ProcessMaker (/admin/package-ellucian-ethos/integration)

For checking Audit-logs:
https://integrate.elluciancloud.com/
testaccount40 / 2letMein!

You find /audit-logs tab under Reports --> Audit logs
it will takes 10 to 15 mins to reflect new audit log entries

## Solution
configured the trusted proxies and got the ip before calling the job

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23773
