### PR TITLE
FOUR-25269: In Grant chart the tabs In progress and Completed does not listed any request

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1888,7 +1888,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
             ],
             'stages' => [
                 [
-                    'stage_id' => 0,
+                    'stage_id' => 'in_progress',
                     'stage_name' => 'In progress',
                     'percentage' => $activePercentage,
                     'percentage_format' => $activePercentage . '%',
@@ -1896,7 +1896,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
                     'agregation_count' => $activeCount,
                 ],
                 [
-                    'stage_id' => 0,
+                    'stage_id' => 'completed',
                     'stage_name' => 'Completed',
                     'percentage' => $completedPercentage,
                     'percentage_format' => $completedPercentage . '%',

--- a/resources/js/processes-catalogue/components/home/TceDistributionGrants.vue
+++ b/resources/js/processes-catalogue/components/home/TceDistributionGrants.vue
@@ -105,6 +105,33 @@ const hookStages = async () => {
 };
 
 const buildAdvancedFilters = (stage) => {
+  //TODO Use case : when there arent any stages, the stages by default are in progress (id:in_progress) and completed (id:completed)
+  if (stage.id === "in_progress") {
+    advancedFilter.value = [
+      {
+        subject: {
+          type: "Status",
+        },
+        operator: "=",
+        value: "In Progress",
+      },
+    ];
+    return;
+  }
+
+  if (stage.id === "completed") {
+    advancedFilter.value = [
+      {
+        subject: {
+          type: "Status",
+        },
+        operator: "=",
+        value: "Completed",
+      },
+    ];
+    return;
+  }
+
   advancedFilter.value = [{
     subject: {
       type: "Stage",

--- a/tests/Feature/Api/ProcessControllerTest.php
+++ b/tests/Feature/Api/ProcessControllerTest.php
@@ -308,12 +308,12 @@ class ProcessControllerTest extends TestCase
             'status' => 'ACTIVE',
         ]);
 
-        // Create 20 requests in "In Progress" stage
+        // Create 18 requests in "In Progress" stage
         ProcessRequest::factory()->count(18)->create([
             'process_id' => $process->id,
             'status' => 'ACTIVE',
         ]);
-        // Create 10 requests in "Completed" stage
+        // Create 12 requests in "Completed" stage
         ProcessRequest::factory()->count(12)->create([
             'process_id' => $process->id,
             'status' => 'COMPLETED',
@@ -352,7 +352,7 @@ class ProcessControllerTest extends TestCase
         // Verify "In Progress" stage
         $inProgress = collect($data['stages'])->firstWhere('stage_name', 'In progress');
         $this->assertNotNull($inProgress);
-        $this->assertEquals(0, $inProgress['stage_id']);
+        $this->assertGreaterThan(0, $inProgress['stage_id']);
         $this->assertEquals(60, $inProgress['percentage']);
         $this->assertEquals('60%', $inProgress['percentage_format']);
         $this->assertEquals(0, $inProgress['agregation_sum']);
@@ -361,7 +361,7 @@ class ProcessControllerTest extends TestCase
         // Verify "Completed" stage
         $completed = collect($data['stages'])->firstWhere('stage_name', 'Completed');
         $this->assertNotNull($completed);
-        $this->assertEquals(0, $completed['stage_id']);
+        $this->assertGreaterThan(0, $completed['stage_id']);
         $this->assertEquals(40, $completed['percentage']);
         $this->assertEquals('40%', $completed['percentage_format']);
         $this->assertEquals(0, $completed['agregation_sum']);


### PR DESCRIPTION
## Issue & Reproduction Steps
1 Create a process without stages
2. Add Start Event → Task → End Event
3. Create so,e request
4. Go to process launchpad
5. Open the process
6. Click on Edit launchpad 
7. Select the “Grant“ in screen launcher
8. Save the changes
9. Click on “IN progress“ card
10. Click on “IN Completed“ card

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25269

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:epic/FOUR-22605
ci:modeler:epic/FOUR-22600
ci:TCE_CUSTOMIZATION_ENABLED=true
