### PR TITLE
FOUR-23865: Fix loading tasks in saved search with process with html entities

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -385,6 +385,11 @@ class ProcessController extends Controller
             $processCreated = ProcessCreated::BPMN_CREATION;
         }
 
+        // Replace html entities with the correct characters
+        if (isset($data['bpmn'])) {
+            $data['bpmn'] = BpmnDocument::replaceHtmlEntities($data['bpmn']);
+        }
+
         if ($schemaErrors = $this->validateBpmn($request)) {
             return response(
                 ['message' => __('The bpm definition is not valid'),
@@ -481,6 +486,11 @@ class ProcessController extends Controller
         }
         $request->validate($rules);
         $original = $process->getOriginal();
+
+        // Replace html entities with the correct characters
+        if ($request->has('bpmn')) {
+            $request->merge(['bpmn' => BpmnDocument::replaceHtmlEntities($request->input('bpmn'))]);
+        }
 
         // bpmn validation
         if ($schemaErrors = $this->validateBpmn($request)) {
@@ -599,7 +609,8 @@ class ProcessController extends Controller
             $process->alternative = $request->input('alternative');
         }
 
-        $process->bpmn = $request->input('bpmn');
+        $bpmn = BpmnDocument::replaceHtmlEntities($request->input('bpmn'));
+        $process->bpmn = $bpmn;
         $process->name = $request->input('name');
         $process->description = $request->input('description');
         $process->saveOrFail();

--- a/tests/Feature/ProcessHtmlTest.php
+++ b/tests/Feature/ProcessHtmlTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use ProcessMaker\Models\Process;
 use ProcessMaker\Models\User;
+use ProcessMaker\Nayra\Storage\BpmnDocument;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
@@ -10,6 +12,7 @@ class ProcessHtmlTest extends TestCase
 {
     use RequestHelper;
 
+    protected static $DO_NOT_SEND = 'DO_NOT_SEND';
 
     /**
      * A process with html entities in the documentation field should be able to be loaded.
@@ -25,5 +28,108 @@ class ProcessHtmlTest extends TestCase
         $definitions = $process->getDefinitions(true);
 
         $this->assertNotEmpty($definitions, 'The process could not be loaded correctly');
+    }
+
+    /**
+     * A process with html entities in the documentation field should be able to be stored.
+     */
+    public function test_store_process_with_html_entities()
+    {
+        $route = route('api.processes.store');
+        $base = Process::factory()->make([
+            'user_id' => static::$DO_NOT_SEND,
+            'process_category_id' => static::$DO_NOT_SEND,
+        ]);
+        $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
+        // Add a bpmn content
+        $bpmn = file_get_contents(base_path('tests/Fixtures/process_with_html.bpmn'));
+        $array['bpmn'] = $bpmn;
+        $response = $this->apiCall('POST', $route, $array);
+        $response->assertStatus(201);
+        $data = $response->json();
+        $process = Process::where('id', $data['id'])->first();
+
+        // Fix bpmn content to remove the html entities
+        $fixedBpmn = BpmnDocument::replaceHtmlEntities($process->bpmn);
+        $this->assertEquals($fixedBpmn, $process->bpmn);
+    }
+    
+    /**
+     * A process with html entities in the documentation field should be able to be updated.
+     */
+    public function test_update_process_with_html_entities()
+    {
+        // First create a process
+        $route = route('api.processes.store');
+        $base = Process::factory()->make([
+            'user_id' => static::$DO_NOT_SEND,
+            'process_category_id' => static::$DO_NOT_SEND,
+        ]);
+        $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
+        $response = $this->apiCall('POST', $route, $array);
+        $response->assertStatus(201);
+        $data = $response->json();
+        $process = Process::where('id', $data['id'])->first();
+        
+        // Now update the process
+        $bpmn = file_get_contents(base_path('tests/Fixtures/process_with_html.bpmn'));
+        $updateRoute = route('api.processes.update', ['process' => $process->id]);
+        $updateData = [
+            'name' => $process->name . ' Updated',
+            'description' => $process->description . ' Updated',
+            'bpmn' => $bpmn,
+        ];
+        $updateResponse = $this->apiCall('PUT', $updateRoute, $updateData);
+        $updateResponse->assertStatus(200);
+        
+        // Reload the process from database
+        $updatedProcess = Process::where('id', $process->id)->first();
+        
+        // Check if the process was updated correctly
+        $this->assertEquals($process->name . ' Updated', $updatedProcess->name);
+        
+        // Fix bpmn content to remove the html entities
+        $fixedBpmn = BpmnDocument::replaceHtmlEntities($updatedProcess->bpmn);
+        $this->assertEquals($fixedBpmn, $updatedProcess->bpmn);
+    }
+
+    /**
+     * Test updating BPMN content directly via the updateBpmn endpoint.
+     * This endpoint allows updating only the BPMN content, not the other process attributes.
+     */
+    public function test_update_bpmn_endpoint_with_html_entities()
+    {
+        // First create a process
+        $route = route('api.processes.store');
+        $base = Process::factory()->make([
+            'user_id' => static::$DO_NOT_SEND,
+            'process_category_id' => static::$DO_NOT_SEND,
+        ]);
+        $array = array_diff($base->toArray(), [static::$DO_NOT_SEND]);
+        $response = $this->apiCall('POST', $route, $array);
+        $response->assertStatus(201);
+        $data = $response->json();
+        $process = Process::where('id', $data['id'])->first();
+        
+        // Now update the process
+        $bpmn = file_get_contents(base_path('tests/Fixtures/process_with_html.bpmn'));
+        $updateRoute = route('api.processes.update_bpmn', ['process' => $process->id]);
+        $updateData = [
+            'name' => $process->name . ' Updated',
+            'description' => $process->description . ' Updated',
+            'bpmn' => $bpmn,
+        ];
+        $updateResponse = $this->apiCall('PUT', $updateRoute, $updateData);
+        $updateResponse->assertStatus(200);
+        
+        // Reload the process from database
+        $updatedProcess = Process::where('id', $process->id)->first();
+        
+        // Check if the process was updated correctly
+        $this->assertEquals($process->name . ' Updated', $updatedProcess->name);
+        
+        // Fix bpmn content to remove the html entities
+        $fixedBpmn = BpmnDocument::replaceHtmlEntities($updatedProcess->bpmn);
+        $this->assertEquals($fixedBpmn, $updatedProcess->bpmn);
     }
 }

--- a/tests/Feature/ProcessHtmlTest.php
+++ b/tests/Feature/ProcessHtmlTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use ProcessMaker\Models\User;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class ProcessHtmlTest extends TestCase
+{
+    use RequestHelper;
+
+
+    /**
+     * A process with html entities in the documentation field should be able to be loaded.
+     * By default, the bpmn processes are loaded with the html entities support.
+     */
+    public function test_process_with_html_can_be_loaded()
+    {
+        $this->user = User::factory()->create([
+            'is_administrator' => false,
+        ]);
+        $process = $this->createProcessFromBPMN('tests/Fixtures/process_with_html.bpmn');
+
+        $definitions = $process->getDefinitions(true);
+
+        $this->assertNotEmpty($definitions, 'The process could not be loaded correctly');
+    }
+}

--- a/tests/Fixtures/process_with_html.bpmn
+++ b/tests/Fixtures/process_with_html.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" pm:allowInterstitial="true" pm:interstitialScreenRef="1" pm:config="{&#34;web_entry&#34;:null}">
+      <bpmn:outgoing>node_23</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_2" name="Form Task" pm:screenRef="110" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]}}" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}">
+      <bpmn:incoming>node_23</bpmn:incoming>
+      <bpmn:outgoing>node_32</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="node_12" name="Form Task" pm:screenRef="439" pm:allowInterstitial="false" pm:isDueInVariable="false" pm:assignment="process_manager" pm:assignedUsers="" pm:assignedGroups="" pm:assignmentLock="false" pm:allowReassignment="false" pm:config="{&#34;web_entry&#34;:null,&#34;email_notifications&#34;:{&#34;notifications&#34;:[]},&#34;selfService&#34;:false,&#34;assigneeManagerEscalation&#34;:true}" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}">
+      <bpmn:documentation>&lt;p&gt;dfgdf g gdf gdf. rt fdg dfg f gs gdfh j ghj. ghk gh j75u y u57 uyh jikuilopiuo ityu rt yertqwerq aasd x czx. bdfhg ty gfh nvb nhjtyu uyijknmb. jkluop tyuyu etgfgcvbsrf werrt gb dr ger t dfgdf g gdf gdf. rt fdg dfg f gs gdfh j ghj. ghk gh j75u y u57 uyh jikuilopiuo ityu rt yertqwerq aasd x czx. bdfhg ty gfh nvb nhjtyu uyijknmb. jkluop tyuyu etgfgcvbsrf werrt gb dr ger t dfgdf g gdf gdf. rt fdg dfg f gs gdfh j ghj. ghk gh j75u y u57 uyh jikuilopiuo ityu rt yertqwerq aasd x czx. bdfhg ty gfh nvb nhjtyu uyijknmb. jkluop tyuyu etgfgcvbsrf werrt gb dr ger t dfgdf g gdf gdf. rt fdg dfg f gs gdfh j ghj. ghk gh j75u y u57 uyh jikuilopiuo ityu rt yertqwerq aasd x czx. bdfhg ty gfh nvb nhjtyu uyijknmb. jkluop tyuyu etgfgcvbsrf werrt gb dr ger t dfgdf g gdf gdf. rt fdg dfg f gs gdfh j ghj. ghk gh j75u y u57 uyh jikuilopiuo ityu rt yertqwerq aasd x czx. bdfhg ty gfh nvb nhjtyu uyijknmb. jkluop tyuyu etgfgcvbsrf werrt gb dr ger t&nbsp;&lt;/p&gt;</bpmn:documentation>
+      <bpmn:incoming>node_32</bpmn:incoming>
+      <bpmn:outgoing>node_36</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="node_22" name="End Event" pm:elementDestination="{&#34;type&#34;:&#34;summaryScreen&#34;,&#34;value&#34;:null}">
+      <bpmn:incoming>node_36</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_23" name="" sourceRef="node_1" targetRef="node_2" />
+    <bpmn:sequenceFlow id="node_32" name="" sourceRef="node_2" targetRef="node_12" />
+    <bpmn:sequenceFlow id="node_36" name="" sourceRef="node_12" targetRef="node_22" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagramId">
+    <bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="200" y="110" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="280" y="150" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_12_di" bpmnElement="node_12">
+        <dc:Bounds x="460" y="160" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_22_di" bpmnElement="node_22">
+        <dc:Bounds x="660" y="190" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_23_di" bpmnElement="node_23">
+        <di:waypoint x="218" y="128" />
+        <di:waypoint x="338" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_32_di" bpmnElement="node_32">
+        <di:waypoint x="338" y="188" />
+        <di:waypoint x="518" y="198" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_36_di" bpmnElement="node_36">
+        <di:waypoint x="518" y="198" />
+        <di:waypoint x="678" y="208" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Error loading tasks in saved search with process with html entities

## Solution
- Add support to html entities in bpmn documents

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23865
- https://github.com/ProcessMaker/nayra/pull/230

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:nayra:bugfix/FOUR-23865
ci:deploy
ci:package-savedsearch:bugfix/FOUR-23865
ci:k8s-branch:task/FOUR-24126

....