### PR TITLE
FOUR-26546:Arrows are not displayed in the carousel when Process information is opened

### DIFF
--- a/resources/js/processes-catalogue/components/CarouselSlide.vue
+++ b/resources/js/processes-catalogue/components/CarouselSlide.vue
@@ -3,8 +3,23 @@
     <b-carousel
       ref="carousel"
       :interval="0"
-      controls
     >
+      <div class="tw-flex tw-content-stretch tw-absolute tw-w-full tw-z-10 tw-top-1/2 tw-flex-wrap">
+        <button
+          class="tw-content-center tw-grow tw-left-0 tw-absolute tw-bg-transparent tw-color-[#556271] tw-text-xl"
+          aria-hidden="false"
+          @click="prevSlide()"
+        >
+          <i class="fas fa-caret-left" />
+        </button>
+        <button
+          class="tw-content-center tw-grow tw-right-0 tw-absolute tw-bg-transparent tw-color-[#556271] tw-text-xl"
+          aria-hidden="false"
+          @click="nextSlide()"
+        >
+          <i class="fas fa-caret-right" />
+        </button>
+      </div>
       <b-carousel-slide
         v-for="(image, index) in images.length > 0 ? images : defaultImage"
         :key="index"
@@ -68,6 +83,12 @@ export default {
     );
   },
   methods: {
+    prevSlide() {
+      this.$refs.carousel.prev();
+    },
+    nextSlide() {
+      this.$refs.carousel.next();
+    },
     resizeCarousel(url, index) {
       this.fullPage = !this.fullPage;
       this.$emit("full-carousel", {

--- a/resources/js/processes-catalogue/components/CarouselSlide.vue
+++ b/resources/js/processes-catalogue/components/CarouselSlide.vue
@@ -3,18 +3,17 @@
     <b-carousel
       ref="carousel"
       :interval="0"
+      class="carousel"
     >
-      <div class="tw-flex tw-content-stretch tw-absolute tw-w-full tw-z-10 tw-top-1/2 tw-flex-wrap">
+      <div class="controls tw-flex tw-content-stretch tw-absolute tw-w-full tw-z-10 tw-top-1/2 tw-flex-wrap">
         <button
           class="tw-content-center tw-grow tw-left-0 tw-absolute tw-bg-transparent tw-color-[#556271] tw-text-xl"
-          aria-hidden="false"
           @click="prevSlide()"
         >
           <i class="fas fa-caret-left" />
         </button>
         <button
           class="tw-content-center tw-grow tw-right-0 tw-absolute tw-bg-transparent tw-color-[#556271] tw-text-xl"
-          aria-hidden="false"
           @click="nextSlide()"
         >
           <i class="fas fa-caret-right" />
@@ -101,6 +100,12 @@ export default {
 </script>
 
 <style scoped>
+.controls {
+  display: none;
+}
+.carousel:hover .controls {
+  display: block;
+}
 .carousel-normal {
   width: 100%;
   height: auto;


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Go to server https://carlos.qa.processmaker.net/ or https://develop-qa.processmaker.net/
2. Create a simple process (start event - task - end event)
3. Publish the process
4. Add some images in the carousel in the launchpad
5. Press processes menu
6. Search the created process 
7. Open the process
8. Press i button to open the process info

**Current Behavior:**
Images are displaying. However, the arrows are not displayed 

**Expected Behavior:**
The arrows should be displayed.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26546

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

.