### PR TITLE
XPROJ-75: Serverless, remove the onQueue method to dispatch queues to another queue over the default

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -192,7 +192,7 @@ class ScriptController extends Controller
         $code = $request->get('code');
         $nonce = $request->get('nonce');
 
-        TestScript::dispatch($script, $request->user(), $code, $data, $config, $nonce)->onQueue('bpmn');
+        TestScript::dispatch($script, $request->user(), $code, $data, $config, $nonce);
 
         return ['status' => 'success'];
     }
@@ -253,7 +253,7 @@ class ScriptController extends Controller
         if ($request->get('sync') === true) {
             return (new ExecuteScript($script, $request->user(), $code, $data, $watcher, $config, true))->handle();
         } else {
-            ExecuteScript::dispatch($script, $request->user(), $code, $data, $watcher, $config)->onQueue('bpmn');
+            ExecuteScript::dispatch($script, $request->user(), $code, $data, $watcher, $config);
         }
 
         return ['status' => 'success', 'key' => $watcher];

--- a/ProcessMaker/Jobs/CatchSignalEvent.php
+++ b/ProcessMaker/Jobs/CatchSignalEvent.php
@@ -73,7 +73,7 @@ class CatchSignalEvent implements ShouldQueue
                 $this->eventDefinition,
                 $this->tokenId,
                 $this->requestId
-            )->onQueue('bpmn');
+            );
         }
         $count = ProcessRequest::where('status', 'ACTIVE')
             ->where('id', '!=', $this->requestId);
@@ -104,7 +104,7 @@ class CatchSignalEvent implements ShouldQueue
                     $this->eventDefinition,
                     $this->tokenId,
                     $this->requestId
-                )->onQueue('bpmn');
+                );
             }
         }
     }

--- a/ProcessMaker/Jobs/ErrorHandling.php
+++ b/ProcessMaker/Jobs/ErrorHandling.php
@@ -83,7 +83,6 @@ class ErrorHandling
             );
         }
         $newJob->delay($this->retryWaitTime());
-        $newJob->onQueue('bpmn');
         dispatch($newJob);
     }
 

--- a/ProcessMaker/Jobs/RunScriptTask.php
+++ b/ProcessMaker/Jobs/RunScriptTask.php
@@ -41,7 +41,6 @@ class RunScriptTask extends BpmnAction implements ShouldQueue
      */
     public function __construct(Definitions $definitions, ProcessRequest $instance, ProcessRequestToken $token, array $data, $attemptNum = 1)
     {
-        $this->onQueue('bpmn');
         $this->definitionsId = $definitions->getKey();
         $this->instanceId = $instance->getKey();
         $this->tokenId = $token->getKey();

--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -36,9 +36,9 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param \ProcessMaker\Models\Process $definitions
-     * @param \ProcessMaker\Models\ProcessRequest $instance
-     * @param \ProcessMaker\Models\ProcessRequestToken $token
+     * @param Definitions $definitions
+     * @param ProcessRequest $instance
+     * @param ProcessRequestToken $token
      * @param array $data
      */
     public function __construct(Definitions $definitions, ProcessRequest $instance, ProcessRequestToken $token, array $data, $attemptNum = 1)
@@ -48,7 +48,6 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
         } else {
             $pmConfig = [];
         }
-        $this->onQueue($pmConfig['queue'] ?? 'bpmn');
         $this->definitionsId = $definitions->getKey();
         $this->instanceId = $instance->getKey();
         $this->tokenId = $token->getKey();

--- a/ProcessMaker/Jobs/ThrowSignalEvent.php
+++ b/ProcessMaker/Jobs/ThrowSignalEvent.php
@@ -73,7 +73,7 @@ class ThrowSignalEvent implements ShouldQueue
                     $chunk,
                     $this->signalRef,
                     $this->data
-                )->onQueue('bpmn');
+                );
             }
         }
         removeTemporalData($this->data_uid);

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerDefault.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerDefault.php
@@ -188,7 +188,7 @@ class WorkflowManagerDefault implements WorkflowManagerInterface
         Log::info('Dispatch a script task: ' . $scriptTask->getId() . ' #' . $token->getId());
         $instance = $token->processRequest;
         $process = $instance->process;
-        RunScriptTask::dispatch($process, $instance, $token, [])->onQueue('bpmn');
+        RunScriptTask::dispatch($process, $instance, $token, []);
     }
 
     /**
@@ -266,7 +266,7 @@ class WorkflowManagerDefault implements WorkflowManagerInterface
         $excludeProcesses = [$token->getInstance()->getModel()->process_id];
 
         $excludeRequests = $this->getCollaboratingInstanceIds($token->getInstance());
-        ThrowSignalEvent::dispatch($signalRef, $data, $excludeProcesses, $excludeRequests)->onQueue('bpmn');
+        ThrowSignalEvent::dispatch($signalRef, $data, $excludeProcesses, $excludeRequests);
     }
 
     /**
@@ -298,7 +298,7 @@ class WorkflowManagerDefault implements WorkflowManagerInterface
      */
     public function throwSignalEvent($signalRef, array $data = [], array $exclude = [])
     {
-        ThrowSignalEvent::dispatch($signalRef, $data, $exclude)->onQueue('bpmn');
+        ThrowSignalEvent::dispatch($signalRef, $data, $exclude);
     }
 
     /**
@@ -314,7 +314,7 @@ class WorkflowManagerDefault implements WorkflowManagerInterface
             $processId,
             $signalRef,
             $data
-        )->onQueue('bpmn');
+        );
     }
 
     /**
@@ -341,7 +341,7 @@ class WorkflowManagerDefault implements WorkflowManagerInterface
      */
     public function throwMessageEvent($instanceId, $elementId, $messageRef, array $payload = [])
     {
-        ThrowMessageEvent::dispatch($instanceId, $elementId, $messageRef, $payload)->onQueue('bpmn');
+        ThrowMessageEvent::dispatch($instanceId, $elementId, $messageRef, $payload);
     }
 
     /**

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerRabbitMq.php
@@ -275,7 +275,7 @@ class WorkflowManagerRabbitMq extends WorkflowManagerDefault implements Workflow
         // Log execution
         Log::info('Dispatch a service task: ' . $serviceTask->getId());
 
-        RunNayraServiceTask::dispatch($token)->onQueue('bpmn');
+        RunNayraServiceTask::dispatch($token);
     }
 
     /**

--- a/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
+++ b/ProcessMaker/Nayra/Repositories/PersistenceHandler.php
@@ -152,7 +152,7 @@ class PersistenceHandler
                     $token = $this->deserializer->unserializeToken($transaction['token']);
 
                     // Trigger script task executor
-                    RunNayraScriptTask::dispatch($token)->onQueue('bpmn');
+                    RunNayraScriptTask::dispatch($token);
                     break;
                 default:
                     throw new Exception('Unknown transaction type ' . $transaction['type']);

--- a/ProcessMaker/Providers/RecommendationsServiceProvider.php
+++ b/ProcessMaker/Providers/RecommendationsServiceProvider.php
@@ -29,7 +29,7 @@ class RecommendationsServiceProvider extends ServiceProvider
 
             // Dispatch the job to the low-priority queue
             if (RecommendationEngine::shouldGenerateFor($processRequestToken->user)) {
-                GenerateUserRecommendations::dispatch($processRequestToken->user_id)->onQueue('low');
+                GenerateUserRecommendations::dispatch($processRequestToken->user_id);
             }
         });
     }

--- a/ProcessMaker/Services/ScriptMicroserviceService.php
+++ b/ProcessMaker/Services/ScriptMicroserviceService.php
@@ -34,7 +34,7 @@ class ScriptMicroserviceService
             $instance = ProcessRequest::find($response['metadata']['script_task']['instance_id']);
             $token = ProcessRequestToken::find($response['metadata']['script_task']['token_id']);
             if ($response['status'] === 'success') {
-                CompleteActivity::dispatch($definitions, $instance, $token, $response['output'])->onQueue('bpmn');
+                CompleteActivity::dispatch($definitions, $instance, $token, $response['output']);
             }
         }
     }

--- a/upgrades/2022_04_19_164837_sanitize_usernames.php
+++ b/upgrades/2022_04_19_164837_sanitize_usernames.php
@@ -25,7 +25,7 @@ class SanitizeUsernames extends Upgrade
      *
      * @return void
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public function preflightChecks()
     {
@@ -39,13 +39,12 @@ class SanitizeUsernames extends Upgrade
      */
     public function up()
     {
-        DB::table('users')->select(['id','username'])->orderBy('id')->chunk(250,
+        DB::table('users')->select(['id', 'username'])->orderBy('id')->chunk(250,
             static function ($users) {
-                dispatch(new SanitizeUsernamesJob($users))->onQueue('high');
+                dispatch(new SanitizeUsernamesJob($users));
             }
         );
     }
-
 
     /**
      * Reverse the upgrade migrations.
@@ -57,4 +56,3 @@ class SanitizeUsernames extends Upgrade
         //
     }
 }
-


### PR DESCRIPTION
Remove dispatch to bpmn queue

## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
