### PR TITLE
FOUR-24634 Business Logic Flaw Allows Admin API Token Generation

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/UserController.php
+++ b/ProcessMaker/Http/Controllers/Admin/UserController.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Http\Controllers\Admin;
 
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Models\Group;
@@ -87,6 +88,9 @@ class UserController extends Controller
         $addons = $this->getPluginAddons('edit', compact(['user']));
         $addonsSettings = $this->getPluginAddons('edit.settings', compact(['user']));
 
+        // The user can only create tokens for themselves or if they are an administrator.
+        $canCreateTokens = Auth::user()->is_administrator || Auth::user()->id === $user->id;
+
         return view('admin.users.edit', compact(
             'user',
             'groups',
@@ -104,6 +108,7 @@ class UserController extends Controller
             'addons',
             'addonsSettings',
             'ssoUser',
+            'canCreateTokens',
         ));
     }
 

--- a/ProcessMaker/Http/Controllers/Api/UserTokenController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserTokenController.php
@@ -141,7 +141,8 @@ class UserTokenController extends Controller
      */
     public function store(Request $request, User $user)
     {
-        if (!Auth::user()->can('edit', $user)) {
+        // The user can only create tokens for themselves or if they are an administrator.
+        if (!Auth::user()->can('edit', $user) || !(Auth::user()->is_administrator || Auth::user()->id === $user->id)) {
             throw new AuthorizationException(__('Not authorized to update this user.'));
         }
 

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -94,7 +94,7 @@
                         </div>
                         <div class="tab-pane" id="nav-tokens" role="tabpanel" aria-labelledby="nav-tokens-tab">
                             <div>
-                                <div class="d-flex justify-content-end mb-3">
+                                <div class="d-flex justify-content-end mb-3" v-if="canCreateTokens">
                                     <button type="button" aria-label="{{__('New Token')}}" class="btn btn-secondary" @click="generateToken">
                                         <i class="fas fa-plus"></i> {{__('Token')}}
                                     </button>
@@ -284,6 +284,7 @@
             focusErrors: 'errors',
             originalEmail: '',
             emailHasChanged: false,
+            canCreateTokens: @json($canCreateTokens),
           }
         },
         created() {


### PR DESCRIPTION
## Issue & Reproduction Steps
A user with "Edit User" permissions is able to generate API tokens for users with higher privileges.

## Solution
Add next validations: Only administrator use can generate tokens for another users. If is not an administrator user, the user only can generate tokens for himself.

## How to Test
Follow the steps mentioned in the attached PDF in the ticket.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-24634

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
