### PR TITLE
FOUR-26170 This action is unauthorized message when logging in with a user without permissions

### DIFF
--- a/resources/js/tasks/components/ProcessesDashboardsMenu.vue
+++ b/resources/js/tasks/components/ProcessesDashboardsMenu.vue
@@ -133,9 +133,13 @@ export default {
     loadProcesses() {
       const url = this.buildURL();
 
-      ProcessMaker.apiClient.get(url).then((response) => {
-        this.processesList = this.processesList.concat(response.data.data);
-      });
+      ProcessMaker.apiClient.get(url)
+        .then((response) => {
+          this.processesList = this.processesList.concat(response.data.data);
+        })
+        .catch((error) => {
+          console.error(error);
+        });
     },
     loadDashboards() {
       try {


### PR DESCRIPTION
## Issue & Reproduction Steps
The error message is due to the user not having the `view-process-catalog` permission and the endpoint `process_bookmarks/processes/menu` is throwing an `Authorize` exception

<img width="2559" height="1268" alt="Screenshot 2025-09-04 at 4 01 36 PM" src="https://github.com/user-attachments/assets/4bd0c364-80b0-4fbe-ad8b-98f39b2ac2ed" />

## Solution
- Enhance the error handling by adding a console error instead of an alert message

https://github.com/user-attachments/assets/da302735-2e67-413f-96a7-e857cdf14b95

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
[FOUR-26170](https://processmaker.atlassian.net/browse/FOUR-26170)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-26170]: https://processmaker.atlassian.net/browse/FOUR-26170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ