### PR TITLE
FOUR-24887: The Cases list show and empty Stage Columns when the process does not have Stages

### DIFF
--- a/ProcessMaker/Repositories/CaseParticipatedRepository.php
+++ b/ProcessMaker/Repositories/CaseParticipatedRepository.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Repositories;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use ProcessMaker\Constants\CaseStatusConstants;
 use ProcessMaker\Models\CaseParticipated;
 use ProcessMaker\Models\CaseStarted;
 
@@ -66,6 +67,10 @@ class CaseParticipatedRepository
      */
     private function mapCaseToArray(CaseStarted $case, int $userId = null): array
     {
+        // Define the case status if is not set the stage
+        if (is_null($case->last_stage_id)) {
+            $case->last_stage_name = $case->case_status;
+        }
         $data = [
             'case_number' => $case->case_number,
             'case_title' => $case->case_title,

--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -53,6 +53,10 @@ class CaseRepository implements CaseRepositoryInterface
             $processData = CaseUtils::extractData($instance->process, 'PROCESS');
             $requestData = CaseUtils::extractData($instance, 'REQUEST');
             $dataKeywords = CaseUtils::extractData($instance, 'KEYWORD');
+            // Check the case status
+            if (is_null($instance->last_stage_id)) {
+                $instance->last_stage_name = $instance->case_status;
+            }
 
             CaseStarted::create([
                 'case_number' => $instance->case_number,
@@ -140,6 +144,7 @@ class CaseRepository implements CaseRepositoryInterface
 
             if (in_array($caseStatus, [CaseStatusConstants::COMPLETED, CaseStatusConstants::CANCELED])) {
                 $data['completed_at'] = $instance->completed_at;
+                $data['last_stage_name'] = $caseStatus;
             }
 
             // Update the case started and case participated

--- a/resources/jscomposition/system/table/cell/StageCell.vue
+++ b/resources/jscomposition/system/table/cell/StageCell.vue
@@ -5,7 +5,7 @@
 </template>
 <script setup>
 import { defineProps, computed } from "vue";
-import { get } from "lodash";
+import { t } from "i18next";
 
 const props = defineProps({
   columns: {
@@ -22,6 +22,25 @@ const props = defineProps({
   },
 });
 
-const value = computed(() => get(props.row, props.column?.field) || "");
+const defaultStages = {
+  COMPLETED: {
+    label: `${t("Completed")}`,
+  },
+  CANCELED: {
+    label: `${t("Canceled")}`,
+  },
+  ERROR: {
+    label: `${t("Error")}`,
+  },
+  IN_PROGRESS: {
+    label: `${t("In Progress")}`,
+  },
+};
+
+const value = computed(() => (
+  props.column.field
+    ? (defaultStages[props.row[props.column.field]]?.label || "")
+    : ""
+));
 
 </script>


### PR DESCRIPTION
## Issue & Reproduction Steps
The Cases list show and empty Stage Columns when the process does not have Stages

Steps 

Create a process without stages

Execute cases

Go to Cases List

Current Behavior

The column Stage is show empty values 

Expected Behavior

When the process does not have stages needs to show the Default Stages In Progress and Completed

## Solution
- when the last_stage_name is empty we will define the `case _status`

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24887

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy