### PR TITLE
Bugfix/FOUR-27729: Randomly, the participants of a task, when it is of the multi-instance type, are not shown in the list of participants.

### DIFF
--- a/ProcessMaker/Repositories/TokenRepository.php
+++ b/ProcessMaker/Repositories/TokenRepository.php
@@ -176,7 +176,7 @@ class TokenRepository implements TokenRepositoryInterface
 
         CaseUpdate::dispatchSync($request, $token);
 
-        if (!is_null($user)) {
+        if (!is_null($user) && is_string($user->email)) {
             // Review if the task has enable the action by email
             $this->validateAndSendActionByEmail($activity, $token, $user->email);
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
After investigating the issue, the problem is caused because some users that are part of the group selected in the assignment configuration for the multi instance task, does not have an email. This users probably were synced using SCIM or similar.

After sync with @Claudia Iriarte we should allow users without an email, but for those users without emails, it will not validate and send actions by email.

## Solution
- Validate user email is a string

## How to Test
Create a process with a multiinstance task and assign a group with users where the email it's null. 

## Related Tickets & Packages
- [FOUR-27729](https://processmaker.atlassian.net/browse/FOUR-27729)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-27729]: https://processmaker.atlassian.net/browse/FOUR-27729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ