### PR TITLE
Add smart-extract to enterprise array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -173,6 +173,7 @@
                 "package-rpa": "1.1.1",
                 "package-savedsearch": "1.43.4",
                 "package-slideshow": "1.4.3",
+                "package-smart-extract": "0.0.2",
                 "package-signature": "1.15.2",
                 "package-testing": "1.8.1",
                 "package-translations": "2.14.4",


### PR DESCRIPTION
This PR updates the enterprise array to include package-smart-extract, ensuring the package is automatically installed across all servers.