### PR TITLE
FOUR-24803

### DIFF
--- a/tests/Feature/Api/EnvironmentVariablesTest.php
+++ b/tests/Feature/Api/EnvironmentVariablesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\EnvironmentVariable;
 use ProcessMaker\Models\User;

--- a/tests/Feature/Api/EnvironmentVariablesTest.php
+++ b/tests/Feature/Api/EnvironmentVariablesTest.php
@@ -241,4 +241,17 @@ class EnvironmentVariablesTest extends TestCase
         $variable = EnvironmentVariable::where('name', 'newname')->first();
         $this->assertEquals('testvalue', $variable->value);
     }
+
+    public function testCreationOfMetricVariable()
+    {
+        Artisan::call('db:seed', ['class' => 'MetricsApiEnvironmentVariableSeeder']);
+
+        // Assert only one record exists
+        $this->assertCount(1, EnvironmentVariable::where('name', 'METRICS_API_ENDPOINT')->get());
+
+        // Assert the original values were preserved
+        $this->assertDatabaseHas('environment_variables', [
+            'name' => 'METRICS_API_ENDPOINT',
+        ]);
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The enviroment variable METRICS_API_ENDPOINT does not show

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24803

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:epic/FOUR-22605
ci:modeler:epic/FOUR-22600
ci:TCE_CUSTOMIZATION_ENABLED=true