### PR TITLE
Reset encrypter after setting tenant app key

### DIFF
--- a/ProcessMaker/Multitenancy/SwitchTenant.php
+++ b/ProcessMaker/Multitenancy/SwitchTenant.php
@@ -113,6 +113,9 @@ class SwitchTenant implements SwitchTenantTask
         }
         config($config);
 
+        // The previous app key was saved in the singleton, so we need to forget it.
+        $app->forgetInstance('encrypter');
+
         // Extend BroadcastManager to our custom implementation that prefixes the channel names with the tenant id.
         $app->extend(BroadcastManager::class, function ($manager, $app) use ($tenant) {
             return new TenantAwareBroadcastManager($app, $tenant->id);


### PR DESCRIPTION
## Issue & Reproduction Steps
Unable to decrypt values in MT

## Solution
- Reset the encrypter after the app key is set for the tenant

## How to Test
- try installing the slack connector or run a script an look at the logs to make sure the env's are decripted

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26610

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
