### PR TITLE
bugfix/FOUR-21604 Display Screen moustache syntax is rendering data as a date

### DIFF
--- a/ProcessMaker/Helpers/DataTypeHelper.php
+++ b/ProcessMaker/Helpers/DataTypeHelper.php
@@ -10,6 +10,9 @@ class DataTypeHelper
     {
         if (is_string($value)) {
             if (strlen($value) > 5) {
+                if (!preg_match('/\d{4}-\d{2}-\d{2}/', $value)) {
+                    return false;
+                }
                 try {
                     $parsed = Carbon::parse($value);
                     if ($parsed->isMidnight()) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Display Screen moustache syntax is rendering data as a date

## Solution
Improved dataTypeHelper isDate method to recognize better the date type

## How to Test
Steps to Reproduce:
Create a process with a screen with an input text
Assign the user permissions.
Run the process.
Insert a value in the input "a1234567"
submit
open the request

<img width="2326" height="1712" alt="image" src="https://github.com/user-attachments/assets/e5040920-aeb1-4e11-8470-0f2fe96a4e70" />



## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21604
