### PR TITLE
FOUR-23828: It is possible to create Site name with blank spaces in IFrame white list

### DIFF
--- a/resources/js/admin/settings/components/ModalWhiteList.vue
+++ b/resources/js/admin/settings/components/ModalWhiteList.vue
@@ -78,6 +78,7 @@ export default {
     show(groupName) {
       this.clear();
       this.groupName = groupName;
+      this.stateSiteName = null;
       return this.$refs["bv-modal-whitelist"].show();
     },
     clear() {
@@ -90,7 +91,7 @@ export default {
       return pattern.test(url);
     },
     addWhiteListURL() {
-      if (!this.siteName) {
+      if (!this.siteName.trim()) {
         this.stateSiteName = false;
         return;
       }

--- a/resources/js/admin/settings/components/ModalWhiteList.vue
+++ b/resources/js/admin/settings/components/ModalWhiteList.vue
@@ -79,6 +79,7 @@ export default {
       this.clear();
       this.groupName = groupName;
       this.stateSiteName = null;
+      this.stateURL = null;
       return this.$refs["bv-modal-whitelist"].show();
     },
     clear() {


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Login as Admin
2. Go to Admin Settings
3. Click on IFrame White list
4. Click on ADD URL
5. In site name type space in blank
6. Tyep a valid URl
7. Save the changes

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23828

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
