### PR TITLE
FOUR-25228: Create default email notification config when task is created in Modeler

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -125,6 +125,18 @@ class ModelerController extends Controller
             $process->load('alternativeInfo');
         }
 
+        $defaultEmailNotification = [
+            'subject' => "RE: {{_user.fullName}} assigned you in {{taskName}}",
+            'type' => "screen",
+            'screenRef' => 2,
+            'toRecipients' => [
+                [
+                    'type' => "assignedUser",
+                    'value' => null
+                ]
+            ],
+        ];
+
         return [
             'process' => $process,
             'manager' => $manager,
@@ -147,6 +159,7 @@ class ModelerController extends Controller
             'alternative' => $alternative,
             'abPublish' => PackageHelper::isPackageInstalled('ProcessMaker\Package\PackageABTesting\PackageServiceProvider'),
             'launchpad' => ProcessLaunchpad::getLaunchpad(true, $process->id),
+            'defaultEmailNotification' => $defaultEmailNotification,
         ];
     }
 

--- a/resources/js/processes/modeler/modelerInit.js
+++ b/resources/js/processes/modeler/modelerInit.js
@@ -1,24 +1,41 @@
-import { nextTick } from "vue";
-
 export default {};
 
 // Highlight the node when it is added
 // TODO: This is a workaround to highlight the node when it is added
 // because the highlightNode method is not working when the node is added
 export const configureTaskNotifications = ({ modeler }) => {
-  modeler.$on("node-added", (node) => {
-    if (node.type.includes("task") && node.notifications) {
-      node.notifications.assignee = {
-        assigned: true,
-        completed: false,
-        due: true,
-        default: false,
+  modeler.$on("before-node-added", (node) => {
+    if (node.type.includes("task") && !node.notifications) {
+      node.notifications = {
+        assignee: {
+          assigned: true,
+          completed: false,
+          due: true,
+          default: false,
+        },
+        requester : {
+          assigned: false,
+          completed: false,
+          due: false,
+        },
+        participants : {
+          assigned: false,
+          completed: false,
+          due: false,
+        },
+        manager : {
+          assigned: false,
+          completed: false,
+          due: false,
+        },
       };
     }
-    modeler.clearSelection();
-    nextTick(() => {
-      modeler.highlightNode(node);
-    });
+
+    if (node.type.includes("task") && !node.config) {
+      node.config = {
+        email_notifications: {},
+      };
+    }
   });
 };
 

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -61,6 +61,8 @@ a {
     },
   ]
 
+  window.ProcessMaker.defaultEmailNotification = @json($defaultEmailNotification);
+
   window.ProcessMaker.multiplayer = {
     broadcaster: "{{config('multiplayer.default')}}",
     host: "{{config('multiplayer.url')}}",
@@ -103,6 +105,7 @@ a {
   }
   const warnings = @json($process->warnings);
 
+  console.log("window.ProcessMaker.EventBus");
   window.ProcessMaker.EventBus.$on('modeler-start', ({ loadXML, addWarnings, addBreadcrumbs }) => {
     loadXML(window.ProcessMaker.modeler.xml);
     addWarnings(warnings || []);


### PR DESCRIPTION
## Issue & Reproduction Steps
New Task — Default Notification Present

Scenario: Default email configuration is applied for a new task
Given I am logged in as a Designer with Edit Process permission
And I have navigated to a Process in the Modeler
When I create a new Task
Then I should see a default email notification configuration populated with:

To: Assigned user

Email Server: Default Email Server

Subject: {userFirstName} assigned you in ‘{TaskName}’

Body: Display Screen

Screen: DEFAULT_EMAIL_TASK_NOTIFICATION

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
