### PR TITLE
FOUR-25775: The Screen "Default Email Task Notification" in qa server is not updated with the last template

### DIFF
--- a/ProcessMaker/Models/Screen.php
+++ b/ProcessMaker/Models/Screen.php
@@ -375,41 +375,4 @@ class Screen extends ProcessMakerModel implements ScreenInterface, PrometheusMet
 
         return $newScreen;
     }
-
-    private static function updateScreenByKey(string $key, $isDefault = 0): self
-    {
-        // If no path is provided, use the default path
-        $path = database_path('processes/screens/' . "{$key}.json");
-
-        // Check if file exists
-        if (!file_exists($path)) {
-            throw new \RuntimeException("Screen configuration file not found: {$path}");
-        }
-
-        // Read and decode JSON with validation
-        $jsonContent = file_get_contents($path);
-        $json = json_decode($jsonContent, true);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException('Invalid JSON in screen configuration: ' . json_last_error_msg());
-        }
-
-        if (!isset($json['screens']) || !is_array($json['screens'])) {
-            throw new \RuntimeException("Invalid screen configuration format: 'screens' array is required");
-        }
-
-        $screen = collect($json['screens'])->first();
-        if (!$screen) {
-            throw new \RuntimeException('No screen configuration found in JSON');
-        }
-
-        $updateScreen = self::updateOrCreate(
-            ['key' => $screen['key']],
-            $screen
-        );
-
-        // Assign system category if needed
-
-        return $updateScreen;
-    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
The Screen "Default Email Task Notification" in qa server is not updated with the last template


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25775

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:connector-send-email:bugfix/FOUR-25775
