### PR TITLE
FOUR-24522: Create Index to Improve Slow Query on cases_participated

### DIFF
--- a/database/migrations/2025_06_05_151344_add_index_case_number_to_cases_participated.php
+++ b/database/migrations/2025_06_05_151344_add_index_case_number_to_cases_participated.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cases_participated', function (Blueprint $table) {
+            $table->index('case_number', 'cases_participated_case_number_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cases_participated', function (Blueprint $table) {
+            $table->dropIndex('cases_participated_case_number_index');
+        });
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
Regarding to a new slow query identified which involve new table cases_participated.

This new index could significantly enhance this query.

The following is the slow query:

`update `cases_participated` set `case_status` = 'ERROR', `cases_participated`.`updated_at` = '2025-05-20 09:38:09' where `case_number` = 9588`

## How to Test
`php artisan migrate`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24522

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
