### PR TITLE
Server Version Disclosure On Error Page

### DIFF
--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -27,6 +27,7 @@ class Kernel extends HttpKernel
         ServerTimingMiddleware::class,
         Middleware\FileSizeCheck::class,
         Middleware\AddTenantHeaders::class,
+        Middleware\HideServerHeaders::class,
     ];
 
     /**

--- a/ProcessMaker/Http/Middleware/HideServerHeaders.php
+++ b/ProcessMaker/Http/Middleware/HideServerHeaders.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class HideServerHeaders
+{
+    /**
+     * Headers that reveal server information and should be removed
+     *
+     * @var array
+     */
+    private $headersToRemove = [
+        // Server identification
+        'Server',
+        'X-Powered-By',
+        'X-AspNet-Version',
+        'X-AspNetMvc-Version',
+
+        // Web technologies and frameworks
+        'X-Generator',
+        'X-Drupal-Cache',
+        'X-Varnish',
+        'X-Cache',
+        'X-Cache-Hits',
+        'X-Framework',
+
+        // Load balancer and proxy information
+        'X-Forwarded-For',
+        'X-Real-IP',
+        'X-Forwarded-Proto',
+        'X-Forwarded-Host',
+        'X-Forwarded-Server',
+        'X-Forwarded-Port',
+
+        // Additional server information
+        'X-Served-By',
+        'X-Cache-Status',
+        'X-Served-From',
+        'X-Content-Source',
+        'X-Request-ID',
+        'X-Request-Id',
+
+        // PHP specific headers
+        'X-PHP-Version',
+        'X-PHP-Originating-Script',
+
+        // Development and debugging headers
+        'X-Debug-Token',
+        'X-Debug-Token-Link',
+        'X-Symfony-Cache',
+    ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        // Only remove headers in production or when explicitly configured
+        if ($this->shouldHideHeaders()) {
+            // Remove all server-revealing headers
+            foreach ($this->headersToRemove as $header) {
+                $response->headers->remove($header);
+            }
+
+            // Set a generic server header to avoid revealing the absence
+            $response->headers->set('Server', 'Web Server');
+        }
+
+        return $response;
+    }
+
+    /**
+     * Determine if headers should be hidden based on environment
+     *
+     * @return bool
+     */
+    private function shouldHideHeaders(): bool
+    {
+        // Hide headers in production or when explicitly configured
+        return app()->environment('production') ||
+               config('app.hide_server_headers', false);
+    }
+}

--- a/ProcessMaker/Http/Middleware/HideServerHeaders.php
+++ b/ProcessMaker/Http/Middleware/HideServerHeaders.php
@@ -41,8 +41,6 @@ class HideServerHeaders
         'X-Cache-Status',
         'X-Served-From',
         'X-Content-Source',
-        'X-Request-ID',
-        'X-Request-Id',
 
         // PHP specific headers
         'X-PHP-Version',
@@ -71,7 +69,7 @@ class HideServerHeaders
             }
 
             // Set a generic server header to avoid revealing the absence
-            $response->headers->set('Server', 'Web Server');
+            $response->headers->set('Server', 'ProcessMaker Server');
         }
 
         return $response;

--- a/config/app.php
+++ b/config/app.php
@@ -41,6 +41,9 @@ return [
     // The timeout length for API calls, in milliseconds (0 for no timeout)
     'api_timeout' => env('API_TIMEOUT', 5000),
 
+    // Hide server headers for security (prevents information disclosure)
+    'hide_server_headers' => env('HIDE_SERVER_HEADERS', true),
+
     // Disables PHP execution in the storage directory
     // TODO Is this config value still used anywhere? :)
     'disable_php_upload_execution' => env('DISABLE_PHP_UPLOAD_EXECUTION', 0),


### PR DESCRIPTION
=## Issue & Reproduction Steps
Server Version Disclosure On Error Page

## Solution
- Add middleware hide server headers

## How to Test
Review the headers returned by requests to ensure they do not contain relevant information about the server or the technologies used.

Note:
Since this is a change that involves all endpoints, it is suggested that a full test be performed, checking that when the HIDE_SERVER_HEADERS variable is set to true by default, the server name will change to ProcessMaker Server and when it is set to false, the normal header will remain.

`HIDE_SERVER_HEADERS=false`
<img width="740" height="402" alt="image" src="https://github.com/user-attachments/assets/c3d63480-b14b-4af4-841c-238b4cbd8825" />
`HIDE_SERVER_HEADERS=true`
<img width="747" height="598" alt="image" src="https://github.com/user-attachments/assets/29d1084c-8d43-475f-b316-db2ed61eb01c" />


## Related Tickets & Packages
- [FOUR-26915](https://processmaker.atlassian.net/browse/FOUR-26915)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.



[FOUR-26915]: https://processmaker.atlassian.net/browse/FOUR-26915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ