### PR TITLE
FOUR-24575 user without permission can completed task assigned to super admin users by Email notifications

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -231,16 +231,26 @@ class TaskController extends Controller
                     if ($task->status === 'CLOSED') {
                         return $this->returnErrorResponse(__('Task already closed'), 404);
                     }
+
+                    $userId = null;
+
+                    // Review if the user is authenticated
+                    if (Auth::check()) {
+                        $user = Auth::user();
+
+                        if (!$user->is_administrator || $user->id !== $task->user_id) {
+                            return $this->returnErrorResponse(__('You are not authorized to update this task'), 403);
+                        }
+
+                        $userId = $user->id;
+                    }
                     // Update the data
                     $data[$request->varName] = $request->varValue;
                     $abe->data = json_encode($data);
                     // Define the answered_at and is_answered
                     $abe->is_answered = true;
                     $abe->answered_at = Carbon::now();
-                    // Review if the user is autenticated
-                    if (Auth::check()) {
-                        $abe->user_id = Auth::id();
-                    }
+                    $abe->user_id = $userId;
                     $abe->save();
                     // Define the parameter for complete the task
                     $process = Process::find($task->process_id);


### PR DESCRIPTION
## Issue & Reproduction Steps
A user without permission can complete an assigned task to super admin users by Email notifications

## Solution
- Add a validation that only a user assigned to the task or a super administrator user can complete the ABE task.

## Related Tickets & Packages
[FOUR-24575](https://processmaker.atlassian.net/browse/FOUR-24575)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-24575]: https://processmaker.atlassian.net/browse/FOUR-24575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ