### PR TITLE
FOUR-24636: Error is showing in the API: api/1.0/cases/stages_bar/2

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/CaseController.php
+++ b/ProcessMaker/Http/Controllers/Api/CaseController.php
@@ -130,7 +130,7 @@ class CaseController extends Controller
         $processId = $request->process_id;
         $process = Process::where('id', $processId)->first();
         if ($process && !empty($process->stages)) {
-            $allStages = json_decode($process->stages, true);
+            $allStages = $process->stages;
         } else {
             // Return the default stages if the process does not have
             return $this->getDefaultCaseStages($request->status);

--- a/tests/Feature/Api/ProcessLaunchpadTest.php
+++ b/tests/Feature/Api/ProcessLaunchpadTest.php
@@ -119,7 +119,6 @@ class ProcessLaunchpadTest extends TestCase
             ['id' => 1, 'name' => 'Stage A', 'order' => 1],
             ['id' => 2, 'name' => 'Stage B', 'order' => 2],
         ];
-        $user = Auth::user();
         // Create a process with stages
         $process = Process::factory()->create([
             'stages' => $stages,


### PR DESCRIPTION
## Issue & Reproduction Steps
Error is showing in the API: api/1.0/cases/stages_bar/2

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24636

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:epic/FOUR-22605
ci:modeler:epic/FOUR-22600
ci:TCE_CUSTOMIZATION_ENABLED=true