### PR TITLE
Set tenant resolved when the event is created

### DIFF
--- a/ProcessMaker/Events/TenantResolved.php
+++ b/ProcessMaker/Events/TenantResolved.php
@@ -13,5 +13,6 @@ class TenantResolved
 {
     public function __construct(public ?IsTenant $tenant = null)
     {
+        app()->instance('tenant-resolved', true);
     }
 }

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -316,7 +316,6 @@ class ProcessMakerServiceProvider extends ServiceProvider
         });
 
         Facades\Event::listen(MadeTenantCurrentEvent::class, function ($event) {
-            app()->instance('tenant-resolved', true);
             event(new TenantResolved($event->tenant));
         });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Accessing any config values, like `config('password-policies.minimum_length', 8)`, where it pulls from the settings table, are not working in non-multitenancy mode

## Solution
- Always set the `tenant-resolved` service container when the event is created

## How to Test
- See reproduction steps in ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25627

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
