### PR TITLE
FOUR-25820:Unable to configure SSO accounts

### DIFF
--- a/resources/js/admin/settings/components/SettingsMain.vue
+++ b/resources/js/admin/settings/components/SettingsMain.vue
@@ -49,7 +49,7 @@ export default {
       this.group = item.name;
       this.settingId = item.setting_id;
       this.settingKey = item.setting_key;
-      this.customConfigurationComponent = item.ui.custom_component ?? null;
+      this.customConfigurationComponent = item.ui?.custom_component ?? null;
       this.selectedItem = true;
       this.reRender();
     },


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Log in
2. Go to Admin
3. Click on Log & Auth 
4. Click on SSO
5. Enable any of the available SSO accounts (Facebook, Google, GitHub, etc.)
6. Click on the SSO account to configure

**Current Behavior:**
As we see in the attached video, the SSO account configuration for logging in is not possible; the settings screen is not displayed.

**Expected Behavior:** 
SSO accounts must be able to be configured on multitenancy instances.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25820

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy