### PR TITLE
FOUR-25239: Create a migration to add a column is_default

### DIFF
--- a/ProcessMaker/Models/Screen.php
+++ b/ProcessMaker/Models/Screen.php
@@ -305,17 +305,17 @@ class Screen extends ProcessMakerModel implements ScreenInterface, PrometheusMet
         return $screen;
     }
 
-    public static function getScreenByKeyNonSystem(string $key) : ?self
+    public static function getScreenByKeyPerDefault(string $key) : ?self
     {
         $screen = self::firstWhere('key', $key);
         if (!$screen) {
-            $screen = self::createScreenByKey($key, false);
+            $screen = self::createScreenByKey($key, false, null, 1);
         }
 
         return $screen;
     }
 
-    private static function createScreenByKey(string $key, bool $isSystem = true, string $path = null): self
+    private static function createScreenByKey(string $key, bool $isSystem = true, string $path = null, $isDefault = 0): self
     {
         // If no path is provided, use the default path
         if (!$path) {
@@ -349,6 +349,7 @@ class Screen extends ProcessMakerModel implements ScreenInterface, PrometheusMet
         // Create new screen
         unset($screen['categories']);
         $screen['screen_category_id'] = null;
+        $screen['is_default'] = $isDefault;
 
         if ($newScreen) {
             $newScreen->fill($screen);

--- a/database/migrations/2025_07_09_215813_add_is_default_column_for_screens.php
+++ b/database/migrations/2025_07_09_215813_add_is_default_column_for_screens.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('screens', function (Blueprint $table) {
+            $table->boolean('is_default')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('screens', function (Blueprint $table) {
+            $table->dropColumn('is_default');
+        });
+    }
+};

--- a/database/seeders/ScreenEmailSeeder.php
+++ b/database/seeders/ScreenEmailSeeder.php
@@ -14,6 +14,6 @@ class ScreenEmailSeeder extends Seeder
      */
     public function run()
     {
-        return Screen::getScreenByKeyNonSystem('default-email-task-notification');
+        return Screen::getScreenByKeyPerDefault('default-email-task-notification');
     }
 }

--- a/upgrades/2025_07_08_151252_update_default_email_task_notification_screen_category.php
+++ b/upgrades/2025_07_08_151252_update_default_email_task_notification_screen_category.php
@@ -27,7 +27,7 @@ class UpdateDefaultEmailTaskNotificationScreenCategory extends Migration
             }
 
             // Set screen_category_id to null to remove any category association
-            $screen->update(['screen_category_id' => null, 'title' => 'Default Email Task Notification']);
+            $screen->update(['screen_category_id' => null, 'title' => 'Default Email Task Notification', 'is_default' => 1]);
         }
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Create a migration to add a column is_default

## Solution
- Add a new property to prevent delete this specific screen, `screens.is_default` boolean per` is_default=0`
- Set the Screen selected with the `is_default=1`

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25239

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
