### PR TITLE
FOUR-24834 | Set Username Character Minimum to Two

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -183,7 +183,7 @@ class User extends Authenticatable implements HasMedia
 
         return [
             // The following characters where not included in the regexp: & %  ' " ? /
-            'username' /****/ => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:3', 'max:255', $unique],
+            'username' /****/ => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:2', 'max:255', $unique],
             'firstname' /***/ => ['required', 'max:50'],
             'lastname' /****/ => ['required', 'max:50'],
             'email' /*******/ => ['required', 'email'],


### PR DESCRIPTION
# Feature
Ticket: [FOUR-24834](https://processmaker.atlassian.net/browse/FOUR-24834)

This PR implements capability for users to create usernames with a minimum of two characters. Previously, ProcessMaker 4 only accepted a minimum of three characters for usernames.

# How to Test
1. Go to branch `task/FOUR-24834` in `processmaker`.
2. Go to Admin → Users → +USER.
3. When creating a new User, only use two characters in the username.
   - There should be no errors and you should be able to create the User successfully.
4. Try to create a username with only 1 character. You should receive the following error message on the username field:
   - "The Username field must be at least 2 characters."

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-24834]: https://processmaker.atlassian.net/browse/FOUR-24834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ