### PR TITLE
FOUR-25271: Total cases does not match with cases started in launchpad to Grant chart

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1952,9 +1952,11 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
     protected static function getProcessDefaultStageCounts(int $processId): array
     {
         return ProcessRequest::where('process_id', $processId)
-            ->whereIn('status', ['ACTIVE', 'COMPLETED'])
+            ->whereIn('status', ['ACTIVE', 'COMPLETED', 'ERROR', 'CANCELED'])
             ->selectRaw("
                 COUNT(CASE WHEN status = 'ACTIVE' THEN 1 END) AS active_count,
+                COUNT(CASE WHEN status = 'ERROR' THEN 1 END) AS error_count,
+                COUNT(CASE WHEN status = 'CANCELED' THEN 1 END) AS cancel_count,
                 COUNT(CASE WHEN status = 'COMPLETED' THEN 1 END) AS completed_count,
                 COUNT(*) AS total_count
             ")


### PR DESCRIPTION
## Issue & Reproduction Steps
Total cases does not match with cases started in launchpad to Grant chart

## Solution
- Consider the ERROR and CANCELED

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25271

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:epic/FOUR-22605
ci:modeler:epic/FOUR-22600
ci:TCE_CUSTOMIZATION_ENABLED=true