### PR TITLE
Add `package-sis-integrations` to composer.json custom package array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,8 @@
                 "package-accessibility": "1.0.0",
                 "package-zj-birmingham": "dev-main",
                 "package-tce": "dev-master",
-                "package-case-overview": "dev-main"
+                "package-case-overview": "dev-main",
+                "package-sis-integration": "dev-main"
             },
             "enterprise": {
                 "connector-docusign": "1.11.0",


### PR DESCRIPTION
This PR adds the missing package-sis-integrations entry into the custom package array in composer.json.
## Solution


## Related Tickets & Packages
- [FOUR-26447](https://processmaker.atlassian.net/browse/FOUR-26447)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-26447]: https://processmaker.atlassian.net/browse/FOUR-26447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

.