### PR TITLE
FOUR-25547: Process Owner field editable.

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -513,6 +513,10 @@ class ProcessController extends Controller
             $process->manager_id = $request->input('manager_id', null);
         }
 
+        if ($request->has('user_id')) {
+            $process->user_id = $request->input('user_id', null);
+        }
+
         if ($request->has('reassignment_permissions')) {
             $process->setProperty('reassignment_permissions', $request->get('reassignment_permissions'));
         }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1593,6 +1593,7 @@
   "Process Launchpad": "Process Launchpad",
   "Process Manager not configured.": "Process Manager not configured.",
   "Process Manager": "Process Manager",
+  "Process Owner": "Process Owner",
   "Process Name": "Process Name",
   "Process was successfully imported": "Process was successfully imported",
   "Process_category_id": "Process Category ID",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -1554,6 +1554,7 @@
   "Process Launchpad": "Lanzador de Procesos",
   "Process Manager not configured.": "El administrador de procesos no está configurado.",
   "Process Manager": "Administrador de procesos",
+  "Process Owner": "Propietario del proceso",
   "Process Name": "Nombre del Proceso",
   "Process was successfully imported": "El proceso fue importado exitosamente",
   "Process_category_id": "ID de Categoría de Proceso",

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -166,6 +166,7 @@
                                     <b-col>
                                         <label class="typo__label">{{__('Process Owner')}}</label>
                                         <select-user
+                                          data-cy="process-owner"
                                           v-model="owner"
                                           :multiple="false"
                                           :class="{'is-invalid': errors.user_id}"

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -164,6 +164,19 @@
                                       </div>
                                     </b-col>
                                     <b-col>
+                                        <label class="typo__label">{{__('Process Owner')}}</label>
+                                        <select-user
+                                          v-model="owner"
+                                          :multiple="false"
+                                          :class="{'is-invalid': errors.user_id}"
+                                          />
+                                        <div
+                                          v-if="errors.user_id"
+                                          class="invalid-feedback"
+                                          role="alert"
+                                          >
+                                          @{{errors.user_id[0]}}
+                                        </div>
                                     </b-col>
                                   </b-row>
                                 </div>
@@ -536,6 +549,7 @@
                     activeUsersAndGroups: @json($list),
                     pause_timer_start_events: false,
                     manager: @json($process->manager),
+                    owner: @json($process->user),
                     activeTab: "",
                     noElementsFoundMsg: 'Oops! No elements found. Consider changing the search query.',
                     reassignmentPermissions: {
@@ -651,6 +665,7 @@
                     this.formData.cancel_screen_id = this.formatValueScreen(this.screenCancel);
                     this.formData.request_detail_screen_id = this.formatValueScreen(this.screenRequestDetail);
                     this.formData.manager_id = this.formatValueScreen(this.manager);
+                    this.formData.user_id = this.formatValueScreen(this.owner);
                     this.formData.reassignment_permissions = this.reassignmentPermissions;
                     
                     ProcessMaker.apiClient.put('processes/' + that.formData.id, that.formData)


### PR DESCRIPTION
## Issue & Reproduction Steps
Create a dropdown in the Process Configuration section where the user with access can edit the Process Owner.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25547

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
