### PR TITLE
FOUR-25273:Labels in stage flows are not lost after deleting all stages.

### DIFF
--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -18,7 +18,9 @@
 </template>
 
 <script setup>
-import { ref, onMounted, getCurrentInstance } from "vue";
+import {
+  ref, onMounted, getCurrentInstance, nextTick,
+} from "vue";
 import StageList from "./StageList.vue";
 import AgregationProperty from "./AgregationProperty.vue";
 
@@ -109,15 +111,16 @@ const updateStagesForAllFlowConfigs = (stages) => {
 
 const removeStageInAllFlowConfig = (stage) => {
   const links = getModeler().graph.getLinks();
-  for (const link of links) {
+  links.forEach((link) => {
     const config = getConfigFromDefinition(link.component.node.definition);
     if (config?.stage?.id === stage.id) {
       delete config.stage;
       Vue.set(link.component.node.definition, "config", JSON.stringify(config));
+      nextTick(() => {
+        link.component.removeStageLabels();
+      });
     }
-    link.component.removeStageLabels();
-    removeStageToFlow();
-  }
+  });
 };
 
 const applyStageToFlow = (stage) => {


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Add Start Event → Task A → Task B → End Event
3. Create two stages
4. Configure the flow in the task with stages
5. Publish the process
6. Delete all stages
7. Check the labels in the flows

**Current behavior**
Labels in stage flows are not lost after deleting all stages

**Expected behavior**
All labels in the flow should be cleared if stages were deleted 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25273

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy