### PR TITLE
FOUR-22972 CRUD for Email Listeners

### DIFF
--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -401,6 +401,7 @@ class Setting extends ProcessMakerModel implements HasMedia, PrometheusMetricInt
         $query = self::query()
             ->select([
                 \DB::raw('MAX(id) as id'),
+                \DB::raw('MAX(`key`) as setting_key'),
                 'group',
             ])
             ->groupBy('group')
@@ -415,6 +416,7 @@ class Setting extends ProcessMakerModel implements HasMedia, PrometheusMetricInt
                 'id' => $setting->group,
                 'name' => $setting->group,
                 'setting_id' => $setting->id,
+                'setting_key' => $setting->setting_key,
             ];
         }
 

--- a/resources/js/admin/settings/components/SettingsMain.vue
+++ b/resources/js/admin/settings/components/SettingsMain.vue
@@ -37,17 +37,16 @@ export default {
     return {
       currentTab: 0,
       settingId: null,
+      settingKey: null,
       group: "",
       setListingKey: 0,
       selectedItem: false,
+      isEmailStartEventInstalled: false,
     };
   },
   computed: {
-    isEmailStartEventInstalled() {
-      return !!window.ProcessMaker.EmailStartEvent;
-    },
     emailListenerConfigurationComponent() {
-      if (this.isEmailStartEventInstalled && this.group.startsWith('Email Listener')) {
+      if (this.isEmailStartEventInstalled && this.settingKey.includes('email_start_event')) {
         return window.ProcessMaker.EmailStartEvent.EmailListenerConfiguration;
       }
 
@@ -56,8 +55,11 @@ export default {
   },
   methods: {
     selectGroup(item) {
+      this.isEmailStartEventInstalled = !!window.ProcessMaker.EmailStartEvent;
+
       this.group = item.name;
       this.settingId = item.setting_id;
+      this.settingKey = item.setting_key;
       this.selectedItem = true;
       this.reRender();
     },

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -27,7 +27,7 @@
 
 @section('js')
     @if (hasPackage('package-email-start-event'))
-    <script src="{{ mix('js/email-listener.js', 'vendor/processmaker/packages/package-email-start-event') }}"></script>
+    <script type="module" src="{{ mix('js/email-listener.js', 'vendor/processmaker/packages/package-email-start-event') }}"></script>
     @endif
 
     <script src="{{mix('js/admin/settings/index.js')}}"></script>


### PR DESCRIPTION
## Issue & Reproduction Steps
Test for CRUD for Email Listeners

## Solution
- Enhance settings uiI to support new setting key for email listener

## Related Tickets & Packages
[FOUR-22972](https://processmaker.atlassian.net/browse/FOUR-22972)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22972]: https://processmaker.atlassian.net/browse/FOUR-22972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ