### PR TITLE
FOUR-24456: Define how we can get Metrics information

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -507,8 +507,7 @@ class ProcessController extends Controller
         // Validate stages
         $stages = $request->input('stages', null);
         if (!empty($stages)) {
-            $stages = json_decode($stages, true);
-            if (!$this->validateStagesStructure($stages)) {
+            if (!is_array($stages) && !$this->validateStagesStructure($stages)) {
                 return ['error' => 'Invalid stages structure. Each stage must have id, name, and order.'];
             }
         }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -30,6 +30,7 @@ class DatabaseSeeder extends Seeder
             SignalSeeder::class,
             SettingsMenusSeeder::class,
             ScreenEmailSeeder::class,
+            MetricsApiEnvironmentVariableSeeder::class,
         ]);
         $this->callPluginSeeders();
     }

--- a/database/seeders/MetricsApiEnvironmentVariableSeeder.php
+++ b/database/seeders/MetricsApiEnvironmentVariableSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use ProcessMaker\Models\EnvironmentVariable;
+
+class MetricsApiEnvironmentVariableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        EnvironmentVariable::firstOrCreate(
+            [
+                'name' => 'METRICS_API_ENDPOINT',
+            ],
+            [
+                'description' => 'API endpoint for retrieving process metrics example: /api/1.0/package-plg/processes/{process}/metrics',
+                'value' => '/api/1.0/processes/{process}/metrics',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Define how we can get Metrics information

## How to Test
A new seeder was created, the following command needs to execute

`php artisan db:seed`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24456

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
