### PR TITLE
FOUR-23786:Screen crashes when changing empty charts in Launchpad

### DIFF
--- a/resources/js/processes-catalogue/components/BaseChart.vue
+++ b/resources/js/processes-catalogue/components/BaseChart.vue
@@ -179,8 +179,7 @@ export default {
       ProcessMaker.apiClient
         .get(`saved-searches/charts/${this.chartId}`, { timeout: 0 })
         .then((response) => {
-          this.charts = response.data;
-          this.transform(this.charts);
+          this.transform(response.data);
         })
         .catch(() => {
           this.getDefaultData();
@@ -267,6 +266,9 @@ export default {
     },
     transform(data) {
       this.chart = data;
+      // Reset chart data
+      this.resetChartData();
+
       if (this.chart.chart_data && this.chart.config) {
         this.chartData = this.transformChartData(this.chart);
         this.chartConfig = this.chart.config;
@@ -278,6 +280,13 @@ export default {
         this.error = this.chart.chart_error;
         this.hint = this.chart.chart_hint;
       }
+    },
+    resetChartData() {
+      this.chartData = null;
+      this.chartConfig = null;
+      this.chartOptions = null;
+      this.error = null;
+      this.hint = null;
     },
     fetchProcessConfigLaunchpad() {
       ProcessMaker.apiClient


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Import a process
2. Not create request yet
3. Go to Request
4. Create a saved search in base the process
5. Create a  chart 1
6. Create a  chart 2
7 Go to process launchpad
8 Open any process by launchpad
9 Click on Edit launch pad
10 Open dev console
11 Select the chart empty save the changes
12 Select a chart not empty and save the changes
13 Select the chart empty save the changes
14 Make these changes and you will notice that the screen freezes.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23786

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy