### PR TITLE
FOUR-24105:Cancel and Assignment buttons are not in the correct position in the Reassignment form

### DIFF
--- a/resources/js/tasks/components/TasksPreview.vue
+++ b/resources/js/tasks/components/TasksPreview.vue
@@ -3,16 +3,19 @@
     <div v-if="tooltipButton === 'inboxRules' && showPreview">
       <splitpane-container
         :size="50"
-        :class-inbox="true">
+        :class-inbox="true"
+      >
         <div
           ref="tasks-preview"
-          class="tasks-preview h-100 p-3">
+          class="tasks-preview h-100 p-3"
+        >
           <div class="d-flex w-100 mb-3">
             <slot
               name="header"
               :close="onClose"
               :screen-filtered-task-data="formData"
-              :task-ready="taskReady" />
+              :task-ready="taskReady"
+            />
           </div>
           <div
             :class="{
@@ -20,7 +23,8 @@
               'frame-container-full': tooltipButton === 'fullTask',
               'frame-container-inbox': tooltipButton === 'inboxRules'
             }"
-            class="iframe-container">
+            class="iframe-container"
+          >
             <iframe
               v-if="showFrame1"
               ref="tasksFrame1"
@@ -30,7 +34,8 @@
               class="iframe"
               :src="linkTasks1"
               :event-parent-id="_uid"
-              @load="frameLoaded('tasksFrame1')" />
+              @load="frameLoaded('tasksFrame1')"
+            />
             <iframe
               v-if="showFrame2"
               ref="tasksFrame2"
@@ -40,11 +45,13 @@
               class="iframe"
               :src="linkTasks2"
               :event-parent-id="_uid"
-              @load="frameLoaded('tasksFrame2')" />
+              @load="frameLoaded('tasksFrame2')"
+            />
 
             <task-loading
               v-show="stopFrame"
-              class="load-frame" />
+              class="load-frame"
+            />
           </div>
         </div>
       </splitpane-container>
@@ -53,29 +60,34 @@
     <div v-else>
       <splitpane-container
         v-if="showPreview"
-        :size="splitpaneSize">
+        :size="splitpaneSize"
+      >
         <div
           ref="tasks-preview"
-          class="tasks-preview h-100 position-relative">
+          class="tasks-preview h-100 position-relative"
+        >
           <div class="d-flex w-100 p-3">
             <slot
               name="header"
               :close="onClose"
               :screen-filtered-task-data="formData"
-              :task-ready="taskReady">
+              :task-ready="taskReady"
+            >
               <b-button-group>
                 <b-button
                   class="arrow-button"
                   variant="outline-secondary"
                   :disabled="!existPrev || disableNavigation"
-                  @click="goPrevNext('Prev')">
+                  @click="goPrevNext('Prev')"
+                >
                   <i class="fas fa-chevron-left" />
                 </b-button>
                 <b-button
                   class="arrow-button"
                   variant="outline-secondary"
                   :disabled="!existNext || disableNavigation"
-                  @click="goPrevNext('Next')">
+                  @click="goPrevNext('Next')"
+                >
                   <i class="fas fa-chevron-right" />
                 </b-button>
               </b-button-group>
@@ -85,7 +97,8 @@
                 :date="lastAutosave"
                 :error="errorAutosave"
                 :form-data="formData"
-                :size="headerResponsive()" />
+                :size="headerResponsive()"
+              />
               <div class="ml-auto mr-0 text-right">
                 <ellipsis-menu
                   v-if="ellipsisButton"
@@ -93,10 +106,12 @@
                   :data="task"
                   :divider="false"
                   style="float:none; color: #566877;"
-                  @navigate="onProcessNavigate" />
+                  @navigate="onProcessNavigate"
+                />
                 <b-button-group
                   v-if="!ellipsisButton"
-                  class="preview-group-button">
+                  class="preview-group-button"
+                >
                   <b-button
                     v-if="taskDraftsEnabled"
                     v-b-tooltip.hover
@@ -104,10 +119,12 @@
                     :aria-label="$t('Clear Draft')"
                     variant="light"
                     :title="$t('Clear Draft')"
-                    @click="eraseDraft()">
+                    @click="eraseDraft()"
+                  >
                     <img
                       src="/img/smartinbox-images/eraser.svg"
-                      :alt="$t('No Image')">
+                      :alt="$t('No Image')"
+                    >
                   </b-button>
                   <b-button
                     v-if="showQuickFillPreview === false"
@@ -116,15 +133,18 @@
                     :aria-label="$t('Quick fill')"
                     :title="$t('Quick fill')"
                     variant="light"
-                    @click="showQuickFillPreview = true">
+                    @click="showQuickFillPreview = true"
+                  >
                     <img
                       src="/img/smartinbox-images/fill.svg"
-                      :alt="$t('No Image')">
+                      :alt="$t('No Image')"
+                    >
                   </b-button>
                 </b-button-group>
                 <b-button-group
                   v-if="!ellipsisButton"
-                  class="preview-group-button">
+                  class="preview-group-button"
+                >
                   <b-button
                     v-b-tooltip.hover
                     class="icon-button"
@@ -132,14 +152,16 @@
                     :aria-label="$t('Priority')"
                     :title="$t('Priority')"
                     :class="{ 'button-priority': isPriority }"
-                    @click="addPriority()">
+                    @click="addPriority()"
+                  >
                     <img
                       :src="
                         isPriority
                           ? '/img/priority.svg'
                           : '/img/priority-header.svg'
                       "
-                      :alt="$t('No Image')">
+                      :alt="$t('No Image')"
+                    >
                   </b-button>
                   <b-button
                     v-if="allowReassignment"
@@ -148,7 +170,8 @@
                     variant="light"
                     :aria-label="$t('Reassign')"
                     :title="$t('Reassign')"
-                    @click="openReassignment()">
+                    @click="openReassignment()"
+                  >
                     <i class="fas fa-user-friends" />
                   </b-button>
                   <b-button
@@ -157,7 +180,8 @@
                     variant="light"
                     :aria-label="$t('Open Task')"
                     :title="$t('Open Task')"
-                    @click="openTask()">
+                    @click="openTask()"
+                  >
                     <i class="fas fa-external-link-alt" />
                   </b-button>
                 </b-button-group>
@@ -167,7 +191,8 @@
                   class="btn-light text-secondary"
                   :aria-label="$t('Close')"
                   :title="$t('Close')"
-                  @click="onClose();showReassignment=false;">
+                  @click="onClose();showReassignment=false;"
+                >
                   <i class="fas fa-times" />
                 </b-button>
               </div>
@@ -177,14 +202,16 @@
             v-if="showReassignment"
             :task="task"
             @on-cancel-reassign="showReassignment = false"
-            @on-reassign-user="e=> reassignUser(e,false)" />
+            @on-reassign-user="e=> reassignUser(e,false)"
+          />
           <div
             :class="{
               'frame-container': tooltipButton === 'previewTask' || tooltipButton === '',
               'frame-container-full': tooltipButton === 'fullTask',
               'frame-container-inbox': tooltipButton === 'inboxRules'
             }"
-            class="iframe-container">
+            class="iframe-container"
+          >
             <iframe
               v-if="showFrame1"
               ref="tasksFrame1"
@@ -194,7 +221,8 @@
               class="iframe"
               :src="linkTasks1"
               :event-parent-id="_uid"
-              @load="frameLoaded('tasksFrame1')" />
+              @load="frameLoaded('tasksFrame1')"
+            />
             <iframe
               v-if="showFrame2"
               ref="tasksFrame2"
@@ -204,15 +232,18 @@
               class="iframe"
               :src="linkTasks2"
               :event-parent-id="_uid"
-              @load="frameLoaded('tasksFrame2')" />
+              @load="frameLoaded('tasksFrame2')"
+            />
 
             <task-loading
               v-show="stopFrame"
-              class="load-frame" />
+              class="load-frame"
+            />
           </div>
           <splitpane-container
             v-if="showQuickFillPreview"
-            :size="93">
+            :size="93"
+          >
             <quick-fill-preview
               class="quick-fill-preview"
               :task="task"
@@ -220,7 +251,8 @@
               :prop-columns="propColumns"
               :prop-filters="propFilters"
               @quick-fill-data="fillWithQuickFillData"
-              @close="showQuickFillPreview = false" />
+              @close="showQuickFillPreview = false"
+            />
           </splitpane-container>
         </div>
       </splitpane-container>

--- a/resources/js/tasks/components/taskPreview/TaskPreviewAssignment.vue
+++ b/resources/js/tasks/components/taskPreview/TaskPreviewAssignment.vue
@@ -1,18 +1,21 @@
 <template>
   <div
     id="reassign-container"
-    class="tw-flex tw-flex-col tw-space-y-3 tw-items-center overlay-div tw-absolute top-0 start-0 tw-w-full bg-white shadow-lg tw-p-2">
+    class="tw-flex tw-flex-col tw-space-y-3 tw-items-center overlay-div tw-absolute top-0 start-0 tw-w-full bg-white shadow-lg tw-p-2"
+  >
     <div class="tw-flex tw-flex-col tw-space-x-2 tw-p-2 tw-w-full">
       <label>{{ $t('Assign to') }}:</label>
       <PMDropdownSuggest
         v-model="selectedUser"
         :options="reassignUsers"
         :placeholder="$t('Type here to search')"
-        @onInput="onReassignInput">
+        @onInput="onReassignInput"
+      >
         <template #pre-text="{ option }">
           <b-badge
             variant="secondary"
-            class="mr-2 custom-badges pl-2 pr-2 rounded-lg">
+            class="mr-2 custom-badges pl-2 pr-2 rounded-lg"
+          >
             {{ option.active_tasks_count }}
           </b-badge>
         </template>
@@ -25,22 +28,25 @@
         v-model="comments"
         rows="5"
         class="tw-w-full tw-border tw-border-gray-300 tw-rounded-md tw-resize-none"
-        :placeholder="$t('Add a comment to the assignment')" />
+        :placeholder="$t('Add a comment to the assignment')"
+      />
     </div>
 
     <div class="tw-flex tw-flex-row tw-space-x-2 tw-w-full tw-justify-end">
       <button
         type="button"
-        class="btn btn-primary btn-sm ml-2"
-        :disabled="disabled || disabledAssign"
-        @click="reassignUser">
-        {{ $t('Assign') }}
+        class="btn btn-outline-secondary btn-sm ml-2"
+        @click="cancelReassign"
+      >
+        {{ $t('Cancel') }}
       </button>
       <button
         type="button"
-        class="btn btn-outline-secondary btn-sm ml-2"
-        @click="cancelReassign">
-        {{ $t('Cancel') }}
+        class="btn btn-primary btn-sm ml-2"
+        :disabled="disabled || disabledAssign"
+        @click="reassignUser"
+      >
+        {{ $t('Assign') }}
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Go to home
2. Search a task in progress
3. Click on preview button 
4. Click on reassignment option 
5. Check the (Cancel and Assign) buttons on the top

**Current Behavior**
Cancel and Assignment buttons are not in the correct position in the Reassignment form 

**Expected Behavior**
Cancel button should be on the left
Assign button should be on the right 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24105

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
