### PR TITLE
Add POST Endpoint to Create Data Source Integrations

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/DataSourceIntegrationsController.php
+++ b/ProcessMaker/Http/Controllers/Api/DataSourceIntegrationsController.php
@@ -14,24 +14,28 @@ class DataSourceIntegrationsController extends Controller
 {
     public function store(Request $request)
     {
-        $request->validate(DataSourceIntegrations::rules());
-        try {
-            $dataSourceIntegration = DataSourceIntegrations::create($request->all());
+        $validatedData = $request->validate(DataSourceIntegrations::rules());
 
-            return response()->json(['message' => 'Integration created successfully'], 201);
-        } catch (ValidationException $e) {
+        try {
+            $integration = DataSourceIntegrations::create($validatedData);
+
             return response()->json([
-                'error' => 'Validation failed',
-                'details' => $e->errors(),
-            ], 422);
+                'message' => 'Integration created successfully',
+            ], 201);
         } catch (QueryException $e) {
-            Log::error('Database error creating integration: ' . $e->getMessage());
+            Log::error('Database error while creating integration', [
+                'message' => $e->getMessage(),
+                'input' => $request->only(['name', 'key', 'auth_type']),
+            ]);
 
             return response()->json([
                 'error' => 'Failed to save integration to the database',
             ], 500);
         } catch (Exception $e) {
-            Log::error('Unexpected error creating integration: ' . $e->getMessage());
+            Log::error('Unexpected error while creating integration', [
+                'message' => $e->getMessage(),
+                'input' => $request->only(['name', 'key', 'auth_type']),
+            ]);
 
             return response()->json([
                 'error' => 'An unexpected error occurred',

--- a/ProcessMaker/Http/Controllers/Api/DataSourceIntegrationsController.php
+++ b/ProcessMaker/Http/Controllers/Api/DataSourceIntegrationsController.php
@@ -2,7 +2,11 @@
 
 namespace ProcessMaker\Http\Controllers\Api;
 
+use Exception;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Models\DataSourceIntegrations;
 
@@ -15,8 +19,23 @@ class DataSourceIntegrationsController extends Controller
             $dataSourceIntegration = DataSourceIntegrations::create($request->all());
 
             return response()->json(['message' => 'Integration created successfully'], 201);
-        } catch (\Exception $e) {
-            return response()->json(['error' => $e->getMessage()], 500);
+        } catch (ValidationException $e) {
+            return response()->json([
+                'error' => 'Validation failed',
+                'details' => $e->errors(),
+            ], 422);
+        } catch (QueryException $e) {
+            Log::error('Database error creating integration: ' . $e->getMessage());
+
+            return response()->json([
+                'error' => 'Failed to save integration to the database',
+            ], 500);
+        } catch (Exception $e) {
+            Log::error('Unexpected error creating integration: ' . $e->getMessage());
+
+            return response()->json([
+                'error' => 'An unexpected error occurred',
+            ], 500);
         }
     }
 }

--- a/ProcessMaker/Http/Controllers/Api/DataSourceIntegrationsController.php
+++ b/ProcessMaker/Http/Controllers/Api/DataSourceIntegrationsController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Models\DataSourceIntegrations;
+
+class DataSourceIntegrationsController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate(DataSourceIntegrations::rules());
+        try {
+            $dataSourceIntegration = DataSourceIntegrations::create($request->all());
+
+            return response()->json(['message' => 'Integration created successfully'], 201);
+        } catch (\Exception $e) {
+            return response()->json(['error' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/ProcessMaker/Http/Controllers/Api/DataSourceIntegrationsController.php
+++ b/ProcessMaker/Http/Controllers/Api/DataSourceIntegrationsController.php
@@ -17,7 +17,7 @@ class DataSourceIntegrationsController extends Controller
         $validatedData = $request->validate(DataSourceIntegrations::rules());
 
         try {
-            $integration = DataSourceIntegrations::create($validatedData);
+            DataSourceIntegrations::create($validatedData);
 
             return response()->json([
                 'message' => 'Integration created successfully',

--- a/ProcessMaker/Models/DataSourceIntegrations.php
+++ b/ProcessMaker/Models/DataSourceIntegrations.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
+
+class DataSourceIntegrations extends Model
+{
+    use HasFactory;
+
+    protected $table = 'data_source_integrations';
+
+    protected $fillable = ['name', 'key', 'base_url', 'auth_type', 'credentials'];
+
+    public static function rules()
+    {
+        return [
+            'name' => 'required',
+            'key' => 'required',
+            'base_url' => 'required',
+            'auth_type' => 'required',
+            'credentials' => 'required',
+        ];
+    }
+
+    public function getCredentialsAttribute($value)
+    {
+        if (!$value) {
+            return null;
+        }
+
+        try {
+            $decrypted = Crypt::decryptString($value);
+
+            return json_decode($decrypted, true) ?? $decrypted;
+        } catch (\Exception $e) {
+            \Log::debug('======== DECRYPTION ERROR ====== ', ['$error' => $e->getMessage()]);
+
+            return null;
+        }
+    }
+
+    public function setCredentialsAttribute($value)
+    {
+        if (is_array($value) || is_object($value)) {
+            $value = json_encode($value);
+        }
+
+        try {
+            $encrypted = Crypt::encryptString($value);
+            $this->attributes['credentials'] = $encrypted;
+        } catch (\Exception $e) {
+            \Log::debug('======== ENCRYPTION ERROR ====== ', ['$error' => $e->getMessage()]);
+        }
+    }
+}

--- a/database/factories/DataSourceIntegrationsFactory.php
+++ b/database/factories/DataSourceIntegrationsFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\ProcessMaker\Models\DataSourceIntegrations>
+ */
+class DataSourceIntegrationsFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/migrations/2025_04_17_164205_create_data_source_integrations_table.php
+++ b/database/migrations/2025_04_17_164205_create_data_source_integrations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('data_source_integrations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('key')->unique();
+            $table->string('base_url');
+            $table->string('auth_type');
+            $table->text('credentials')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('data_source_integrations');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use ProcessMaker\Http\Controllers\Api\BookmarkController;
 use ProcessMaker\Http\Controllers\Api\ChangePasswordController;
 use ProcessMaker\Http\Controllers\Api\CommentController;
 use ProcessMaker\Http\Controllers\Api\CssOverrideController;
+use ProcessMaker\Http\Controllers\Api\DataSourceIntegrationsController;
 use ProcessMaker\Http\Controllers\Api\DebugController;
 use ProcessMaker\Http\Controllers\Api\DevLinkController;
 use ProcessMaker\Http\Controllers\Api\EncryptedDataController;
@@ -425,5 +426,8 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
         // Put these last to avoid conflicts with the other devlink routes
         Route::get('devlink/{devLink}', [DevLinkController::class, 'show'])->name('devlink.show');
     });
+
+    // Data Source Integrations
+    Route::post('data-source-integrations', [DataSourceIntegrationsController::class, 'store'])->name('data-source-integrations.store');
 });
 Route::post('devlink/bundle-updated/{bundle}/{token}', [DevLinkController::class, 'bundleUpdated'])->name('devlink.bundle-updated');

--- a/tests/Feature/Api/DataSourceIntegrationsTest.php
+++ b/tests/Feature/Api/DataSourceIntegrationsTest.php
@@ -38,4 +38,12 @@ class DataSourceIntegrationsTest extends TestCase
             'key' => 'test_key',
         ]);
     }
+
+    public function testItFailsValidationWithMissingRequiredFields()
+    {
+        $response = $this->apiCall('POST', route('api.data-source-integrations.store', []));
+
+        $response->assertStatus(422)
+        ->assertJsonValidationErrors(['name', 'key', 'auth_type', 'base_url', 'credentials']);
+    }
 }

--- a/tests/Feature/Api/DataSourceIntegrationsTest.php
+++ b/tests/Feature/Api/DataSourceIntegrationsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use ProcessMaker\Models\DataSourceIntegrations;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class DataSourceIntegrationsTest extends TestCase
+{
+    use RefreshDatabase;
+    use RequestHelper;
+
+    public function testItCreatesDataSourceIntegration()
+    {
+        $payload = [
+            'name' => 'Test Integration',
+            'key' => 'test_key',
+            'auth_type' => 'token',
+            'base_url' => 'https://api.test.com',
+            'credentials' => [
+                'token' => 'test_token',
+            ],
+        ];
+
+        $response = $this->apiCall('POST', route('api.data-source-integrations.store', $payload));
+
+        $response->assertStatus(201);
+        $response->assertJson([
+            'message' => 'Integration created successfully',
+        ]);
+
+        $this->assertDatabaseHas('data_source_integrations', [
+            'name' => 'Test Integration',
+            'key' => 'test_key',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR introduces a new API endpoint `POST /api/1.0/data-source-integrations` to allow the creation and storage of data source integrations. It also includes the creation of the `DataSourceIntegrationsController` and corresponding tests to validate the endpoint behavior.

### What's Included

- `DataSourceIntegrationsController` to handle creation requests
- Endpoint registration for `POST /api/1.0/data-source-integrations`
- Validation logic for required fields
- Unit tests under `tests/Feature/Api/DataSourceIntegrationsTest.php`


## How to Test
### Automated Tests

1. Run the tests
`phpunit  tests/Feature/Api/DataSourceIntegrationsTest.php`
2. Confirm all tests pass

### Manual Testing via API Call

1. Make a `POST` request to:
`/api/1.0/data-source-integrations`
2. Example request body:

```
{
  "name": "Test Integration",
  "key": "test-integration",
  "auth_type": "token",
  "base_url": "https://api.test-integration.com",
  "credentials": "ENCRYPTED_STRING"
}
```

3. Confirm:
    - A `201 Created` response is returned with a success message
    - The record is created in the `data_source_integratios` table
4. Send a request with missing or invalid fields to test validation
    - Confirm that the validation error messages are returned (`422 Unprocessable Entity`)

## Related Tickets & Packages
- [FOUR-23912](https://processmaker.atlassian.net/browse/FOUR-23912)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-23912]: https://processmaker.atlassian.net/browse/FOUR-23912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ