### PR TITLE
FOUR-25729: The total cases card show only one decimal

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1939,11 +1939,11 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         return [
             'total' => [
                 'stage_id' => 0,
-                'stage_name' => 'Total Cases',
+                'stage_name' => 'Total Identified Grants',
                 'percentage' => 100,
                 'percentage_format' => '100%',
-                'agregation_sum' => $totalCount,
-                'agregation_count' => $totalSum,
+                'agregation_sum' => $totalSum,
+                'agregation_count' => $totalCount,
             ],
             'stages' => $stages,
         ];


### PR DESCRIPTION
## Issue & Reproduction Steps
UI: The total cases card show only one decimal

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25729

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:TCE_CUSTOMIZATION_ENABLED=true