### PR TITLE
FOUR-26094: When I click the stage name to edit it, the elements are misaligned in edit action

### DIFF
--- a/resources/js/processes/modeler/components/inspector/StageItem.vue
+++ b/resources/js/processes/modeler/components/inspector/StageItem.vue
@@ -13,9 +13,6 @@
           @input="onInput"
           @paste="onPaste"
         >
-        <small class="tw-text-gray-500 tw-text-xs">
-          {{ localName.length }}/200 {{ t('characters') }}
-        </small>
       </template>
       <template v-else>
         <div


### PR DESCRIPTION
## Issue & Reproduction Steps
When I click the stage name to edit it, the elements are misaligned.

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26094

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy