### PR TITLE
FOUR-24972: There is not scroll in "Completed & Form" Cases

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <div v-if="isTceCustomization()">
+    <div
+      v-if="isTceCustomization()"
+      class="tw-h-[323px] tw-overflow-auto"
+    >
       <component :is="componentToShow" />
     </div>
     <Tabs

--- a/resources/jscomposition/cases/casesDetail/components/Tabs.vue
+++ b/resources/jscomposition/cases/casesDetail/components/Tabs.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-pointer-events-auto tw-h-full">
+  <div
+    class="tw-flex tw-flex-col tw-pointer-events-auto"
+    :class="isTceCustomization() ? 'tw-h-[calc(100vh-480px)]' : 'tw-h-full'"
+  >
     <nav
       class="tw-mb-px tw-flex tw-space-x-2 tw-border-b tw-border-gray-300"
       aria-label="Tabs"
@@ -32,6 +35,7 @@
 
 <script>
 import { defineComponent, ref, onMounted } from "vue";
+import { isTceCustomization } from "../variables/index";
 
 export default defineComponent({
   props: {
@@ -68,6 +72,7 @@ export default defineComponent({
       content,
       selectTab,
       tabSelected,
+      isTceCustomization,
     };
   },
 });

--- a/resources/jscomposition/cases/casesDetail/components/Tabs.vue
+++ b/resources/jscomposition/cases/casesDetail/components/Tabs.vue
@@ -1,8 +1,9 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-pointer-events-auto">
+  <div class="tw-flex tw-flex-col tw-pointer-events-auto tw-h-full">
     <nav
       class="tw-mb-px tw-flex tw-space-x-2 tw-border-b tw-border-gray-300"
-      aria-label="Tabs">
+      aria-label="Tabs"
+    >
       <template v-for="(tab, index) in tabs">
         <a
           v-if="tab.show"
@@ -13,7 +14,8 @@
             : 'tw-border-transparent tw-text-gray-500 hover:tw-border-gray-600 hover:tw-text-gray-600'
           ]"
           :aria-current="tab.current ? 'page' : undefined"
-          @click="selectTab(tab)">
+          @click="selectTab(tab)"
+        >
           {{ tab.name }}
         </a>
       </template>
@@ -53,7 +55,7 @@ export default defineComponent({
     const selectTab = (tab) => {
       content.value = tab.content;
       tabSelected.value = tab.current;
-      ProcessMaker.EventBus.$emit('case-tab-switched', tab);
+      ProcessMaker.EventBus.$emit("case-tab-switched", tab);
     };
 
     const defaultTab = () => props.tabs.find((tab) => tab.current === tabSelected.value);


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Import or created a process with more than one page
2. Create a case 
3. Complete all the task 
4. Go to cases
5. Click on “Completed & Forms“
6. Displays all completed screens

**Current Behavior**
There is not scroll in "Completed & Form" Cases, so it is not possible all data of screens

**Expected Behavior**
The scroll should be enabled in cases where there are many screens like previous versions

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24972

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
