### PR TITLE
FOUR-24983: It is possible to add more than 8 stages in modeler 

### DIFF
--- a/resources/js/processes/modeler/components/inspector/StageList.vue
+++ b/resources/js/processes/modeler/components/inspector/StageList.vue
@@ -37,6 +37,7 @@
     </div>
     <div class="tw-flex tw-justify-end tw-mt-2">
       <button
+        v-if="!loadingStages"
         :disabled="disableButton"
         class="tw-bg-blue-500 text-white tw-text-sm tw-px-2 tw-py-0.5 tw-rounded"
         :class="{'tw-bg-gray-300 tw-cursor-not-allowed': disableButton}"
@@ -60,6 +61,10 @@ const props = defineProps({
   initialStages: {
     type: Array,
     default: () => [],
+  },
+  loadingStages: {
+    type: Boolean,
+    default: true,
   },
 });
 

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -77,6 +77,17 @@ const getConfigFromDefinition = (definition) => {
   return config;
 };
 
+const selectItemFromDefinition = (stages) => {
+  const config = getConfigFromDefinition(getDefinition());
+  const id = config?.stage?.id;
+  if (id === undefined) {
+    return;
+  }
+  for (const stage of stages) {
+    stage.selected = stage.id === id;
+  }
+};
+
 const updateStagesForAllFlowConfigs = (stages) => {
   const links = getModeler().graph.getLinks();
   for (const link of links) {

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -6,6 +6,7 @@
     </p>
     <StageList
       :initial-stages="defaultStages"
+      :loading-stages="isLoading"
       @onUpdate="onUpdate"
       @onRemove="onRemove"
       @onChange="onChange"
@@ -24,8 +25,10 @@ import AgregationProperty from "./AgregationProperty.vue";
 const props = defineProps({
   value: Object,
 });
+
 const defaultStages = ref([]);
 const currentInstance = getCurrentInstance();
+const isLoading = ref(true);
 
 const loadStagesFromApi = () => {
   const { id } = window.ProcessMaker.modeler.process;
@@ -38,6 +41,7 @@ const loadStagesFromApi = () => {
       stages.forEach((item) => {
         defaultStages.value = [...defaultStages.value, item];
       });
+      isLoading.value = false;
     });
 };
 
@@ -73,17 +77,6 @@ const getConfigFromDefinition = (definition) => {
   return config;
 };
 
-const selectItemFromDefinition = (stages) => {
-  const config = getConfigFromDefinition(getDefinition());
-  const id = config?.stage?.id;
-  if (id === undefined) {
-    return;
-  }
-  for (const stage of stages) {
-    stage.selected = stage.id === id;
-  }
-};
-
 const updateStagesForAllFlowConfigs = (stages) => {
   const links = getModeler().graph.getLinks();
   for (const link of links) {
@@ -103,7 +96,6 @@ const removeStageInAllFlowConfig = (stage) => {
   const links = getModeler().graph.getLinks();
   for (const link of links) {
     const config = getConfigFromDefinition(link.component.node.definition);
-    debugger;
     if (config?.stage?.id === stage.id) {
       delete config.stage;
       Vue.set(link.component.node.definition, "config", JSON.stringify(config));


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Add Start Event  → Task form → End Event
3. Select the first flow 
4. Add 8 stages
5. Select the second flow
6. Click on “+“ button 
7. Add ninth stage

**Current Behavior**
loading stages takes time to render, So it is possible to add more than 8 stage 

**Expected Behavior**
The “+“ button should be blocked until all stages are rendered

## Solution
- wait for the stages to load

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24983

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:epic/FOUR-22605
ci:modeler:epic/FOUR-22600
ci:TCE_CUSTOMIZATION_ENABLED=true