### PR TITLE
FOUR-25773:Case detail is choppy when TCE_CUSTOMIZATION_ENABLED=true

### DIFF
--- a/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CaseDetail.vue
@@ -10,6 +10,7 @@
       :tab-default="tabDefault"
       :tabs="tabs"
       :keep-alive="['NewOverview']"
+      :is-tce-customization="isTceCustomization()"
     />
   </div>
 </template>

--- a/resources/jscomposition/cases/casesDetail/components/Tabs.vue
+++ b/resources/jscomposition/cases/casesDetail/components/Tabs.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="tw-flex tw-flex-col tw-pointer-events-auto"
-    :class="isTceCustomization() ? 'tw-h-[calc(100vh-480px)]' : 'tw-h-full'"
+    :class="isTceCustomization ? 'tw-h-[calc(100vh-480px)]' : 'tw-h-full'"
   >
     <nav
       class="tw-mb-px tw-flex tw-space-x-2 tw-border-b tw-border-gray-300"
@@ -35,7 +35,6 @@
 
 <script>
 import { defineComponent, ref, onMounted } from "vue";
-import { isTceCustomization } from "../variables/index";
 
 export default defineComponent({
   props: {
@@ -51,6 +50,11 @@ export default defineComponent({
       type: Array,
       required: false,
       default: () => [],
+    },
+    isTceCustomization: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   setup(props) {
@@ -72,7 +76,6 @@ export default defineComponent({
       content,
       selectTab,
       tabSelected,
-      isTceCustomization,
     };
   },
 });

--- a/resources/jscomposition/cases/casesDetail/edit.js
+++ b/resources/jscomposition/cases/casesDetail/edit.js
@@ -8,7 +8,7 @@ import {
   updateUserConfiguration, getUserConfiguration, getCommentsData, updateRequest,
 } from "./api";
 import {
-  useStore, getRequest, getRequestId, getStageName, getProgressStage, isTceCustomization,
+  useStore, getRequest, getRequestId, getStageName, getProgressStage,
 } from "./variables";
 
 Vue.globalStore.registerModule("core:cases", cases);
@@ -53,7 +53,6 @@ const caseDetail = new Vue({
       headerModel: false,
       progressStage: getProgressStage(),
       stageName: getStageName(),
-      isTceCustomization: isTceCustomization(),
     };
   },
   computed: {

--- a/resources/jscomposition/cases/casesDetail/edit.js
+++ b/resources/jscomposition/cases/casesDetail/edit.js
@@ -8,7 +8,7 @@ import {
   updateUserConfiguration, getUserConfiguration, getCommentsData, updateRequest,
 } from "./api";
 import {
-  useStore, getRequest, getRequestId, getStageName, getProgressStage,
+  useStore, getRequest, getRequestId, getStageName, getProgressStage, isTceCustomization,
 } from "./variables";
 
 Vue.globalStore.registerModule("core:cases", cases);
@@ -53,6 +53,7 @@ const caseDetail = new Vue({
       headerModel: false,
       progressStage: getProgressStage(),
       stageName: getStageName(),
+      isTceCustomization: isTceCustomization(),
     };
   },
   computed: {


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Add TCE_CUSTOMIZATION_ENABLED=true variable in .ENV file
2. Create a process
3. Open the case
4. Check the cases detail

**Current Behavior**
Case detail is choppy when TCE_CUSTOMIZATION_ENABLED=true

**Expected Behavior**
Case detail  should take up the screen size like previous versions, when TCE_CUSTOMIZATION_ENABLED=true

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25773

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
