### PR TITLE
FOUR-24917: Fix unit tests

### DIFF
--- a/ProcessMaker/Providers/AuthServiceProvider.php
+++ b/ProcessMaker/Providers/AuthServiceProvider.php
@@ -57,8 +57,6 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        \Log::info('AuthServiceProvider boot');
-
         $this->registerPolicies();
 
         Passport::enablePasswordGrant();

--- a/phpunit.package.xml
+++ b/phpunit.package.xml
@@ -43,7 +43,7 @@
 
     <!-- Workflow Database -->
     <env name="DB_ADAPTER" value="mysql" />
-    <env name="DB_DATABASE" value="test" />
+    <env name="DB_DATABASE" value="processmaker" />
     <env name="DB_TIMEZONE" value="+00:00" />
     <env name="NAYRA_DOCKER_NETWORK" value="pm4-tools_default" />
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -48,7 +48,7 @@
       
       <!-- Workflow Database -->
       <env name="DB_ADAPTER" value="mysql" />
-      <env name="DB_DATABASE" value="test" />
+      <env name="DB_DATABASE" value="processmaker" />
       <env name="DB_TIMEZONE" value="+00:00" />
       <env name="NAYRA_DOCKER_NETWORK" value="pm4-tools_default" />
 

--- a/tests/Feature/Docker/TimeoutsTest.php
+++ b/tests/Feature/Docker/TimeoutsTest.php
@@ -26,18 +26,11 @@ class TimeoutsTest extends TestCase
     const SLEEP_NOT_EXCEED = 1;
 
     /**
-     * Make sure we have a personal access client set up
-     */
-    public function setUpWithPersonalAccessClient()
-    {
-        $this->withPersonalAccessClient();
-    }
-
-    /**
      * Run a test script and assert that the specified timeout is exceeded
      */
     private function assertTimeoutExceeded($data)
     {
+        $this->withPersonalAccessClient();
         Event::fake([
             ScriptResponseEvent::class,
         ]);
@@ -95,6 +88,7 @@ class TimeoutsTest extends TestCase
      */
     public function testPhpScriptTimeoutExceeded()
     {
+        $this->withPersonalAccessClient();
         config(['simulate_timeout' => true]);
         $this->assertTimeoutExceeded([
             'language' => 'php',
@@ -107,6 +101,7 @@ class TimeoutsTest extends TestCase
      */
     public function testPhpScriptTimeoutNotExceeded()
     {
+        $this->withPersonalAccessClient();
         $this->assertTimeoutNotExceeded([
             'language' => 'php',
             'timeout' => self::TIMEOUT_LENGTH,

--- a/tests/Feature/RouteTest.php
+++ b/tests/Feature/RouteTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Routing\Router;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
@@ -14,6 +15,12 @@ class RouteTest extends TestCase
      * This this does some basic checks to make sure we converted routes
      * to the correct class-based routes as part of the Laravel 8 upgrade
      */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['queue.tenant_tracking_enabled' => true]);
+    }
+
     public function testIndexRoute()
     {
         $ethosRoutePath = base_path('vendor/processmaker/package-ellucian-ethos/routes/');

--- a/tests/Feature/Shared/LoggingHelper.php
+++ b/tests/Feature/Shared/LoggingHelper.php
@@ -118,7 +118,7 @@ trait LoggingHelper
     {
         $records = app('log')->getHandlers()[0]->getRecords();
 
-        return $this->assertEquals(0, count($records), 'Failed asserting that the log is empty.');
+        return $this->assertEquals(0, count($records), 'Failed asserting that the log is empty: ' . print_r($records, true));
     }
 
     /**


### PR DESCRIPTION
## Solution
-  improve collection test
- improve docker timeout tests
- improve route test
- improve docker timeout test
- improve savedsearch installation so data conection was deprecated
- fix auth import export issue (the UserExporterExtension was not registered)

## How to Test
-  run the unit test

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24917


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:k8s-branch:multitenancy-support-b
ci:package-analytics-reporting:epic/FOUR-22888
ci:package-auth:feature/FOUR-24917_B
ci:package-collections:feature/FOUR-24917_B
ci:package-savedsearch:feature/FOUR-24917_B
ci:package-data-sources:bugfix/FOUR-25195

ci:deploy
ci:multitenancy