### PR TITLE
[Regression] SAML admin users prompted for password when updating user details

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -773,6 +773,7 @@
   "Element is not connected": "Element is not connected",
   "Element": "Element",
   "Email Address": "Email Address",
+  "Email address for users created via SAML synchronization cannot be edited manually.": "Email address for users created via SAML synchronization cannot be edited manually.",
   "Email": "Email",
   "Embed Media": "Embed Media",
   "Embed URL": "Embed URL",

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -478,9 +478,16 @@
             }
             return true
           },
+
           profileUpdate($event) {
-            if(this.emailHasChanged && !this.ssoUser) {
-              $('#validateModal').modal('show');
+            if (this.emailHasChanged) {
+              if (this.ssoUser) {
+                let message = 'Email address for users created via SAML synchronization cannot be edited manually.';
+                ProcessMaker.alert(this.$t($message), 'warning');
+                return;
+              } else {
+                $('#validateModal').modal('show');
+              }
             } else {
               this.saveProfileChanges();
             }

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -483,7 +483,7 @@
             if (this.emailHasChanged) {
               if (this.ssoUser) {
                 let message = 'Email address for users created via SAML synchronization cannot be edited manually.';
-                ProcessMaker.alert(this.$t($message), 'warning');
+                ProcessMaker.alert(this.$t(message), 'warning');
                 return;
               } else {
                 $('#validateModal').modal('show');

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -192,8 +192,14 @@
                   modalVueInstance.$refs.updateAvatarModal.show();
                 },
                 profileUpdate() {
-                  if(this.emailHasChanged && !this.ssoUser) {
-                    $('#validateModal').modal('show');
+                  if(this.emailHasChanged) {
+                    if (this.ssoUser) {
+                      let message = 'Email address for users created via SAML synchronization cannot be edited manually.';
+                      ProcessMaker.alert(this.$t($message), 'warning');
+                      return;
+                    } else {
+                      $('#validateModal').modal('show');
+                    }
                   } else {
                     this.saveProfileChanges();
                   }

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -195,7 +195,7 @@
                   if(this.emailHasChanged) {
                     if (this.ssoUser) {
                       let message = 'Email address for users created via SAML synchronization cannot be edited manually.';
-                      ProcessMaker.alert(this.$t($message), 'warning');
+                      ProcessMaker.alert(this.$t(message), 'warning');
                       return;
                     } else {
                       $('#validateModal').modal('show');


### PR DESCRIPTION
## Issue & Reproduction Steps
The page will ask you for a user's unknown password when admin edits the email information

## Solution
- Implement SAML email edit restriction alert in user profile updates

## How to Test
Password Confirmation should not be displayed for imported users from AD and SAML. The following message should be shown: "Email address for users created via SAML synchronization cannot be edited manually."

[recording.webm](https://github.com/user-attachments/assets/7e8cb57f-d2f7-4a86-8e6c-bcc5049a9bf2)


ci:deploy

## Related Tickets & Packages
- [FOUR-26588](https://processmaker.atlassian.net/browse/FOUR-26588)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-26588]: https://processmaker.atlassian.net/browse/FOUR-26588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ