### PR TITLE
FOUR-26791 Implement Message data mapping from Throw to Catch Events

### DIFF
--- a/ProcessMaker/Models/MessageEventDefinition.php
+++ b/ProcessMaker/Models/MessageEventDefinition.php
@@ -48,6 +48,6 @@ class MessageEventDefinition extends Base
             }
         }
 
-        return $this;
+        return parent::execute($event, $target, $targetRequest, $token);
     }
 }


### PR DESCRIPTION
## Implement Message data mapping from Throw to Catch Events

Send data from sub-process using `Intermediate Message Event C` to parent process on Boundary Event at `Call-Activity A`.

<img width="652" height="548" alt="image" src="https://github.com/user-attachments/assets/3d81f146-f76a-4f6d-b5f6-5691ee5f7349" />

## Related ticket
- https://processmaker.atlassian.net/browse/FOUR-26791

ci:modeler:bugfix/FOUR-27021
ci:nayra:feature/FOUR-26791

ci:deploy
