### PR TITLE
FOUR-24450: Add indexes to improve the queries about stage_id

### DIFF
--- a/database/migrations/2025_05_19_205653_add_index_stage_id_for_requests_cases_and_tokens.php
+++ b/database/migrations/2025_05_19_205653_add_index_stage_id_for_requests_cases_and_tokens.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            $table->index('stage_id');
+        });
+        Schema::table('process_requests', function (Blueprint $table) {
+            $table->index('last_stage_id');
+        });
+        Schema::table('cases_participated', function (Blueprint $table) {
+            $table->index('last_stage_id');
+        });
+        Schema::table('cases_started', function (Blueprint $table) {
+            $table->index('last_stage_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('process_request_tokens', function (Blueprint $table) {
+            $table->dropIndex(['stage_id']);
+        });
+        Schema::table('process_requests', function (Blueprint $table) {
+            $table->dropIndex(['last_stage_id']);
+        });
+        Schema::table('cases_participated', function (Blueprint $table) {
+            $table->dropIndex(['last_stage_id']);
+        });
+        Schema::table('cases_started', function (Blueprint $table) {
+            $table->dropIndex(['last_stage_id']);
+        });
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
Add indexes to improve the queries about stage_id

## Solution
- Add index to filter per stage:
```
process_request_token.stage_id
process_request. last_stage_id
case_participant. last_stage_id
case_started. last_stage_id
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24450

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
