### PR TITLE
FOUR-25966: It is not possible to delete "Default Email Task Notification" that were copied

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -166,7 +166,7 @@ class ModelerController extends Controller
      */
     private function getDefaultEmailNotification(): array
     {
-        $screen = Screen::getScreenByKey('default-email-task-notification');
+        $screen = Screen::getScreenByKey('default-email-task-notification-v2');
 
         return [
             'subject' => 'RE: {{_user.firstname}} assigned you in "{{_task_name}}"',

--- a/ProcessMaker/Models/Screen.php
+++ b/ProcessMaker/Models/Screen.php
@@ -309,8 +309,6 @@ class Screen extends ProcessMakerModel implements ScreenInterface, PrometheusMet
     {
         $screen = self::firstWhere('key', $key);
         if (!$screen) {
-            $screen = self::createScreenByKey($key, false, null, 1);
-        } else {
             $screen = self::createScreenByKey($key, false, null, 1, 'key');
         }
 

--- a/database/processes/screens/default-email-task-notification-v2.json
+++ b/database/processes/screens/default-email-task-notification-v2.json
@@ -4,7 +4,7 @@
   "screens": [
     {
       "screen_category_id": null,
-      "title": "Default Email Task Notification",
+      "title": "Default Email Task Notification v2",
       "description": "Screen for the email task notification",
       "type": "EMAIL",
       "config": [
@@ -532,7 +532,7 @@
       "computed": [],
       "custom_css": ".link-button {\n    max-width: max-content;\n    margin-left: auto;\n    margin-right: auto;\n}\n.email-wrapper {\n    background-color: #F3F5F7;\n}",
       "status": "ACTIVE",
-      "key": "default-email-task-notification",
+      "key": "default-email-task-notification-v2",
       "watchers": [],
       "translations": null,
       "is_template": 0,

--- a/database/seeders/ScreenEmailSeeder.php
+++ b/database/seeders/ScreenEmailSeeder.php
@@ -14,6 +14,6 @@ class ScreenEmailSeeder extends Seeder
      */
     public function run()
     {
-        return Screen::getScreenByKeyPerDefault('default-email-task-notification');
+        return Screen::getScreenByKeyPerDefault('default-email-task-notification-v2');
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
It is not possible to delete "Default Email Task Notification" that were copied

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25966

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy