### PR TITLE
FOUR-26751: Make the dangerous_extensions verification configurable

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -450,15 +450,17 @@ class ProcessRequestFileController extends Controller
     private function validateFile(UploadedFile $file, &$errors)
     {
         // Explicitly reject archive files for security
-        $this->rejectArchiveFiles($file, $errors);
+        if (config('files.enable_dangerous_validation')) {
+            $this->rejectArchiveFiles($file, $errors);
+        }
 
         // Validate file extension if enabled
-        if (config('files.enable_extension_validation', true)) {
+        if (config('files.enable_extension_validation')) {
             $this->validateFileExtension($file, $errors);
         }
 
         // Validate MIME type vs extension if enabled
-        if (config('files.enable_mime_validation', true)) {
+        if (config('files.enable_mime_validation')) {
             $this->validateExtensionMimeTypeMatch($file, $errors);
         }
 

--- a/config/files.php
+++ b/config/files.php
@@ -74,6 +74,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Enable DANGEROUS Validation
+    |--------------------------------------------------------------------------
+    |
+    | Whether to enable dangerous file validation that checks against
+    |
+    */
+    'enable_dangerous_validation' => env('ENABLE_DANGEROUS_VALIDATION', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Enable MIME Type Validation
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Issue & Reproduction Steps
Make the dangerous_extensions verification configurable

## Solution
Per default all is true.
In order to disable the validation add those in the .env

```
ENABLE_DANGEROUS_VALIDATION=false
ENABLE_MIME_VALIDATION=false
ENABLE_EXTENSION_VALIDATION=false
```

## How to Test
```
'dangerous_extensions' => [
        'zip', 'rar', '7z', 'tar', 'gz', 'bz2', 'xz', 'lzma',
        'cab', 'ar', 'iso', 'dmg', 'pkg', 'deb', 'rpm',
    ],
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26751

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:ENABLE_DANGEROUS_VALIDATION=false
ci:ENABLE_MIME_VALIDATION=false
ci:ENABLE_EXTENSION_VALIDATION=false