### PR TITLE
FOUR-24887: UI: the progress Bar needs work when the stages are the defaults

### DIFF
--- a/ProcessMaker/Repositories/CaseParticipatedRepository.php
+++ b/ProcessMaker/Repositories/CaseParticipatedRepository.php
@@ -70,6 +70,7 @@ class CaseParticipatedRepository
         // Define the case status if is not set the stage
         if (is_null($case->last_stage_id)) {
             $case->last_stage_name = $case->case_status;
+            $case->progress = 50;
         }
         $data = [
             'case_number' => $case->case_number,

--- a/ProcessMaker/Repositories/CaseRepository.php
+++ b/ProcessMaker/Repositories/CaseRepository.php
@@ -56,6 +56,7 @@ class CaseRepository implements CaseRepositoryInterface
             // Check the case status
             if (is_null($instance->last_stage_id)) {
                 $instance->last_stage_name = $instance->case_status;
+                $instance->progress = 50;
             }
 
             CaseStarted::create([
@@ -145,6 +146,7 @@ class CaseRepository implements CaseRepositoryInterface
             if (in_array($caseStatus, [CaseStatusConstants::COMPLETED, CaseStatusConstants::CANCELED])) {
                 $data['completed_at'] = $instance->completed_at;
                 $data['last_stage_name'] = $caseStatus;
+                $data['progress'] = 100;
             }
 
             // Update the case started and case participated


### PR DESCRIPTION
## Issue & Reproduction Steps
UI: the progress Bar needs work when the stages are the defaults

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25306

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:epic/FOUR-22605
ci:modeler:epic/FOUR-22600
ci:TCE_CUSTOMIZATION_ENABLED=true