### PR TITLE
FOUR-24570 scripts not able to rebuild

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "predis/predis": "^2.3",
         "processmaker/docker-executor-lua": "^1.0",
         "processmaker/docker-executor-node": "1.1.0",
-        "processmaker/docker-executor-php": "1.2.0",
+        "processmaker/docker-executor-php": "1.4.0",
         "processmaker/laravel-i18next": "dev-master",
         "processmaker/nayra": "1.12.1",
         "processmaker/pmql": "1.13.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc4e1d6ad038a94b5d18d580b703cd2c",
+    "content-hash": "7ba63c73ac657f624e9b7fde3a777a1c",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -7815,16 +7815,16 @@
         },
         {
             "name": "processmaker/docker-executor-php",
-            "version": "1.2.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ProcessMaker/docker-executor-php.git",
-                "reference": "92949d9a7524054901926f1523587030f8c5a686"
+                "reference": "495c2c58991b7f58b1e466304b0b72bc565d8f19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ProcessMaker/docker-executor-php/zipball/92949d9a7524054901926f1523587030f8c5a686",
-                "reference": "92949d9a7524054901926f1523587030f8c5a686",
+                "url": "https://api.github.com/repos/ProcessMaker/docker-executor-php/zipball/495c2c58991b7f58b1e466304b0b72bc565d8f19",
+                "reference": "495c2c58991b7f58b1e466304b0b72bc565d8f19",
                 "shasum": ""
             },
             "type": "library",
@@ -7848,9 +7848,9 @@
             "description": "PHP script executor for processmaker 4",
             "support": {
                 "issues": "https://github.com/ProcessMaker/docker-executor-php/issues",
-                "source": "https://github.com/ProcessMaker/docker-executor-php/tree/v1.2.0"
+                "source": "https://github.com/ProcessMaker/docker-executor-php/tree/v1.4.0"
             },
-            "time": "2023-04-29T06:11:07+00:00"
+            "time": "2025-01-24T20:34:35+00:00"
         },
         {
             "name": "processmaker/laravel-i18next",


### PR DESCRIPTION
## Issue & Reproduction Steps
Update processmaker/docker-executor-php to version 1.4.0

## Related Tickets & Packages
[FOUR-24570](https://processmaker.atlassian.net/browse/FOUR-24570)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
