### PR TITLE
FOUR-24448: Consider use cases for return Default Stages per Case and case_number not required

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -215,7 +215,7 @@ Route::middleware('auth:api', 'setlocale', 'bindings', 'sanitize')->prefix('api/
     Route::get('tasks/user-can-reassign', [TaskController::class, 'userCanReassign'])->name('tasks.user_can_reassign');
 
     // Cases
-    Route::get('cases/{case_number}/stages_bar', [CaseController::class, 'getStageCase'])->name('cases.stage');
+    Route::get('cases/stages_bar/{case_number?}', [CaseController::class, 'getStagePerCase'])->name('cases.stage');
     Route::get('processes/{process}/default-stages', [ProcessController::class, 'getDefaultStagesPerProcess'])->name('processes.default-stages');
     Route::get('processes/{process}/stages', [ProcessController::class, 'getStagesPerProcess'])->name('processes.stages');
     Route::get('processes/{process}/metrics', [ProcessController::class, 'getMetricsPerProcess'])->name('processes.metrics');

--- a/tests/Feature/CasesControllerTest.php
+++ b/tests/Feature/CasesControllerTest.php
@@ -329,6 +329,50 @@ class CasesControllerTest extends TestCase
     }
 
     /**
+     * Test getting stage case with an invalid case number.
+     *
+     * @return void
+     */
+    public function testGetStageCaseWithInvalidCaseNumber()
+    {
+        // Call the API endpoint with a case number that does not exist
+        $response = $this->apiCall('GET', '/cases' . '/stages_bar');
+        // Assert the response status and structure
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'parentRequest',
+                'requestCount',
+                'all_stages',
+                'current_stage',
+                'stages_per_case',
+            ]);
+        $this->assertNotEmpty($response->json('stages_per_case'));
+        $expectedStages = [
+            [
+                'id' => 0,
+                'name' => 'In Progress',
+                'status' => 'In Progress',
+                'completed_at' => '',
+            ],
+            [
+                'id' => 0,
+                'name' => 'Completed',
+                'status' => 'Pending',
+                'completed_at' => '',
+            ],
+        ];
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'parentRequest',
+                'requestCount',
+                'all_stages',
+                'current_stage',
+                'stages_per_case',
+            ])
+            ->assertJsonPath('stages_per_case', $expectedStages);
+    }
+
+    /**
      * Test getting stage case with a valid case number.
      *
      * @return void
@@ -391,7 +435,7 @@ class CasesControllerTest extends TestCase
         ]);
 
         // Call the API endpoint
-        $response = $this->apiCall('GET', '/cases' . '/' . $parentRequest->case_number . '/stages_bar');
+        $response = $this->apiCall('GET', '/cases' . '/stages_bar' . '/' . $parentRequest->case_number);
 
         // Assert the response status and structure
         $response->assertStatus(200)
@@ -445,17 +489,112 @@ class CasesControllerTest extends TestCase
     }
 
     /**
-     * Test getting stage case with an invalid case number.
+     * Test getting stage case with a valid case number when the process does not have stages
      *
      * @return void
      */
-    public function testGetStageCaseWithInvalidCaseNumber()
+    public function testGetStageCaseWithValidCaseNumberWithoutProcessStages()
     {
-        // Call the API endpoint with a case number that does not exist
-        $response = $this->apiCall('GET', '/cases' . '/' . '99999' . '/stages_bar');
+        // Create a new process and save stages as JSON
+        $process = Process::factory()->create([
+            'status' => 'ACTIVE',
+            'stages' => null,
+        ]);
+        // Create a parent request
+        $parentRequest = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'status' => 'ACTIVE',
+            'completed_at' => null,
+            'parent_request_id' => null, // This is a parent request
+        ]);
 
-        // Assert the response status and error message
-        $response->assertStatus(404)
-                 ->assertJson(['error' => 'No requests found for this case number']);
+        // Create a child request
+        ProcessRequest::factory()->create([
+            'process_id' => $parentRequest->process_id,
+            'case_number' => $parentRequest->case_number,
+            'status' => 'ACTIVE',
+            'completed_at' => null,
+            'parent_request_id' => $parentRequest->id, // This is a child request
+        ]);
+        ProcessRequestToken::factory()->create([
+            'process_id' => $parentRequest->process_id,
+            'process_request_id' => $parentRequest->id,
+            'completed_at' => '2025-05-01 21:24:24',
+            'status' => 'CLOSED',
+        ]);
+        ProcessRequestToken::factory()->create([
+            'process_id' => $parentRequest->process_id,
+            'process_request_id' => $parentRequest->id,
+            'status' => 'ACTIVE',
+            'completed_at' => null,
+        ]);
+
+        // Call the API endpoint
+        $response = $this->apiCall('GET', '/cases' . '/stages_bar' . '/' . $parentRequest->case_number);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'parentRequest',
+                'requestCount',
+                'all_stages',
+                'current_stage',
+                'stages_per_case',
+            ]);
+        $this->assertNotEmpty($response->json('stages_per_case'));
+    }
+
+    /**
+     * Test getting stage case with a valid case number when the process does not have stages
+     *
+     * @return void
+     */
+    public function testGetStageCaseWithValidCaseNumberWithoutTask()
+    {
+        $stagesData = [
+            [
+                'id' => 1,
+                'name' => 'Request Send',
+                'order' => 2,
+            ],
+            [
+                'id' => 2,
+                'name' => 'Request Reviewed',
+                'order' => 1,
+            ],
+        ];
+        // Create a new process and save stages as JSON
+        $process = Process::factory()->create([
+            'status' => 'ACTIVE',
+            'stages' => json_encode($stagesData),
+        ]);
+        // Create a parent request
+        $parentRequest = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'status' => 'ACTIVE',
+            'completed_at' => null,
+            'parent_request_id' => null, // This is a parent request
+        ]);
+
+        // Create a child request
+        ProcessRequest::factory()->create([
+            'process_id' => $parentRequest->process_id,
+            'case_number' => $parentRequest->case_number,
+            'status' => 'ACTIVE',
+            'completed_at' => null,
+            'parent_request_id' => $parentRequest->id, // This is a child request
+        ]);
+
+        // Call the API endpoint
+        $response = $this->apiCall('GET', '/cases' . '/stages_bar' . '/' . $parentRequest->case_number);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'parentRequest',
+                'requestCount',
+                'all_stages',
+                'current_stage',
+                'stages_per_case',
+            ]);
+        $this->assertNotEmpty($response->json('stages_per_case'));
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Consider use cases for return Default Stages per Case and Case_number not required

## Solution
- Update the API to return a Default stages when the case_number does not exist

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24448

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:feature/FOUR-24448