### PR TITLE
FOUR-24665:IFrame Whitelist recognize others protocol beside https

### DIFF
--- a/resources/js/admin/settings/components/ModalWhiteList.vue
+++ b/resources/js/admin/settings/components/ModalWhiteList.vue
@@ -67,7 +67,10 @@
 </template>
 
 <script>
+import settingMixin from "../mixins/setting";
+
 export default {
+  mixins: [settingMixin],
   data() {
     return {
       siteName: "",
@@ -91,10 +94,6 @@ export default {
       this.siteName = "";
       this.url = "";
       this.urlError = "";
-    },
-    validateURL(url) {
-      const pattern = /^(https:\/\/|http:\/\/)(\*\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(:\d+)?$/;
-      return pattern.test(url);
     },
     addWhiteListURL() {
       if (!this.siteName.trim()) {

--- a/resources/js/admin/settings/components/SettingText.vue
+++ b/resources/js/admin/settings/components/SettingText.vue
@@ -203,10 +203,6 @@ export default {
       this.type = this.type === "text" ? "password" : "text";
       this.$refs.input.focus();
     },
-    validateURL(url) {
-      const pattern = /^(https:\/\/|http:\/\/)(\*\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(:\d+)?$/;
-      return pattern.test(url);
-    },
   },
 };
 </script>

--- a/resources/js/admin/settings/mixins/setting.js
+++ b/resources/js/admin/settings/mixins/setting.js
@@ -27,5 +27,9 @@ export default {
       }
       return null;
     },
+    validateURL(url) {
+      const pattern = /^(https:\/\/|http:\/\/)(\*\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(:\d+)?$/;
+      return pattern.test(url);
+    },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Login to PM4
2. Go to admin settings
3. Go to IFrame White list config
4. +ADD URL
5. Set a name
6. Set a url with other protocol that http ([tp.example.com/software/setup.exe](http://tp.example.com/software/setup.exe))
7. Save the changes 
8. Review the ancestor

**Current Behavior**
It is possible to add other protocol in IFrame white list 

**Current Behavior**
It is possible to add other protocol in IFrame white list 



## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24665
- https://processmaker.atlassian.net/browse/FOUR-24693

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy