### PR TITLE
FOUR-23394 | Handle UI State Changes

### DIFF
--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -271,7 +271,16 @@
                             this.formData.valpassword = "";
                         })
                         .catch(error => {
-                            this.errors = error.response.data.errors;
+                            if (error.response?.data?.errors) {
+                                this.errors = error.response.data.errors;
+                            }
+                            
+                            // Handle Slack notification errors
+                            if (error.response?.data?.message?.includes('Slack')) {
+                                ProcessMaker.alert(this.$t(error.response.data.message), 'danger');
+                                // Need to ensure the slack toggle is now disabled in the ui
+                                this.handleConnectedAccountToggle(DEFAULT_ACCOUNTS.connectorSlack, false);
+                            }
                         });
 
                   this.closeModal();


### PR DESCRIPTION
Display Slack Notification errors to users in UI

## Related Tickets & Packages
[FOUR-23394](https://processmaker.atlassian.net/browse/FOUR-23394)
[Slack Connector PR](https://github.com/ProcessMaker/connector-slack/pull/33)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-23394]: https://processmaker.atlassian.net/browse/FOUR-23394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ