### PR TITLE
FOUR-23765: Update the message error when the name exists

### DIFF
--- a/tests/Feature/Api/SettingsTest.php
+++ b/tests/Feature/Api/SettingsTest.php
@@ -174,4 +174,59 @@ class SettingsTest extends TestCase
         //Verify variable were not updated
         $this->assertDatabaseMissing('settings', ['config' => '{"1myVar":"This is my variable 1","myVar space":"This is my variable 2"}']);
     }
+
+    public function test_it_can_create_a_setting()
+    {
+        $menu = SettingsMenus::create([
+            'menu_group' => 'Log-In & Auth',
+        ]);
+        $data = [
+            'key' => 'white_list.drive',
+            'format' => 'text',
+            'config' => 'https://drive.google.com',
+            'name' => 'Drive',
+            'group' => 'IFrame Whitelist Config',
+            'group_id' => $menu->id,
+            'hidden' => false,
+            'ui' => null,
+        ];
+        $route = route('api.settings.store');
+        $response = $this->apiCall('POST', $route, $data);
+        //Verify the status
+        $response->assertStatus(201);
+    }
+
+    public function test_it_returns_error_for_duplicate_entry()
+    {
+        $menu = SettingsMenus::create([
+            'menu_group' => 'Log-In & Auth',
+        ]);
+        // Create a setting first
+        Setting::create([
+            'key' => 'white_list.drive',
+            'format' => 'text',
+            'config' => 'https://drive.google.com',
+            'name' => 'Drive',
+            'group' => 'IFrame Whitelist Config',
+            'group_id' => $menu->id,
+            'hidden' => false,
+            'ui' => null,
+        ]);
+        // Data to create
+        $data = [
+            'key' => 'white_list.drive',
+            'format' => 'text',
+            'config' => 'https://drive.google.com',
+            'name' => 'Drive',
+            'group' => 'IFrame Whitelist Config',
+            'group_id' => $menu->id,
+            'hidden' => false,
+            'ui' => null,
+        ];
+        $route = route('api.settings.store');
+        $response = $this->apiCall('POST', $route, $data);
+        //Verify the status
+        $response->assertStatus(409)
+                 ->assertJson(['message' => 'The "Site Name" you\'re trying to add already exists. Please select a different name or review the existing entries to avoid duplication.']);
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Update the message error when the name exists

## Solution
- Catch the error and show a specific message

## How to Test

1. Go to Settings - Iframe With List
2. Add the same Name URL

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23765

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy