### PR TITLE
FOUR-24946: The API task needs to load the 'data' only if is necesary

### DIFF
--- a/ProcessMaker/Helpers/DefaultColumns.php
+++ b/ProcessMaker/Helpers/DefaultColumns.php
@@ -52,24 +52,22 @@ class DefaultColumns
     public static function verifyDefaultColumns($savedColumns, string $key): bool
     {
         // Handle null savedColumns
-        if ($savedColumns === null || !is_array($savedColumns)) {
-            return false;
+        if ($savedColumns === null || !is_array($savedColumns) || empty($savedColumns)) {
+            return true;
         }
 
         // Determine the type based on the key
         $type = null;
         if ($key === SavedSearch::KEY_TASKS) {
             $type = 'task';
-        } elseif ($key === SavedSearch::KEY_REQUESTS) {
-            $type = 'request';
         } else {
-            return false;
+            return true;
         }
 
         // Get default columns using the HasDataColumns trait
         $defaultColumns = SavedSearch::getDefaultColumns($type);
         if ($defaultColumns->isEmpty()) {
-            return false;
+            return true;
         }
 
         // Extract only the 'field' values from default columns

--- a/ProcessMaker/Helpers/DefaultColumns.php
+++ b/ProcessMaker/Helpers/DefaultColumns.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Helpers;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Package\SavedSearch\Http\Controllers\SavedSearchController;
 use ProcessMaker\Package\SavedSearch\Models\SavedSearch;
+use ProcessMaker\Package\SavedSearch\Traits\HasDataColumns;
 
 class DefaultColumns
 {
@@ -39,5 +40,54 @@ class DefaultColumns
         }
 
         return $defaultColumns;
+    }
+
+    /**
+     * Simple verification if columns are default - returns true or false
+     *
+     * @param array|null $savedColumns The columns to verify
+     * @param string $key The key to identify the type can be tasks or requests
+     * @return bool True if columns have the same fields as defaults, false otherwise
+     */
+    public static function verifyDefaultColumns($savedColumns, string $key): bool
+    {
+        // Handle null savedColumns
+        if ($savedColumns === null || !is_array($savedColumns)) {
+            return false;
+        }
+
+        // Determine the type based on the key
+        $type = null;
+        if ($key === SavedSearch::KEY_TASKS) {
+            $type = 'task';
+        } elseif ($key === SavedSearch::KEY_REQUESTS) {
+            $type = 'request';
+        } else {
+            return false;
+        }
+
+        // Get default columns using the HasDataColumns trait
+        $defaultColumns = SavedSearch::getDefaultColumns($type);
+        if ($defaultColumns->isEmpty()) {
+            return false;
+        }
+
+        // Extract only the 'field' values from default columns
+        $defaultFields = $defaultColumns->map(function ($column) {
+            return $column->field ?? null;
+        })->filter()->sort()->values()->toArray();
+
+        // Extract only the 'field' values from saved columns (handling both formats)
+        $savedFields = collect($savedColumns)->map(function ($column) {
+            // Handle both object and array formats
+            if (is_object($column)) {
+                return $column->field ?? null;
+            } else {
+                return $column['field'] ?? null;
+            }
+        })->filter()->sort()->values()->toArray();
+
+        // Compare only the field arrays
+        return $defaultFields == $savedFields;
     }
 }

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -66,6 +66,8 @@ class TaskController extends Controller
 
         $defaultColumns = DefaultColumns::get('tasks');
 
+        $isDefaultColumns = DefaultColumns::verifyDefaultColumns($defaultColumns, 'tasks');
+
         $taskDraftsEnabled = TaskDraft::draftsEnabled();
 
         $userConfiguration = (new UserConfigurationController())->index()['ui_configuration'] ?? [];
@@ -74,7 +76,7 @@ class TaskController extends Controller
 
         $defaultSavedSearchId = $this->getDefaultSavedSearchId();
 
-        return view('tasks.index', compact('title', 'userFilter', 'defaultColumns', 'taskDraftsEnabled', 'userConfiguration', 'showOldTaskScreen', 'currentUser', 'selectedProcess', 'defaultSavedSearchId', 'manager'));
+        return view('tasks.index', compact('title', 'userFilter', 'defaultColumns', 'isDefaultColumns', 'taskDraftsEnabled', 'userConfiguration', 'showOldTaskScreen', 'currentUser', 'selectedProcess', 'defaultSavedSearchId', 'manager'));
     }
 
     public function edit(ProcessRequestToken $task, string $preview = '')

--- a/resources/js/tasks/components/ListMixin.js
+++ b/resources/js/tasks/components/ListMixin.js
@@ -82,8 +82,14 @@ const ListMixin = {
           this.page = 1;
         }
         this.previousAdvancedFilter = advancedFilter;
-        const include =
-          "process,processRequest,processRequest.user,user,data".split(",");
+        let includeString = "process,processRequest,processRequest.user,user,data";
+        // If columns are default (isDefaultColumns = true), don't include data
+        // If columns are NOT default (isDefaultColumns = false), include data
+        const isDefaultColumns = window.ProcessMaker?.isDefaultColumns ?? false;
+        if (isDefaultColumns) {
+          includeString = "process,processRequest,processRequest.user,user";
+        }
+        const include = includeString.split(",");
         if (this.additionalIncludes) {
           include.push(...this.additionalIncludes);
         }

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -155,6 +155,7 @@
         window.ProcessMaker.taskDraftsEnabled = @json($taskDraftsEnabled);
         window.ProcessMaker.advanced_filter = @json($userFilter);
         window.Processmaker.defaultColumns = @json($defaultColumns);
+        window.ProcessMaker.isDefaultColumns = @json($isDefaultColumns ?? false);
         window.ProcessMaker.userConfiguration = @json($userConfiguration ?? []);
         window.sessionStorage.setItem('elementDestinationURL', window.location.href);
         window.ProcessMaker.showOldTaskScreen = @json($showOldTaskScreen);

--- a/tests/unit/ProcessMaker/Helpers/DefaultColumnsTest.php
+++ b/tests/unit/ProcessMaker/Helpers/DefaultColumnsTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Helpers;
+
+use ProcessMaker\Helpers\DefaultColumns;
+use ProcessMaker\Package\SavedSearch\Models\SavedSearch;
+use Tests\TestCase;
+
+class DefaultColumnsTest extends TestCase
+{
+    /**
+     * Test verifyDefaultColumns with null savedColumns
+     */
+    public function testVerifyDefaultColumnsWithNull()
+    {
+        $result = DefaultColumns::verifyDefaultColumns(null, SavedSearch::KEY_TASKS);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with non-array savedColumns
+     */
+    public function testVerifyDefaultColumnsWithNonArray()
+    {
+        $result = DefaultColumns::verifyDefaultColumns('not_an_array', SavedSearch::KEY_TASKS);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with invalid key
+     */
+    public function testVerifyDefaultColumnsWithInvalidKey()
+    {
+        $savedColumns = [
+            ['field' => 'case_number', 'label' => 'Case #'],
+            ['field' => 'case_title', 'label' => 'Case Title'],
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, 'invalid_key');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with empty array
+     */
+    public function testVerifyDefaultColumnsWithEmptyArray()
+    {
+        $result = DefaultColumns::verifyDefaultColumns([], SavedSearch::KEY_TASKS);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with exact default columns for tasks (array format)
+     */
+    public function testVerifyDefaultColumnsWithExactDefaultColumnsForTasks()
+    {
+        $savedColumns = [
+            ['field' => 'case_number', 'label' => 'Case #'],
+            ['field' => 'case_title', 'label' => 'Case Title'],
+            ['field' => 'is_priority', 'label' => 'Priority'],
+            ['field' => 'element_name', 'label' => 'Task'],
+            ['field' => 'status', 'label' => 'Status'],
+            ['field' => 'due_at', 'label' => 'Due Date'],
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, SavedSearch::KEY_TASKS);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with default columns in different order
+     */
+    public function testVerifyDefaultColumnsWithDifferentOrder()
+    {
+        $savedColumns = [
+            ['field' => 'status', 'label' => 'Status'],
+            ['field' => 'case_number', 'label' => 'Case #'],
+            ['field' => 'due_at', 'label' => 'Due Date'],
+            ['field' => 'element_name', 'label' => 'Task'],
+            ['field' => 'case_title', 'label' => 'Case Title'],
+            ['field' => 'is_priority', 'label' => 'Priority'],
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, SavedSearch::KEY_TASKS);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with object format columns
+     */
+    public function testVerifyDefaultColumnsWithObjectFormat()
+    {
+        $savedColumns = [
+            (object) ['field' => 'case_number', 'label' => 'Case #'],
+            (object) ['field' => 'case_title', 'label' => 'Case Title'],
+            (object) ['field' => 'is_priority', 'label' => 'Priority'],
+            (object) ['field' => 'element_name', 'label' => 'Task'],
+            (object) ['field' => 'status', 'label' => 'Status'],
+            (object) ['field' => 'due_at', 'label' => 'Due Date'],
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, SavedSearch::KEY_TASKS);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with missing default columns
+     */
+    public function testVerifyDefaultColumnsWithMissingColumns()
+    {
+        $savedColumns = [
+            ['field' => 'case_number', 'label' => 'Case #'],
+            ['field' => 'case_title', 'label' => 'Case Title'],
+            ['field' => 'element_name', 'label' => 'Task'],
+            // Missing: is_priority, status, due_at
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, SavedSearch::KEY_TASKS);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with extra columns
+     */
+    public function testVerifyDefaultColumnsWithExtraColumns()
+    {
+        $savedColumns = [
+            ['field' => 'case_number', 'label' => 'Case #'],
+            ['field' => 'case_title', 'label' => 'Case Title'],
+            ['field' => 'is_priority', 'label' => 'Priority'],
+            ['field' => 'element_name', 'label' => 'Task'],
+            ['field' => 'status', 'label' => 'Status'],
+            ['field' => 'due_at', 'label' => 'Due Date'],
+            ['field' => 'custom_field', 'label' => 'Custom Field'],
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, SavedSearch::KEY_TASKS);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with different field names
+     */
+    public function testVerifyDefaultColumnsWithDifferentFieldNames()
+    {
+        $savedColumns = [
+            ['field' => 'case_number', 'label' => 'Case #'],
+            ['field' => 'case_title', 'label' => 'Case Title'],
+            ['field' => 'priority', 'label' => 'Priority'],
+            ['field' => 'element_name', 'label' => 'Task'],
+            ['field' => 'status', 'label' => 'Status'],
+            ['field' => 'due_at', 'label' => 'Due Date'],
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, SavedSearch::KEY_TASKS);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with columns missing field property
+     */
+    public function testVerifyDefaultColumnsWithMissingFieldProperty()
+    {
+        $savedColumns = [
+            ['field' => 'case_number', 'label' => 'Case #'],
+            ['label' => 'Case Title'],
+            ['field' => 'is_priority', 'label' => 'Priority'],
+            ['field' => 'element_name', 'label' => 'Task'],
+            ['field' => 'status', 'label' => 'Status'],
+            ['field' => 'due_at', 'label' => 'Due Date'],
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, SavedSearch::KEY_TASKS);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test verifyDefaultColumns with additional properties in columns
+     */
+    public function testVerifyDefaultColumnsWithAdditionalProperties()
+    {
+        $savedColumns = [
+            ['field' => 'case_number', 'label' => 'Case #', 'sortable' => true, 'width' => 100],
+            ['field' => 'case_title', 'label' => 'Case Title', 'sortable' => true, 'width' => 200],
+            ['field' => 'is_priority', 'label' => 'Priority', 'sortable' => false, 'width' => 50],
+            ['field' => 'element_name', 'label' => 'Task', 'sortable' => true, 'width' => 150],
+            ['field' => 'status', 'label' => 'Status', 'sortable' => true, 'width' => 100],
+            ['field' => 'due_at', 'label' => 'Due Date', 'sortable' => true, 'width' => 120],
+        ];
+
+        $result = DefaultColumns::verifyDefaultColumns($savedColumns, SavedSearch::KEY_TASKS);
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
The API task needs to load the 'data' only if is necesary
**Steps to Reproduce:**

1. Go to Task List
2. Review the API called `https://dev.cloud.processmaker.net/api/1.0/tasks?page=1&include=process,processRequest,processRequest.user,user,data`

**Current Behavior**

When the task List is not using a custom Columns the data is not necesary to call. 

**Expected Behavior**

We need to call data only if the list requires this information

## Solution
- Detect if the data is necesary to add

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24946

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy