### PR TITLE
FOUR-24546L The columns available in a save search can be duplicated each time we enter the save search configuration.

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
@@ -219,11 +219,22 @@ class ProcessVariableController extends Controller
         }
 
         // If the classes or tables do not exist, fallback to a saved search approach.
+
+        if ($savedSearch && $request->has('onlyAvailable')) {
+            $paginator = $this->getProcessesVariablesFrom($processIds);
+            $availableColumns = $this->mergeAvailableColumns($savedSearch);
+            $availableColumns = $this->filterActiveColumns($availableColumns, $activeColumns);
+            $paginator->setCollection(
+                $availableColumns->merge($paginator->items())
+            );
+
+            return $paginator;
+        }
+
         if (
             !class_exists(ProcessVariable::class)
             || !Schema::hasTable('process_variables')
             || !self::$useVarFinder
-            || $savedSearch
         ) {
             $paginator = $this->getProcessesVariablesFrom($processIds);
             if ($request->has('onlyAvailable')) {

--- a/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
@@ -210,6 +210,7 @@ class ProcessVariableController extends Controller
     {
         // Determine which columns to exclude based on the saved search
         $activeColumns = [];
+        $savedSearch = null;
         if ($excludeSavedSearch) {
             $savedSearch = SavedSearch::find($excludeSavedSearch);
             if ($savedSearch && $savedSearch->current_columns) {
@@ -222,6 +223,7 @@ class ProcessVariableController extends Controller
             !class_exists(ProcessVariable::class)
             || !Schema::hasTable('process_variables')
             || !self::$useVarFinder
+            || $savedSearch
         ) {
             $paginator = $this->getProcessesVariablesFrom($processIds);
             if ($request->has('onlyAvailable')) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

    Log in 

    Have a collection

    Create a save search 

    Create a save search for that collection

    Open the save search

    Click on save search settings

    Click on columns

    Add any column

    Re-enter save search settings

Current Behavior:

As we see, every time we enter the save search configuration, the added columns are displayed again, so we can add them again. With this behavior, we can add columns multiple times.


Expected Behavior:

When entering Columns in the save search settings, it should not be duplicated.

## Solution
- Keep the logic of filtering available columns when a saved search is used

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24546

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
