### PR TITLE
FOUR-26122: Start email event is not reflected in Documentation

### DIFF
--- a/resources/js/processes/modeler/process-map.js
+++ b/resources/js/processes/modeler/process-map.js
@@ -1,17 +1,19 @@
 import Vue from "vue";
 import ProcessMap from "./components/ProcessMap.vue";
 
-window.ProcessMaker.i18nPromise.then(() => {
-  new Vue({
-    render: (h) => h(ProcessMap, {
-      props: {
-        enableTooltip: (window.document
-                          .getElementById("modeler-app")
-                          .getAttribute("enable-tooltip") ?? "true") === "true",
-        forDocumenting: (window.document
-                          .getElementById("modeler-app")
-                          .getAttribute("for-documenting") ?? "false") === "true",
-      },
-    }),
-  }).$mount("#modeler-app");
+window.addEventListener('load', () => {
+  window.ProcessMaker.i18nPromise.then(() => {
+    new Vue({
+      render: (h) => h(ProcessMap, {
+        props: {
+          enableTooltip: (window.document
+                            .getElementById("modeler-app")
+                            .getAttribute("enable-tooltip") ?? "true") === "true",
+          forDocumenting: (window.document
+                            .getElementById("modeler-app")
+                            .getAttribute("for-documenting") ?? "false") === "true",
+        },
+      }),
+    }).$mount("#modeler-app");
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
The emails start event should show its configuration in PDF documentation and preview documentation
## Solution
- update the code to support scripts with type module in package-ai
<img width="1726" height="933" alt="image" src="https://github.com/user-attachments/assets/a9d1a754-0791-4748-9083-1d1bbe1a8370" />

## How to Test
See the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26122

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-email-start-event:develop
