### PR TITLE
FOUR-25996: It is not possible to delete "Default Email Task Notification" that were copied

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -430,7 +430,7 @@ class ScreenController extends Controller
         $request->validate(Screen::rules());
         $newScreen = new Screen();
 
-        $exclude = ['id', 'uuid', 'created_at', 'updated_at', 'key'];
+        $exclude = ['id', 'uuid', 'created_at', 'updated_at', 'key', 'is_default'];
         foreach ($screen->getAttributes() as $attribute => $value) {
             if (!in_array($attribute, $exclude)) {
                 $newScreen->{$attribute} = $screen->{$attribute};


### PR DESCRIPTION
## Issue & Reproduction Steps
It is not possible to delete "Default Email Task Notification" that were copied

## Solution
- List the changes you've introduced to solve the issue.

## How to Test

1. Go to screen list
2. Search the screen “Default Email Task Notification”
3. Cloned this screen
4. Try to delete the screen cloned

**Current Behavior**
It is not possible to delete "Default Email Task Notification" that were copied

**Expected Behavior**
Only "Default Email Task Notification" should not be possible to delete, but screen that are imported cloned should be possible to delete them

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25966

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
