### PR TITLE
Tasks with status Self service do not reach Processes I manage

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -142,15 +142,16 @@ class TaskController extends Controller
 
         $this->applyStatusFilter($query, $request);
 
-        $this->applyPmql($query, $request, $user);
-
-        $this->applyAdvancedFilter($query, $request);
-
+        // Apply process manager filter BEFORE PMQL to avoid conflicts with is_self_service filtering
         if ($request->input('processesIManage') === 'true') {
             $this->applyProcessManager($query, $user);
         } else {
             $this->applyForCurrentUser($query, $user);
         }
+
+        $this->applyPmql($query, $request, $user);
+
+        $this->applyAdvancedFilter($query, $request);
 
         // Apply filter overdue
         $query->overdue($request->input('overdue'));

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -289,6 +289,20 @@ trait TaskControllerIndexMethods
             } catch (SyntaxError $e) {
                 abort('Your PMQL contains invalid syntax.', 400);
             }
+
+            // After PMQL is applied, if processesIManage is active, add self-service tasks
+            // This is done after PMQL to avoid the is_self_service = 0 filter that PMQL might add
+            if ($request->input('processesIManage') === 'true' && isset($query->getQuery()->processManagerIds)) {
+                $ids = $query->getQuery()->processManagerIds;
+                $selfServiceTaskIds = ProcessRequestToken::select(['id'])
+                    ->whereIn('process_id', $ids)
+                    ->where('is_self_service', 1)
+                    ->whereNull('user_id')
+                    ->where('status', 'ACTIVE');
+
+                // Add self-service tasks using orWhereIn to override PMQL's is_self_service = 0 filter
+                $query->orWhereIn('process_request_tokens.id', $selfServiceTaskIds);
+            }
         }
     }
 
@@ -340,11 +354,26 @@ trait TaskControllerIndexMethods
                     ->orWhereRaw("JSON_CONTAINS(JSON_EXTRACT(properties, '$.manager_id'), CAST(? AS JSON))", [$user->id]);
             })
             ->where('status', 'ACTIVE')
-            ->get()
+            ->pluck('id')
             ->toArray();
 
+        if (empty($ids)) {
+            // If user is not a manager of any process, return no results
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        // Show tasks from processes the user manages that are ACTIVE
+        // OR show self-service tasks from those processes
+        // Store the process IDs in the query so we can use them later to add self-service tasks
+        // We'll add self-service tasks after PMQL is applied to avoid the is_self_service = 0 filter
+        $query->getQuery()->processManagerIds = $ids;
+
+        // Apply condition for regular tasks from managed processes
+        // Self-service tasks will be added after PMQL to avoid conflicts
         $query->where(function ($query) use ($ids) {
-            $query->whereIn('process_request_tokens.process_id', array_column($ids, 'id'))
+            $query->whereIn('process_request_tokens.process_id', $ids)
                 ->where('process_request_tokens.status', 'ACTIVE');
         });
     }


### PR DESCRIPTION

## Issue & Reproduction Steps
When you are a process manager, and the tasks are in self-service, they are not displayed in the IManage list.

## Solution
- Apply the process manager filter before PMQL to avoid conflicts and ensure that self-service tasks are added after PMQL to resolve potential filtering issues.

## How to Test
If you have a self-service process and assign a manager, and tasks have been created, check the IManage list; the self-service tasks should be displayed.

## Related Tickets & Packages
- [FOUR-27726](https://processmaker.atlassian.net/browse/FOUR-27726)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-27726]: https://processmaker.atlassian.net/browse/FOUR-27726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ