### PR TITLE
FOUR-25816:When the TCE is disable the dashboard does not show nothing

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessScreen.vue
+++ b/resources/js/processes-catalogue/components/ProcessScreen.vue
@@ -58,6 +58,8 @@ import processNavigationMixin from "../../components/shared/processNavigation";
 import ProcessesMixin from "./mixins/ProcessesMixin";
 import ProcessHeaderStart from "./ProcessHeaderStart.vue";
 
+const tceValidScreen = ["tce-student", "tce-college", "tce-grants"];
+
 export default {
   components: {
     DisplayScreen,
@@ -96,6 +98,11 @@ export default {
         .then((response) => {
           this.screen = response.data;
           this.showScreen = response.data.config !== null;
+        })
+        .catch(() => {
+          if(tceValidScreen.includes(this.screen_id)){
+            window.ProcessMaker.alert(this.$t("TCE dashboards are currently unavailable, please contact with the administrator in order to enable"), "danger");
+          }
         });
     },
   },

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2132,6 +2132,7 @@
   "Task": "Task",
   "TASK": "TASK",
   "Tasks": "Tasks",
+  "TCE dashboards are currently unavailable, please contact with the administrator in order to enable": "TCE dashboards are currently unavailable, please contact with the administrator in order to enable",
   "Template Author": "Template Author",
   "Template Documentation": "Template Documentation",
   "Template Name": "Template Name",


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Enabled TCE TCE_CUSTOMIZATION_ENABLED=true
2. Create a process
3. Configure the Launch Screen with one of the TCE dashboards 
4. Save the configuracion
5. See the changes
6. Disable the TCE_CUSTOMIZATION_ENABLED=false

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25816

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
