### PR TITLE
Fix error when dependent screen is missing

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ScreenExporter.php
@@ -97,11 +97,12 @@ class ScreenExporter extends ExporterBase
         $screenFinder = new ScreensInScreen();
         foreach ($screenFinder->referencesToExport($this->model, [], null, false) as $screen) {
             try {
-                $screen = Screen::find($screen[1]);
+                $screenId = $screen[1];
+                $screen = Screen::find($screenId);
                 if ($screen) {
                     $screens[] = $screen;
                 } else {
-                    \Log::debug("NestedScreen screenId: $screen[1] not exists");
+                    \Log::debug("NestedScreen screenId: $screenId not exists");
                 }
             } catch (ModelNotFoundException $error) {
                 \Log::error($error->getMessage());

--- a/tests/Feature/ImportExport/Exporters/ScreenExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ScreenExporterTest.php
@@ -330,4 +330,28 @@ class ScreenExporterTest extends TestCase
         $newInterstitial = Screen::where('title', 'Default Interstitial 2')->firstOrFail();
         $this->assertNull($newInterstitial->key);
     }
+
+    public function testExportScreenWithMissingDependentScreen()
+    {
+        $screen = Screen::factory()->create([
+            'title' => 'Screen with missing dependent screen',
+            'key' => 'screen',
+            'config' => [
+                ['items' => [
+                    ['component' => 'FormNestedScreen', 'config' => ['screen' => 9999999999]],
+                ]],
+            ],
+        ]);
+
+        $exporter = new Exporter();
+        $exporter->exportScreen($screen);
+        $payload = $exporter->payload();
+
+        $screens = Arr::where($payload['export'], function ($value) {
+            return $value['type'] === 'Screen';
+        });
+
+        $this->assertCount(1, $screens);
+        $this->assertEquals($screen->uuid, Arr::first($screens)['attributes']['uuid']);
+    }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
When importing a screen via devlink we get a 500 error when a dependent screen is missing

## Solution
- Ignore missing dependent screen instead of throwing an error

## How to Test
- Have a screen with a missing nested screen
- Try to export a process that uses the main screen

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-27169

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
