### PR TITLE
FOUR-24707: Stages - Update the Checklist design with click option

### DIFF
--- a/resources/js/processes/modeler/components/inspector/StageItem.vue
+++ b/resources/js/processes/modeler/components/inspector/StageItem.vue
@@ -1,82 +1,93 @@
 <template>
   <div class="tw-flex tw-items-center tw-space-x-2 tw-w-full tw-py-1">
     <span class="tw-w-6 text-center stage-item-number">{{ order }}</span>
-    <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move"></i>
+    <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move" />
     <div class="tw-flex-1">
       <template v-if="editing">
         <input
           v-model="localName"
           class="tw-w-full tw-border tw-rounded px-2"
-          @keyup.enter="onKeyupEnter"
-        />
+          @keyup.enter="onKeyupEnter">
       </template>
       <template v-else>
-        <span :class="{ 'font-bold stage-item-selected': selected }">{{ name }}</span>
+        <span
+          class="tw-cursor-pointer"
+          :class="{ 'font-bold stage-item-selected': selected }"
+          @click.stop.prevent="handleClick">{{ name }}
+        </span>
       </template>
     </div>
-    <i v-if="selected" class="fas fp-check-circle-blue stage-item-color" @click="onClickSelected"></i>
-    <input v-else type="checkbox" v-model="isChecked" @change="onClickCheckbox"/>
-    <button @click="editing = !editing" class="p-1 bg-transparent border-0">
-      <i class="fas fp-pen-edit stage-item-color"></i>
+    <button
+      class="p-1 bg-transparent border-0"
+      @click="editing = !editing">
+      <i class="fas fp-pen-edit stage-item-color" />
     </button>
-    <button @click="$emit('onRemove')" class="p-1 bg-transparent border-0">
-      <i class="fas fp-trash-blue stage-item-color"></i>
+    <button
+      class="p-1 bg-transparent border-0"
+      @click="$emit('onRemove')">
+      <i class="fas fp-trash-blue stage-item-color" />
     </button>
   </div>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref } from "vue";
 
 const props = defineProps({
   id: Number,
   order: Number,
   name: String,
-  selected: Boolean
+  selected: Boolean,
 });
 
-const emit = defineEmits(['onRemove', 'onUpdate', 'onClickCheckbox', 'onClickSelected']);
+const emit = defineEmits(["onRemove", "onUpdate", "onClickSelected", "onClickStage"]);
 const editing = ref(false);
 const localName = ref(props.name);
-const isChecked = ref(false);
+const clicks = ref(0);
+const delay = 300;
 
 const onKeyupEnter = () => {
-  emit('onUpdate', localName.value);
+  emit("onUpdate", localName.value);
   editing.value = false;
 };
 
-const onClickCheckbox = () => {
-  emit('onClickCheckbox');
-};
-
 const onClickSelected = () => {
-  emit('onClickSelected');
+  emit("onClickSelected");
 };
 
-watch(() => props.name, (val) => {
-  localName.value = val;
-});
-
-watch(() => props.selected, (val) => {
-  isChecked.value = val;
-});
+const handleClick = () => {
+  clicks.value += 1;
+  if (clicks.value === 1) {
+    setTimeout(() => {
+      if (clicks.value === 1) {
+        emit("onClickStage", true);
+      } else if (clicks.value === 2) {
+        emit("onClickStage", false);
+      }
+      clicks.value = 0;
+    }, delay);
+  }
+};
 </script>
 <style scoped>
-  .stage-item-selected {
-    font-weight: bold;
-    color: #2773F3;
-  }
-  .stage-item-color {
-    color: #2773F3;
-  }
-  .stage-item-number {
-    background-color: #788793;
-    font-weight: bold;
-    border-radius: 0.25rem;
-    color: white;
-    min-width: 24px;
-  }
-  .stage-item-grip-vertical {
-    color: #788793;
-  }
+.stage-item-selected {
+  font-weight: bold;
+  color: #2773F3;
+}
+
+.stage-item-color {
+  color: #2773F3;
+}
+
+.stage-item-number {
+  background-color: #788793;
+  font-weight: bold;
+  border-radius: 0.25rem;
+  color: white;
+  min-width: 24px;
+}
+
+.stage-item-grip-vertical {
+  color: #788793;
+}
 </style>

--- a/resources/js/processes/modeler/components/inspector/StageItem.vue
+++ b/resources/js/processes/modeler/components/inspector/StageItem.vue
@@ -1,93 +1,92 @@
 <template>
   <div class="tw-flex tw-items-center tw-space-x-2 tw-w-full tw-py-1">
     <span class="tw-w-6 text-center stage-item-number">{{ order }}</span>
-    <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move" />
-    <div class="tw-flex-1">
+    <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move"></i>
+    <div class="tw-flex-1 tw-cursor-pointer"
+         @click="check"
+         @dblclick.stop="uncheck">
       <template v-if="editing">
         <input
           v-model="localName"
           class="tw-w-full tw-border tw-rounded px-2"
-          @keyup.enter="onKeyupEnter">
+          @keyup.enter="onKeyupEnter"
+        />
       </template>
       <template v-else>
-        <span
-          class="tw-cursor-pointer"
-          :class="{ 'font-bold stage-item-selected': selected }"
-          @click.stop.prevent="handleClick">{{ name }}
-        </span>
+        <span :class="{ 'font-bold stage-item-selected': selected }">{{ name }}</span>
       </template>
     </div>
-    <button
-      class="p-1 bg-transparent border-0"
-      @click="editing = !editing">
-      <i class="fas fp-pen-edit stage-item-color" />
+    <button @click="editing = !editing" class="p-1 bg-transparent border-0">
+      <i class="fas fp-pen-edit stage-item-color"></i>
     </button>
-    <button
-      class="p-1 bg-transparent border-0"
-      @click="$emit('onRemove')">
-      <i class="fas fp-trash-blue stage-item-color" />
+    <button @click="$emit('onRemove')" class="p-1 bg-transparent border-0">
+      <i class="fas fp-trash-blue stage-item-color"></i>
     </button>
   </div>
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { ref, watch } from 'vue';
 
 const props = defineProps({
   id: Number,
   order: Number,
   name: String,
-  selected: Boolean,
+  selected: Boolean
 });
 
-const emit = defineEmits(["onRemove", "onUpdate", "onClickSelected", "onClickStage"]);
+const emit = defineEmits(['onRemove', 'onUpdate', 'onClickCheckbox', 'onClickSelected']);
 const editing = ref(false);
 const localName = ref(props.name);
-const clicks = ref(0);
-const delay = 300;
+const isChecked = ref(false);
 
 const onKeyupEnter = () => {
-  emit("onUpdate", localName.value);
+  emit('onUpdate', localName.value);
   editing.value = false;
 };
 
-const onClickSelected = () => {
-  emit("onClickSelected");
+const onClickCheckbox = () => {
+  emit('onClickCheckbox');
 };
 
-const handleClick = () => {
-  clicks.value += 1;
-  if (clicks.value === 1) {
-    setTimeout(() => {
-      if (clicks.value === 1) {
-        emit("onClickStage", true);
-      } else if (clicks.value === 2) {
-        emit("onClickStage", false);
-      }
-      clicks.value = 0;
-    }, delay);
-  }
+const onClickSelected = () => {
+  emit('onClickSelected');
 };
+
+const check = () => {
+  isChecked.value = true;
+  emit('onClickCheckbox');
+};
+
+const uncheck = () => {
+  isChecked.value = false;
+  emit('onClickSelected');
+};
+
+watch(() => props.name, (val) => {
+  localName.value = val;
+});
+
+watch(() => props.selected, (val) => {
+  isChecked.value = val;
+});
 </script>
 <style scoped>
-.stage-item-selected {
-  font-weight: bold;
-  color: #2773F3;
-}
-
-.stage-item-color {
-  color: #2773F3;
-}
-
-.stage-item-number {
-  background-color: #788793;
-  font-weight: bold;
-  border-radius: 0.25rem;
-  color: white;
-  min-width: 24px;
-}
-
-.stage-item-grip-vertical {
-  color: #788793;
-}
+  .stage-item-selected {
+    font-weight: bold;
+    color: #2773F3;
+  }
+  .stage-item-color {
+    color: #2773F3;
+  }
+  .stage-item-number {
+    background-color: #788793;
+    font-weight: bold;
+    border-radius: 0.25rem;
+    color: white;
+    min-width: 24px;
+  }
+  .stage-item-grip-vertical {
+    color: #788793;
+  }
 </style>

--- a/resources/js/processes/modeler/components/inspector/StageList.vue
+++ b/resources/js/processes/modeler/components/inspector/StageList.vue
@@ -1,75 +1,62 @@
 <template>
   <div>
-    <draggable
-      v-model="stages"
-      item-key="id"
-      handle=".fa-grip-vertical"
+    <draggable 
+      v-model="stages" 
+      item-key="id" 
+      handle=".fa-grip-vertical" 
       class="divide-y"
       @end="onReorder">
       <StageItem
-        v-for="(item, index) in stages"
-        :id="item.id"
+        v-for="(item, index) in stages" 
         :key="index"
+        :id="item.id"
         :order="item.order"
         :name="item.name"
         :selected="item.selected"
         @onUpdate="onUpdate(index, $event)"
         @onRemove="onRemove(index)"
-        @onClickStage="(e) => onClickStage(e, index)"
-        @onClickSelected="onClickSelected(index)" />
+        @onClickCheckbox="onClickCheckbox(index)"
+        @onClickSelected="onClickSelected(index)"
+      ></StageItem>
     </draggable>
 
-    <div
-      v-show="adding"
-      class="tw-flex tw-items-center tw-space-x-2 tw-w-full tw-py-1">
-      <span class="tw-w-6 text-center stage-item-number">{{
-        totalStages + 1
-      }}</span>
-      <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move" />
+    <div v-show="adding" class="tw-flex tw-items-center tw-space-x-2 tw-w-full tw-py-1">
+      <span class="tw-w-6 text-center stage-item-number">{{ totalStages + 1 }}</span>
+      <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move"></i>
       <input
         v-model="newStage"
         class="tw-flex-1 tw-border tw-rounded px-2"
         :placeholder="$t('Enter name')"
-        @keyup.enter="onKeyupEnter">
+        @keyup.enter="onKeyupEnter"
+      />
     </div>
     <div class="tw-flex tw-justify-end tw-mt-2">
-      <button
+      <button 
+        @click="onClickAdd" 
         :disabled="disableButton"
-        class="tw-bg-blue-500 text-white tw-text-sm tw-px-2 tw-py-0.5 tw-rounded"
-        :class="{
-          'tw-bg-gray-300 tw-cursor-not-allowed': disableButton,
-        }"
-        @click="onClickAdd">
-        <i class="fas fa-plus" />
+        class="tw-bg-blue-500 text-white tw-text-sm tw-px-2 tw-py-0.5 tw-rounded" 
+        :class="{'tw-bg-gray-300 tw-cursor-not-allowed': disableButton}">
+        <i class="fas fa-plus"></i>
       </button>
     </div>
   </div>
 </template>
 
 <script setup>
-import {
-  ref, computed, watch, onMounted,
-} from "vue";
-import draggable from "vuedraggable";
-import i18next from "i18next";
-import StageItem from "./StageItem.vue";
+import { ref, computed, watch, onMounted } from 'vue';
+import draggable from 'vuedraggable';
+import StageItem from './StageItem.vue';
+import i18next from 'i18next';
 
 const props = defineProps({
   initialStages: {
     type: Array,
-    default: () => [],
-  },
+    default: () => []
+  }
 });
-const emit = defineEmits([
-  "onAdd",
-  "onUpdate",
-  "onRemove",
-  "onChange",
-  "onClickCheckbox",
-  "onClickSelected",
-]);
+const emit = defineEmits(['onAdd', 'onUpdate', 'onRemove', 'onChange', 'onClickCheckbox', 'onClickSelected']);
 const adding = ref(false);
-const newStage = ref("");
+const newStage = ref('');
 const stages = ref([...props.initialStages]);
 const totalStages = computed(() => stages.value.length);
 const disableButton = computed(() => totalStages.value >= 8);
@@ -78,17 +65,17 @@ const onClickAdd = () => {
   if (disableButton.value) {
     return;
   }
-  adding.value = !adding.value;
-  newStage.value = "";
+  adding.value = !adding.value; 
+  newStage.value = '';
 };
 
 const generateUniqueId = () => {
   const timestamp = Math.floor(Date.now() / 1000);
   const random = Math.floor(Math.random() * 1000);
-  const paddedRandom = random.toString().padStart(3, "0");
+  const paddedRandom = random.toString().padStart(3, '0');
   const combined = `${timestamp}${paddedRandom}`.slice(0, 10);
   return Number(combined);
-};
+}
 
 const onKeyupEnter = () => {
   if (newStage.value.trim()) {
@@ -96,29 +83,22 @@ const onKeyupEnter = () => {
     const order = stages.value.length + 1;
     stages.value.push({
       id: uniqueId,
-      order,
+      order: order,
       name: newStage.value,
-      selected: false,
+      selected: false
     });
-    newStage.value = "";
+    newStage.value = '';
     adding.value = false;
-    emit("onAdd", stages.value, stages.value.length - 1);
-    emit("onChange", stages.value);
+    emit('onAdd', stages.value, stages.value.length - 1);
+    emit('onChange', stages.value);
   }
 };
 
 const onUpdate = (index, newName) => {
   const oldName = stages.value[index].name;
   stages.value[index].name = newName;
-  emit("onUpdate", stages.value, index, newName, oldName);
-  emit("onChange", stages.value);
-};
-
-const onReorder = () => {
-  stages.value.forEach((item, index) => {
-    item.order = index + 1;
-  });
-  emit("onChange", stages.value);
+  emit('onUpdate', stages.value, index, newName, oldName);
+  emit('onChange', stages.value);
 };
 
 const onRemove = (index) => {
@@ -128,42 +108,49 @@ const onRemove = (index) => {
     "",
     () => {
       const removed = stages.value.splice(index, 1);
-      emit("onRemove", stages.value, index, removed[0]);
-
-      onReorder();
-      emit("onChange", stages.value);
-    },
+      emit('onRemove', stages.value, index, removed[0]);
+      emit('onChange', stages.value);
+    }
   );
 };
 
-const onClickStage = (value, index) => {
+const onClickCheckbox = (index) => {
   stages.value.forEach((stage, i) => {
-    stage.selected = i === index ? value : false;
+    Vue.set(stage, "selected", i === index);
   });
-  emit("onClickStage", stages.value[index]);
+  emit('onClickCheckbox', stages.value[index]);
 };
 
 const onClickSelected = (index) => {
   stages.value.forEach((stage, i) => {
     if (i === index) {
-      stage.selected = false;
+      Vue.set(stage, "selected", false);
     }
   });
-  emit("onClickSelected", stages.value[index]);
+  emit('onClickSelected', stages.value[index]);
 };
 
+const onReorder = () => {
+  stages.value.forEach((item, index) => {
+    item.order = index + 1;
+  });
+  emit('onChange', stages.value);
+};
+
+watch(() => props.initialStages, (newVal) => {
+  stages.value = [...newVal];
+});
 </script>
 
 <style scoped>
-.stage-item-number {
-  background-color: #788793;
-  font-weight: bold;
-  border-radius: 0.25rem;
-  color: white;
-  min-width: 24px;
-}
-
-.stage-item-grip-vertical {
-  color: #788793;
-}
+  .stage-item-number {
+    background-color: #788793;
+    font-weight: bold;
+    border-radius: 0.25rem;
+    color: white;
+    min-width: 24px;
+  }
+  .stage-item-grip-vertical {
+    color: #788793;
+  }
 </style>

--- a/resources/js/processes/modeler/components/inspector/StageList.vue
+++ b/resources/js/processes/modeler/components/inspector/StageList.vue
@@ -114,6 +114,13 @@ const onUpdate = (index, newName) => {
   emit("onChange", stages.value);
 };
 
+const onReorder = () => {
+  stages.value.forEach((item, index) => {
+    item.order = index + 1;
+  });
+  emit("onChange", stages.value);
+};
+
 const onRemove = (index) => {
   ProcessMaker.confirmModal(
     i18next.t("Caution!"),
@@ -122,6 +129,8 @@ const onRemove = (index) => {
     () => {
       const removed = stages.value.splice(index, 1);
       emit("onRemove", stages.value, index, removed[0]);
+
+      onReorder();
       emit("onChange", stages.value);
     },
   );
@@ -143,12 +152,6 @@ const onClickSelected = (index) => {
   emit("onClickSelected", stages.value[index]);
 };
 
-const onReorder = () => {
-  stages.value.forEach((item, index) => {
-    item.order = index + 1;
-  });
-  emit("onChange", stages.value);
-};
 </script>
 
 <style scoped>

--- a/resources/js/processes/modeler/components/inspector/StageList.vue
+++ b/resources/js/processes/modeler/components/inspector/StageList.vue
@@ -1,62 +1,75 @@
 <template>
   <div>
-    <draggable 
-      v-model="stages" 
-      item-key="id" 
-      handle=".fa-grip-vertical" 
+    <draggable
+      v-model="stages"
+      item-key="id"
+      handle=".fa-grip-vertical"
       class="divide-y"
       @end="onReorder">
       <StageItem
-        v-for="(item, index) in stages" 
-        :key="index"
+        v-for="(item, index) in stages"
         :id="item.id"
+        :key="index"
         :order="item.order"
         :name="item.name"
         :selected="item.selected"
         @onUpdate="onUpdate(index, $event)"
         @onRemove="onRemove(index)"
-        @onClickCheckbox="onClickCheckbox(index)"
-        @onClickSelected="onClickSelected(index)"
-      ></StageItem>
+        @onClickStage="(e) => onClickStage(e, index)"
+        @onClickSelected="onClickSelected(index)" />
     </draggable>
 
-    <div v-show="adding" class="tw-flex tw-items-center tw-space-x-2 tw-w-full tw-py-1">
-      <span class="tw-w-6 text-center stage-item-number">{{ totalStages + 1 }}</span>
-      <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move"></i>
+    <div
+      v-show="adding"
+      class="tw-flex tw-items-center tw-space-x-2 tw-w-full tw-py-1">
+      <span class="tw-w-6 text-center stage-item-number">{{
+        totalStages + 1
+      }}</span>
+      <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move" />
       <input
         v-model="newStage"
         class="tw-flex-1 tw-border tw-rounded px-2"
         :placeholder="$t('Enter name')"
-        @keyup.enter="onKeyupEnter"
-      />
+        @keyup.enter="onKeyupEnter">
     </div>
     <div class="tw-flex tw-justify-end tw-mt-2">
-      <button 
-        @click="onClickAdd" 
+      <button
         :disabled="disableButton"
-        class="tw-bg-blue-500 text-white tw-text-sm tw-px-2 tw-py-0.5 tw-rounded" 
-        :class="{'tw-bg-gray-300 tw-cursor-not-allowed': disableButton}">
-        <i class="fas fa-plus"></i>
+        class="tw-bg-blue-500 text-white tw-text-sm tw-px-2 tw-py-0.5 tw-rounded"
+        :class="{
+          'tw-bg-gray-300 tw-cursor-not-allowed': disableButton,
+        }"
+        @click="onClickAdd">
+        <i class="fas fa-plus" />
       </button>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue';
-import draggable from 'vuedraggable';
-import StageItem from './StageItem.vue';
-import i18next from 'i18next';
+import {
+  ref, computed, watch, onMounted,
+} from "vue";
+import draggable from "vuedraggable";
+import i18next from "i18next";
+import StageItem from "./StageItem.vue";
 
 const props = defineProps({
   initialStages: {
     type: Array,
-    default: () => []
-  }
+    default: () => [],
+  },
 });
-const emit = defineEmits(['onAdd', 'onUpdate', 'onRemove', 'onChange', 'onClickCheckbox', 'onClickSelected']);
+const emit = defineEmits([
+  "onAdd",
+  "onUpdate",
+  "onRemove",
+  "onChange",
+  "onClickCheckbox",
+  "onClickSelected",
+]);
 const adding = ref(false);
-const newStage = ref('');
+const newStage = ref("");
 const stages = ref([...props.initialStages]);
 const totalStages = computed(() => stages.value.length);
 const disableButton = computed(() => totalStages.value >= 8);
@@ -65,17 +78,17 @@ const onClickAdd = () => {
   if (disableButton.value) {
     return;
   }
-  adding.value = !adding.value; 
-  newStage.value = '';
+  adding.value = !adding.value;
+  newStage.value = "";
 };
 
 const generateUniqueId = () => {
   const timestamp = Math.floor(Date.now() / 1000);
   const random = Math.floor(Math.random() * 1000);
-  const paddedRandom = random.toString().padStart(3, '0');
+  const paddedRandom = random.toString().padStart(3, "0");
   const combined = `${timestamp}${paddedRandom}`.slice(0, 10);
   return Number(combined);
-}
+};
 
 const onKeyupEnter = () => {
   if (newStage.value.trim()) {
@@ -83,22 +96,22 @@ const onKeyupEnter = () => {
     const order = stages.value.length + 1;
     stages.value.push({
       id: uniqueId,
-      order: order,
+      order,
       name: newStage.value,
-      selected: false
+      selected: false,
     });
-    newStage.value = '';
+    newStage.value = "";
     adding.value = false;
-    emit('onAdd', stages.value, stages.value.length - 1);
-    emit('onChange', stages.value);
+    emit("onAdd", stages.value, stages.value.length - 1);
+    emit("onChange", stages.value);
   }
 };
 
 const onUpdate = (index, newName) => {
   const oldName = stages.value[index].name;
   stages.value[index].name = newName;
-  emit('onUpdate', stages.value, index, newName, oldName);
-  emit('onChange', stages.value);
+  emit("onUpdate", stages.value, index, newName, oldName);
+  emit("onChange", stages.value);
 };
 
 const onRemove = (index) => {
@@ -108,17 +121,17 @@ const onRemove = (index) => {
     "",
     () => {
       const removed = stages.value.splice(index, 1);
-      emit('onRemove', stages.value, index, removed[0]);
-      emit('onChange', stages.value);
-    }
+      emit("onRemove", stages.value, index, removed[0]);
+      emit("onChange", stages.value);
+    },
   );
 };
 
-const onClickCheckbox = (index) => {
+const onClickStage = (value, index) => {
   stages.value.forEach((stage, i) => {
-    stage.selected = i === index;
+    stage.selected = i === index ? value : false;
   });
-  emit('onClickCheckbox', stages.value[index]);
+  emit("onClickStage", stages.value[index]);
 };
 
 const onClickSelected = (index) => {
@@ -127,30 +140,27 @@ const onClickSelected = (index) => {
       stage.selected = false;
     }
   });
-  emit('onClickSelected', stages.value[index]);
+  emit("onClickSelected", stages.value[index]);
 };
 
 const onReorder = () => {
   stages.value.forEach((item, index) => {
     item.order = index + 1;
   });
-  emit('onChange', stages.value);
+  emit("onChange", stages.value);
 };
-
-watch(() => props.initialStages, (newVal) => {
-  stages.value = [...newVal];
-});
 </script>
 
 <style scoped>
-  .stage-item-number {
-    background-color: #788793;
-    font-weight: bold;
-    border-radius: 0.25rem;
-    color: white;
-    min-width: 24px;
-  }
-  .stage-item-grip-vertical {
-    color: #788793;
-  }
+.stage-item-number {
+  background-color: #788793;
+  font-weight: bold;
+  border-radius: 0.25rem;
+  color: white;
+  min-width: 24px;
+}
+
+.stage-item-grip-vertical {
+  color: #788793;
+}
 </style>

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -5,13 +5,13 @@
       {{ $t("Here you have all the stages already set in this process. Define the order you prefer:") }}
     </p>
     <StageList
+      :key="keyStage"
       :initial-stages="defaultStages"
       @onUpdate="onUpdate"
       @onRemove="onRemove"
       @onChange="onChange"
-      @onClickCheckbox="onClickCheckbox"
-      @onClickSelected="onClickSelected"
-    />
+      @onClickStage="onClickStage"
+      @onClickSelected="onClickSelected" />
     <AgregationProperty />
   </div>
 </template>
@@ -28,6 +28,7 @@ const props = defineProps({
 });
 const defaultStages = ref([]);
 const currentInstance = getCurrentInstance();
+const keyStage = ref(0);
 
 const loadStagesFromApi = () => {
   const { id } = window.ProcessMaker.modeler.process;
@@ -40,6 +41,7 @@ const loadStagesFromApi = () => {
       stages.forEach((item) => {
         defaultStages.value = [...defaultStages.value, item];
       });
+      keyStage.value += 1;
     });
 };
 
@@ -146,8 +148,9 @@ const onRemove = (stages, index, removed) => {
   removeStageInAllFlowConfig(removed);
 };
 
-const onClickCheckbox = (stage) => {
+const onClickStage = (stage) => {
   applyStageToFlow(stage);
+  keyStage.value += 1;
 };
 
 const onClickSelected = (stage) => {

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -138,6 +138,7 @@ const removeStageToFlow = () => {
 const onChange = (stages) => {
   updateStagesForAllFlowConfigs(stages);
   saveStagesToApi(stages);
+  defaultStages.value = [...stages];
 };
 
 const onUpdate = (stages, index, val, Oldal) => {
@@ -149,7 +150,11 @@ const onRemove = (stages, index, removed) => {
 };
 
 const onClickStage = (stage) => {
-  applyStageToFlow(stage);
+  if (!stage.selected) {
+    removeStageToFlow();
+  } else {
+    applyStageToFlow(stage);
+  }
   keyStage.value += 1;
 };
 

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -17,11 +17,11 @@
 
 <script setup>
 import StageList from "./StageList.vue";
-import { ref, watch, reactive, toRefs, onMounted, computed, getCurrentInstance, nextTick } from "vue";
+import { ref, onMounted, getCurrentInstance } from "vue";
 import AgregationProperty from "./AgregationProperty.vue";
 
 const props = defineProps({
-  value: Object
+  value: Object,
 });
 const defaultStages = ref([]);
 const currentInstance = getCurrentInstance();
@@ -56,17 +56,11 @@ const saveStagesToApi = (stages) => {
     });
 };
 
-const getModeler = () => {
-   return currentInstance.proxy.$root.$children[0].$refs.modeler;
-};
+const getModeler = () => currentInstance.proxy.$root.$children[0].$refs.modeler;
 
-const getHighlightedNode = () => {
-  return getModeler().highlightedNode;
-};
+const getHighlightedNode = () => getModeler().highlightedNode;
 
-const getDefinition = () => {
-  return getHighlightedNode().definition;
-};
+const getDefinition = () => getHighlightedNode().definition;
 
 const getConfigFromDefinition = (definition) => {
   let config = {};
@@ -121,7 +115,7 @@ const applyStageToFlow = (stage) => {
   config.stage = {
     id: stage.id,
     order: stage.order,
-    name: stage.name
+    name: stage.name,
   };
   let definition = getDefinition();
   Vue.set(definition, "config", JSON.stringify(config));

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -16,8 +16,8 @@
 </template>
 
 <script setup>
-import StageList from "./StageList.vue";
 import { ref, onMounted, getCurrentInstance } from "vue";
+import StageList from "./StageList.vue";
 import AgregationProperty from "./AgregationProperty.vue";
 
 const props = defineProps({

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -47,7 +47,7 @@ const saveStagesToApi = (stages) => {
   });
   const id = window.ProcessMaker.modeler.process.id;
   const params = {
-    stages: copy
+    stages: copy,
   };
   ProcessMaker
     .apiClient


### PR DESCRIPTION
## Issue & Reproduction Steps
In the Stages  configuration of the modeler we need to update the following
Remove the checklist
To select the stage of the sequence flow user should make one click
To remove the Stage of the sequence flow user should make two clicks
When a stage is selected, the stage name should be highlighted in blue to indicate its active.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24707

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:epic/FOUR-22605
ci:modeler:epic/FOUR-22600
ci:TCE_CUSTOMIZATION_ENABLED=true