### PR TITLE
FOUR-24286: Advanced filter on PROCESS in task saved search does not work

### DIFF
--- a/ProcessMaker/Filters/BaseFilter.php
+++ b/ProcessMaker/Filters/BaseFilter.php
@@ -29,6 +29,8 @@ abstract class BaseFilter
 
     public const TYPE_PROCESS_NAME = 'ProcessName';
 
+    public const PROCESS_NAME_IN_REQUEST = 'process_request.name';
+
     public const TYPE_RELATIONSHIP = 'Relationship';
 
     public string|null $subjectValue;
@@ -98,6 +100,8 @@ abstract class BaseFilter
             $this->valueAliasAdapter($valueAliasMethod, $query);
         } elseif ($this->subjectType === self::TYPE_PROCESS) {
             $this->filterByProcessId($query);
+        } elseif ($this->subjectValue === self::PROCESS_NAME_IN_REQUEST) {
+            $this->filterByProcessName($query);
         } elseif ($this->subjectType === self::TYPE_PROCESS_NAME) {
             $this->filterByProcessName($query);
         } elseif ($this->subjectType === self::TYPE_RELATIONSHIP) {
@@ -310,8 +314,8 @@ abstract class BaseFilter
     {
         if ($query->getModel() instanceof ProcessRequestToken) {
             $query->whereIn('process_request_id', function ($query) {
-                $query->select('id')->from('process_requests');
-                $this->applyQueryBuilderMethod($query);
+                $query->select('id')->from('process_requests')
+                      ->where('name', '=', $this->value());
             });
         } else {
             $query->whereIn('name', (array) $this->value());

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -788,6 +788,39 @@ class TasksTest extends TestCase
         $this->assertEquals($hitTask->id, $json['data'][0]['id']);
     }
 
+    public function testAdvancedFilterByProcessRequestName()
+    {
+        $hitProcess = Process::factory()->create(['name' => 'foo']);
+        $missProcess = Process::factory()->create(['name' => 'bar']);
+        $hitRequest = ProcessRequest::factory()->create([
+            'process_id' => $hitProcess->id,
+            'name' => $hitProcess->name,
+        ]);
+        $missRequest = ProcessRequest::factory()->create([
+            'process_id' => $missProcess->id,
+        ]);
+        $hitTask = ProcessRequestToken::factory()->create([
+            'process_request_id' => $hitRequest->id,
+        ]);
+        ProcessRequestToken::factory()->create([
+            'process_request_id' => $missRequest->id,
+        ]);
+
+        $filterString = json_encode([
+            [
+                'subject' => ['type' => 'Field', 'value' => 'process_request.name'],
+                'operator' => '=',
+                'value' => $hitProcess->name,
+
+            ],
+        ]);
+
+        $response = $this->apiCall('GET', '/tasks', ['advanced_filter' => $filterString]);
+        $json = $response->json();
+
+        $this->assertEquals($hitTask->id, $json['data'][0]['id']);
+    }
+
     public function testGetScreenFields()
     {
         $this->be($this->user);


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a tasks saved search that includes the PROCESS column
3. Once created, use the advanced filters in the PROCESS column to filter by any process name
4. The search does not work and the following error is showed

`[2025-05-08 17:43:33] production.ERROR: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'process_request.name' in 'where clause' (Connection: processmaker, SQL: select count(*) as aggregate from process_request_tokens where (element_type = task or (element_type = serviceTask and element_name = AI Assistant)) and exists (select * from processes where process_request_tokens.process_id = processes.id and exists (select * from process_categories inner join category_assignments on process_categories.id = category_assignments.category_id where processes.id = category_assignments.assignable_id and category_assignments.category_type = ProcessMaker\Models\ProcessCategory and is_system = 0 and category_assignments.assignable_type = ProcessMaker\Models\Process) and processes.deleted_at is null and exists (select * from process_versions where processes.id = process_versions.process_id and draft = 0)) and ((is_self_service = 0 and process_request_tokens.status in (ACTIVE)) and process_request.name = PFSS Simple Process))`

## How to Test
Follow the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24286

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy