### PR TITLE
Bugfix/FOUR-25649: The action of using the mouse cursor on the translate button at login is not enabled on the entire button.

### DIFF
--- a/resources/views/auth/newLogin.blade.php
+++ b/resources/views/auth/newLogin.blade.php
@@ -309,8 +309,9 @@ body {
   height: 100vh;
 }
 .language-button-container {
-  right: 0;
-  margin: 3rem 4rem;
+  right: 2.4rem;
+  top: 2.4rem;
+  z-index: 1041;
 }
 </style>
 </html>


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to Login page
- Try to make click on the center of button translation

**Current Behavior**

The action of using the mouse cursor on the translate button at login is not enabled on the entire button. if you click on the center of the button it is not possible to click on it. To open the translation form, click on the button at the top.

**Expected Behavior**
The translation form should open after any part of the button is clicked

## Solution
- Increase z-index of language selector button in login


https://github.com/user-attachments/assets/c771812b-24ae-41ce-bcce-cc600477e6ed



## How to Test
Follow steps above

## Related Tickets & Packages
- [FOUR-25649](https://processmaker.atlassian.net/browse/FOUR-25649)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-25649]: https://processmaker.atlassian.net/browse/FOUR-25649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ