### PR TITLE
FOUR-27118: Review process_request_tokens rows to display in TASK page Inbox

### DIFF
--- a/ProcessMaker/Http/Resources/Task.php
+++ b/ProcessMaker/Http/Resources/Task.php
@@ -74,6 +74,8 @@ class Task extends ApiResource
 
         $this->addAssignableUsers($array, $include);
 
+        $this->mergeHitlCaseNumber($array);
+
         return $array;
     }
 
@@ -114,6 +116,28 @@ class Task extends ApiResource
         }
     }
 
+    private function mergeHitlCaseNumber(array &$array): void
+    {
+        if (!config('smart-extract.hitl_enabled')) {
+            return;
+        }
+
+        if (!empty(data_get($array, 'process_request.case_number'))) {
+            return;
+        }
+
+        $this->processRequest->loadMissing('parentRequest');
+        $parentCaseNumber = $this->processRequest->parentRequest?->case_number;
+        if (!$parentCaseNumber) {
+            return;
+        }
+
+        data_set($array, 'process_request.case_number', $parentCaseNumber);
+        if (empty($array['case_number'])) {
+            $array['case_number'] = $parentCaseNumber;
+        }
+    }
+
     /**
      * Add the active users to the list of assigned users
      *
@@ -131,7 +155,7 @@ class Task extends ApiResource
                 ->whereNotIn('status', Process::NOT_ASSIGNABLE_USER_STATUS)
                 ->whereIn('id', $chunk)
                 ->pluck('id')->toArray();
-            $assignedUsers = array_merge($assignedUsers,$activeUsers);
+            $assignedUsers = array_merge($assignedUsers, $activeUsers);
         }
 
         return $assignedUsers;

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -164,8 +164,20 @@ trait TaskControllerIndexMethods
                 });
             });
         })
-            ->when($nonSystem && !$hitlEnabled, function ($query) {
-                $query->nonSystem();
+            ->when($nonSystem, function ($query) use ($hitlEnabled) {
+                if (!$hitlEnabled) {
+                    $query->nonSystem();
+
+                    return;
+                }
+
+                $query->where(function ($query) {
+                    $query->nonSystem();
+                    $query->orWhere(function ($query) {
+                        $query->where('element_type', '=', 'task');
+                        $query->where('element_name', '=', 'Manual Document Review');
+                    });
+                });
             });
     }
 

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -154,6 +154,7 @@ trait TaskControllerIndexMethods
     {
         $nonSystem = filter_var($request->input('non_system'), FILTER_VALIDATE_BOOLEAN);
         $allTasks = filter_var($request->input('all_tasks'), FILTER_VALIDATE_BOOLEAN);
+        $hitlEnabled = filter_var(config('smart-extract.hitl_enabled'), FILTER_VALIDATE_BOOLEAN);
         $query->when(!$allTasks, function ($query) {
             $query->where(function ($query) {
                 $query->where('element_type', '=', 'task');
@@ -163,7 +164,7 @@ trait TaskControllerIndexMethods
                 });
             });
         })
-            ->when($nonSystem, function ($query) {
+            ->when($nonSystem && !$hitlEnabled, function ($query) {
                 $query->nonSystem();
             });
     }

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -496,7 +496,7 @@ export default {
       return `
       <a href="${this.openTask(record, 1)}"
          class="text-nowrap">
-         # ${processRequest.case_number || record.case_number}
+         # ${processRequest.case_number || record.case_number || ""}
       </a>`;
     },
     formatCaseTitle(processRequest, record) {


### PR DESCRIPTION
## Issue
When config('smart-extract.hitl_enabled') is true, the `/api/1.0/tasks` endpoint still applies the nonSystem() scope, so the HITL task “Manual Document Review” never reaches the /tasks UI. Once visible, its case_number remains null, so the task list renders “undefined”. Reproduce by enabling HITL, assigning the task to a user and loading /tasks with non_system=true.

## Solution
- Adjusted excludeNonVisibleTasks to keep filtering system tasks while explicitly whitelisting the “Manual Document Review” HITL task when the HITL feature flag is on.
- Augmented the Task API resource to inject the parent request’s case_number for that HITL task so the UI receives a complete payload.
- Simplified the Vue task list renderer now that the backend provides the correct case number.

## How to Test
1. Set smart-extract.hitl_enabled to true and confirm a “Manual Document Review” task is assigned to the test user.
2. Call /api/1.0/tasks?include=process,processRequest,processRequest.user,user&non_system=true and verify the task appears with a populated case_number.
3. Visit /tasks and confirm the row shows the HITL task with the correct case number, while other system tasks remain hidden.

## Related Tickets & Packages
- [FOUR-27118](https://processmaker.atlassian.net/browse/FOUR-27118)

[FOUR-27118]: https://processmaker.atlassian.net/browse/FOUR-27118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ