### PR TITLE
FOUR-24795:The stage ID is duplicated if the first stages are deleted.

### DIFF
--- a/resources/js/processes/modeler/components/inspector/StageList.vue
+++ b/resources/js/processes/modeler/components/inspector/StageList.vue
@@ -108,6 +108,13 @@ const onKeyupEnter = () => {
   }
 };
 
+const onReorder = () => {
+  stages.value.forEach((item, index) => {
+    item.order = index + 1;
+  });
+  emit("onChange", stages.value);
+};
+
 const onUpdate = (index, newName) => {
   const oldName = stages.value[index].name;
   stages.value[index].name = newName;
@@ -122,6 +129,7 @@ const onRemove = (index) => {
     "",
     () => {
       const removed = stages.value.splice(index, 1);
+      onReorder();
       emit("onRemove", stages.value, index, removed[0]);
       emit("onChange", stages.value);
     },
@@ -142,13 +150,6 @@ const onClickSelected = (index) => {
     }
   });
   emit("onClickSelected", stages.value[index]);
-};
-
-const onReorder = () => {
-  stages.value.forEach((item, index) => {
-    item.order = index + 1;
-  });
-  emit("onChange", stages.value);
 };
 
 watch(() => props.initialStages, (newVal) => {

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -4,13 +4,14 @@
     <p class="text-sm mb-4">
       {{ $t("Here you have all the stages already set in this process. Define the order you prefer:") }}
     </p>
-    <StageList :initialStages="defaultStages"
-               @onUpdate="onUpdate"
-               @onRemove="onRemove"
-               @onChange="onChange"
-               @onClickCheckbox="onClickCheckbox"
-               @onClickSelected="onClickSelected"
-      ></StageList>
+    <StageList
+      :initial-stages="defaultStages"
+      @onUpdate="onUpdate"
+      @onRemove="onRemove"
+      @onChange="onChange"
+      @onClickCheckbox="onClickCheckbox"
+      @onClickSelected="onClickSelected"
+    />
     <AgregationProperty />
   </div>
 </template>
@@ -27,14 +28,14 @@ const defaultStages = ref([]);
 const currentInstance = getCurrentInstance();
 
 const loadStagesFromApi = () => {
-  const id = window.ProcessMaker.modeler.process.id;
+  const { id } = window.ProcessMaker.modeler.process;
   ProcessMaker
     .apiClient
     .get(`/processes/${id}/stages`)
     .then((response) => {
-      let stages = response.data.data;
+      const stages = response.data.data;
       selectItemFromDefinition(stages);
-      stages.forEach(item => {
+      stages.forEach((item) => {
         defaultStages.value = [...defaultStages.value, item];
       });
     });
@@ -42,10 +43,10 @@ const loadStagesFromApi = () => {
 
 const saveStagesToApi = (stages) => {
   const copy = structuredClone(stages);
-  copy.forEach(item => {
+  copy.forEach((item) => {
     delete item.selected;
   });
-  const id = window.ProcessMaker.modeler.process.id;
+  const { id } = window.ProcessMaker.modeler.process;
   const params = {
     stages: copy,
   };
@@ -87,7 +88,7 @@ const updateStagesForAllFlowConfigs = (stages) => {
   const links = getModeler().graph.getLinks();
   for (const link of links) {
     for (const stage of stages) {
-      let config = getConfigFromDefinition(link.component.node.definition);
+      const config = getConfigFromDefinition(link.component.node.definition);
       if (config?.stage?.id === stage.id) {
         config.stage.order = stage.order;
         config.stage.name = stage.name;
@@ -101,7 +102,8 @@ const updateStagesForAllFlowConfigs = (stages) => {
 const removeStageInAllFlowConfig = (stage) => {
   const links = getModeler().graph.getLinks();
   for (const link of links) {
-    let config = getConfigFromDefinition(link.component.node.definition);
+    const config = getConfigFromDefinition(link.component.node.definition);
+    debugger;
     if (config?.stage?.id === stage.id) {
       delete config.stage;
       Vue.set(link.component.node.definition, "config", JSON.stringify(config));
@@ -111,20 +113,20 @@ const removeStageInAllFlowConfig = (stage) => {
 };
 
 const applyStageToFlow = (stage) => {
-  let config = getConfigFromDefinition(getDefinition());
+  const config = getConfigFromDefinition(getDefinition());
   config.stage = {
     id: stage.id,
     order: stage.order,
     name: stage.name,
   };
-  let definition = getDefinition();
+  const definition = getDefinition();
   Vue.set(definition, "config", JSON.stringify(config));
   getModeler().getCurrentStageModelComponent().setStageLabel();
 };
 
 const removeStageToFlow = () => {
-  let definition = getDefinition();
-  let config = getConfigFromDefinition(definition);
+  const definition = getDefinition();
+  const config = getConfigFromDefinition(definition);
   delete config.stage;
   Vue.set(definition, "config", JSON.stringify(config));
   getModeler().getCurrentStageModelComponent().removeStageLabels();


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Add controls with flow
3. Create 8 stages in one flow
4. Delete the stage 1 
5. Create a new 
6. Check the ID of the last stage created

**Current Behavior**
The stage ID is duplicated if the first stages are deleted. 

**Expected Behavior**
The stage ID should not be duplicated

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24795

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
