### PR TITLE
FOUR-24227: Add in the display screen a New control - Case Progress Bar

### DIFF
--- a/resources/js/processes/screen-builder/typeDisplay.js
+++ b/resources/js/processes/screen-builder/typeDisplay.js
@@ -14,6 +14,7 @@ ProcessMaker.EventBus.$on("screen-builder-init", (manager) => {
   const FormListTable = FormBuilderControls.find((control) => control.rendererBinding === "FormListTable");
   const FormAnalyticsChart = FormBuilderControls.find((control) => control.rendererBinding === "FormAnalyticsChart");
   const FormCollectionViewControl = FormBuilderControls.find((control) => control.rendererBinding === "FormCollectionViewControl");
+  const CaseProgressBar = FormBuilderControls.find((control) => control.rendererBinding === "CaseProgressBar");
   // Remove editable inspector props
   FormRecordList.control.inspector = FormRecordList.control.inspector.filter((prop) => prop.field !== "editable" && prop.field !== "form");
 
@@ -32,6 +33,7 @@ ProcessMaker.EventBus.$on("screen-builder-init", (manager) => {
     FormListTable,
     FormAnalyticsChart,
     FormCollectionViewControl,
+    CaseProgressBar,
   ];
 
   controlsDisplay.forEach((item) => {

--- a/resources/js/processes/screen-builder/typeForm.js
+++ b/resources/js/processes/screen-builder/typeForm.js
@@ -20,6 +20,7 @@ ProcessMaker.EventBus.$on("screen-builder-init", (manager) => {
       && config.control.component !== "FormAvatar"
       && config.control.component !== "LinkButton"
       && config.control.component !== "FormCollectionViewControl"
+      && config.control.component !== "CaseProgressBar"
     ) {
       manager.addControl(
         config.control,

--- a/resources/views/cases/edit.blade.php
+++ b/resources/views/cases/edit.blade.php
@@ -155,6 +155,7 @@
   <script src="{{mix('js/initialLoad.js')}}"></script>
 
   <script>
+    window.ProcessMaker.caseNumber = request.case_number;
     window.ProcessMaker.modeler = {
       xml: @json($bpmn),
       configurables: [],


### PR DESCRIPTION
Add in the display screen a New control - Case Progress Bar

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24227

## PR's Related
https://github.com/ProcessMaker/screen-builder/pull/1815

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:feature/FOUR-24227
