### PR TITLE
FOUR-26065: Create an upgrade instead to execute the ScreenEmailSeeder

### DIFF
--- a/upgrades/2025_08_26_174003_install_default_email_task_notification_screen.php
+++ b/upgrades/2025_08_26_174003_install_default_email_task_notification_screen.php
@@ -1,0 +1,60 @@
+<?php
+
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class InstallDefaultEmailTaskNotificationScreen extends Upgrade
+{
+    /**
+     * Run the upgrade migration.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        echo PHP_EOL . '    Installing default email task notification screen...' . PHP_EOL;
+
+        // Obtener solo los IDs para mayor eficiencia
+        $screenIds = Screen::where('key', 'default-email-task-notification')->pluck('id')->toArray();
+
+        if (count($screenIds) > 0) {
+            echo '    Found ' . count($screenIds) . " existing screen(s) with key 'default-email-task-notification'" . PHP_EOL;
+
+            // Update por batch usando los IDs obtenidos directamente
+            $updatedCount = Screen::whereIn('id', $screenIds)
+                ->update([
+                    'key' => 'default-email-task-notification-old',
+                    'is_default' => 0,
+                ]);
+
+            echo "    Successfully renamed {$updatedCount} screen(s) to 'default-email-task-notification-old'" . PHP_EOL;
+        } else {
+            echo "    No existing screens found with key 'default-email-task-notification'" . PHP_EOL;
+        }
+
+        try {
+            $screen = Screen::getScreenByKeyPerDefault('default-email-task-notification');
+
+            if ($screen) {
+                echo "    Successfully installed/updated screen: {$screen->title}" . PHP_EOL;
+            } else {
+                echo '    Warning: Screen installation returned null' . PHP_EOL;
+            }
+        } catch (Exception $e) {
+            echo '    Error installing screen: ' . $e->getMessage() . PHP_EOL;
+            throw $e;
+        }
+
+        echo PHP_EOL;
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Nothing to do here
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Create an upgrade instead to execute the ScreenEmailSeeder

## Solution
- The following command is required `php artisan upgrade`

```
Upgrading: 2025_08_26_174003_install_default_email_task_notification_screen

    Installing default email task notification screen...
    Successfully installed/updated screen: Default Email Task Notification

Upgraded:  2025_08_26_174003_install_default_email_task_notification_screen (0.04 seconds)
```
## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26065

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy