### PR TITLE
FOUR-25425:The stage is assigned to the flow when it is edited

### DIFF
--- a/resources/js/processes/modeler/components/inspector/StageItem.vue
+++ b/resources/js/processes/modeler/components/inspector/StageItem.vue
@@ -2,11 +2,7 @@
   <div class="tw-flex tw-items-center tw-space-x-2 tw-w-full tw-py-1">
     <span class="tw-w-6 text-center stage-item-number">{{ order }}</span>
     <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move" />
-    <div
-      class="tw-flex-1 tw-cursor-pointer"
-      @click="check"
-      @dblclick.stop="uncheck"
-    >
+    <div class="tw-flex-1 tw-cursor-pointer">
       <template v-if="editing">
         <input
           v-model="localName"
@@ -22,12 +18,17 @@
         </small>
       </template>
       <template v-else>
-        <span
-          class="tw-line-clamp-2"
-          :class="{ 'font-bold stage-item-selected': selected }"
+        <div
+          @click="check"
+          @dblclick.stop="uncheck"
         >
-          {{ name }}
-        </span>
+          <span
+            class="tw-line-clamp-2"
+            :class="{ 'font-bold stage-item-selected': selected }"
+          >
+            {{ name }}
+          </span>
+        </div>
       </template>
     </div>
     <button


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Add Start Event → Task → End Event 
3. Click on one flow
4. Add a new stage
5. Edit the stage

**Current Behavior**
When the stage is edited it is assigned in the flow

**Expected Behavior**
The stage should assigned in the flow only if this is selected with click 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25425

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
