### PR TITLE
bugfix/FOUR-25792 added a rsync to create the lang folders when creating a new tenant

### DIFF
--- a/ProcessMaker/Console/Commands/TenantsCreate.php
+++ b/ProcessMaker/Console/Commands/TenantsCreate.php
@@ -108,6 +108,7 @@ class TenantsCreate extends Command
 
         // Check if an existing lang folder is provided
         $langFolderOption = $this->option('lang-folder', null);
+        $sourceLangPath = resource_path('lang');
         $tenantLangPath = resource_path('lang/tenant_' . $tenant->id);
         if ($langFolderOption) {
             if (File::isDirectory($langFolderOption)) {
@@ -129,6 +130,18 @@ class TenantsCreate extends Command
             if (!File::isDirectory($tenantLangPath)) {
                 mkdir($tenantLangPath, 0755, true);
             }
+        }
+
+        $cmd = sprintf(
+            "rsync -azv --ignore-existing --exclude='tenant_*' %s %s",
+            escapeshellarg($sourceLangPath . '/'),
+            escapeshellarg($tenantLangPath)
+        );
+        exec($cmd, $output, $returnVar);
+        if ($returnVar !== 0) {
+            $this->error('Failed to rsync lang folder to tenant: ' . implode(PHP_EOL, $output));
+
+            return 1;
         }
 
         $subfolders = [


### PR DESCRIPTION
## Issue & Reproduction Steps
It is not possible to add new languages in translations, shows a "server error"

## Solution
added a rsync to create the lang folders when creating a new tenant

## How to Test
Log in 
Go to Admin 
Click on Translations
Add new language
Select any language
Click on save

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-25792
