### PR TITLE
FORU-25678 Enhance Settings Page to support custom UI configurations

### DIFF
--- a/ProcessMaker/Models/Setting.php
+++ b/ProcessMaker/Models/Setting.php
@@ -402,6 +402,7 @@ class Setting extends ProcessMakerModel implements HasMedia, PrometheusMetricInt
             ->select([
                 \DB::raw('MAX(id) as id'),
                 \DB::raw('MAX(`key`) as setting_key'),
+                \DB::raw('MAX(`ui`) as ui'),
                 'group',
             ])
             ->groupBy('group')
@@ -417,6 +418,7 @@ class Setting extends ProcessMakerModel implements HasMedia, PrometheusMetricInt
                 'name' => $setting->group,
                 'setting_id' => $setting->id,
                 'setting_key' => $setting->setting_key,
+                'ui' => $setting->ui,
             ];
         }
 

--- a/resources/js/admin/settings/components/SettingsMain.vue
+++ b/resources/js/admin/settings/components/SettingsMain.vue
@@ -9,9 +9,9 @@
         @selectGroup="selectGroup"
       />
     </div>
-    <div class="setting-info pl-3">
+    <div :class="customConfigurationComponent ? 'setting-info-custom mr-3' :'setting-info pl-3'">
       <settings-listing
-        v-if="selectedItem && !emailListenerConfigurationComponent"
+        v-if="selectedItem && !customConfigurationComponent"
         :key="setListingKey"
         ref="listings"
         :group="group"
@@ -19,8 +19,8 @@
         @refresh-all="refreshAll"
       />
       <component
-        :is="emailListenerConfigurationComponent"
-        ref="emailListenerConfiguration"
+        :is="customConfigurationComponent"
+        ref="customConfiguration"
         :setting-id="settingId"
       />
     </div>
@@ -41,25 +41,15 @@ export default {
       group: "",
       setListingKey: 0,
       selectedItem: false,
-      isEmailStartEventInstalled: false,
+      customConfigurationComponent: null,
     };
-  },
-  computed: {
-    emailListenerConfigurationComponent() {
-      if (this.isEmailStartEventInstalled && this.settingKey.includes('email_start_event')) {
-        return window.ProcessMaker.EmailStartEvent.EmailListenerConfiguration;
-      }
-
-      return null;
-    },
   },
   methods: {
     selectGroup(item) {
-      this.isEmailStartEventInstalled = !!window.ProcessMaker.EmailStartEvent;
-
       this.group = item.name;
       this.settingId = item.setting_id;
       this.settingKey = item.setting_key;
+      this.customConfigurationComponent = item.ui.custom_component ?? null;
       this.selectedItem = true;
       this.reRender();
     },
@@ -101,5 +91,10 @@ export default {
   padding: 16px 16px 106px 16px;
   border-radius: 4px;
   border: 1px solid var(--borders, #CDDDEE);
+}
+.setting-info-custom {
+  width: 100%;
+  height: calc(100vh - 150px);
+  overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
## Enhance Settings Page to support custom UI configurations

## Solution

https://github.com/user-attachments/assets/50590b1f-0ffd-4684-9e00-91257036ef7a

From a package to can register a new ui property:
```
        Setting::updateOrCreate(
            [
                'key' => 'email_start_event_default',
            ],
            [
                'name' => 'Email Listener Default',
                'helper' => 'This setting allows you to configure the email listener for the Email Start Event.',
                'group' => 'Email Listener Default',
                'config' => 1,
                'format' => 'text',
                'hidden' => false,
                'readonly' => true,
                'ui' => ['custom_component' => 'email-listener-index'],
            ],
        );

```
`'custom_component' => 'email-listener-index'` where `email-listener-index` is the custom component.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25678

ci:package-email-start-event:FOUR-25678
