### PR TITLE
FOUR-23812:The variables are duplicated in Available columns in TASK and REQUEST Saved search

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/ProcessVariableController.php
@@ -219,18 +219,6 @@ class ProcessVariableController extends Controller
         }
 
         // If the classes or tables do not exist, fallback to a saved search approach.
-
-        if ($savedSearch && $request->has('onlyAvailable')) {
-            $paginator = $this->getProcessesVariablesFrom($processIds);
-            $availableColumns = $this->mergeAvailableColumns($savedSearch);
-            $availableColumns = $this->filterActiveColumns($availableColumns, $activeColumns);
-            $paginator->setCollection(
-                $availableColumns->merge($paginator->items())
-            );
-
-            return $paginator;
-        }
-
         if (
             !class_exists(ProcessVariable::class)
             || !Schema::hasTable('process_variables')


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create Saved search in Request or Task
2. Open the saved search
3. Click on RESET TO DEFAULT button
4. Open the columns agains
5. Move one variables of available columns to active columns
6. Save the changes
7. Open the columns agains

**Current Behavior**
The variables are duplicated in Available columns in task and request Saved search 

**Expected Behavior**
The variables should not be duplicated in Available columns in task and request Saved search

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23812

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
