### PR TITLE
FOUR-25919: Processmaker is not registering the name of user performing a task on behalf of someone else

### DIFF
--- a/ProcessMaker/Listeners/CommentsSubscriber.php
+++ b/ProcessMaker/Listeners/CommentsSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Listeners;
 
+use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -26,11 +27,26 @@ class CommentsSubscriber
         $user_id = $token->user ? $token->user_id : null;
         $user_name = $token->user ? $token->user->fullname : __('The System');
 
+        // Check the authenticated user
+        $executer_user_id = null;
+        $executer_user = __('The System');
+        if (Auth::check()) {
+            $executer_user_id = Auth::user() ? Auth::user()?->id : null;
+            $executer_user = Auth::user() ? Auth::user()?->fullname : __('The System');
+        }
+
         if (!is_int($token->process_request_id)) {
             return;
         }
 
-        $message = ':user has completed the task :task_name';
+        if (!is_null($executer_user_id) && $user_id !== $executer_user_id) {
+            $subject = 'Task Completed by Different User';
+            $message = ':executer_user has completed the task :task_name (assigned to: :user)';
+        } else {
+            $subject = 'Task Complete';
+            $message = ':user has completed the task :task_name';
+        }
+
         if ($token->is_actionbyemail) {
             $message = $message . ' via email';
         }
@@ -42,8 +58,8 @@ class CommentsSubscriber
             'user_id' => $user_id,
             'commentable_type' => ProcessRequest::class,
             'commentable_id' => $token->process_request_id,
-            'subject' => 'Task Complete',
-            'body' => __($message, ['user' => $user_name, 'task_name' => $token->element_name]),
+            'subject' => $subject,
+            'body' => __($message, ['user' => $user_name, 'task_name' => $token->element_name, 'executer_user' => $executer_user]),
             'case_number' => $caseNumber,
         ]);
     }

--- a/ProcessMaker/Listeners/CommentsSubscriber.php
+++ b/ProcessMaker/Listeners/CommentsSubscriber.php
@@ -30,9 +30,10 @@ class CommentsSubscriber
         // Check the authenticated user
         $executer_user_id = null;
         $executer_user = __('The System');
-        if (Auth::check()) {
-            $executer_user_id = Auth::user() ? Auth::user()?->id : null;
-            $executer_user = Auth::user() ? Auth::user()?->fullname : __('The System');
+        $user = Auth::user();
+        if ($user) {
+            $executer_user_id = $user->id;
+            $executer_user = $user->fullname;
         }
 
         if (!is_int($token->process_request_id)) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Processmaker is not registering the name of user performing a task on behalf of someone else

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Steps to Reproduce: 

1. Create a process with two or more tasks.
2. Assign different users to each task.
3. Create a case using this process.
4. Submit the case using a user who has permission to view all cases (e.g., Admin user), acting on behalf of the users assigned to each task.
5. Review the Requests or Cases list.

**Current Behavior:** 

The Participated column (requests or cases) displays the names of users assigned to the tasks, but does not show the user who submitted the case.

**Expected Behavior:** 
The Participated column should include the user who submitted the case, even if the submission incurred on behalf of.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25919

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy 