### PR TITLE
FOUR-24773:One or two lines should be visible in stages name configuration

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessInfo.vue
@@ -40,7 +40,6 @@
             :process="process"
             :collapsed="collapsed"
           />
-          <progress-bar-section :stages-summary="process.stagesSummary" />
         </div>
       </div>
     </slide-process-info>

--- a/resources/js/processes-catalogue/components/home/PercentageButtonGroup/PercentageCardButton.vue
+++ b/resources/js/processes-catalogue/components/home/PercentageButtonGroup/PercentageCardButton.vue
@@ -15,7 +15,7 @@
             :class="[`tw-text-lg`, icon]" />
         </slot>
         <slot name="header">
-          <div class="tw-text-base">
+          <div class="tw-text-base tw-line-clamp-1">
             {{ header }}
           </div>
         </slot>

--- a/resources/js/processes-catalogue/components/progressBar/ProgressInfo.vue
+++ b/resources/js/processes-catalogue/components/progressBar/ProgressInfo.vue
@@ -1,17 +1,19 @@
 <template>
   <div class="tw-flex tw-flex-row tw-gap-1 tw-full tw-py-2">
     <div class="tw-flex tw-justify-center">
-      <div
-        :class="`tw-flex tw-text-sm tw-bg-${color}-200 tw-text-${color}-700  tw-rounded-lg tw-font-bold tw-p-2`">
+      <div :class="`tw-flex tw-text-sm tw-bg-${color}-200 tw-text-${color}-700 tw-rounded-lg tw-font-bold tw-p-2`">
         {{ value }}
       </div>
     </div>
 
     <div class="tw-flex tw-w-full tw-flex-col">
-      <span class="tw-text-sm tw-text-gray-500">{{ title }}</span>
+      <span class="tw-text-sm tw-text-gray-500 tw-line-clamp-1">
+        {{ title }}
+      </span>
       <progress-bar
         :percentage="percentage"
-        :color="color" />
+        :color="color"
+      />
     </div>
   </div>
 </template>

--- a/resources/js/processes/modeler/components/inspector/StageItem.vue
+++ b/resources/js/processes/modeler/components/inspector/StageItem.vue
@@ -16,7 +16,12 @@
         >
       </template>
       <template v-else>
-        <span :class="{ 'font-bold stage-item-selected': selected }">{{ name }}</span>
+        <span
+          class="tw-line-clamp-2"
+          :class="{ 'font-bold stage-item-selected': selected }"
+        >
+          {{ name }}
+        </span>
       </template>
     </div>
     <button


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Add Start Event → Task form 
3. Select sequence flow 
4. Go to Stages 
5. Set a stage with large name
6. Press enter key 
7. Check the stage 

**Current Behavior**
When the stage is too long it is displayed on several lines.

**Expected Behavior**
When the stage is too long, only two or one lines should be displayed; the rest should be shown with dots.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24773
- https://processmaker.atlassian.net/browse/FOUR-24771

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
