### PR TITLE
observation/FOUR-23820 devLink > options are not synchronized

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/DevLinkController.php
+++ b/ProcessMaker/Http/Controllers/Api/DevLinkController.php
@@ -283,7 +283,12 @@ class DevLinkController extends Controller
 
     public function addSettings(Request $request, Bundle $bundle)
     {
-        $bundle->addSettings($request->input('setting'), $request->input('config'), $request->input('type'));
+        $bundle->addSettings(
+            $request->input('setting'),
+            $request->input('config'),
+            $request->input('type'),
+            $request->input('replaceIds', false)
+        );
     }
 
     public function addAssetToBundles(Request $request)

--- a/ProcessMaker/Models/Bundle.php
+++ b/ProcessMaker/Models/Bundle.php
@@ -158,7 +158,7 @@ class Bundle extends ProcessMakerModel implements HasMedia
         ]);
     }
 
-    public function addSettings($setting, $newId, $type = null)
+    public function addSettings($setting, $newId, $type = null, $replaceIds = false)
     {
         $existingSetting = $this->settings()->where('setting', $setting)->first();
 
@@ -169,7 +169,7 @@ class Bundle extends ProcessMakerModel implements HasMedia
         $decodedNewId = $this->parseNewId($newId);
 
         if ($existingSetting) {
-            return $this->updateExistingSetting($existingSetting, $decodedNewId);
+            return $this->updateExistingSetting($existingSetting, $decodedNewId, $replaceIds);
         }
 
         $this->createNewSetting($setting, $decodedNewId, $type);
@@ -210,7 +210,7 @@ class Bundle extends ProcessMakerModel implements HasMedia
         return ['id' => [$newId]];
     }
 
-    private function updateExistingSetting($existingSetting, $decodedNewId)
+    private function updateExistingSetting($existingSetting, $decodedNewId, $replaceIds = false)
     {
         if (isset($decodedNewId['id']) && $decodedNewId['id'] === []) {
             $existingSetting->delete();
@@ -224,8 +224,12 @@ class Bundle extends ProcessMakerModel implements HasMedia
             $config['id'] = [];
         }
 
-        foreach ($decodedNewId['id'] as $id) {
-            $config['id'][] = $id;
+        if ($replaceIds) {
+            $config['id'] = $decodedNewId['id'];
+        } else {
+            foreach ($decodedNewId['id'] as $id) {
+                $config['id'][] = $id;
+            }
         }
 
         $config['id'] = array_values(array_unique($config['id']));

--- a/resources/js/admin/devlink/components/BundleSettingsModal.vue
+++ b/resources/js/admin/devlink/components/BundleSettingsModal.vue
@@ -91,7 +91,8 @@ const onOk = async () => {
   await window.ProcessMaker.apiClient.post(`devlink/local-bundles/${bundleId}/add-settings`, {
     setting: settingKey.value,
     config: JSON.stringify(configs.value),
-    type: null
+    type: null,
+    replaceIds: true
   });
   window.ProcessMaker.alert('Settings saved', 'success');
   emit('settings-saved');


### PR DESCRIPTION
## Issue & Reproduction Steps
devLink > options are not synchronized

## Solution
fixed the add settings API when changing the settings from a bundle

## How to Test
Go to serverA

Create a bundle
Go to Settings page (/admin/settings)
configure settings (Email settings, Log-in & Auth, User Settings, integrations and UI Settings)
Add each setting to bundle
Publish the bundle

Go to serverB

Create a instance to serverA
Download the bundle
Open the bundle
Search the cards related to settings  (Email settings, Log-in & Auth, User Settings, integrations and UI Settings)
Press gear icon
Check the options

Go to serverA

Open the bundle
Check the options

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23820
