### PR TITLE
FOUR-26105: The Progress does not appear when a case starts from an Start Event

### DIFF
--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -85,16 +85,9 @@ class CasesController extends Controller
             $request->summary_screen = $request->getSummaryScreen();
         }
         // Stage information
-        if ($request->status === 'COMPLETED') {
-            $currentStages = [
-                'stage_name' => __('Completed'),
-            ];
-            $progressStage = 100.0; // 100% completed
-        } else {
-            $currentStages = $this->formatCurrentStage($request->last_stage_id, $request->last_stage_name);
-            $allStages = $this->getStagesByProcessId($request->process_id);
-            $progressStage = calculateProgressById($request->last_stage_id, $allStages);
-        }
+        $stageInfo = $this->getStageInfoByStatus($request);
+        $currentStages = $stageInfo['currentStages'];
+        $progressStage = $stageInfo['progressStage'];
         // Load the screen configured in "Request Detail Screen"
         $request->request_detail_screen = Screen::find($request->process->request_detail_screen_id);
         // The user canCancel if has the processPermission and the case has only one request
@@ -214,5 +207,53 @@ class CasesController extends Controller
         }
 
         return $currentStages;
+    }
+
+    /**
+     * Get stage information based on request status
+     *
+     * @param ProcessRequest $request
+     * @return array
+     */
+    private function getStageInfoByStatus(ProcessRequest $request): array
+    {
+        switch ($request->status) {
+            case 'COMPLETED':
+                return [
+                    'currentStages' => [
+                        'stage_name' => __('Completed'),
+                    ],
+                    'progressStage' => 100.0, // 100% completed
+                ];
+            case 'CANCELED':
+                return [
+                    'currentStages' => [
+                        'stage_name' => __('Canceled'),
+                    ],
+                    'progressStage' => 0.0, // 0% progress when canceled
+                ];
+            case 'ERROR':
+                return [
+                    'currentStages' => [
+                        'stage_name' => __('Error'),
+                    ],
+                    'progressStage' => 0.0, // 0% progress when error
+                ];
+            default:
+                $currentStages = $this->formatCurrentStage($request->last_stage_id, $request->last_stage_name);
+                $allStages = $this->getStagesByProcessId($request->process_id);
+                $progressStage = calculateProgressById($request->last_stage_id, $allStages);
+                if (empty($currentStages)) {
+                    $currentStages = [
+                        'stage_name' => __('In Progress'),
+                    ];
+                    $progressStage = 50.0;
+                }
+
+                return [
+                    'currentStages' => $currentStages,
+                    'progressStage' => $progressStage,
+                ];
+        }
     }
 }

--- a/resources/jscomposition/cases/casesDetail/components/StageBar.vue
+++ b/resources/jscomposition/cases/casesDetail/components/StageBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="percentage > 0 && title !== ''">
+  <div v-if="title !== ''">
     <span class="tw-text-[#3C3C3C] tw-font-sans tw-text-sm tw-font-normal tw-leading-normal tw-tracking-[-0.014em]">
       {{ title }}
     </span>


### PR DESCRIPTION
## Issue & Reproduction Steps
The Progress does not appear when a case starts from an Start Event

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26105

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-email-start-event:develop