### PR TITLE
FOUR-24777: Migration error during upgrade with 2025_02_25_215239_encrypt_devlink_tokens

### DIFF
--- a/upgrades/2025_03_25_215239_encrypt_devlink_tokens.php
+++ b/upgrades/2025_03_25_215239_encrypt_devlink_tokens.php
@@ -28,11 +28,6 @@ class EncryptDevlinkTokens extends Upgrade
      */
     public function up()
     {
-        // Change the column type to TEXT
-        Schema::table('dev_links', function ($table) {
-            $table->text('client_secret')->change()->nullable();
-        });
-
         $devlinks = DB::table('dev_links')->get();
 
         // Encrypt the client_secret, access_token, and refresh_token columns
@@ -77,11 +72,6 @@ class EncryptDevlinkTokens extends Upgrade
                 continue;
             }
         }
-
-        // Change the column type back to String
-        Schema::table('dev_links', function ($table) {
-            $table->string('client_secret')->change()->nullable();
-        });
     }
 
     /**

--- a/upgrades/2025_05_27_183259_validate_devlink_tokens_encryption.php
+++ b/upgrades/2025_05_27_183259_validate_devlink_tokens_encryption.php
@@ -40,7 +40,7 @@ class ValidateDevlinkTokensEncryption extends Upgrade
         // If the column is not nullable, make the change
         if (!$isNullable || $columnInfo->Type === 'varchar(255)') {
             Schema::table('dev_links', function ($table) {
-                $table->text('client_secret')->change()->nullable();
+                $table->text('client_secret')->nullable()->change();
             });
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

1. When the migrations are executed the following errors is showed with `2025_02_25_215239_encrypt_devlink_tokens`
```
2025-06-02T14:47:59.043606787Z Upgrading: 2025_02_25_215239_encrypt_devlink_tokens
PHP Fatal error:  Uncaught PDOException: SQLSTATE[22004]: Null value not allowed: 1138 Invalid use of NULL value in /opt/processmaker/vendor/laravel/framework/src/Illuminate/Database/Connection.php:571
2025-06-02T14:47:59.097220385Z Stack trace:
2025-06-02T14:47:59.097228165Z #0 /opt/processmaker/vendor/laravel/framework/src/Illuminate/Database/Connection.php(571): PDOStatement->execute()
2025-06-02T14:47:59.097234096Z #1 /opt/processmaker/vendor/laravel/framework/src/Illuminate/Database/Connection.php(812): Illuminate\Database\Connection->Illuminate\Database\{closure}()
2025-06-02T14:47:59.097240165Z #2 /opt/processmaker/vendor/laravel/framework/src/Illuminate/Database/Connection.php(779): Illuminate\Database\Connection->runQueryCallback()
2025-06-02T14:47:59.097245785Z #3 /opt/processmaker/vendor/laravel/framework/src/Illuminate/Database/Connection.php(560): Illuminate\Database\Connection->run()
```

## Solution
- As I can see the problem is the order of the execution in order to accept null values

```
2024_08_26_183754_create_dev_links_table ................................................................................................ [21] Ran  
2025_02_26_194048_modify_client_secret_in_dev_links_table ............................................................................... [38] Ran  
2025_03_24_223125_make_dev_links_client_secret_nullable ................................................................................. [40] Ran 
then
2025_03_27_215239_encrypt_devlink_tokens
```
The solution is rename to make sure that the upgrade will execute after the migrations related to the **dev_links**

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24777

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
