### PR TITLE
FOUR-25979 Label are not lost in alternative B

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -484,8 +484,6 @@ class ProcessController extends Controller
         $process->bpmn = $lastVersion->bpmn;
         $process->alternative = $lastVersion->alternative;
         $process->stages = $lastVersion->stages;
-        logger('update alternative:' .  json_encode($lastVersion->alternative));
-        logger('update stages:' .  json_encode($lastVersion->stages));
 
         $rules = Process::rules($process);
         if (!$request->has('name')) {
@@ -2083,6 +2081,7 @@ class ProcessController extends Controller
             $process->stages = $stages;
             $process->save();
         }
+
         return new ApiCollection($stages);
     }
 

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -483,6 +483,9 @@ class ProcessController extends Controller
         $lastVersion = $process->getDraftOrPublishedLatestVersion();
         $process->bpmn = $lastVersion->bpmn;
         $process->alternative = $lastVersion->alternative;
+        $process->stages = $lastVersion->stages;
+        logger('update alternative:' .  json_encode($lastVersion->alternative));
+        logger('update stages:' .  json_encode($lastVersion->stages));
 
         $rules = Process::rules($process);
         if (!$request->has('name')) {
@@ -2066,24 +2069,21 @@ class ProcessController extends Controller
         $stages = $request->input('stages');
 
         if ($alternative === 'B') {
-
-            // Get or create alternative B version
-            $alternativeVersion = ProcessVersion::where('process_id', $process->id)
+            ProcessVersion::where('process_id', $process->id)
                 ->where('alternative', 'B')
-                ->first();
-
-            // Save stages to alternative B version
-            $alternativeVersion->stages = $stages;
-            $alternativeVersion->save();
-
-            return new ApiCollection($alternativeVersion->stages);
+                ->update([
+                    'stages' => $stages,
+                ]);
         } else {
-            // Save stages to main process (alternative A)
+            ProcessVersion::where('process_id', $process->id)
+                ->where('alternative', 'A')
+                ->update([
+                    'stages' => $stages,
+                ]);
             $process->stages = $stages;
             $process->save();
-
-            return new ApiCollection($process->stages);
         }
+        return new ApiCollection($stages);
     }
 
     /**

--- a/ProcessMaker/Traits/HasVersioning.php
+++ b/ProcessMaker/Traits/HasVersioning.php
@@ -84,7 +84,10 @@ trait HasVersioning
             $alternative = $alternative ?: $this->alternative;
             $attributes['alternative'] = $alternative;
 
-            $processVersion = ProcessVersion::where('process_id', $this->id)->where('alternative', $attributes['alternative'])->first();
+            $processVersion = ProcessVersion::where('process_id', $this->id)
+                ->where('alternative', $attributes['alternative'])
+                ->where('draft', 1)
+                ->first();
             if ($processVersion) {
                 $attributes['stages'] = $processVersion->stages;
             }

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -74,10 +74,7 @@ const getHighlightedNode = () => getModeler().highlightedNode;
 const getDefinition = () => getHighlightedNode().definition;
 
 const saveProcess = () => {
-  console.log("saveProcess");
   window.$modelerApp?.autosaveApiCall?.();
-  //Index 0 implies that the component is in a loop; therefore, it will exist anyway, and its existence is validated.
-  //window.$modelerApp?.$refs["external-ModalSaveVersion"]?.[0]?.saveModal?.();
 }
 
 const getConfigFromDefinition = (definition) => {

--- a/resources/js/processes/modeler/components/inspector/StageManager.vue
+++ b/resources/js/processes/modeler/components/inspector/StageManager.vue
@@ -74,9 +74,10 @@ const getHighlightedNode = () => getModeler().highlightedNode;
 const getDefinition = () => getHighlightedNode().definition;
 
 const saveProcess = () => {
+  console.log("saveProcess");
   window.$modelerApp?.autosaveApiCall?.();
   //Index 0 implies that the component is in a loop; therefore, it will exist anyway, and its existence is validated.
-  window.$modelerApp?.$refs["external-ModalSaveVersion"]?.[0]?.saveModal?.();
+  //window.$modelerApp?.$refs["external-ModalSaveVersion"]?.[0]?.saveModal?.();
 }
 
 const getConfigFromDefinition = (definition) => {
@@ -152,6 +153,7 @@ const removeStageToFlow = () => {
 const onChange = (stages) => {
   updateStagesForAllFlowConfigs(stages);
   saveStagesToApi(stages);
+  saveProcess();
 };
 
 const onUpdate = (stages, index, val, Oldal) => {


### PR DESCRIPTION
 ## Description
- Steps to Reproduce Create a process
Add Start Event → Task form → End Event
Add new stages
Assign the stages in the flow
Create alternative B
Delete one alternative
Publish the changes
- Current Behavior Stage labels are not lost in both alternatives, this remain in alternative B
- Expected Behavior Stage labels should lost in both alternatives

 ## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-25979

ci:deploy
