### PR TITLE
Bugfix/FOUR-25472: There is not translation button in login page

### DIFF
--- a/resources/views/auth/newLogin.blade.php
+++ b/resources/views/auth/newLogin.blade.php
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
+  <meta name="settings-translations-enabled" content="{{ config('translations.enabled') ? 'true' : 'false' }}">
   <title>{{ __('Login') }} - {{ __('ProcessMaker') }}</title>
   <link href="{{ mix('css/app.css') }}" rel="stylesheet">
   <link rel="icon" type="image/png" sizes="16x16" href="{{ \ProcessMaker\Models\Setting::getFavicon() }}">


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to Reproduce**
- Go to Admin settings
- Click on user settings
- Enable translations toggle
- Log out
- In the login page

**Current Behavior** 
There is not translation button in login page, after the translation was enables from admin settings

**Expected Behavior** 
There should be a translation button in login page like previous version 4.14.2 

## Solution
- Make the translations settings available in login page to show/hide the language selector button

## Working video

https://github.com/user-attachments/assets/c709beb7-9cdb-4a4c-9423-3251e081d0de


## How to Test
Follow steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25472

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
