### PR TITLE
FOUR-25222: There is no synchronization with the 'i' button and the form process info when it is open or closed

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
@@ -172,6 +172,9 @@ export default {
       this.showProcessInfo = !this.showProcessInfo;
       this.$emit("toggle-info");
     },
+    setShowProcessInfo(show) {
+      this.showProcessInfo = show;
+    },
     updateMyTasksColumns(columns) {
       this.$emit("updateMyTasksColumns", columns);
     },

--- a/resources/js/processes-catalogue/components/ProcessInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessInfo.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="tw-relative tw-h-full">
     <process-collapse-info
+      ref="processCollapseInfo"
       :process="process"
       :current-user-id="currentUserId"
       :ellipsis-permission="ellipsisPermission"
@@ -140,6 +141,7 @@ export default {
     },
     closeProcessInfo() {
       this.showProcessInfo = false;
+      this.$refs.processCollapseInfo.setShowProcessInfo(false);
     },
     showFullCarousel() {
       this.fullCarousel = true;


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process
2. Go to process launchpad
3. Open the process created 
4. Click on “i“ button
5. Close the process info form 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25222

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy