### PR TITLE
FOUR-26201 It is not possible to start a case from the launchpad if the process contains an Email Start Event

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -332,14 +332,20 @@ class ProcessController extends Controller
         $currentUser = Auth::user();
         foreach ($process->start_events as $event) {
             if (count($event['eventDefinitions']) === 0) {
+                $isEmailStartEvent = false;
+
                 if (array_key_exists('config', $event)) {
-                    $webEntry = json_decode($event['config'])->web_entry;
+                    $config = json_decode($event['config']);
+                    $webEntry = $config->web_entry ?? null;
                     $event['webEntry'] = $webEntry;
+
+                    $isEmailStartEvent = is_object($config) && property_exists($config, 'email_start');
                 }
-                if (
-                    $this->checkUserCanStartProcess($event, $currentUser->id, $process, $request) ||
-                    Auth::user()->is_administrator
-                ) {
+
+                $canStart = $this->checkUserCanStartProcess($event, $currentUser->id, $process, $request);
+                $isAdmin = Auth::user()->is_administrator;
+
+                if (($canStart || $isAdmin) && !$isEmailStartEvent) {
                     $startEvents[] = $event;
                 }
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
It is not possible to start a case from the launchpad if the process contains an Email Start Event

## Solution
- Add an extra validation for email start events

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-26201](https://processmaker.atlassian.net/browse/FOUR-26201)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-26201]: https://processmaker.atlassian.net/browse/FOUR-26201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ