### PR TITLE
bugfix/FOUR-25165 Case Status still In-Progress in All-Cases Page After Terminate End Event Triggered by Boundary Signal

### DIFF
--- a/ProcessMaker/Jobs/TerminateRequestEndEvent.php
+++ b/ProcessMaker/Jobs/TerminateRequestEndEvent.php
@@ -40,5 +40,7 @@ class TerminateRequestEndEvent extends BpmnAction implements ShouldQueue
 
         $instance->status = 'COMPLETED';
         $instance->save();
+
+        CaseUpdateStatus::dispatchSync($instance);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Case Status still In-Progress in All-Cases Page After Terminate End Event Triggered by Boundary Signal

## Solution
Added a case sync status when a request end with a signal

## How to Test

Import the process attached - test_boundary_event (1).json 
Start a new case using the “Test boundary event” process.
Submit the first form that displays the Case Number.
On the next task, do not submit the form.
Start a second new case using the same “Test boundary event” process.
Submit the first form to proceed to the second task and submit it
Return to the All-Cases Page.
Observe the status for both cases:
The second case should show as Completed.
The first case still shows as In-Progress in the All-Cases view, but when opening the case details, it shows as Completed.


https://github.com/user-attachments/assets/81473a62-c2af-467a-809d-49fb26f6ad48



## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-25165

ci:deploy
