### PR TITLE
Bugfix/FOUR-25971: Add a processmaker phone number or an IT email to Reset Password Email Notification

### DIFF
--- a/ProcessMaker/Notifications/ResetPassword.php
+++ b/ProcessMaker/Notifications/ResetPassword.php
@@ -21,6 +21,6 @@ class ResetPassword extends LaravelResetPassword
             ->line(Lang::get('You are receiving this email because we received a password reset request for your account.'))
             ->action(Lang::get('Reset Password'), $url)
             ->line(Lang::get('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.' . config('auth.defaults.passwords') . '.expire')]))
-            ->line(Lang::get('If you did not request a password reset, please call us.'));
+            ->line(Lang::get('If you did not request a password reset, please call us at support@processmaker.com'));
     }
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1064,7 +1064,7 @@
   "If the expression evaluates to true, create or update the following variable": "If the expression evaluates to true, create or update the following variable",
   "If the FEEL Expression evaluates to true then": "If the FEEL Expression evaluates to true then",
   "If you believe this is an error, please contact the system administrator or support team for assistance.": "If you believe this is an error, please contact the system administrator or support team for assistance.",
-  "If you did not request a password reset, please call us.": "If you did not request a password reset, please call us.",
+  "If you did not request a password reset, please call us at support@processmaker.com": "If you did not request a password reset, please call us at support@processmaker.com",
   "If you do, you won’t be able to recover the Calc configuration.": "If you do, you won’t be able to recover the Calc configuration.",
   "If you want to establish an automatic submit for this rule,": "If you want to establish an automatic submit for this rule,",
   "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:",


### PR DESCRIPTION
## Issue & Reproduction Steps

- On login page, click on forgot password option.
- Enter de email address
- Receive the email notification to reset the password

**Current Behavior:**
It does not have neither phone number nor email to contact processmaker

**Acceptance criteria**
The email should end with: "If you did not request a password reset, please contact us at support@processmaker.com"

## Solution
- Add support email in reset password email


https://github.com/user-attachments/assets/d1dd83d2-51b8-4a78-b75b-81bea1bfa633



## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- [FOUR-25971](https://processmaker.atlassian.net/browse/FOUR-25971)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-25971]: https://processmaker.atlassian.net/browse/FOUR-25971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ