### PR TITLE
FOUR-26361: Allow upload text/plain mime type for CSV files.

### DIFF
--- a/config/files.php
+++ b/config/files.php
@@ -56,7 +56,7 @@ return [
         'ppt'  => ['application/vnd.ms-powerpoint'],
         'pptx' => ['application/vnd.openxmlformats-officedocument.presentationml.presentation'],
         'txt'  => ['text/plain'],
-        'csv'  => ['text/csv', 'application/csv'],
+        'csv'  => ['text/csv', 'application/csv', 'text/plain'],
 
         // Audio
         'jpg'  => ['image/jpeg'],


### PR DESCRIPTION
## Issue & Reproduction Steps
It's not possible to upload .csv files containing special characters from the public file manager.

Steps to Reproduce:
1. Have a .csv file with special characters in its data.
2. Log in to PM4.
3. Navigate to Admin > File Manager.
4. Try to upload the file.

## Solution
- Added the text/plain mimeType to the list of allowed MIME types for the .csv file extension in the config/files.php file.

## How to Test
Attempt to upload a .csv file containing special characters to the file manager. The file should upload successfully.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26361

## Code Review Checklist
- [ x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ x] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy