### PR TITLE
FOUR-26094: UI: When I click the stage name to edit it, the elements are misaligned.

### DIFF
--- a/resources/js/processes/modeler/components/inspector/StageList.vue
+++ b/resources/js/processes/modeler/components/inspector/StageList.vue
@@ -35,12 +35,7 @@
           :placeholder="$t('Enter name')"
           maxlength="200"
           @keyup.enter="onKeyupEnter"
-          @input="onInput"
-          @paste="onPaste"
-        >
-        <small class="tw-text-gray-500 tw-text-xs">
-          {{ newStage.length }}/200 {{ $t('characters') }}
-        </small>
+          @paste="onPaste" />
       </div>
     </div>
     <div class="tw-flex tw-justify-end tw-mt-2">
@@ -84,13 +79,6 @@ const stages = ref([...props.initialStages]);
 const totalStages = computed(() => stages.value.length);
 const disableButton = computed(() => totalStages.value >= 8);
 const stateNewStage = ref(true);
-
-const onInput = (event) => {
-  // Limit to 200 characters
-  if (newStage.value.length > 200) {
-    newStage.value = newStage.value.substring(0, 200);
-  }
-};
 
 const onPaste = (event) => {
   // Handle paste event to ensure proper character counting

--- a/resources/js/processes/modeler/components/inspector/StageList.vue
+++ b/resources/js/processes/modeler/components/inspector/StageList.vue
@@ -35,7 +35,9 @@
           :placeholder="$t('Enter name')"
           maxlength="200"
           @keyup.enter="onKeyupEnter"
-          @paste="onPaste" />
+          @input="onInput"
+          @paste="onPaste"
+        >
       </div>
     </div>
     <div class="tw-flex tw-justify-end tw-mt-2">
@@ -79,6 +81,13 @@ const stages = ref([...props.initialStages]);
 const totalStages = computed(() => stages.value.length);
 const disableButton = computed(() => totalStages.value >= 8);
 const stateNewStage = ref(true);
+
+const onInput = (event) => {
+  // Limit to 200 characters
+  if (newStage.value.length > 200) {
+    newStage.value = newStage.value.substring(0, 200);
+  }
+};
 
 const onPaste = (event) => {
   // Handle paste event to ensure proper character counting


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Open a process
2. Select a flow
3. Open the properties
4. Add Stages
5. Edit one Stage

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26094

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
