### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,11 +109,11 @@
             "build": "8c08f440",
             "cicd-enabled": true,
             "custom": {
-                "package-ellucian-ethos": "1.19.5",
+                "package-ellucian-ethos": "1.19.7",
                 "package-plaid": "1.6.0",
                 "paypal-package": "dev-fall",
                 "pps-adsync": "dev-fall",
-                "ps_ethos": "dev-fall",
+                "ps_ethos": "dev-main",
                 "package-irisbank": "dev-fall",
                 "package-pinnacle": "1.0.9",
                 "package-esign": "dev-fall",


### PR DESCRIPTION
Claudia asked that we release these ethos changes before 4.15.7 so they have been published and CloudOps will install them manually where needed. This PR updates the versions for 4.15.7

https://github.com/ProcessMaker/package-ellucian-ethos/pull/137
https://github.com/ProcessMaker/ps_ethos/pull/6
https://github.com/ProcessMaker/ps_ethos/pull/6