### PR TITLE
FOUR-25925: Error in the chart of the list type, when we add "Assigne" in a self-service status save search

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -760,7 +760,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
 
                 if ($user) {
                     $taskIds = $user->availableSelfServiceTaskIds();
-                    $query->whereIn('id', $taskIds);
+                    $query->whereIn('process_request_tokens.id', $taskIds);
                 } else {
                     $query->where('is_self_service', 1);
                 }

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -762,18 +762,18 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                     $taskIds = $user->availableSelfServiceTaskIds();
                     $query->whereIn('process_request_tokens.id', $taskIds);
                 } else {
-                    $query->where('is_self_service', 1);
+                    $query->where('process_request_tokens.is_self_service', 1);
                 }
             } elseif (array_key_exists($value, $statusMap)) {
-                $query->where('is_self_service', 0);
+                $query->where('process_request_tokens.is_self_service', 0);
                 if ($expression->operator == '=') {
                     $query->whereIn('process_request_tokens.status', $statusMap[$value]);
                 } elseif ($expression->operator == '!=') {
                     $query->whereNotIn('process_request_tokens.status', $statusMap[$value]);
                 }
             } else {
-                $query->where('status', $expression->operator, $value)
-                    ->where('is_self_service', 0);
+                $query->where('process_request_tokens.status', $expression->operator, $value)
+                    ->where('process_request_tokens.is_self_service', 0);
             }
         };
     }

--- a/tests/unit/ProcessMaker/FilterTest.php
+++ b/tests/unit/ProcessMaker/FilterTest.php
@@ -228,7 +228,7 @@ class FilterTest extends TestCase
         ], ProcessRequestToken::class);
 
         $this->assertEquals(
-            "select * from `process_request_tokens` where ((`id` in ({$selfServiceTask->id})))",
+            "select * from `process_request_tokens` where ((`process_request_tokens`.`id` in ({$selfServiceTask->id})))",
             $sql
         );
     }

--- a/tests/unit/ProcessMaker/FilterTest.php
+++ b/tests/unit/ProcessMaker/FilterTest.php
@@ -206,7 +206,7 @@ class FilterTest extends TestCase
         );
     }
 
-    public function testTaskStatus()
+    public function testTaskStatusSelfservice()
     {
         $user = User::factory()->create();
 
@@ -229,6 +229,32 @@ class FilterTest extends TestCase
 
         $this->assertEquals(
             "select * from `process_request_tokens` where ((`process_request_tokens`.`id` in ({$selfServiceTask->id})))",
+            $sql
+        );
+    }
+
+    public function testTaskStatusActive()
+    {
+        $user = User::factory()->create();
+
+        $selfServiceTask = ProcessRequestToken::factory()->create([
+            'is_self_service' => false,
+            'status' => 'ACTIVE',
+            'user_id' => $user->id,
+        ]);
+
+        Auth::shouldReceive('user')->andReturn($user);
+
+        $sql = $this->filter([
+            [
+                'subject' => ['type' => 'Status'],
+                'operator' => '=',
+                'value' => 'ACTIVE',
+            ],
+        ], ProcessRequestToken::class);
+
+        $this->assertEquals(
+            "select * from `process_request_tokens` where ((`process_request_tokens`.`status` = 'active' and `process_request_tokens`.`is_self_service` = 0))",
             $sql
         );
     }


### PR DESCRIPTION
## Issue & Reproduction Steps
Error in the chart of the list type, when we add "Assigne" in a self-service status save search

## Solution
- In order to avoid  `Integrity constraint violation: 1052 Column 'id' `is important define the name of the table


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-25925

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy