### PR TITLE
FOUR-25905: Error in alternatives when changing the position of the stages

### DIFF
--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -86,7 +86,7 @@ trait HasVersioning
 
             $processVersion = ProcessVersion::where('process_id', $this->id)->where('alternative', $attributes['alternative'])->first();
             if ($processVersion) {
-                $attributes['stages'] =  $processVersion->stages;
+                $attributes['stages'] = $processVersion->stages;
             }
         }
 

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -11,6 +11,7 @@ use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessMakerModel;
 use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessVersion;
 
 trait HasVersioning
 {
@@ -77,10 +78,16 @@ trait HasVersioning
     public function saveDraft(string $alternative = null)
     {
         $attributes = $this->getModelAttributes();
+
         $attributes['draft'] = true;
         if ($this->hasAlternative()) {
             $alternative = $alternative ?: $this->alternative;
             $attributes['alternative'] = $alternative;
+
+            $processVersion = ProcessVersion::where('process_id', $this->id)->where('alternative', $attributes['alternative'])->where('draft', false)->first();
+            if ($processVersion) {
+                $attributes['stages'] =  $processVersion->stages;
+            }
         }
 
         return $this->versions()->updateOrCreate(

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -84,7 +84,7 @@ trait HasVersioning
             $alternative = $alternative ?: $this->alternative;
             $attributes['alternative'] = $alternative;
 
-            $processVersion = ProcessVersion::where('process_id', $this->id)->where('alternative', $attributes['alternative'])->where('draft', false)->first();
+            $processVersion = ProcessVersion::where('process_id', $this->id)->where('alternative', $attributes['alternative'])->first();
             if ($processVersion) {
                 $attributes['stages'] =  $processVersion->stages;
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process
2. Add Start Event → Task Form → End Event
3. Add stages and assign the stage in the flows
4. Publish the process
5. Add Alternative B
6. In Alternative A move the stages of position 
7. Go to Alternative B

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25905

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
