### PR TITLE
FOUR-22013 Fix log of Case not Found when a script task is executed

### DIFF
--- a/ProcessMaker/Repositories/CaseTaskRepository.php
+++ b/ProcessMaker/Repositories/CaseTaskRepository.php
@@ -44,6 +44,13 @@ class CaseTaskRepository
      */
     public function updateTaskStatus()
     {
+        // Skip non-user tasks (e.g. script task, sub-process, etc.)
+        // tasks column contains only user tasks
+        $isUserTask = ($this->task->element_type ?? null) === 'task';
+        if (!$isUserTask) {
+            return;
+        }
+
         try {
             $case = $this->findCaseByTaskId($this->caseNumber, (string) $this->task->id);
 


### PR DESCRIPTION
## Fix log of Case not Found when a script task is executed

Log is not required for script tasks, just skip it since `tasks` column updated at `updateTaskStatus` only stores user Tasks, not other tasks like script tasks, call activity, etc.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22013

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

