### PR TITLE
FOUR-25042: The Priority and Draft tab are moved to the Inbox, when you click the browser's reloaded this page

### DIFF
--- a/resources/js/tasks/components/ParticipantHomeScreen.vue
+++ b/resources/js/tasks/components/ParticipantHomeScreen.vue
@@ -265,13 +265,55 @@ export default {
       urlConfiguration: "users/configuration",
       localUserConfiguration: {},
       selectedProcess: window.Processmaker.selectedProcess,
+      tab: "inbox",
     };
   },
   mounted() {
     this.defineUserConfiguration();
     this.callingTaskList();
+    this.setDefaultTab();
   },
   methods: {
+    // Set the default tab based on the advanced filter
+    setDefaultTab() {
+      const advancedFilter = window.ProcessMaker.advanced_filter?.filters;
+      const draft = advancedFilter.find((filter) => filter._column_field === "draft");
+      const priority = advancedFilter.find((filter) => filter._column_field === "is_priority");
+      if (draft) {
+        this.tab = "draft";
+      } else if (priority) {
+        this.tab = "priority";
+      }
+    },
+    // Switch the tab and update the advanced filter
+    switchTab(tab) {
+      this.tab = tab;
+      const taskListComponent = this.$refs.taskList;
+      taskListComponent.advancedFilter[this.priorityField] = [];
+      taskListComponent.advancedFilter[this.draftField] = [];
+      switch (tab) {
+        case "priority":
+          taskListComponent.advancedFilter["is_priority"] = this.priorityFilter;
+          break;
+        case "draft":
+          taskListComponent.advancedFilter["draft"] = this.draftFilter;
+          break;
+      }
+      taskListComponent.markStyleWhenColumnSetAFilter();
+      taskListComponent.storeFilterConfiguration();
+      taskListComponent.fetch(true);
+    },
+    handleTabCount(value) {
+      if (this.tab === "inbox") {
+        this.inboxCount = value;
+      }
+      if (this.tab === "draft") {
+        this.draftCount = value;
+      }
+      if (this.tab === "priority") {
+        this.priorityCount = value;
+      }
+    },
     callingTaskList() {
       this.$nextTick(() => {
         if (this.$refs.taskList) {

--- a/resources/js/tasks/mixins/TasksMixin.js
+++ b/resources/js/tasks/mixins/TasksMixin.js
@@ -19,7 +19,6 @@ export default {
       inbox: true,
       priority: false,
       draft: false,
-      tab: "inbox",
       inboxCount: null,
       draftCount: null,
       priorityCount: null,
@@ -87,23 +86,6 @@ export default {
           console.error("Error", error);
         });
     },
-    switchTab(tab) {
-      this.tab = tab;
-      const taskListComponent = this.$refs.taskList;
-      taskListComponent.advancedFilter[this.priorityField] = [];
-      taskListComponent.advancedFilter[this.draftField] = [];
-      switch (tab) {
-        case "priority":
-          taskListComponent.advancedFilter["is_priority"] = this.priorityFilter;
-          break;
-        case "draft":
-          taskListComponent.advancedFilter["draft"] = this.draftFilter;
-          break;
-      }
-      taskListComponent.markStyleWhenColumnSetAFilter();
-      taskListComponent.storeFilterConfiguration();
-      taskListComponent.fetch(true);
-    },
     dataLoading(value) {
       this.isDataLoading = value;
     },
@@ -124,17 +106,6 @@ export default {
           this.inbox = this.priority = false;
         }
       });
-    },
-    handleTabCount(value) {
-      if (this.tab === "inbox") {
-        this.inboxCount = value;
-      }
-      if (this.tab === "draft") {
-        this.draftCount = value;
-      }
-      if (this.tab === "priority") {
-        this.priorityCount = value;
-      }
     },
     onFiltersPmqlChange(value) {
       this.filtersPmql = value[0];


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Log in 
2. Have cases in Tab Inbox/ Priority and Draft 
3. Click on Tab Priority 
4. Click on Reloaded this page to browser

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25042

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy