### PR TITLE
Textarea Control - Rich text does not work correctly in nested screens

### DIFF
--- a/ProcessMaker/Managers/ExportManager.php
+++ b/ProcessMaker/Managers/ExportManager.php
@@ -83,13 +83,11 @@ class ExportManager
         $newReferences = $this->uniqueDiff($newReferences, $references);
         $references = array_merge($references, $newReferences);
         // Find recursively dependencies
-        if ($recursive) {
-            foreach ($newReferences as $ref) {
-                list($class, $id) = $ref;
-                $nextOwner = $class::find($id);
-                if ($nextOwner) {
-                    $references = $this->reviewDependenciesOf($nextOwner, $references, $reviewed, $recursive);
-                }
+        foreach ($newReferences as $ref) {
+            list($class, $id) = $ref;
+            $nextOwner = $class::find($id);
+            if ($nextOwner) {
+                $references = $this->reviewDependenciesOf($nextOwner, $references, $reviewed, $recursive);
             }
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
When you have a Nested Screen and it contains richtext, the content is formatted and any styles are removed.
The reason is that when the case is created, this field doesn't appear in the field list so it doesn't need to be cleaned up.

## Solution
- Enable recursive dependency searching

## How to Test

- Create a screen with a Textarea Control configured as rich text
- Create another screen and use a nested screen control pointing to the previous one created.
- Create a process and two tasks. You can assign the same main screen to both tasks.
- Run a new case and in the first task in the textarea control fill using different styles, formats, colors, etc.

## Related Tickets & Packages
- [FOUR-25970](https://processmaker.atlassian.net/browse/FOUR-25970)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-25970]: https://processmaker.atlassian.net/browse/FOUR-25970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ