### PR TITLE
FOUR-25714:Auto scroll stop to work in process launchpad

### DIFF
--- a/resources/js/processes-catalogue/components/CardProcess.vue
+++ b/resources/js/processes-catalogue/components/CardProcess.vue
@@ -124,10 +124,10 @@ export default {
     },
   },
   mounted() {
-    this.loadCard(()=>{
-      this.$nextTick(()=>{
-          const listCard = document.querySelector(".processes-info");
-          listCard.addEventListener("scrollend", () => this.handleScroll());
+    this.loadCard(() => {
+      this.$nextTick(() => {
+        const listCard = document.querySelector(".processes-info");
+        listCard.addEventListener("scrollend", () => this.handleScroll());
       });
     }, null);
     this.$root.$on("sizeChanged", (val) => {
@@ -254,7 +254,7 @@ export default {
       this.loadCard();
     },
     handleScroll() {
-      const container =  document.querySelector(".processes-info");
+      const container = document.querySelector(".processes-info");
       if ((container.scrollTop + container.clientHeight >= container.scrollHeight - 5) && this.isCardProcess) {
         this.cardMessage = "show-page";
         this.onPageChanged(this.currentPage + 1);
@@ -273,6 +273,7 @@ export default {
   position: relative;
   overflow: unset;
   justify-content: flex-start;
+  padding: 30px;
 
   @media (max-width: $lp-breakpoint) {
     display: block;

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -52,9 +52,7 @@
           </div>
           <div
             class="search-button"
-            @click="
-              $root.mobileSearchVisible = !$root.mobileSearchVisible
-            "
+            @click="$root.mobileSearchVisible = !$root.mobileSearchVisible"
           >
             <i class="fas fa-search" />
           </div>

--- a/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
+++ b/resources/js/processes-catalogue/components/ProcessesCatalogue.vue
@@ -5,51 +5,57 @@
       ref="breadcrumb"
       :category="category ? category.name : ''"
       :process="selectedProcess ? selectedProcess.name : ''"
-      :template="guidedTemplates ? 'Guided Templates' : ''" />
+      :template="guidedTemplates ? 'Guided Templates' : ''"
+    />
     <div class="tw-flex tw-h-full">
       <CollapsableContainer
         v-model="showMenu"
         class="tw-w-80"
         position="right"
-        @change="hideMenu">
-        <template>
-          <MenuCatologue
-            ref="categoryList"
-            title="Available Processes"
-            preicon="fas fa-play-circle"
-            class="pt-3 menu-catalog"
-            show-bookmark="true"
-            :category-count="categoryCount"
-            :data="listCategories"
-            :from-process-list="fromProcessList"
-            :filter-categories="filterCategories"
-            @categorySelected="selectCategory"
-            @addCategories="addCategories" />
-        </template>
+        @change="hideMenu"
+      >
+        <MenuCatologue
+          ref="categoryList"
+          title="Available Processes"
+          preicon="fas fa-play-circle"
+          class="pt-3 menu-catalog"
+          show-bookmark="true"
+          :category-count="categoryCount"
+          :data="listCategories"
+          :from-process-list="fromProcessList"
+          :filter-categories="filterCategories"
+          @categorySelected="selectCategory"
+          @addCategories="addCategories"
+        />
       </CollapsableContainer>
 
       <div
         ref="processInfo"
-        class="tw-overflow-hidden tw-flex-1">
+        class="processes-info tw-overflow-auto tw-flex-1"
+      >
         <div
           v-show="showMobileMenuControl"
-          class="mobile-menu-control">
+          class="mobile-menu-control"
+        >
           <div
             class="menu-button"
-            @click="hideMenu">
+            @click="hideMenu"
+          >
             <i class="fa fa-bars" />
             {{ category?.name || "" }}
           </div>
           <div
             class="bookmark-button"
-            @click="showBookmarks">
+            @click="showBookmarks"
+          >
             <i class="fas fa-bookmark" />
           </div>
           <div
             class="search-button"
             @click="
               $root.mobileSearchVisible = !$root.mobileSearchVisible
-            ">
+            "
+          >
             <i class="fas fa-search" />
           </div>
         </div>

--- a/resources/views/processes-catalogue/index.blade.php
+++ b/resources/views/processes-catalogue/index.blade.php
@@ -13,7 +13,7 @@
 @endsection
 
 @section('content')
-  <div class="px-3 tw-h-full" id="processes-catalogue">
+  <div id="processes-catalogue" class="px-3 tw-h-[99%] tw-overflow-hidden">
     <processes-catalogue
       :process="{{$process ?? 0}}"
       :current-user-id="{{ \Auth::user()->id }}"


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Have more than 12 processes
2. Go to process launchpad
3. Slide the scroll down

**Current Behavior**
Auto scroll stop to work in process launchpad 

**Expected Behavior**
Auto scroll in process launchpad should slide if there are more process

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25714

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
