### PR TITLE
FOUR-24942: The Default Icon is not centered on the LaunchPad icon

### DIFF
--- a/resources/js/components/shared/IconDropdown.vue
+++ b/resources/js/components/shared/IconDropdown.vue
@@ -134,7 +134,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 $iconSize: 19px;
 $multiselect-height: 33px;
 
@@ -223,7 +223,7 @@ $multiselect-height: 33px;
   .icon-selected {
     width: 19px;
     height: 19px;
-    margin-top: -4px;
+    margin-top: 0;
   }
 
   .icon-squares {

--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -1275,11 +1275,7 @@ label {
     text-align: left;
   }
 }
-.multiselect-icons.custom-multiselect {
-  .icon-selected {
-    margin-top: 0;
-  }
-}
+
 .modal-content-custom .column-container {
   overflow-y: auto;
 }

--- a/resources/js/components/shared/LaunchpadSettingsModal.vue
+++ b/resources/js/components/shared/LaunchpadSettingsModal.vue
@@ -1275,6 +1275,11 @@ label {
     text-align: left;
   }
 }
+.multiselect-icons.custom-multiselect {
+  .icon-selected {
+    margin-top: 0;
+  }
+}
 .modal-content-custom .column-container {
   overflow-y: auto;
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

In the LaunchPad process settings, the **Default Icon** is not centered within the LaunchPad select box, as shown in the attached image.

**Steps to Reproduce:**
1. Open LaunchPad process settings.
2. Observe the Default Icon inside the LaunchPad select box.
3. Notice that the icon is misaligned and not centered.

**Expected Behavior:**  
The Default Icon image must be displayed in the center of the select box in the LaunchPad icon field.

## Solution
- Updated the CSS for the multiselect icons component

Before:
<img width="390" height="78" alt="before" src="https://github.com/user-attachments/assets/cdfb3e34-5850-4a85-818b-fe8887133e4f" />

After:
<img width="390" height="78" alt="after" src="https://github.com/user-attachments/assets/0f6f6aed-b047-441c-a208-85f7bdaa1872" />

## How to Test
How to Test
1. Open LaunchPad process settings.
2. Verify that the Default Icon is displayed and now centered within the LaunchPad combo box.
3. Compare with the previous misaligned state (see attached image).
4. Confirm no regressions occur in other areas using .multiselect-icons.custom-multiselect.

## Related Tickets & Packages
- [FOUR-24942](https://processmaker.atlassian.net/browse/FOUR-24942)

ci:deploy

[FOUR-24942]: https://processmaker.atlassian.net/browse/FOUR-24942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ