### PR TITLE
Task/FOUR-25275: Add setting to enable translations and language type

### DIFF
--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -470,7 +470,8 @@ class Setting extends ProcessMakerModel implements HasMedia, PrometheusMetricInt
                         $id = SettingsMenus::getId(SettingsMenus::LOG_IN_AUTH_MENU_GROUP);
                         break;
                     case 'User Signals':
-                    case 'Users': // Additional Properties
+                    case 'Users':
+                    case 'Translations': // Additional Properties
                         $id = SettingsMenus::getId(SettingsMenus::USER_SETTINGS_MENU_GROUP);
                         break;
                     case 'IDP': // Intelligent Document Processing

--- a/upgrades/2025_07_23_114259_add_menu_translations_to_users_settings.php
+++ b/upgrades/2025_07_23_114259_add_menu_translations_to_users_settings.php
@@ -1,0 +1,45 @@
+<?php
+
+use ProcessMaker\Models\Setting;
+use ProcessMaker\Models\SettingsMenus;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class AddMenuTranslationsToUsersSettings extends Upgrade
+{
+    /**
+     * Run the upgrade migration.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $groupId = SettingsMenus::getId(SettingsMenus::USER_SETTINGS_MENU_GROUP);
+        $translationsKey = [
+            'key' => 'translations.enabled',
+        ];
+        $translationsOption = [
+            'format' => 'boolean',
+            'group' => 'Translations',
+            'group_id' => $groupId,
+            'helper' => 'Select whether the translations button is enabled',
+            'config' => true,
+            'name' => 'Translations button',
+            'hidden' => false,
+        ];
+
+        Setting::firstOrCreate($translationsKey, $translationsOption);
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $translationsKey = [
+            'key' => 'translations.enabled',
+        ];
+        Setting::where($translationsKey)->delete();
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Add setting to enable translations and language type

## Solution
- Added an upgrade command to add the translation setting to users menu

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25275

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
