### PR TITLE
FOUR-26562 FIX Process variable, not assigned to the user by its ID

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -773,8 +773,8 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         $dataManager = new DataManager();
         $instanceData = $dataManager->getData($token);
 
-        $assignedUsers = $usersVariable ? Arr::get($instanceData, $usersVariable) : [];
-        $assignedGroups = $groupsVariable ? Arr::get($instanceData, $groupsVariable) : [];
+        $assignedUsers = $usersVariable ? feelExpression($usersVariable, $instanceData) : [];
+        $assignedGroups = $groupsVariable ? feelExpression($groupsVariable, $instanceData) : [];
 
         if (!is_array($assignedUsers)) {
             $assignedUsers = [$assignedUsers];

--- a/helpers.php
+++ b/helpers.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Auth;
 use Laravel\Horizon\Repositories\RedisJobRepository;
 use ProcessMaker\Events\MarkArtisanCachesAsInvalid;
+use ProcessMaker\Models\FormalExpression;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\SanitizeHelper;
 use ProcessMaker\Support\JsonOptimizer;
@@ -357,5 +358,22 @@ if (!function_exists('json_optimize_decode')) {
     function json_optimize_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
     {
         return JsonOptimizer::decode($json, $assoc, $depth, $options);
+    }
+}
+
+if (!function_exists('feelExpression')) {
+    /**
+     * Evaluate a BPMN FEEL expression
+     *
+     * @param string $expression
+     * @param array $data
+     * @return mixed
+     */
+    function feelExpression(string $expression, array $data)
+    {
+        $formalExp = new FormalExpression();
+        $formalExp->setLanguage('FEEL');
+        $formalExp->setBody($expression);
+        return $formalExp($data);
     }
 }

--- a/tests/Feature/Api/TaskAssignmentByVariableTest.php
+++ b/tests/Feature/Api/TaskAssignmentByVariableTest.php
@@ -250,6 +250,26 @@ class TaskAssignmentByVariableTest extends TestCase
         $this->assertEquals($users->first()->id, $task->user_id);
     }
 
+    public function testProcessVariableAssignmentWithLiteralId()
+    {
+        // Create users of a group and a user without group
+        $user = User::factory()->create(['status'=>'ACTIVE']);
+        $group = $this->createGroup(5);
+        $process = $this->createProcess('process_variable', $user->id, $group->id, '', false);
+
+        // The first assignment should be to user (is the first created user)
+        $response = $this->startTestProcess($process, []);
+        $requestId = $response['id'];
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
+        $this->assertEquals($user->id, $task->user_id);
+
+        // The second assignment should be to the first user of the created group
+        $response = $this->startTestProcess($process, []);
+        $requestId = $response['id'];
+        $task = ProcessRequestToken::where(['process_request_id' => $requestId, 'status' => 'ACTIVE'])->firstOrFail();
+        $this->assertEquals($group->users->first()->id, $task->user_id);
+    }
+
     /**
      * Creates a process in which the assignment of the first task is configured based on the parameters of this function
      *


### PR DESCRIPTION
## Issue & Reproduction Steps
Assignment by process variable is not working with literal values.

## Solution
- Use FEEL instead of Array::get() to evaluate the assignments.

## How to Test
- Import or create a process with a Task assigned by variable
- Use a Literal User ID for the assignment, ex: `3`
- Run the process

https://github.com/user-attachments/assets/14dc83dd-4feb-4fe8-8fa6-0998e6d00989

**Attached process**:
[task_assignment_by_variable.json](https://github.com/user-attachments/files/22371583/task_assignment_by_variable.json)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26562

...