### PR TITLE
FOUR-25243: Show the Email Screen in the Screen list

### DIFF
--- a/ProcessMaker/Models/Screen.php
+++ b/ProcessMaker/Models/Screen.php
@@ -305,6 +305,16 @@ class Screen extends ProcessMakerModel implements ScreenInterface, PrometheusMet
         return $screen;
     }
 
+    public static function getScreenByKeyNonSystem(string $key) : ?self
+    {
+        $screen = self::firstWhere('key', $key);
+        if (!$screen) {
+            $screen = self::createScreenByKey($key, false);
+        }
+
+        return $screen;
+    }
+
     private static function createScreenByKey(string $key, bool $isSystem = true, string $path = null): self
     {
         // If no path is provided, use the default path

--- a/database/processes/screens/default-email-task-notification.json
+++ b/database/processes/screens/default-email-task-notification.json
@@ -4,12 +4,12 @@
     "screens": [
         {
             "screen_category_id": null,
-            "title": "DEFAULT_EMAIL_TASK_NOTIFICATION",
+            "title": "Default Email Task Notification",
             "description": "Screen for the email task notification",
             "type": "EMAIL",
             "config": [
                 {
-                    "name": "DEFAULT_EMAIL_TASK_NOTIFICATION",
+                    "name": "Default Email Task Notification",
                     "items": [
                         {
                             "uuid": "c331f828-3b0f-47a3-bf6e-9037717a7690",

--- a/database/seeders/ScreenEmailSeeder.php
+++ b/database/seeders/ScreenEmailSeeder.php
@@ -14,6 +14,6 @@ class ScreenEmailSeeder extends Seeder
      */
     public function run()
     {
-        return Screen::getScreenByKey('default-email-task-notification');
+        return Screen::getScreenByKeyNonSystem('default-email-task-notification');
     }
 }

--- a/tests/unit/ScreenEmailSeederTest.php
+++ b/tests/unit/ScreenEmailSeederTest.php
@@ -12,13 +12,6 @@ class ScreenEmailSeederTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function upgrade()
-    {
-        $this->artisan('migrate', [
-            '--path' => 'upgrades/2025_07_08_151252_update_default_email_task_notification_screen_category.php',
-        ])->run();
-    }
-
     public function test_seeder_creates_screen_without_system_flag()
     {
         $seeder = new ScreenEmailSeeder();

--- a/tests/unit/ScreenEmailSeederTest.php
+++ b/tests/unit/ScreenEmailSeederTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit;
+
+use Database\Seeders\ScreenEmailSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\ScreenCategory;
+use Tests\TestCase;
+
+class ScreenEmailSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function upgrade()
+    {
+        $this->artisan('migrate', [
+            '--path' => 'upgrades/2025_07_08_151252_update_default_email_task_notification_screen_category.php',
+        ])->run();
+    }
+
+    public function test_seeder_creates_screen_without_system_flag()
+    {
+        $seeder = new ScreenEmailSeeder();
+        $seeder->run();
+
+        $screen = Screen::where('key', 'default-email-task-notification')->first();
+
+        $this->assertNotNull($screen);
+        $this->assertEquals('default-email-task-notification', $screen->key);
+
+        $systemCategory = ScreenCategory::where('name', 'System')->first();
+        if ($systemCategory) {
+            $this->assertFalse($screen->categories()->where('category_id', $systemCategory->id)->exists());
+        }
+
+        $this->assertNull($screen->screen_category_id);
+    }
+
+    public function test_get_screen_by_key_non_system_method()
+    {
+        $screen = Screen::getScreenByKeyNonSystem('default-email-task-notification');
+
+        $this->assertNotNull($screen);
+        $this->assertEquals('default-email-task-notification', $screen->key);
+
+        $systemCategory = ScreenCategory::where('name', 'System')->first();
+        if ($systemCategory) {
+            $this->assertFalse($screen->categories()->where('category_id', $systemCategory->id)->exists());
+        }
+
+        $this->assertNull($screen->screen_category_id);
+    }
+}

--- a/upgrades/2025_07_08_151252_update_default_email_task_notification_screen_category.php
+++ b/upgrades/2025_07_08_151252_update_default_email_task_notification_screen_category.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\ScreenCategory;
+
+class UpdateDefaultEmailTaskNotificationScreenCategory extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Find the default email task notification screen
+        $screen = Screen::where('key', 'default-email-task-notification')->first();
+
+        if ($screen) {
+            // Remove the screen from the System category
+            $systemCategory = ScreenCategory::where('is_system', 1)->first();
+
+            if ($systemCategory) {
+                $screen->categories()->detach($systemCategory->id);
+            }
+
+            // Set screen_category_id to null to remove any category association
+            $screen->update(['screen_category_id' => null]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Find the default email task notification screen
+        $screen = Screen::where('key', 'default-email-task-notification')->first();
+
+        if ($screen) {
+            // Re-add the screen to the System category
+            $systemCategory = ScreenCategory::where('is_system', 1)->first();
+
+            if ($systemCategory) {
+                $screen->categories()->attach($systemCategory->id);
+                $screen->update(['screen_category_id' => $systemCategory->id]);
+            }
+        }
+    }
+}

--- a/upgrades/2025_07_08_151252_update_default_email_task_notification_screen_category.php
+++ b/upgrades/2025_07_08_151252_update_default_email_task_notification_screen_category.php
@@ -27,7 +27,7 @@ class UpdateDefaultEmailTaskNotificationScreenCategory extends Migration
             }
 
             // Set screen_category_id to null to remove any category association
-            $screen->update(['screen_category_id' => null]);
+            $screen->update(['screen_category_id' => null, 'title' => 'Default Email Task Notification']);
         }
     }
 
@@ -47,7 +47,7 @@ class UpdateDefaultEmailTaskNotificationScreenCategory extends Migration
 
             if ($systemCategory) {
                 $screen->categories()->attach($systemCategory->id);
-                $screen->update(['screen_category_id' => $systemCategory->id]);
+                $screen->update(['screen_category_id' => $systemCategory->id, 'title' => 'DEFAULT_EMAIL_TASK_NOTIFICATION']);
             }
         }
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
Then create an migration to update this value and remove the screen system flag

## Solution
- Display the screen DEFAULT_EMAIL_TASK_NOTIFICATION in the Screen List

## How to Test
Please execute the following commands:

- For the old enviroments to Update the Default Email Task Notification  `php artisan upgrade`

- For the new enviroments to Create the Default Email Task Notification `php artisan db:seed`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25243

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy