### PR TITLE
FOUR-26074 New Cases can be created from Email Start Event

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -203,16 +203,19 @@ class ProcessController extends Controller
                             return $eventDefinition['$type'] == 'timerEventDefinition';
                         })->count() > 0;
 
-                // Filter out web entry start events
+                // Filter out web entry start events and email start events
                 $eventIsWebEntry = false;
+                $eventIsEmailStart = false;
                 if (isset($event['config'])) {
                     $config = json_decode($event['config'], true);
                     if (isset($config['web_entry']) && $config['web_entry'] !== null) {
                         $eventIsWebEntry = true;
+                    } elseif (isset($config['email_start']) && $config['email_start'] !== null) {
+                        $eventIsEmailStart = true;
                     }
                 }
 
-                return !$eventIsTimerStart && !$eventIsWebEntry;
+                return !$eventIsTimerStart && !$eventIsWebEntry && !$eventIsEmailStart;
             })->values();
 
             // Get the id bookmark related
@@ -1026,16 +1029,19 @@ class ProcessController extends Controller
                             return $eventDefinition['$type'] == 'timerEventDefinition';
                         })->count() > 0;
 
-                // Filter out web entry start events
+                // Filter out web entry start events and email start events
                 $eventIsWebEntry = false;
+                $eventIsEmailStart = false;
                 if (isset($event['config'])) {
                     $config = json_decode($event['config'], true);
                     if (isset($config['web_entry']) && $config['web_entry'] !== null) {
                         $eventIsWebEntry = true;
+                    } elseif (isset($config['email_start']) && $config['email_start'] !== null) {
+                        $eventIsEmailStart = true;
                     }
                 }
 
-                return !$eventIsTimerStart && !$eventIsWebEntry;
+                return !$eventIsTimerStart && !$eventIsWebEntry && !$eventIsEmailStart;
             })->values();
 
             // Filter all processes that have event definitions (start events like message event, conditional event, signal event, timer event)


### PR DESCRIPTION
## Issue & Reproduction Steps
When the users try to create a new case, the email start events are displayed in the list

## Solution
Filter email start events from the endpoint results 

## How to Test
Create a process with email start event
Try to create a new case

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-26074

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
