### PR TITLE
Create Data Source Integrations Database Schema

### DIFF
--- a/ProcessMaker/Models/DataSourceIntegrations.php
+++ b/ProcessMaker/Models/DataSourceIntegrations.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
+
+class DataSourceIntegrations extends Model
+{
+    use HasFactory;
+
+    protected $table = 'data_source_integrations';
+
+    protected $fillable = ['name', 'key', 'base_url', 'auth_type', 'credentials'];
+
+    public static function rules()
+    {
+        return [
+            'name' => 'required',
+            'key' => 'required',
+            'base_url' => 'required',
+            'auth_type' => 'required',
+            'credentials' => 'required',
+        ];
+    }
+
+    public function getCredentialsAttribute($value)
+    {
+        if (!$value) {
+            return null;
+        }
+
+        try {
+            $decrypted = Crypt::decryptString($value);
+
+            return json_decode($decrypted, true) ?? $decrypted;
+        } catch (\Exception $e) {
+            \Log::debug('======== DECRYPTION ERROR ====== ', ['$error' => $e->getMessage()]);
+
+            return null;
+        }
+    }
+
+    public function setCredentialsAttribute($value)
+    {
+        if (is_array($value) || is_object($value)) {
+            $value = json_encode($value);
+        }
+
+        try {
+            $encrypted = Crypt::encryptString($value);
+            $this->attributes['credentials'] = $encrypted;
+        } catch (\Exception $e) {
+            \Log::debug('======== ENCRYPTION ERROR ====== ', ['$error' => $e->getMessage()]);
+        }
+    }
+}

--- a/database/migrations/2025_04_17_164205_create_data_source_integrations_table.php
+++ b/database/migrations/2025_04_17_164205_create_data_source_integrations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('data_source_integrations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('key')->unique();
+            $table->string('base_url');
+            $table->string('auth_type');
+            $table->text('credentials')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('data_source_integrations');
+    }
+};


### PR DESCRIPTION
This PR adds the initial implementation for storing configured data source integrations in the database. It includes:

- Creation of the `data_source_integrations` table
- The `DataSourceIntegration` Eloquent model

### Database Schema
`id` - int- Primary key 
`name` - string - Display name of the integration
`key` - string - Unique id of the integration (`pitchbook`)
`auth_type` - string - Authentication type (api_key, oauth, token etc..)
`base_url` - string - API base URL
`credentials` - text - Encrypted credentials (token or object)

## How to Test
1. Run `php artisan migrate`
2. A new table `data_source_integrations` should be created in your database
3. Run `php artisan migrate:rollback --step=1`
4. The `data_source_integrations` table should be dropped.

## Related Tickets & Packages
- [FOUR-23909](https://processmaker.atlassian.net/browse/FOUR-23909)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-23909]: https://processmaker.atlassian.net/browse/FOUR-23909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ