### PR TITLE
FOUR-24577: Threads of cases in parallel are reloaded automatically into a parent case

### DIFF
--- a/ProcessMaker/Events/ProcessUpdated.php
+++ b/ProcessMaker/Events/ProcessUpdated.php
@@ -24,6 +24,8 @@ class ProcessUpdated implements ShouldBroadcastNow
 
     private $processRequest;
 
+    public $activeTokens;
+
     /**
      * Create a new event instance.
      *
@@ -35,7 +37,7 @@ class ProcessUpdated implements ShouldBroadcastNow
         $this->event = $event;
 
         $this->processRequest = $processRequest;
-
+        $this->activeTokens = $this->processRequest->getActiveTokens($this->processRequest);
         if ($token) {
             $this->tokenId = $token->getId();
             $this->elementType = $token->element_type;
@@ -65,7 +67,7 @@ class ProcessUpdated implements ShouldBroadcastNow
     /**
      * Return the process request.
      *
-     * @return \ProcessMaker\Models\ProcessRequest
+     * @return ProcessRequest
      */
     public function getProcessRequest()
     {

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -1141,9 +1141,19 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
      */
     public static function getActiveTokens(self $processRequest)
     {
-        return $processRequest->tokens()
+        return ProcessRequestToken::query()
             ->select('id')
             ->where('status', 'ACTIVE')
+            // where if collaborationId is not null
+            ->where(function ($query) use ($processRequest) {
+                if ($processRequest->process_collaboration_id) {
+                    $query->whereIn('process_request_id', function ($query) use ($processRequest) {
+                        $query->select('id')->from('process_requests')->where('process_collaboration_id', $processRequest->process_collaboration_id);
+                    });
+                } else {
+                    $query->where('process_request_id', $processRequest->id);
+                }
+            })
             ->pluck('id')
             ->toArray();
     }

--- a/tests/unit/ProcessMaker/Models/ProcessRequestTest.php
+++ b/tests/unit/ProcessMaker/Models/ProcessRequestTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Models;
+
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class ProcessRequestTest extends TestCase
+{
+    /**
+     * Test that getActiveTokens correctly returns active tokens for a process request
+     * with and without process_collaboration_id
+     */
+    public function testGetActiveTokens()
+    {
+        // Test scenario 1: Process request without collaboration ID
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'status' => 'ACTIVE',
+            'process_collaboration_id' => null,
+        ]);
+
+        // Create tokens for the request (2 active, 1 completed)
+        $activeToken1 = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'status' => 'ACTIVE',
+        ]);
+
+        $activeToken2 = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'status' => 'ACTIVE',
+        ]);
+
+        $completedToken = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'status' => 'CLOSED',
+        ]);
+
+        // Test getActiveTokens for request without collaboration
+        $activeTokens = ProcessRequest::getActiveTokens($request);
+        $this->assertCount(2, $activeTokens);
+        $this->assertContains($activeToken1->id, $activeTokens);
+        $this->assertContains($activeToken2->id, $activeTokens);
+        $this->assertNotContains($completedToken->id, $activeTokens);
+
+        // Test scenario 2: Process requests with collaboration ID
+        $collaborationId = 123456; // Using an integer instead of a string
+
+        // Update the existing request with collaboration ID
+        $request->process_collaboration_id = $collaborationId;
+        $request->save();
+
+        // Create a second request with the same collaboration ID
+        $request2 = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'status' => 'ACTIVE',
+            'process_collaboration_id' => $collaborationId,
+        ]);
+
+        // Create tokens for the second request (1 active, 1 completed)
+        $activeToken3 = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request2->id,
+            'status' => 'ACTIVE',
+        ]);
+
+        $completedToken2 = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request2->id,
+            'status' => 'CLOSED',
+        ]);
+
+        // Test getActiveTokens for request with collaboration
+        $collaborationActiveTokens = ProcessRequest::getActiveTokens($request);
+        $this->assertCount(3, $collaborationActiveTokens);
+
+        // Should contain all active tokens from both requests with the same collaboration ID
+        $this->assertContains($activeToken1->id, $collaborationActiveTokens);
+        $this->assertContains($activeToken2->id, $collaborationActiveTokens);
+        $this->assertContains($activeToken3->id, $collaborationActiveTokens);
+
+        // Should not contain any completed tokens
+        $this->assertNotContains($completedToken->id, $collaborationActiveTokens);
+        $this->assertNotContains($completedToken2->id, $collaborationActiveTokens);
+    }
+}


### PR DESCRIPTION

## Issue & Reproduction Steps
The task is set to "Task Source (Default)" in the Task Destination. Submitting one thread reloads the other and redirects to the request page (see the attached video on the parallel problem)

## Solution
- improve getActiveTokens
- add activeTokens to processUpdated model
- add test for getActiveTokens method


https://github.com/user-attachments/assets/752fb093-c99b-4adf-9206-e0be6191e33a


## How to Test
Described in the related ticket 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24577

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
