### PR TITLE
FOUR-25242: Prevent deletion of DEFAULT_EMAIL_TASK_NOTIFICATION

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -482,6 +482,14 @@ class ScreenController extends Controller
      */
     public function destroy(Screen $screen)
     {
+        // Check if the screen is a default screen
+        if ($screen->is_default == 1) {
+            return response([
+                'message' => 'Cannot delete a default screen',
+                'errors' => ['is_default' => 'Default screens cannot be deleted'],
+            ], 422);
+        }
+
         $screen->delete();
         // Call new event to store changes in LOG
         ScreenDeleted::dispatch($screen);


### PR DESCRIPTION
## Issue & Reproduction Steps
Prevent deletion of DEFAULT_EMAIL_TASK_NOTIFICATION

## Solution
- The following message is showed when the **Default Email Task Notification** is tried to delete
<img width="809" alt="Captura de pantalla 2025-07-09 a las 6 59 29 p  m" src="https://github.com/user-attachments/assets/7b99a3cb-c61f-43ea-bcc6-87ea83bfb554" />

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25242

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
