### PR TITLE
FOUR-27198 Request > Timeline is displaying many messages when one condition is accomplished

### DIFF
--- a/ProcessMaker/Services/ConditionalRedirectService.php
+++ b/ProcessMaker/Services/ConditionalRedirectService.php
@@ -2,25 +2,24 @@
 
 namespace ProcessMaker\Services;
 
+use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use ProcessMaker\Contracts\ConditionalRedirectServiceInterface;
 use ProcessMaker\Managers\DataManager;
-use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\FormalExpression;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 
 /**
  * ConditionalRedirectService
- * 
+ *
  * This service handles the evaluation of conditional redirects in ProcessMaker workflows.
  * It processes a set of conditions and returns the first condition that evaluates to true,
  * along with its associated redirect configuration.
- * 
+ *
  * The service uses FEEL (Friendly Enough Expression Language) expressions to evaluate
  * conditions against process data, allowing for dynamic routing based on runtime data.
- * 
- * @package ProcessMaker\Services
+ *
  * @since 4.0.0
  */
 class ConditionalRedirectService implements ConditionalRedirectServiceInterface
@@ -29,7 +28,7 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
      * @var FormalExpression
      */
     private FormalExpression $feel;
-    
+
     /**
      * @var DataManager
      */
@@ -39,7 +38,7 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
 
     /**
      * Constructor
-     * 
+     *
      * Initializes the service with required dependencies for expression evaluation
      * and data management.
      */
@@ -51,11 +50,11 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
 
     /**
      * Process a set of conditional redirects and return the first condition that evaluates to true
-     * 
+     *
      * This method iterates through an array of conditional redirect configurations,
      * evaluating each condition using FEEL expressions against the provided data.
      * Returns the first condition that evaluates to true, or null if no conditions match.
-     * 
+     *
      * @param array $conditionalRedirect Array of conditional redirect configurations
      *                                  Each item must contain a 'condition' key with a FEEL expression
      *                                  Example: [
@@ -73,15 +72,15 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
      * @param array $data Process data to evaluate conditions against
      *                    Contains variables from the process instance
      *                    Example: ['amount' => 1500, 'status' => 'urgent', 'user' => 'john']
-     * 
+     *
      * @return array|null The first matching conditional redirect configuration, or null if none match
-     * 
+     *
      * @throws InvalidArgumentException When a condition item is missing the required 'condition' key
-     * 
+     *
      * @example
      * ```php
      * $service = new ConditionalRedirectService();
-     * 
+     *
      * $conditionalRedirect = [
      *     [
      *         'condition' => 'amount > 1000',
@@ -94,9 +93,9 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
      *         'value' => null
      *     ]
      * ];
-     * 
+     *
      * $data = ['amount' => 1500, 'status' => 'pending'];
-     * 
+     *
      * $result = $service->resolve($conditionalRedirect, $data);
      * // Returns: ['condition' => 'amount > 1000', 'type' => 'externalURL', 'value' => 'https://example.com/approval']
      * ```
@@ -128,13 +127,13 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
 
     /**
      * Process conditional redirects for a specific process request token
-     * 
+     *
      * This method is a convenience wrapper that automatically retrieves process data
      * from a ProcessRequestToken and evaluates conditional redirects against that data.
      * It's commonly used when you have a token and want to determine the appropriate
      * redirect based on the current process state and data, it also considers
      * multi-instance tasks.
-     * 
+     *
      * @param array $conditionalRedirect Array of conditional redirect configurations
      *                                  Each item must contain a 'condition' key with a FEEL expression
      *                                  Example: [
@@ -151,16 +150,16 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
      *                                  ]
      * @param ProcessRequestToken $token The process request token to evaluate conditions against
      *                                   The token contains the process instance data and context
-     * 
+     *
      * @return array|null The first matching conditional redirect configuration, or null if none match
-     * 
+     *
      * @throws InvalidArgumentException When a condition item is missing the required 'condition' key
-     * 
+     *
      * @example
      * ```php
      * $service = new ConditionalRedirectService();
      * $token = ProcessRequestToken::find(123);
-     * 
+     *
      * $conditionalRedirect = [
      *     [
      *         'condition' => 'taskStatus = "completed"',
@@ -173,11 +172,11 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
      *         'value' => null
      *     ]
      * ];
-     * 
+     *
      * $result = $service->resolveForToken($conditionalRedirect, $token);
      * // Returns the appropriate redirect configuration based on the token's data
      * ```
-     * 
+     *
      * @see resolve() For detailed parameter documentation
      */
     public function resolveForToken(array $conditionalRedirect, ProcessRequestToken $token): ?array
@@ -187,9 +186,10 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
         if ($this->errors) {
             $case_number = $this->getCaseNumber($token);
             foreach ($this->errors as $error) {
-                $this->addLogComment($token, $error, $case_number);
+                $this->logError($token, $error, $case_number);
             }
         }
+
         return $result;
     }
 
@@ -206,16 +206,15 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
         return $case_number;
     }
 
-    private function addLogComment(ProcessRequestToken $token, string $error, string $case_number)
+    /**
+     * Log an error when evaluating conditional redirects
+     *
+     * @param ProcessRequestToken $token
+     * @param string $error
+     * @param string $case_number
+     */
+    private function logError(ProcessRequestToken $token, string $error, int $case_number)
     {
-        Comment::create([
-            'body' => $error,
-            'user_id' => null,
-            'subject' => $error,
-            'type' => 'LOG',
-            'case_number' => $case_number,
-            'commentable_type' => ProcessRequest::class,
-            'commentable_id' => $token->process_request_id,
-        ]);
+        Log::error('Conditional Redirect: ', ['error' => $error, 'case_number' => $case_number, 'token' => $token->id]);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
### Request > Timeline is displaying many messages when one condition is accomplished

Current behavior
Timeline displays all conditions twice. The information displayed is not the correct

Expected behavior
- The condition information should be displayed in the log file instead of the timeline.
- Information about the conditions in a Request should not be displayed.

## Solution
- Improve error logging in conditional redirect service

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-27198](https://processmaker.atlassian.net/browse/FOUR-27198)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-27198]: https://processmaker.atlassian.net/browse/FOUR-27198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ