### PR TITLE
Observation/FOUR-27719: Iframe displays “No iframe source provided for Manual Edit” on non–Smart Extract tasks

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -140,7 +140,7 @@ class TaskController extends Controller
         $element = $task->getDefinition(true);
         $screenFields = $screenVersion ? $screenVersion->screenFilteredFields() : [];
         $taskDraftsEnabled = TaskDraft::draftsEnabled();
-
+        $is_smart_extract_task = $task->element_name === 'Manual Document Review';
         // Remove screen parent to reduce the size of the response
         $screen = $task->screen;
         $screen['parent'] = null;
@@ -205,6 +205,7 @@ class TaskController extends Controller
                 'taskDraftsEnabled' => $taskDraftsEnabled,
                 'userConfiguration' => $userConfiguration,
                 'hitlEnabled' => config('smart-extract.hitl_enabled', false),
+                'is_smart_extract_task' => $is_smart_extract_task,
             ]);
         }
     }

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -140,7 +140,7 @@ class TaskController extends Controller
         $element = $task->getDefinition(true);
         $screenFields = $screenVersion ? $screenVersion->screenFilteredFields() : [];
         $taskDraftsEnabled = TaskDraft::draftsEnabled();
-        $is_smart_extract_task = $task->element_name === 'Manual Document Review';
+        $isSmartExtractTask = $task->element_name === 'Manual Document Review';
         // Remove screen parent to reduce the size of the response
         $screen = $task->screen;
         $screen['parent'] = null;
@@ -204,8 +204,7 @@ class TaskController extends Controller
                 'screenFields' => $screenFields,
                 'taskDraftsEnabled' => $taskDraftsEnabled,
                 'userConfiguration' => $userConfiguration,
-                'hitlEnabled' => config('smart-extract.hitl_enabled', false),
-                'is_smart_extract_task' => $is_smart_extract_task,
+                'hitlEnabled' => config('smart-extract.hitl_enabled', false) && $isSmartExtractTask,
             ]);
         }
     }

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -87,7 +87,7 @@
             <div id="tabContent" class="tab-content tw-flex tw-flex-col tw-grow tw-overflow-y-scroll">
               <div id="tab-form" role="tabpanel" aria-labelledby="tab-form" class="tab-pane active show">
                 @can('update', $task)
-                  @unless($hitlEnabled)
+                  @unless($hitlEnabled && $is_smart_extract_task)
                     <task
                       ref="task"
                       class="card border-0"

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -87,7 +87,7 @@
             <div id="tabContent" class="tab-content tw-flex tw-flex-col tw-grow tw-overflow-y-scroll">
               <div id="tab-form" role="tabpanel" aria-labelledby="tab-form" class="tab-pane active show">
                 @can('update', $task)
-                  @unless($hitlEnabled && $is_smart_extract_task)
+                  @unless($hitlEnabled)
                     <task
                       ref="task"
                       class="card border-0"
@@ -108,7 +108,7 @@
                       @redirect="redirectToTask"
                       @form-data-changed="handleFormDataChange" />
                   @else
-                  @include('tasks.partials.hitl-iframe')
+                    @include('tasks.partials.hitl-iframe')
                   @endunless
                 @endcan
                 <div v-if="taskHasComments">


### PR DESCRIPTION
## Solution
- A new variable was added in TaskController to handle iframe component on edit.blade.php file

## How to Test
1. Create Process: Start Event → Upload File Task → Smart Extract → End Event
2. run the process

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-27719

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
