### PR TITLE
FOUR-25735:UI: The rest of the stages cards lost when the stage name is long

### DIFF
--- a/resources/js/processes-catalogue/components/home/PercentageButtonGroup/PercentageCardButtonGroup.vue
+++ b/resources/js/processes-catalogue/components/home/PercentageButtonGroup/PercentageCardButtonGroup.vue
@@ -7,8 +7,8 @@
       :style="{ width: `${item.percentage}%` }"
       class=" tw-w-auto tw-flex tw-flex-col sm:tw-space-y-0 sm:tw-py-0
         first:tw-rounded-l-lg last:tw-rounded-r-lg tw-border-y tw-border-gray-200
-        first:tw-overflow-hidden first:tw-border-l
-        last:tw-overflow-hidden last:tw-border-r">
+        first:tw-border-l
+        tw-overflow-hidden last:tw-border-r">
       <PercentageCardButton
         :id="item.id"
         :header="item.body"

--- a/resources/js/processes/modeler/components/inspector/StageItem.vue
+++ b/resources/js/processes/modeler/components/inspector/StageItem.vue
@@ -2,7 +2,7 @@
   <div class="tw-flex tw-items-center tw-space-x-2 tw-w-full tw-py-1">
     <span class="tw-w-6 text-center stage-item-number">{{ order }}</span>
     <i class="fas fa-grip-vertical stage-item-grip-vertical tw-cursor-move" />
-    <div class="tw-flex-1 tw-cursor-pointer">
+    <div class="tw-flex-1 tw-cursor-pointer tw-overflow-hidden">
       <template v-if="editing">
         <input
           v-model="localName"


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process 
2. Add Start event → Task A → Task B → End Event
3. Create 3 stages with name
4. Set large name in the stages with 200 characters 
5. Save the changes
6. Create a cases
7. Open the process by launch pad
8. Open edit launchpad 
9. n Launch screen select “Distribution Bar Aid Student“
10. Save teh changes
11. Check the cards

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25735

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy