### PR TITLE
FOUR-25284:Stages are duplicated in process info

### DIFF
--- a/resources/js/processes-catalogue/components/home/ProcessInfo.vue
+++ b/resources/js/processes-catalogue/components/home/ProcessInfo.vue
@@ -5,17 +5,19 @@
     :process="process"
     :full-carousel="fullCarousel"
     @closeCarousel="closeFullCarousel"
-    @close="closeProcessInfo">
+    @close="closeProcessInfo"
+  >
     <div class="tw-flex tw-flex-col tw-gap-4 tw-pl-10 tw-pr-10">
       <carousel-slide
         :process="process"
-        @full-carousel="showFullCarousel" />
+        @full-carousel="showFullCarousel"
+      />
       <div v-show="!fullCarousel">
         <process-options
           class="tw-w-full"
           :process="process"
-          :collapsed="collapsed" />
-        <progress-bar-section :stages-summary="process.stagesSummary" />
+          :collapsed="collapsed"
+        />
       </div>
     </div>
   </slide-process-info>
@@ -27,7 +29,6 @@ import { t } from "../variables/index";
 import SlideProcessInfo from "../slideProcessInfo/SlideProcessInfo.vue";
 import CarouselSlide from "../CarouselSlide.vue";
 import ProcessOptions from "../ProcessOptions.vue";
-import ProgressBarSection from "../progressBar/ProgressBarSection.vue";
 
 const props = defineProps({
   showProcessInfo: {


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Add some stages
3. Open the process by launchpad
4. Select a screen launcher as  “Distribution Bar Grant“
5. Save the changes
6. Click on “info“ button
7. Check the stages

**Current Behavior**
Stages are duplicated in process info

**Expected Behavior**
Stages should not be duplicated in process info when a Distribution of the screen is selected in screen launcher

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25284

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
