### PR TITLE
Refresh config cache in synchronously

### DIFF
--- a/ProcessMaker/Jobs/RefreshArtisanCaches.php
+++ b/ProcessMaker/Jobs/RefreshArtisanCaches.php
@@ -10,35 +10,9 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Artisan;
 
-class RefreshArtisanCaches implements ShouldQueue, ShouldBeUnique
+class RefreshArtisanCaches implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
-
-    public $tries = 2; // One extra try to handle the debounce release
-
-    public $queuedAt;
-
-    /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->queuedAt = time();
-    }
-
-    /**
-     * Debounce when multiple Settings are saved at the same time
-     *
-     * @return array<int, object>
-     */
-    public function middleware(): array
-    {
-        return [
-            (new WithoutOverlapping('refresh_artisan_caches'))->dontRelease(),
-        ];
-    }
 
     /**
      * Execute the job.
@@ -51,13 +25,6 @@ class RefreshArtisanCaches implements ShouldQueue, ShouldBeUnique
         // meaning we loose transactions, and sets the console output verbosity
         // to quiet so we loose expectsOutput assertions.
         if (app()->environment('testing')) {
-            return;
-        }
-
-        // Wait 3 seconds before running the job - debounce
-        if ($this->queuedAt && $this->queuedAt >= time() - 3) {
-            $this->release(3);
-
             return;
         }
 

--- a/ProcessMaker/Observers/SettingObserver.php
+++ b/ProcessMaker/Observers/SettingObserver.php
@@ -10,6 +10,8 @@ use ProcessMaker\Models\Setting;
 
 class SettingObserver
 {
+    private static $added_refresh_artisan_caches = false;
+
     /**
      * Handle the setting "created" event.
      *
@@ -91,6 +93,19 @@ class SettingObserver
         $key = $settingCache->createKey(['key' => $setting->key]);
         $settingCache->invalidate(['key' => $key]);
 
-        RefreshArtisanCaches::dispatch();
+        // Check to see if we already added the refresh to the app's terminating queue.
+        // This is important for install commands when multiple settings are being created/updated.
+        if (self::$added_refresh_artisan_caches) {
+            return;
+        }
+
+        // Use app()->terminating to ensure the cache is refreshed after the settings have been saved.
+        app()->terminating(function () {
+            // Do this synchronously so we dont have to wait after settings have been saved.
+            // This command runs pretty fast and only when an admin is updating settings.
+            RefreshArtisanCaches::dispatchSync();
+        });
+
+        self::$added_refresh_artisan_caches = true;
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
With the complicated debounce logic we added the admin user would need to wait for the queued job to run before testing that the setting worked. Since this is a relatively quick command and only runs when the admin user is updating a setting, we can run it synchronously.

## Solution
- Remove queued job debounce logic
- Run with dispatchSync

## How to Test
Change a setting and ensure it's immediately updated.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-27150

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
