### PR TITLE
Axios timeour after 60000ms in Flow Genie

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -12,4 +12,7 @@ return [
     'rag_collections' => [
         'enabled' => env('AI_RAG_COLLECTIONS_ENABLED', false),
     ],
+    'genie_client' => [
+        'timeout' => (int) env('AI_GENIE_CLIENT_TIMEOUT', env('API_TIMEOUT', 60000)),
+    ],
 ];

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -135,6 +135,10 @@
 <script src="{{ mix('js/app.js') }}"></script>
 <script>
   window.ProcessMaker.packages = @json(\App::make(ProcessMaker\Managers\PackageManager::class)->listPackages());
+  window.ProcessMaker.ai = {
+    ragCollections: @json(config('ai.rag_collections.enabled')),
+    genieClientTimeout: @json(config('ai.genie_client.timeout'))
+  };
 </script>
 <script src="{{ mix('js/app-layout.js') }}"></script>
 @include('shared.monaco')


### PR DESCRIPTION
## Issue & Reproduction Steps
Resolves tickets:
https://processmaker.atlassian.net/browse/FOUR-24559
https://processmaker.atlassian.net/browse/FOUR-24259

Axios timeout after 60000ms in Flow Genie
The RAG collection type is not visible, but Genie does show the selection option.

## Solution
- Added an environment variable (AI_GENIE_CLIENT_TIMEOUT) for avoid the hardcoded 60000 ms.
- Read the env. variable AI_RAG_COLLECTIONS_ENABLED to hide/show rag collections from configuration

## How to Test
Follow the instructions of the related tickets

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-24559
https://processmaker.atlassian.net/browse/FOUR-24259

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
