### PR TITLE
FOUR-24213: Errors related to templates in builds and CICD

### DIFF
--- a/ProcessMaker/Jobs/SyncDefaultTemplates.php
+++ b/ProcessMaker/Jobs/SyncDefaultTemplates.php
@@ -73,7 +73,8 @@ class SyncDefaultTemplates implements ShouldQueue
                     continue;
                 }
 
-                $url = $config['base_url'] . $config['template_repo'] . '/' . $config['template_branch'] . '/' . $template['relative_path'];
+                $relativePath = ltrim($template['relative_path'], './');
+                $url = $config['base_url'] . $config['template_repo'] . '/' . $config['template_branch'] . '/' . $relativePath;
                 $response = Http::get($url);
                 if (!$response->successful()) {
                     throw new Exception("Unable to fetch default template {$template['name']}.");


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR addresses an error encountered during the upgrade command, specifically when running the 2023_08_15_183028_remove_seeded_default_templates migration.
The issue occurs when the SyncDefaultTemplates job attempts to fetch raw templates from GitHub, resulting in an exception such as:

```
Unable to fetch default template Purchase Order.
```

The relative_path for each template (e.g., ./accounting-and-finance/purchase-order.json) was used directly to build the raw GitHub URL. While this worked in local environments, CI/CD environments reported a 404 error for one specific template.

Interestingly, only the 5th template in the list (Purchase Order) failed, which suggests the possibility of an edge case such as:
- The file being temporarily unavailable in the 2023-fall branch during the build
- GitHub raw URL redirection not being handled consistently by the CI runner
- A race condition or caching issue in GitHub’s CDN

## Solution
- The relative_path is now normalized by removing any leading ./ before building the raw GitHub URL.
- This ensures all requests are made with clean, absolute paths that are compatible across environments.

```
- https://raw.githubusercontent.com/processmaker/process-templates/2023-fall/./accounting-and-finance/purchase-order.json
+ https://raw.githubusercontent.com/processmaker/process-templates/2023-fall/accounting-and-finance/purchase-order.json
```

Although this change may not have been the direct cause of the original failure, it eliminates ambiguity in how paths are constructed and helps future-proof the sync process.

## How to Test
1. Run: `php artisan processmaker:sync-default-templates`
2. Confirm that all templates are fetched successfully from GitHub.
3. Review logs for any failed template fetches.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
