### PR TITLE
FOUR-26293 The interstitial screen is not assigned by default in a start event

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -83,8 +83,15 @@ class ScreenController extends Controller
     {
         $exclusions = ($request->input('exclude', '') ? explode(',', $request->input('exclude', '')) : []);
 
-        $query = Screen::nonSystem()
-            ->leftJoin('screen_categories as category', 'screens.screen_category_id', '=', 'category.id')
+        // Get main query instance
+        $query = Screen::query();
+
+        // Include system srceens if is requested
+        if (!$request->filled('include_system')) {
+            $query->nonSystem();
+        }
+
+        $query->leftJoin('screen_categories as category', 'screens.screen_category_id', '=', 'category.id')
             ->when($request->has('exclude'), function ($query) use ($exclusions) {
                 $query->exclude($exclusions);
             })

--- a/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScreenSelect.vue
@@ -159,6 +159,7 @@ export default {
       const params = {
         type: this.type(),
         interactive: this.interactive(),
+        include_system: 1,
         order_direction: "asc",
         status: "active",
         selectList: true,
@@ -187,6 +188,7 @@ export default {
       ProcessMaker.apiClient
         .get("screens", { params: { 
           key: this.defaultKey,
+          include_system: 1,
           order_by: "id",
           order_direction: "ASC",
           per_page: 1,


### PR DESCRIPTION
## Issue & Reproduction Steps
The default interstitial screen is not displayed in the select list in inspector component

## Solution
Now the system screens also are displayed in the list from the inspector component

## How to Test
1. Create a process
2. Add a start event
3. Click Configuration

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-26293

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
