### PR TITLE
FOUR-24578: The Stage for the End Event is not registered and the progress is not showing correctly

### DIFF
--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -85,10 +85,18 @@ class CasesController extends Controller
         } else {
             $request->summary_screen = $request->getSummaryScreen();
         }
-        // Stage data
-        $currentStages = $this->formatCurrentStage($request->last_stage_id, $request->last_stage_name);
-        $allStages = $this->getStagesByProcessId($request->process_id);
-        $progressStage = StageProgressCalculator::getProgressStage($allStages, $currentStages);
+        // Stage information
+        if ($request->status === 'COMPLETED') {
+            $currentStages = [
+                'stage_id' => 0,
+                'stage_name' => __('Completed'),
+            ];
+            $progressStage = 100.0; // 100% completed
+        } else {
+            $currentStages = $this->formatCurrentStage($request->last_stage_id, $request->last_stage_name, $request->status);
+            $allStages = $this->getStagesByProcessId($request->process_id);
+            $progressStage = StageProgressCalculator::getProgressStage($allStages, $currentStages);
+        }
         // Load the screen configured in "Request Detail Screen"
         $request->request_detail_screen = Screen::find($request->process->request_detail_screen_id);
         // The user canCancel if has the processPermission and the case has only one request

--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -88,12 +88,11 @@ class CasesController extends Controller
         // Stage information
         if ($request->status === 'COMPLETED') {
             $currentStages = [
-                'stage_id' => 0,
                 'stage_name' => __('Completed'),
             ];
             $progressStage = 100.0; // 100% completed
         } else {
-            $currentStages = $this->formatCurrentStage($request->last_stage_id, $request->last_stage_name, $request->status);
+            $currentStages = $this->formatCurrentStage($request->last_stage_id, $request->last_stage_name);
             $allStages = $this->getStagesByProcessId($request->process_id);
             $progressStage = StageProgressCalculator::getProgressStage($allStages, $currentStages);
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
The Stage for the End Event is not registered and the progress is not showing correctly

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24578

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:screen-builder:epic/FOUR-22605
ci:modeler:epic/FOUR-22600