### PR TITLE
FOUR-24430: CI Unit Test are given error SyncDefaultTemplates.php:79

### DIFF
--- a/ProcessMaker/Jobs/SyncDefaultTemplates.php
+++ b/ProcessMaker/Jobs/SyncDefaultTemplates.php
@@ -3,14 +3,13 @@
 namespace ProcessMaker\Jobs;
 
 use Exception;
-use Facades\ProcessMaker\JsonColumnIndex;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use ProcessMaker\ImportExport\Importer;
 use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Models\ProcessCategory;
@@ -22,8 +21,6 @@ class SyncDefaultTemplates implements ShouldQueue
 
     /**
      * Create a new job instance.
-     *
-     * @return void
      */
     public function __construct()
     {
@@ -34,7 +31,6 @@ class SyncDefaultTemplates implements ShouldQueue
      * Execute the job.
      * Function to handle the execution of this job when it is run.
      * Here the function fetches default templates list from Github and saves them to the database.
-     * @return void
      */
     public function handle()
     {
@@ -54,10 +50,11 @@ class SyncDefaultTemplates implements ShouldQueue
         )->getKey();
 
         // Get the default template list from Github.
-        $response = Http::get($url);
-
+        $response = Http::timeout(10)->get($url);
         if (!$response->successful()) {
-            throw new Exception('Unable to fetch default template list.');
+            Log::warning("[SyncDefaultTemplates] Failed to fetch template index from GitHub: {$url} - Status: {$response->status()}");
+
+            return; // skip the job gracefully
         }
 
         // Extract the json data from the response and iterate over the categories and templates to retrieve them.
@@ -75,9 +72,10 @@ class SyncDefaultTemplates implements ShouldQueue
 
                 $relativePath = ltrim($template['relative_path'], './');
                 $url = $config['base_url'] . $config['template_repo'] . '/' . $config['template_branch'] . '/' . $relativePath;
-                $response = Http::get($url);
+                $response = Http::timeout(10)->get($url);
                 if (!$response->successful()) {
-                    throw new Exception("Unable to fetch default template {$template['name']}.");
+                    Log::warning("[SyncDefaultTemplates] Skipped template due to failed fetch: {$template['name']} ({$template['uuid']}) - Status: {$response->status()}");
+                    continue;
                 }
                 $payload = $response->json();
                 data_set($payload, 'export.' . $payload['root'] . '.attributes.process_category_id', $processCategoryId);
@@ -87,7 +85,7 @@ class SyncDefaultTemplates implements ShouldQueue
                     'saveAssetsMode' => 'saveAllAssets',
                 ]);
                 $importer = new Importer($payload, $options);
-                $manifest = $importer->doImport();
+                $importer->doImport();
             }
         }
     }

--- a/tests/Jobs/SyncDefaultTemplatesTest.php
+++ b/tests/Jobs/SyncDefaultTemplatesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Jobs;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use ProcessMaker\Jobs\SyncDefaultTemplates;
+use Tests\TestCase;
+
+class SyncDefaultTemplatesTest extends TestCase
+{
+    public function test_job_skips_failed_template_fetches_and_logs_warning()
+    {
+        // Mock GitHub config.
+        Config::set('services.github', [
+            'base_url' => 'https://fake.test/',
+            'template_repo' => 'repo',
+            'template_branch' => 'main',
+            'template_categories' => 'all',
+        ]);
+
+        // Fake HTTP responses.
+        Http::fake([
+            'https://fake.test/repo/main/index.json' => Http::response([
+                'default' => [
+                    [
+                        'uuid' => 'template-uuid',
+                        'name' => 'Broken Template',
+                        'relative_path' => './broken-template.json',
+                    ],
+                ],
+            ]),
+            'https://fake.test/repo/main/broken-template.json' => Http::response(null, 500),
+        ]);
+
+        // Fake logging.
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function ($message) {
+                return str_contains($message, 'Skipped template due to failed fetch');
+            });
+
+        // Run the job.
+        $job = new SyncDefaultTemplates();
+        $job->handle();
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
During the upgrade process, the job SyncDefaultTemplates was failing with the following error:

```
PHP Fatal error:  Uncaught Exception: Unable to fetch default template Payment request form.
```

This only occurred intermittently during CI/CD pipelines, while working fine locally. The issue was caused by transient failures when fetching template files from GitHub (e.g., timeouts, rate limiting, or connectivity issues).

See error here: https://github.com/ProcessMaker/processmaker/actions/runs/15070208108/job/42366062358?pr=8234

## Solution

- Added timeout(10) to avoid indefinite hanging during GitHub requests.
- Replaced throw new Exception() with a Log::warning() and continue if a template file cannot be fetched.
- Ensures the job will continue processing the next templates even if one fails.
- This prevents the entire pipeline from failing due to a single transient network error.

## How to Test
1. Run the upgrade or sync templates job: `php artisan processmaker:sync-default-templates`
2. Templates that are available should still be fetched and imported correctly.

## Related Tickets & Packages
- [FOUR-24430](https://processmaker.atlassian.net/browse/FOUR-24430)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-24430]: https://processmaker.atlassian.net/browse/FOUR-24430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ