### PR TITLE
FOUR-26188 implement service to read YAML config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ storage/ssl
 storage/api/*
 storage/data-sources/logs/*
 storage/decision-tables/*
+storage/saved_search_advanced_configuration/*
 npm.sh
 laravel-echo-server.lock
 public/.htaccess

--- a/ProcessMaker/Multitenancy/SwitchTenant.php
+++ b/ProcessMaker/Multitenancy/SwitchTenant.php
@@ -76,6 +76,8 @@ class SwitchTenant implements SwitchTenantTask
             'filesystems.disks.samlidp.root' => storage_path('samlidp'),
             'filesystems.disks.decision_tables.root' => storage_path('decision-tables'),
             'filesystems.disks.decision_tables.url' => $tenant->config['app.url'] . '/storage/decision-tables',
+            'filesystems.disks.saved_search_advanced_configuration.root' => storage_path('saved_search_advanced_configuration'),
+            'filesystems.disks.decision_tables.url' => $tenant->config['app.url'] . '/storage/saved_search_advanced_configuration',
             'filesystems.disks.tenant_translations' => [
                 'driver' => 'local',
                 'root' => storage_path('lang'),

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -131,6 +131,13 @@ return [
         // Others declared in packages
         // - translations - package-translations
         // - 'filesystems.disks.install' configured on the fly
+
+        'saved_search_advanced_configuration' => [
+            'driver' => 'local',
+            'root' => storage_path('saved_search_advanced_configuration'),
+            'url' => env('APP_URL') . '/storage/saved_search_advanced_configuration',
+            'visibility' => 'private',
+        ],
     ],
 
     /*


### PR DESCRIPTION
## Issue & Reproduction Steps
### Implement a service to read YAML Config

## Related Tickets & Packages
[FOUR-26188](https://processmaker.atlassian.net/browse/FOUR-26188)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-savedsearch:FOUR-26188


[FOUR-26188]: https://processmaker.atlassian.net/browse/FOUR-26188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ