### PR TITLE
FOUR-25078 Response time in data connector resources has increased afer the upgrade to version 4.14

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/SettingController.php
+++ b/ProcessMaker/Http/Controllers/Api/SettingController.php
@@ -263,6 +263,8 @@ class SettingController extends Controller
         ]);
         // set to cache with key and setting
         $settingCache->set($key, $setting->refresh());
+        // update config
+        config([$setting->key => $setting->config]);
 
         return response([], 204);
     }

--- a/ProcessMaker/Repositories/SettingsConfigRepository.php
+++ b/ProcessMaker/Repositories/SettingsConfigRepository.php
@@ -87,6 +87,7 @@ class SettingsConfigRepository extends Repository
         $setting = Setting::byKey($key);
 
         if ($setting !== null) {
+            Arr::set($this->items, $key, $setting->config);
             return $setting->config;
         }
 

--- a/tests/Repositories/SettingsConfigRepositoryTest.php
+++ b/tests/Repositories/SettingsConfigRepositoryTest.php
@@ -20,4 +20,23 @@ class SettingsConfigRepositoryTest extends TestCase
 
         $this->assertEquals('the value', config('test.dot.notation'));
     }
+
+    public function testCachesValueSimple()
+    {
+        Setting::create([
+            'key' => 'cache-test',
+            'config' => 'foo',
+            'format' => 'text',
+        ]);
+
+        $this->assertEquals('foo', config('cache-test'));
+
+        // Update the setting directly in DB and Redis Cache to simulate external change
+        Setting::where('key', 'cache-test')->update(['config' => 'bar']);
+        $settingCache = SettingCacheFactory::getSettingsCache();
+        $settingCache->clear();
+
+        // Should still return Class cached value, not updated one
+        $this->assertEquals('foo', config('cache-test'));
+    }
 }

--- a/tests/Repositories/SettingsConfigRepositoryTest.php
+++ b/tests/Repositories/SettingsConfigRepositoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Repositories;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
+use ProcessMaker\Cache\Settings\SettingCacheFactory;
 use ProcessMaker\Models\Setting;
 use Tests\TestCase;
 
@@ -23,20 +24,21 @@ class SettingsConfigRepositoryTest extends TestCase
 
     public function testCachesValueSimple()
     {
+        // "collections.<id>.obfuscate" is a key generated in "Records" model in collection package
         Setting::create([
-            'key' => 'cache-test',
+            'key' => 'collections.6.obfuscate',
             'config' => 'foo',
             'format' => 'text',
         ]);
 
-        $this->assertEquals('foo', config('cache-test'));
+        $this->assertEquals('foo', config('collections.6.obfuscate'));
 
         // Update the setting directly in DB and Redis Cache to simulate external change
-        Setting::where('key', 'cache-test')->update(['config' => 'bar']);
+        Setting::where('key', 'collections.6.obfuscate')->update(['config' => 'bar']);
         $settingCache = SettingCacheFactory::getSettingsCache();
         $settingCache->clear();
 
         // Should still return Class cached value, not updated one
-        $this->assertEquals('foo', config('cache-test'));
+        $this->assertEquals('foo', config('collections.6.obfuscate'));
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Endpoint to get all records from a collection is very slow

## Solution
Improvement in the local cache for settings

## How to Test
Use the endpoint: 
`http://<server>/api/1.0/collections/<collection_id>/records`
with a collection with 1500 records at least

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-25078

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
