### PR TITLE
Task/FOUR-26050: Hide Enable Client Credentials option from Auth

### DIFF
--- a/resources/views/admin/auth-clients/index.blade.php
+++ b/resources/views/admin/auth-clients/index.blade.php
@@ -38,9 +38,6 @@
               <div class="form-group">
                 <b-form-checkbox value="password_client">{{__('Enable Password Grant')}}</b-form-checkbox>
               </div>
-              <div class="form-group">
-                <b-form-checkbox value="personal_access_client">{{__('Enable Personal Access Tokens')}}</b-form-checkbox>
-              </div>
             </b-form-checkbox-group>
         </pm-modal>
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Hide the Enable Client Credentials since it’s not currently supported.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26050


<img width="1603" height="1041" alt="Screenshot 2025-08-26 at 13 56 59" src="https://github.com/user-attachments/assets/a623be93-0630-4832-8d6e-2e93c0f73b52" />
