### PR TITLE
FOUR-24591 [45224]Script Execution fails when the environment variabl…

### DIFF
--- a/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
@@ -60,7 +60,7 @@ trait ScriptDockerBindingFilesTrait
     {
         $cmd = Docker::command($timeout) . sprintf(
             ' run --rm %s %s %s %s 2>&1',
-            buildEnvFileAndArgs($parameters, 1),
+            buildEnvFileAndArgs($parameters, 30),
             $bindings,
             $image,
             $command

--- a/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
+++ b/ProcessMaker/Models/ScriptDockerBindingFilesTrait.php
@@ -60,7 +60,7 @@ trait ScriptDockerBindingFilesTrait
     {
         $cmd = Docker::command($timeout) . sprintf(
             ' run --rm %s %s %s %s 2>&1',
-            $parameters,
+            buildEnvFileAndArgs($parameters, 1),
             $bindings,
             $image,
             $command

--- a/helpers.php
+++ b/helpers.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Laravel\Horizon\Repositories\RedisJobRepository;
 use ProcessMaker\Events\MarkArtisanCachesAsInvalid;
 use ProcessMaker\Models\Setting;
@@ -357,5 +359,75 @@ if (!function_exists('json_optimize_decode')) {
     function json_optimize_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
     {
         return JsonOptimizer::decode($json, $assoc, $depth, $options);
+    }
+}
+
+if (!function_exists('buildEnvFileAndArgs')) {
+    /**
+     * Builds a temporary Docker env file from a string of parameters containing `-e KEY=VALUE` entries
+     * and returns a command-line argument string including the env file and any extra parameters.
+     *
+     * Only `-e KEY=VALUE` pairs are written to the env file; all other parameters are preserved separately.
+     * Values with line breaks are sanitized to prevent invalid env files.
+     *
+     * @param string $parameters The string containing Docker parameters, e.g. "-e 'FOO'='bar' --shm-size=256m".
+     * @param int $maxFileAgeMinutes Maximum age of temporary env files before cleanup (default: 60 minutes).
+     *
+     * @return string A command-line string like "--env-file '/path/to/tmp.env' --shm-size=256m".
+     */
+    function buildEnvFileAndArgs(string $parameters, int $maxFileAgeMinutes = 60): string
+    {
+        $tmpDir = storage_path('app/docker_envs');
+        File::ensureDirectoryExists($tmpDir, 0755);
+
+        // Clean old env files
+        collect(File::files($tmpDir))
+            ->filter(fn($file) => now()->diffInMinutes(date('Y-m-d H:i:s', File::lastModified($file))) > $maxFileAgeMinutes)
+            ->each(fn($file) => File::delete($file));
+
+        $envLines = [];
+        $rest = [];
+
+        $normalizePair = function (string $pair): string {
+            if (str_contains($pair, '=')) {
+                [$key, $value] = explode('=', $pair, 2);
+                $key = trim($key, "'"); // Remove quotes only from the key
+
+                // Sanitize value: replace line breaks with literal \n
+                $value = str_replace(["\r\n", "\r", "\n"], '\\n', $value);
+
+                return $key . '=' . $value;
+            }
+            return $pair;
+        };
+
+        // Tokenize input respecting single quotes
+        preg_match_all("/(?:[^\s']+|'[^']*')+/", $parameters, $matches);
+        $tokens = $matches[0];
+
+        $i = 0;
+        while ($i < count($tokens)) {
+            $token = $tokens[$i];
+
+            if ($token === '-e') {
+                $pair = $tokens[++$i] ?? '';
+                if ($pair !== '') {
+                    $envLines[] = $normalizePair($pair);
+                }
+            } elseif (Str::startsWith($token, '-e')) {
+                $envLines[] = $normalizePair(substr($token, 2));
+            } else {
+                // All other parameters (extras) go to $rest
+                $rest[] = $token;
+            }
+
+            $i++;
+        }
+
+        // Create unique temporary env file
+        $tmpFile = $tmpDir . '/' . Str::random(12) . '.env';
+        File::put($tmpFile, implode(PHP_EOL, $envLines) . PHP_EOL);
+
+        return '--env-file ' . escapeshellarg($tmpFile) . ' ' . implode(' ', $rest);
     }
 }

--- a/helpers.php
+++ b/helpers.php
@@ -382,8 +382,8 @@ if (!function_exists('buildEnvFileAndArgs')) {
 
         // Clean old env files
         collect(File::files($tmpDir))
-            ->filter(fn($file) => now()->diffInMinutes(date('Y-m-d H:i:s', File::lastModified($file))) > $maxFileAgeMinutes)
-            ->each(fn($file) => File::delete($file));
+            ->filter(fn ($file) => now()->diffInMinutes(date('Y-m-d H:i:s', File::lastModified($file))) > $maxFileAgeMinutes)
+            ->each(fn ($file) => File::delete($file));
 
         $envLines = [];
         $rest = [];
@@ -398,6 +398,7 @@ if (!function_exists('buildEnvFileAndArgs')) {
 
                 return $key . '=' . $value;
             }
+
             return $pair;
         };
 


### PR DESCRIPTION
…es reach the limit of data size

 ## Description:
- Steps to Reproduce: Go-to Environmental Variables.
Add a new environmental variable.
In the value field ensure the character length is equal to or above 5000 or more (you can use a character generator). Save it
Run a simple PHP  “Hello World“ Script.

- Current Behavior: When you run the script, you get an error below ( I have attached a file, due to the length of the error)

- Expected Behavior: There should not be any limit on adding environment variables based on the size, or if there is, it must be part of the documentation, or if this is related to any other parameter to be increased must also be documented. On the other hand, this should not affect the script's execution, or at least there should be a message that the number or size has been exceeded.

- Notes to QA: The error was discovered when initially testing the addition of a PGP key as an environmental variable. Further investigations made us detect that adding new values to an environmental variable of large length lead to error being returned. The use case of our client was having more than 30 PGP keys stored. Not using microservices.

 ## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-24591
