### PR TITLE
FOUR-25282: UI: Cards in screen launcher are not the same as in figma when this calculate the Amount

### DIFF
--- a/resources/js/processes-catalogue/components/home/ArrowButtonGroup/ArrowButton.vue
+++ b/resources/js/processes-catalogue/components/home/ArrowButtonGroup/ArrowButton.vue
@@ -15,7 +15,7 @@
           </div>
         </slot>
         <slot name="helper">
-          <div class="tw-text-sm tw-truncate">
+          <div v-if="helper" class="tw-text-sm tw-truncate">
             {{ helper }}
           </div>
         </slot>

--- a/resources/js/processes-catalogue/components/home/ArrowButtonGroup/ArrowButtonHome.vue
+++ b/resources/js/processes-catalogue/components/home/ArrowButtonGroup/ArrowButtonHome.vue
@@ -5,8 +5,7 @@
       [`tw-bg-${color}-200 hover:tw-bg-${color}-300`]:!active,
       [`tw-outline tw-bg-${color}-100 tw-border-${color}-500 tw-outline-${color}-300 tw-bg-${color}-100 hover:tw-bg-${color}-200`]:active
     }]"
-    @click="onClick"
-  >
+    @click="onClick">
     <div class=" tw-flex tw-flex-col tw-w-full">
       <div class="tw-flex tw-flex-col tw-justify-start tw-px-6 tw-py-4 tw-gap-0">
         <slot name="header">
@@ -20,7 +19,9 @@
           </div>
         </slot>
         <slot name="helper">
-          <div class="tw-text-sm tw-truncate">
+          <div
+            v-if="helper"
+            class="tw-text-sm tw-truncate">
             {{ helper }}
           </div>
         </slot>
@@ -41,8 +42,8 @@ const props = defineProps({
     required: true,
   },
   helper: {
-    type: [String, Number],
-    required: true,
+    type: [String, Number, null],
+    required: false,
   },
   active: {
     type: Boolean,

--- a/resources/js/processes-catalogue/components/home/TceDistributionGrants.vue
+++ b/resources/js/processes-catalogue/components/home/TceDistributionGrants.vue
@@ -16,7 +16,6 @@
         color="red"
         :header="firstStage.header"
         :body="firstStage.body"
-        :helper="firstStage.helper"
         :active="firstStage.active"
         @click="onClickFirstStage" />
 


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process 
2. Open the process by launchpad
3. Click on Edit launch pad
4. Configure the screen launch with “Distribution Bar Grant“
5. Check the design of the card

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25282

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
