### PR TITLE
FOUR-25965:Process name overlap the header in process launchpad

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
@@ -18,11 +18,11 @@
                 class="fas fa-chevron-left mr-2 custom-color hover:tw-cursor-pointer"
                 @click="goBack()"
               />
-              <div>
-              <div
-                v-b-tooltip.hover
-                class="title text-truncate"
-                :title="process.name"
+              <div class="tw-grid">
+                <div
+                  v-b-tooltip.hover
+                  class="title text-truncate"
+                  :title="process.name"
                 >
                   {{ process.name }}
                 </div>


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process with large name
2. Save the changes
3. Open the process by launchpad
4. Check the header on the process launch pad

**Current Behavior**
Process name overlap the header in process launchpad 

**Expected Behavior**
The process name should not overlap the header on process launchpad

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25965

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
