### PR TITLE
Fix memory issues with queue workers

### DIFF
--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -70,6 +70,9 @@ class ProcessMakerServiceProvider extends ServiceProvider
     // Track the landlord values for multitenancy
     private static $landlordValues = null;
 
+    // Cache tenant app containers to save memory
+    private static $tenantAppContainers = [];
+
     public function boot(): void
     {
         // Track the start time for service providers boot
@@ -261,12 +264,16 @@ class ProcessMakerServiceProvider extends ServiceProvider
             // Create a new tenant app instance
             $_SERVER['TENANT'] = $tenantId;
             $_ENV['TENANT'] = $tenantId;
-            $tenantApp = require app()->bootstrapPath('app.php');
-            $tenantApp->instance('landlordValues', self::$landlordValues);
-            $tenantApp->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+            if (!isset(self::$tenantAppContainers[$tenantId])) {
+                $tenantApp = require app()->bootstrapPath('app.php');
+                $tenantApp->instance('landlordValues', self::$landlordValues);
+                $tenantApp->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+                self::$tenantAppContainers[$tenantId] = $tenantApp;
+            }
 
             // Change the job's app service container to the tenant app
-            $event->job->getRedisQueue()->setContainer($tenantApp);
+            $event->job->getRedisQueue()->setContainer(self::$tenantAppContainers[$tenantId]);
         }
     }
 

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -127,7 +127,7 @@ return [
     |
     */
 
-    'memory_limit' => 256,
+    'memory_limit' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
 
     /*
     |--------------------------------------------------------------------------
@@ -151,6 +151,7 @@ return [
                 'sleep' => intval(env('BPMN_QUEUE_INTERVAL', 3000)) * 0.001,
                 'minProcesses' => env('PM4_HORIZON_SUPERVISOR_BPMN_MIN_PROCESSES', 1),
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_BPMN_MAX_PROCESSES', 1),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
             'supervisor-1' => [
                 'connection' => 'redis',
@@ -160,6 +161,7 @@ return [
                 'timeout' => env('PM4_HORIZON_SUPERVISOR_1_TIMEOUT', 600),
                 'minProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MIN_PROCESSES', 1),
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MAX_PROCESSES', 1),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
         ],
 
@@ -173,6 +175,7 @@ return [
                 'sleep' => intval(env('BPMN_QUEUE_INTERVAL', 3000)) * 0.001,
                 'minProcesses' => env('PM4_HORIZON_SUPERVISOR_BPMN_MIN_PROCESSES', 1),
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_BPMN_MAX_PROCESSES', 1),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
             'supervisor-1' => [
                 'connection' => 'redis',
@@ -182,6 +185,7 @@ return [
                 'timeout' => env('PM4_HORIZON_SUPERVISOR_1_TIMEOUT', 600),
                 'minProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MIN_PROCESSES', 1),
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MAX_PROCESSES', 1),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
         ],
 
@@ -195,6 +199,7 @@ return [
                 'sleep' => intval(env('BPMN_QUEUE_INTERVAL', 3000)) * 0.001,
                 'minProcesses' => env('PM4_HORIZON_SUPERVISOR_BPMN_MIN_PROCESSES', 1),
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_BPMN_MAX_PROCESSES', 1),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
             'supervisor-1' => [
                 'connection' => 'redis',
@@ -204,6 +209,7 @@ return [
                 'timeout' => env('PM4_HORIZON_SUPERVISOR_1_TIMEOUT', 600),
                 'minProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MIN_PROCESSES', 1),
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MAX_PROCESSES', 1),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
         ],
     ],


### PR DESCRIPTION
`$tenantApp = require app()->bootstrapPath('app.php');` adds about 5mb of memory per iteration in the queue worker. We need to cache/memoize and increase the worker memory limit

ci:deploy
ci:multitenancy