### PR TITLE
bugfix/FOUR-25670: Archived processes are listed in the Home > Inbox page

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
@@ -199,6 +199,7 @@ class ProcessLaunchpadController extends Controller
         $userId = $user->id;
 
         $processes = Process::select('processes.*')
+            ->notArchived()
             ->distinct()
             ->whereHas('requests', function($query) use ($userId) {
                 $query->where('user_id', $userId)


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to server https://develop-qa.processmaker.net/
- Create a normal user
- Create a simple process (start event - task - task - end event)
- Assign the normal user in the start event and both tasks
- Publish the process
- Login with the normal user
- Run a Request
- Go to home > inbox
- The process is listed
- Login with Admin user
- Archive the created process
- Login with normal user
- Go to Home > Inbox

**Current Behavior:**
Archived process are listed in the processes list in the inbox page
NOTE: when a user opens an archived process from inbox page, the start this process button is not displayed


**Expected Behavior:**

All archived processes should not be listed in the processes list
**NOTE:** despite of some Tasks can be with in progress status still

## Solution
- Added the scope notArchived when getting the processes in inbox

https://github.com/user-attachments/assets/9caf1fad-b8b9-4b49-9cb4-5464435f5877

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-25670](https://processmaker.atlassian.net/browse/FOUR-25670)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-25670]: https://processmaker.atlassian.net/browse/FOUR-25670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ