### PR TITLE
FOUR-25915: Process creation from templates is not completed guide template

### DIFF
--- a/ProcessMaker/Console/Commands/SyncGuidedTemplates.php
+++ b/ProcessMaker/Console/Commands/SyncGuidedTemplates.php
@@ -23,27 +23,15 @@ class SyncGuidedTemplates extends Command
     protected $description = 'Synchronize guided templates from a central repository';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
-     *
-     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         if ($this->option('queue')) {
             $randomDelay = random_int(10, 120);
             Job::dispatch()->delay(now()->addMinutes($randomDelay));
-        } else {
-            Job::dispatchSync();
+
+            return 0;
         }
 
         Job::dispatchSync();

--- a/ProcessMaker/Listeners/HandleEndEventRedirect.php
+++ b/ProcessMaker/Listeners/HandleEndEventRedirect.php
@@ -107,9 +107,16 @@ class HandleEndEventRedirect extends HandleRedirectListener
      */
     private function handleMainProcessRedirect(ProcessRequest $request, ProcessCompleted $event): void
     {
-        // Type hints ensure $request and $event are valid, no need for null check
+        // Type hints ensure $request and $event are valid, no need for null check.
+        // Try to get the authenticated user id (will be null in non-HTTP contexts like queued jobs).
         $userId = Auth::id();
         $requestId = $request->id;
+
+        // Fallback: if there's no authenticated user (Auth::id() is null) use the request owner.
+        // This covers cases where the listener runs in the background and there is no session.
+        if (!$userId && !empty($request->user_id)) {
+            $userId = (int) $request->user_id;
+        }
 
         if ($userId) {
             try {


### PR DESCRIPTION
## Issue & Reproduction Steps
When ProcessCompleted fires outside an HTTP request (queue) Auth::id() is null and the listener logs: "No authenticated user found when handling end event redirect".

## Solution
- Fall back to $request->user_id when Auth::id() is null.

## How to Test
- From Guided Template section dispatch the import process; tail logs.
  - It should work without issues.

## Related Tickets & Packages
- [FOUR-25915](https://processmaker.atlassian.net/browse/FOUR-25915)

[FOUR-25915]: https://processmaker.atlassian.net/browse/FOUR-25915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ