### PR TITLE
Fix multitenancy settings cache

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/TenantQueueController.php
+++ b/ProcessMaker/Http/Controllers/Admin/TenantQueueController.php
@@ -15,35 +15,11 @@ use ReflectionClass;
 class TenantQueueController extends Controller
 {
     /**
-     * Constructor to check if tenant tracking is enabled.
-     */
-    public function __construct()
-    {
-        // Check if tenant job tracking is enabled
-        $enabled = TenantQueueServiceProvider::enabled();
-
-        if (!$enabled) {
-            if (!app()->runningInConsole()) {
-                abort(404, 'Tenant queue tracking is disabled');
-            }
-        }
-
-        // If the route binding has a tenant id, check if the user is allowed to access the tenant queue
-        if ($id = (int) request()->route('tenantId')) {
-            if (!TenantQueueServiceProvider::allowAllTenats() && $id !== app('currentTenant')?->id) {
-                throw new AuthorizationException();
-            }
-        }
-    }
-
-    /**
      * Show the tenant jobs dashboard.
      */
     public function index()
     {
-        if (!Auth::user()->is_administrator) {
-            throw new AuthorizationException();
-        }
+        $this->checkPermissions();
 
         return view('admin.tenant-queues.index');
     }
@@ -53,9 +29,7 @@ class TenantQueueController extends Controller
      */
     public function getTenants(): JsonResponse
     {
-        if (!Auth::user()->is_administrator) {
-            throw new AuthorizationException();
-        }
+        $this->checkPermissions();
 
         $tenantsWithJobs = TenantQueueServiceProvider::getTenantsWithJobs();
 
@@ -87,9 +61,7 @@ class TenantQueueController extends Controller
      */
     public function getTenantJobs(Request $request, string $tenantId): JsonResponse
     {
-        if (!Auth::user()->is_administrator) {
-            throw new AuthorizationException();
-        }
+        $this->checkPermissions();
 
         $status = $request->get('status');
         $limit = min((int) $request->get('limit', 50), 100); // Max 100 jobs
@@ -125,9 +97,7 @@ class TenantQueueController extends Controller
      */
     public function getOverallStats(): JsonResponse
     {
-        if (!Auth::user()->is_administrator) {
-            throw new AuthorizationException();
-        }
+        $this->checkPermissions();
 
         $tenantsWithJobs = TenantQueueServiceProvider::getTenantsWithJobs();
 
@@ -163,9 +133,7 @@ class TenantQueueController extends Controller
      */
     public function getJobDetails(string $tenantId, string $jobId): JsonResponse
     {
-        if (!Auth::user()->is_administrator) {
-            throw new AuthorizationException();
-        }
+        $this->checkPermissions();
 
         $tenantKey = "tenant_jobs:{$tenantId}:{$jobId}";
         $jobData = Redis::hgetall($tenantKey);
@@ -199,9 +167,7 @@ class TenantQueueController extends Controller
      */
     public function clearTenantJobs(string $tenantId): JsonResponse
     {
-        if (!Auth::user()->is_administrator) {
-            throw new AuthorizationException();
-        }
+        $this->checkPermissions();
 
         try {
             $pattern = "tenant_jobs:{$tenantId}:*";
@@ -226,6 +192,27 @@ class TenantQueueController extends Controller
             return response()->json(['message' => 'Tenant job data cleared successfully']);
         } catch (\Exception $e) {
             return response()->json(['error' => 'Failed to clear tenant job data'], 500);
+        }
+    }
+
+    private function checkPermissions(): void
+    {
+        // Check if tenant job tracking is enabled
+        $enabled = TenantQueueServiceProvider::enabled();
+
+        if (!$enabled) {
+            throw new AuthorizationException('Tenant queue tracking is disabled');
+        }
+
+        if (!Auth::user()->is_administrator) {
+            throw new AuthorizationException();
+        }
+
+        // If the route binding has a tenant id, check if the user is allowed to access the tenant queue
+        if ($id = (int) request()->route('tenantId')) {
+            if (!TenantQueueServiceProvider::allowAllTenats() && $id !== app('currentTenant')?->id) {
+                throw new AuthorizationException();
+            }
         }
     }
 }

--- a/ProcessMaker/Multitenancy/SwitchTenant.php
+++ b/ProcessMaker/Multitenancy/SwitchTenant.php
@@ -55,11 +55,6 @@ class SwitchTenant implements SwitchTenantTask
             'app.instance' => config('app.instance') . '_' . $tenant->id,
         ];
 
-        if (!isset($tenant->config['cache.stores.cache_settings.prefix'])) {
-            $newConfig['cache.stores.cache_settings.prefix'] =
-                'tenant_id_' . $tenant->id . ':' . $tenant->getOriginalValue('CACHE_SETTING_PREFIX');
-        }
-
         if (!isset($tenant->config['script-runner-microservice.callback'])) {
             $newConfig['script-runner-microservice.callback'] = str_replace(
                 $tenant->getOriginalValue('APP_URL'),

--- a/ProcessMaker/Multitenancy/SwitchTenant.php
+++ b/ProcessMaker/Multitenancy/SwitchTenant.php
@@ -65,7 +65,7 @@ class SwitchTenant implements SwitchTenantTask
 
         if (!isset($tenant->config['app.docker_host_url'])) {
             // There is no specific override in the tenant's config so set it to the app url
-            $newConfig['app.docker_host_url'] = config('app.docker_host_url', config('app.url'));
+            $newConfig['app.docker_host_url'] = config('app.url');
         }
 
         // Set config from the entry in the tenants table

--- a/ProcessMaker/Multitenancy/TenantBootstrapper.php
+++ b/ProcessMaker/Multitenancy/TenantBootstrapper.php
@@ -86,7 +86,10 @@ class TenantBootstrapper
         $this->set('APP_KEY', $this->decrypt($config['app.key']));
         $this->set('DB_DATABASE', $tenantData['database']);
         $this->set('DB_USERNAME', $tenantData['username'] ?? $this->getOriginalValue('DB_USERNAME'));
-        $this->set('CACHE_PREFIX', $this->getOriginalValue('CACHE_PREFIX') . 'tenant_' . $tenantData['id'] . ':');
+
+        // Do not set REDIS_PREFIX because it is used by the queue (not tenant specific)
+        $this->set('CACHE_PREFIX', 'tenant_' . $tenantData['id'] . ':' . $this->getOriginalValue('CACHE_PREFIX'));
+        $this->set('CACHE_SETTING_PREFIX', 'tenant_' . $tenantData['id'] . ':' . $this->getOriginalValue('CACHE_SETTING_PREFIX'));
 
         $encryptedPassword = $tenantData['password'];
         $password = null;

--- a/ProcessMaker/Providers/TenantQueueServiceProvider.php
+++ b/ProcessMaker/Providers/TenantQueueServiceProvider.php
@@ -286,7 +286,7 @@ class TenantQueueServiceProvider extends ServiceProvider
         } else {
             // If job is already in the list, move it to the front (most recent)
             Redis::pipeline(function ($pipe) use ($listKey, $jobId) {
-                $pipe->lrem($listKey, 0, $jobId);
+                $pipe->lrem($listKey, $jobId, 0);
                 $pipe->lpush($listKey, $jobId);
                 $pipe->expire($listKey, 86400); // Expire in 24 hours
             });


### PR DESCRIPTION
This fixes a problem where, in multitenancy, changing a setting did not take effect. To test it, setup an email server and send a test email or test the imap connection.

- Set CACHE_PREFIX in the bootstrapper and remove it from SetTenant
- Remove tenant-queue authorization from the controller and so it doesn't break commands like `APP_RUNNING_IN_CONSOLE=false php artisan route:list`
- Fix redis call to `lrem` that was causing errors in the logs

https://processmaker.atlassian.net/browse/FOUR-27531

ci:multitenancy
ci:deploy