### PR TITLE
Disable SSL on local environments

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -436,7 +436,8 @@ trait MakeHttpRequests
     {
         $client = $this->client ?? app()->make(Client::class, [
             'config' => [
-                'verify' => $this->verifySsl,
+                // Disable SSL verification in local development environment
+                'verify' => $this->verifySsl && (config('app.env') !== 'local'),
                 'timeout' => $this->timeout,
             ],
         ]);


### PR DESCRIPTION
## Issue & Reproduction Steps
Data connectors fails by default in dev environments.

## Solution
- Disable SSL on local environments.

