### PR TITLE
Task/FOUR-25276: Modify PM Core layout to show the language code instead flag icon: Login, screen builder, nav bar

### DIFF
--- a/resources/js/components/Menu.vue
+++ b/resources/js/components/Menu.vue
@@ -51,7 +51,7 @@
             id="language-screen-builder"
             class="ml-2"
             :type="'screen-builder'"
-            :show-language-code="false">
+            :show-language-code="true">
           </language-selector-button>
       </div>
       <b-col

--- a/resources/views/auth/newLogin.blade.php
+++ b/resources/views/auth/newLogin.blade.php
@@ -27,7 +27,8 @@
           class="d-flex justify-content-end position-absolute language-button-container">
           <language-selector-button
             id="language-login"
-            :type="'login'">
+            :type="'login'"
+            :show-language-code="true">
           </language-selector-button>
         </div>
         <div class="d-flex justify-content-center align-items-center h-100-vh" align-v="center">

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -151,7 +151,7 @@
                 id="language-navbar"
                 class="ml-2"
                 :type="'navbar'"
-                :show-language-code="false"
+                :show-language-code="true"
                 :language="'{{ $user->language }}'">
             </language-selector-button>
         </b-navbar-nav>


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR changes the flag icon with a language code. Also there are some UI adjustments.

## Solution
- UI Adjustments for language code
- Show language code instead flag icon

## Screen record

https://github.com/user-attachments/assets/8d70e91f-8725-4b61-b54f-7959f2280d2c

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25276
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/8384)
- [Package Translations PR](https://github.com/ProcessMaker/package-translations/pull/179)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
