### PR TITLE
Add tenant-aware logging functionality

### DIFF
--- a/ProcessMaker/Logging/TenantAwareHandler.php
+++ b/ProcessMaker/Logging/TenantAwareHandler.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace ProcessMaker\Logging;
+
+use Illuminate\Support\Facades\Context;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\LogRecord;
+use Monolog\Formatter\LineFormatter;
+
+class TenantAwareHandler extends AbstractProcessingHandler
+{
+    private string $baseFilename;
+    private int $maxFiles;
+    private array $handlers = [];
+    
+    /**
+     * Create a new tenant-aware handler instance.
+     *
+     * @param string $filename
+     * @param int $maxFiles
+     * @param string $level
+     * @param bool $bubble
+     */
+    public function __construct(
+        string $filename,
+        int $maxFiles = 7,
+        $level = 'DEBUG',
+        bool $bubble = true
+    ) {
+        $this->baseFilename = $filename;
+        $this->maxFiles = $maxFiles;
+        
+        parent::__construct($level, $bubble);
+        
+        // Set default formatter
+        $this->setFormatter(new LineFormatter(
+            "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n",
+            'Y-m-d H:i:s',
+            true,
+            true
+        ));
+    }
+    
+    /**
+     * Handle a log record.
+     *
+     * @param LogRecord $record
+     * @return bool
+     */
+    public function handle(LogRecord $record): bool
+    {
+        // Get current tenant ID from context
+        $tenantId = Context::get('tenantId') ?? 'no-tenant';
+
+        // Get or create handler for this tenant
+        $handler = $this->getHandlerForTenant($tenantId);
+        
+        // Remove context from the log record (e.g. {"tenantId":1})
+        $record->extra = [];
+
+        return $handler->handle($record);
+    }
+    
+    /**
+     * Get handler for specific tenant.
+     *
+     * @param string $tenantId
+     * @return \Monolog\Handler\RotatingFileHandler
+     */
+    private function getHandlerForTenant(string $tenantId): \Monolog\Handler\RotatingFileHandler
+    {
+        if (!isset($this->handlers[$tenantId])) {
+            $filename = $this->getTenantFilename($tenantId);
+            
+            $this->handlers[$tenantId] = new \Monolog\Handler\RotatingFileHandler(
+                $filename,
+                $this->maxFiles,
+                $this->level,
+                $this->bubble
+            );
+            
+            $this->handlers[$tenantId]->setFormatter($this->getFormatter());
+        }
+        
+        return $this->handlers[$tenantId];
+    }
+    
+    /**
+     * Get tenant-specific filename.
+     *
+     * @param string $tenantId
+     * @return string
+     */
+    private function getTenantFilename(string $tenantId): string
+    {
+        $pathInfo = pathinfo($this->baseFilename);
+        $directory = $pathInfo['dirname'];
+        $filename = $pathInfo['filename'];
+        $extension = isset($pathInfo['extension']) ? '.' . $pathInfo['extension'] : '';
+
+        // Define the log directory
+        $logDir = $directory;
+        if (!is_dir($logDir)) {
+            mkdir($logDir, 0755, true);
+        }
+
+        // If tenant ID is no-tenant, return the base filename
+        if ($tenantId === 'no-tenant') {
+            return $logDir . '/' . $filename . $extension;
+        }
+        // Create tenant-specific filename
+        return $logDir . '/' . $filename . '_tenant_' . $tenantId . $extension;
+    }
+    
+    /**
+     * Write a log record.
+     *
+     * @param LogRecord $record
+     * @return void
+     */
+    protected function write(LogRecord $record): void
+    {
+        // This method is not used since we override handle()
+    }
+}

--- a/ProcessMaker/Logging/TenantAwareLogManager.php
+++ b/ProcessMaker/Logging/TenantAwareLogManager.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace ProcessMaker\Logging;
+
+use Illuminate\Log\LogManager;
+use Illuminate\Support\Facades\Context;
+
+class TenantAwareLogManager extends LogManager
+{
+    /**
+     * Get a log channel instance.
+     *
+     * @param  string|null  $channel
+     * @return \Psr\Log\LoggerInterface
+     */
+    public function channel($channel = null)
+    {
+        $channel = $channel ?: $this->getDefaultDriver();
+        
+        // If we're using the default channel and have tenant context, use tenant channel
+        if ($channel === $this->getDefaultDriver() && Context::get('tenantId')) {
+            return $this->get('tenant');
+        }
+        
+        return parent::channel($channel);
+    }
+    
+    /**
+     * Get the default log driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver()
+    {
+        return $this->app['config']['logging.default'];
+    }
+    
+    /**
+     * Create a custom log channel instance.
+     *
+     * @param  array  $config
+     * @return \Psr\Log\LoggerInterface
+     */
+    protected function createCustomDriver(array $config)
+    {
+        $driver = $config['driver'] ?? null;
+        
+        if ($driver === 'tenant-aware') {
+            return $this->createTenantAwareDriver($config);
+        }
+        
+        return parent::createCustomDriver($config);
+    }
+    
+    /**
+     * Create a tenant-aware driver.
+     *
+     * @param  array  $config
+     * @return \Psr\Log\LoggerInterface
+     */
+    protected function createTenantAwareDriver(array $config)
+    {
+        $tenantId = Context::get('tenantId') ?? 'no-tenant';
+        
+        // Create tenant-specific log path (use base_path to avoid tenant storage path issues)
+        $logPath = base_path("storage/logs/tenants/tenant_{$tenantId}.log");
+        
+        // Ensure the directory exists
+        $logDir = dirname($logPath);
+        if (!is_dir($logDir)) {
+            mkdir($logDir, 0755, true);
+        }
+        
+        // Create the logger with tenant-specific configuration
+        return $this->app->make('log')->build([
+            'driver' => 'daily',
+            'path' => $logPath,
+            'level' => $config['level'] ?? 'debug',
+            'days' => $config['days'] ?? 7,
+            'processors' => [
+                \Monolog\Processor\PsrLogMessageProcessor::class,
+                \ProcessMaker\Logging\TenantContextProcessor::class,
+            ],
+        ]);
+    }
+}

--- a/ProcessMaker/Providers/TenantLoggingServiceProvider.php
+++ b/ProcessMaker/Providers/TenantLoggingServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ProcessMaker\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use ProcessMaker\Logging\TenantAwareLogManager;
+
+class TenantLoggingServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        // Bind our custom LogManager
+        $this->app->singleton('log', function ($app) {
+            return new TenantAwareLogManager($app);
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/ProcessMaker/Repositories/SettingsConfigRepository.php
+++ b/ProcessMaker/Repositories/SettingsConfigRepository.php
@@ -118,7 +118,7 @@ class SettingsConfigRepository extends Repository
     {
         if (!$this->readyToUseSettingsDatabase) {
             $this->readyToUseSettingsDatabase =
-                app('tenant-resolved') &&
+                (!config('app.multitenancy') || app('tenant-resolved')) &&
                 $this->databaseAvailable() &&
                 $this->redisAvailable() &&
                 $this->settingsTableExists();

--- a/config/app.php
+++ b/config/app.php
@@ -183,6 +183,7 @@ return [
          * ProcessMaker Service Providers
          */
         ProcessMaker\Providers\ProcessMakerServiceProvider::class,
+        ProcessMaker\Providers\TenantLoggingServiceProvider::class,
         ProcessMaker\Providers\RecommendationsServiceProvider::class,
         ProcessMaker\Providers\AuthServiceProvider::class,
         ProcessMaker\Providers\EventServiceProvider::class,

--- a/config/logging.php
+++ b/config/logging.php
@@ -68,11 +68,16 @@ return [
         ],
 
         'daily' => [
-            'driver' => 'daily',
-            'path' => base_path('storage/logs/processmaker.log'),
-            'level' => env('LOG_LEVEL', 'debug'),
-            'days' => 7,
-            'replace_placeholders' => true,
+            'driver' => 'monolog',
+            'handler' => \ProcessMaker\Logging\TenantAwareHandler::class,
+            'handler_with' => [
+                'filename' => base_path('storage/logs/processmaker.log'),
+                'maxFiles' => 7,
+                'level' => env('LOG_LEVEL', 'debug'),
+            ],
+            'processors' => [
+                \Monolog\Processor\PsrLogMessageProcessor::class,
+            ],
         ],
 
         'slack' => [


### PR DESCRIPTION
## Add tenant-aware logging functionality

- Introduced TenantAwareHandler for handling logs specific to tenants.
- Created TenantAwareLogManager to manage log channels with tenant context.
- Implemented TenantLoggingServiceProvider to bind the custom log manager.
- Updated logging configuration to utilize the new tenant-aware handler.

## How to Test
- Test a Log on a tenant web server.
- Test a Log on a web server without without tenant.
- Also on terminal:
Test Log without tenant
```
php artisan tinker
\Log::info('test')
```

Test Log with tenant
```
TENTANT=1 php artisan tinker
\Log::info('test')
```

https://github.com/user-attachments/assets/d8392584-d377-4d42-883a-8dfce3ed3e44


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26245
