### PR TITLE
Rebuild config cache when settings change

### DIFF
--- a/ProcessMaker/Jobs/RefreshArtisanCaches.php
+++ b/ProcessMaker/Jobs/RefreshArtisanCaches.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Artisan;
 
 class RefreshArtisanCaches implements ShouldQueue
@@ -25,6 +26,16 @@ class RefreshArtisanCaches implements ShouldQueue
     }
 
     /**
+     * Debounce when multiple Settings are saved at the same time
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [(new WithoutOverlapping('refresh_artisan_caches'))->dontRelease()];
+    }
+
+    /**
      * Execute the job.
      *
      * @return void
@@ -38,12 +49,7 @@ class RefreshArtisanCaches implements ShouldQueue
 
         if (app()->configurationIsCached()) {
             Artisan::call('config:cache', $options);
-        } else {
-            Artisan::call('queue:restart', $options);
-
-            // We call this manually here since this job is dispatched
-            // automatically when the config *is* cached
-            RestartMessageConsumers::dispatchSync();
         }
+        Artisan::call('queue:restart', $options);
     }
 }

--- a/ProcessMaker/Observers/SettingObserver.php
+++ b/ProcessMaker/Observers/SettingObserver.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Observers;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use ProcessMaker\Cache\Settings\SettingCacheFactory;
+use ProcessMaker\Jobs\RefreshArtisanCaches;
 use ProcessMaker\Models\Setting;
 
 class SettingObserver
@@ -89,5 +90,7 @@ class SettingObserver
         // Invalidate the setting cache
         $key = $settingCache->createKey(['key' => $setting->key]);
         $settingCache->invalidate(['key' => $key]);
+
+        RefreshArtisanCaches::dispatch();
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
See comments in https://processmaker.atlassian.net/browse/FOUR-26641

## Solution
- Rebuild the config cache and restart queue workers when settings change

## How to Test
See jira issues

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26641

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
