### PR TITLE
Bugfix/FOUR-26739: Magic variable _request.name not working inside calc properties or visibility rules

### DIFF
--- a/ProcessMaker/Http/Resources/V1_1/TaskResource.php
+++ b/ProcessMaker/Http/Resources/V1_1/TaskResource.php
@@ -107,6 +107,7 @@ class TaskResource extends ApiResource
             'case_number',
             'callable_id',
             'process_version_id',
+            'name',
         ],
         'draft' => ['id', 'task_id', 'data'],
         'screen' => ['id', 'config'],


### PR DESCRIPTION
## Issue & Reproduction Steps

- Enter into a screen.
- Set up a calculated property and add a console.log with the code that references the magic variable this._request.name.
- Run a case.
- Inside the request, go to the Data tab and search for the _request variable → the name is correctly defined there.
- Open the browser console → check the values printed from the calculated property.

**Current Behavior:**
The magic variable _request.id is obtained correctly inside calculated properties and visibility rules, but _request.name is not. Instead of showing the process name, it returns undefined.

**Expected Behavior:**
Both _request.id and _request.name should be accessible and return the corresponding values inside calculated properties and visibility rules.

## Solution
- Added name attribute in defaultfields for processRequest

**Working video**

https://github.com/user-attachments/assets/a6e72ab6-a354-4072-ab2a-c5505372c5ee


## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-26739](https://processmaker.atlassian.net/browse/FOUR-26739)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-26739]: https://processmaker.atlassian.net/browse/FOUR-26739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ