### PR TITLE
fix  trying to use an undefined constant

### DIFF
--- a/ProcessMaker/Console/Commands/MultitenancyCreate.php
+++ b/ProcessMaker/Console/Commands/MultitenancyCreate.php
@@ -94,7 +94,7 @@ class MultitenancyCreate extends Command
         }
 
         // Create the database
-        if (!exists) {
+        if (!DB::connection('mysql')->getPdo()) {
             DB::statement("CREATE DATABASE IF NOT EXISTS `{$this->option('database')}`");
             $this->tenantArtisan('migrate --seed --force', $tenant->id);
 

--- a/ProcessMaker/Console/Commands/MultitenancyCreate.php
+++ b/ProcessMaker/Console/Commands/MultitenancyCreate.php
@@ -94,7 +94,7 @@ class MultitenancyCreate extends Command
         }
 
         // Create the database
-        if (!DB::connection('mysql')->getPdo()) {
+        if (DB::connection('mysql')->getPdo()) {
             DB::statement("CREATE DATABASE IF NOT EXISTS `{$this->option('database')}`");
             $this->tenantArtisan('migrate --seed --force', $tenant->id);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
There's a bug in the MultitenancyCreate.php file at line 97 - it's trying to use an undefined constant

## Solution
- update this line

## How to Test
run the command 

`php artisan multitenancy:create --name="Another Tenant" --database=another_tenant --url=http://another-tenant.test --username=test --password=test
`
## Related Tickets & Packages
- n/a

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
