### PR TITLE
FOUR-23421 There is confusion with the stages when they are not publi…

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -173,6 +173,7 @@ export default {
     },
   },
   mounted() {
+    window.$modelerApp = this;
     ProcessMaker.$modeler = this.$refs.modeler;
     window.ProcessMaker.EventBus.$emit("modeler-app-init", this);
 

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -73,6 +73,10 @@ const getHighlightedNode = () => getModeler().highlightedNode;
 
 const getDefinition = () => getHighlightedNode().definition;
 
+const saveProcess = () => {
+  currentInstance.proxy.$root.$children[0].$refs["external-ModalSaveVersion"]?.[0]?.saveModal?.();
+}
+
 const getConfigFromDefinition = (definition) => {
   let config = {};
   try {
@@ -150,14 +154,17 @@ const onChange = (stages) => {
 
 const onUpdate = (stages, index, val, Oldal) => {
   updateStagesForAllFlowConfigs(stages);
+  saveProcess();
 };
 
 const onRemove = (stages, index, removed) => {
   removeStageInAllFlowConfig(removed);
+  saveProcess();
 };
 
 const onClickCheckbox = (stage) => {
   applyStageToFlow(stage);
+  saveProcess();
 };
 
 const onClickSelected = (stage) => {

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -74,8 +74,9 @@ const getHighlightedNode = () => getModeler().highlightedNode;
 const getDefinition = () => getHighlightedNode().definition;
 
 const saveProcess = () => {
-  currentInstance.proxy.$root.$children[0]?.autosaveApiCall?.();
-  currentInstance.proxy.$root.$children[0].$refs["external-ModalSaveVersion"]?.[0]?.saveModal?.();
+  window.$modelerApp?.autosaveApiCall?.();
+  //Index 0 implies that the component is in a loop; therefore, it will exist anyway, and its existence is validated.
+  window.$modelerApp?.$refs["external-ModalSaveVersion"]?.[0]?.saveModal?.();
 }
 
 const getConfigFromDefinition = (definition) => {

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -74,6 +74,7 @@ const getHighlightedNode = () => getModeler().highlightedNode;
 const getDefinition = () => getHighlightedNode().definition;
 
 const saveProcess = () => {
+  currentInstance.proxy.$root.$children[0]?.autosaveApiCall?.();
   currentInstance.proxy.$root.$children[0].$refs["external-ModalSaveVersion"]?.[0]?.saveModal?.();
 }
 


### PR DESCRIPTION
…shed.

 ## Description:
Create a process
Add Start Event → Task Form → End Event
Create two stages and assigned these to flow to each task Publish the process
Open the process by launchpad
Create a case
Return to process
Delete the stages in the process
Does not publish the changes
Go to process launchpad
Check that stages are not present after the changes Create new cases
The new cases are created with stage but it is not visible in process launchpad Current Behavior:
To stages are visible to start a CASE is necessary to publish the process with stages To stages are visible in LAUNCH PAD does not necessary to publish the process with stages which causes confusion when displaying case information Expected Behavior:
The information in launch pad should be sync
If there are stages the new cases should be created with the corresponding stage If there are not stages the new cases should be created without stages To this it necessary that stages will be publish to avoid errors and confusions

 ## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-25926

ci:deploy