### PR TITLE
FOUR-25728: The progress bar does not show the completed in cases list from launch pad 

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -356,6 +356,8 @@ class TokenRepository implements TokenRepositoryInterface
 
         $request = $token->getInstance();
         $request->notifyProcessUpdated('ACTIVITY_COMPLETED', $token);
+        $request->last_stage_name = 'Completed';
+        $request->progress = 100;
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
The progress bar does not show the completed in cases list from launch pad 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25728

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy