### PR TITLE
bugfix/FOUR-24333 Inconsistencies with Session Timeout before Alloted time

### DIFF
--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -284,10 +284,7 @@ class ProcessMakerServiceProvider extends ServiceProvider
         });
 
         $this->app->extend('config', function ($originalConfig) {
-            $config = $originalConfig->all();
-            unset($config['session']['lifetime']);
-
-            return new SettingsConfigRepository($config);
+            return new SettingsConfigRepository($originalConfig->all());
         });
 
         $this->app->singleton('currentTenant', function () {

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -284,7 +284,10 @@ class ProcessMakerServiceProvider extends ServiceProvider
         });
 
         $this->app->extend('config', function ($originalConfig) {
-            return new SettingsConfigRepository($originalConfig->all());
+            $config = $originalConfig->all();
+            unset($config['session']['lifetime']);
+
+            return new SettingsConfigRepository($config);
         });
 
         $this->app->singleton('currentTenant', function () {

--- a/ProcessMaker/Repositories/SettingsConfigRepository.php
+++ b/ProcessMaker/Repositories/SettingsConfigRepository.php
@@ -45,6 +45,12 @@ class SettingsConfigRepository extends Repository
             return $this->getMany($key);
         }
 
+        if ($key === 'session.lifetime') {
+            $settingValue = $this->getFromSettings($key);
+
+            return $settingValue ?? $default;
+        }
+
         if (Arr::has($this->items, $key)) {
             return Arr::get($this->items, $key);
         }

--- a/resources/js/next/config/session.js
+++ b/resources/js/next/config/session.js
@@ -10,7 +10,6 @@ export default () => {
   const closeSessionModal = getGlobalPMVariable("closeSessionModal");
   const alert = getGlobalPMVariable("alert");
   const user = getGlobalPMVariable("user");
-  const sessionModal = getGlobalPMVariable("sessionModal");
 
   const isSameDevice = (e) => {
     const localDeviceId = Vue.$cookies.get(e.device_variable);
@@ -26,6 +25,7 @@ export default () => {
     const AccountTimeoutWorker = new Worker(timeoutScript);
 
     AccountTimeoutWorker.addEventListener("message", (e) => {
+      const sessionModal = getGlobalPMVariable("sessionModal");
       if (e.data.method === "countdown") {
         sessionModal(
           "Session Warning",


### PR DESCRIPTION
## Issue & Reproduction Steps
Inconsistencies with Session Timeout before Alloted time
The config('session.lifetime') value gets overridden by the vendor/laravel/framework/config/session.php env value

## Solution
removed session.lifetime from cache and fix session modal on layoutnext.blade

## How to Test
Steps to Reproduce
Goto Admin
Settings
Under log-in & auth, choose session control
Set a timer for session inactivity 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-24333

