### PR TITLE
FOUR-23891: UI: The Assign button needs to block for avoid send the comments a more than one time

### DIFF
--- a/resources/js/tasks/components/taskPreview/TaskPreviewAssignment.vue
+++ b/resources/js/tasks/components/taskPreview/TaskPreviewAssignment.vue
@@ -31,7 +31,7 @@
       <button
         type="button"
         class="btn btn-primary btn-sm ml-2"
-        :disabled="disabled"
+        :disabled="disabled || disabledAssign"
         @click="reassignUser">
         {{ $t('Assign') }}
       </button>
@@ -67,13 +67,13 @@ const emit = defineEmits(["on-reassign-user"]);
 const selectedUser = ref(null);
 const comments = ref(null);
 const reassignUsers = ref([]);
+const disabledAssign = ref(false);
 
 // Computed properties
 const disabled = computed(() => {
   const hasOnlyWhitespace = comments.value && comments.value.trim().length === 0;
   return !selectedUser.value || hasOnlyWhitespace;
 });
-const currentTaskUserId = computed(() => props.task.user_id);
 
 // Load the reassign users
 const loadReassignUsers = async (filter) => {
@@ -118,17 +118,24 @@ const prepareToUpdateComment = async () => {
  * Reassign the user
  */
 const reassignUser = async () => {
+  disabledAssign.value = true;
   if (selectedUser.value) {
-    const response = await updateReassignUser(props.task.id, selectedUser.value, comments.value);
-    const commentResponse = await prepareToUpdateComment();
+    try {
+      const response = await updateReassignUser(props.task.id, selectedUser.value, comments.value);
+      const commentResponse = await prepareToUpdateComment();
 
-    if (response && commentResponse) {
-      emit("on-reassign-user", selectedUser.value);
+      if (response && commentResponse) {
+        emit("on-reassign-user", selectedUser.value);
+      }
+
+      nextTick(() => {
+        selectedUser.value = null;
+      });
+    } catch (error) {
+      console.error(error);
+    } finally {
+      disabledAssign.value = false;
     }
-
-    nextTick(() => {
-      selectedUser.value = null;
-    });
   }
 };
 

--- a/resources/js/tasks/components/taskPreview/TaskPreviewAssignment.vue
+++ b/resources/js/tasks/components/taskPreview/TaskPreviewAssignment.vue
@@ -22,8 +22,8 @@
     <div class="tw-flex tw-flex-col tw-space-x-2 tw-p-2 tw-w-full">
       <label>{{ $t('Comments') }}</label>
       <textarea
-        v-model="comments"
-        class="tw-w-full tw-border tw-border-gray-300 tw-rounded-md"
+        rows="5"
+        class="tw-w-full tw-border tw-border-gray-300 tw-rounded-md tw-resize-none"
         :placeholder="$t('Add a comment to the assignment')" />
     </div>
 

--- a/resources/js/tasks/components/taskPreview/TaskPreviewAssignment.vue
+++ b/resources/js/tasks/components/taskPreview/TaskPreviewAssignment.vue
@@ -22,6 +22,7 @@
     <div class="tw-flex tw-flex-col tw-space-x-2 tw-p-2 tw-w-full">
       <label>{{ $t('Comments') }}</label>
       <textarea
+        v-model="comments"
         rows="5"
         class="tw-w-full tw-border tw-border-gray-300 tw-rounded-md tw-resize-none"
         :placeholder="$t('Add a comment to the assignment')" />
@@ -65,15 +66,12 @@ const emit = defineEmits(["on-reassign-user"]);
 
 // Refs
 const selectedUser = ref(null);
-const comments = ref(null);
+const comments = ref("");
 const reassignUsers = ref([]);
 const disabledAssign = ref(false);
 
 // Computed properties
-const disabled = computed(() => {
-  const hasOnlyWhitespace = comments.value && comments.value.trim().length === 0;
-  return !selectedUser.value || hasOnlyWhitespace;
-});
+const disabled = computed(() => !selectedUser.value || !comments.value?.trim());
 
 // Load the reassign users
 const loadReassignUsers = async (filter) => {


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Go to task or Process I Manager
2. Open Preview from a request in order to Reassing
3. select a person 
4. Add a comment
5. Click assign more than one time


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23891

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy