### PR TITLE
FOUR-23814: Available Columns, in Edit Task Column, in Launchpad Settings shows all columns in bulk at the bottom

### DIFF
--- a/resources/js/components/shared/Column.vue
+++ b/resources/js/components/shared/Column.vue
@@ -86,6 +86,7 @@ export default {
 
   .column-label {
     padding-left: 181px;
+    word-break: break-all;
   }
 
   .column-card a {

--- a/resources/js/components/shared/ColumnChooser.vue
+++ b/resources/js/components/shared/ColumnChooser.vue
@@ -230,6 +230,9 @@ export default {
           let afterHeight = this.$refs.columnAfter.offsetHeight;
           
           let height = (containerHeight - (beforeHeight + afterHeight) - adjustHeight);
+          if (height < 0) {
+            height = 378;
+          }
           this.$refs.columnContainer.style.height = `${height}px`;
           this.$refs.columnContainer.style.maxHeight = `${height}px`;
         },

--- a/resources/js/components/shared/ColumnChooser.vue
+++ b/resources/js/components/shared/ColumnChooser.vue
@@ -16,8 +16,8 @@
                     </div>                                    
                 </div>
             </div>
-            <div class="column-container d-flex flex-row align-content-stretch" ref="columnContainer">
-                <div class="w-50 mr-3">
+            <div class="d-flex flex-row align-content-stretch" ref="columnContainer">
+                <div class="column-container w-50 mr-3">
                     <draggable group="columns" class="border bg-muted px-3 draggable-list draggable-current" :list="currentColumns">
                         <column v-for="(element, index) in currentColumns" 
                                 :column="element"
@@ -26,7 +26,7 @@
                                 @remove="removeColumn(index)"></column>
                     </draggable>
                 </div>
-                <div class="w-50">
+                <div class="column-container w-50">
                     <div v-if="availableColumnsDirect === false" class="d-flex align-items-center justify-content-center border bg-muted h-100 w-100 text-center px-3 draggable-list draggable-available">
                         <data-loading-basic
                         desc="Finding available columns..."

--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -124,6 +124,7 @@
       size="lg"
       class="modal-dialog modal-dialog-centered"
       hide-footer
+      scrollable
       :title="$t('Edit Task Column')"
     >
       <div class="modal-content-custom">


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Log in 
2. Create a process
3. Click on Publish 
4. View  the Launchpad settings 
5. click on “Edit Task Column“

**Current Behavior:**
As we see the columns in Available Column of launchpad settings of a process, all are displayed

**Expected Behavior:**
Edit Task Column should maintain the normal size even if it has more data. Only the scroll should grow and not the form.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23814

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
