### PR TITLE
FOUR-23617: When reloading the page, the completed status filter show all clear

### DIFF
--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -27,17 +27,6 @@ trait TaskControllerIndexMethods
 
         $query = ProcessRequestToken::exclude(['data']);
 
-        // If all_inbox is true and user has process requests, filter to only show the latest process
-        if ($request->has('all_inbox') && $request->input('all_inbox') === 'false') {
-            $latestProcessRequest = ProcessRequestToken::where('user_id', auth()->id())
-                ->orderBy('created_at', 'desc')
-                ->first();
-
-            if ($latestProcessRequest) {
-                $query->where('process_id', $latestProcessRequest->process_id);
-            }
-        }
-
         $query = $query->with([
             'processRequest' => function ($q) use ($includeData) {
                 if (!$includeData) {

--- a/resources/js/tasks/components/ListMixin.js
+++ b/resources/js/tasks/components/ListMixin.js
@@ -87,8 +87,6 @@ const ListMixin = {
         if (this.additionalIncludes) {
           include.push(...this.additionalIncludes);
         }
-
-        const getAllTasksInbox = "&all_inbox=true";
         // Load from our api client
         ProcessMaker.apiClient
           .get(
@@ -98,7 +96,6 @@ const ListMixin = {
                 this.perPage + this.sumCards
               }${filterParams}${this.getSortParam()}&non_system=true` +
               `&processesIManage=${this.processesIManage ? "true" : "false"}` +
-              getAllTasksInbox +
               advancedFilter +
               this.columnsQuery,
             {

--- a/resources/js/tasks/components/ListMixin.js
+++ b/resources/js/tasks/components/ListMixin.js
@@ -87,19 +87,8 @@ const ListMixin = {
         if (this.additionalIncludes) {
           include.push(...this.additionalIncludes);
         }
-        const currentUrl = window.location.href;
-        const path = new URL(currentUrl).pathname.split("/").pop();
 
-        let getAllTasksInbox = "";
-        if (path === "inbox") {
-          if (this.$parent.allInbox) {
-            getAllTasksInbox = "&all_inbox=true";
-          } else {
-            getAllTasksInbox = "&all_inbox=false";
-          }
-        } else {
-          getAllTasksInbox = "&all_inbox=true";
-        }
+        const getAllTasksInbox = "&all_inbox=true";
         // Load from our api client
         ProcessMaker.apiClient
           .get(

--- a/resources/js/tasks/components/ParticipantHomeScreen.vue
+++ b/resources/js/tasks/components/ParticipantHomeScreen.vue
@@ -281,7 +281,11 @@ export default {
     },
     getAllTasks() {
       this.selectedProcess = "inbox";
-      this.allInbox = true;
+      if (this.$route.name !== 'inbox') {
+        this.$router.push({
+          name: "inbox",
+        });
+      }
       this.$refs.processesDashboardsMenu?.clearSelection();
       this.callingTaskList();
     },

--- a/resources/js/tasks/router.js
+++ b/resources/js/tasks/router.js
@@ -22,6 +22,16 @@ const router = new VueRouter({
       })
     },
     {
+      path: "",
+      name: "inbox",
+      component: Process,
+      props: route => ({
+        processId: null,
+        process: null,
+        ellipsisPermission: window.ProcessMaker.ellipsisPermission
+      })
+    },
+    {
       path: "/dashboard/:dashboardId",
       name: "dashboard",
       component: DashboardViewer,


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Log in
2. Click the Inbox button
3. Filter the "completed" status and apply
4. Click "reload this page"

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23617

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy