### PR TITLE
Support getenv by setting vars with putenv

### DIFF
--- a/ProcessMaker/Jobs/CompileUI.php
+++ b/ProcessMaker/Jobs/CompileUI.php
@@ -41,7 +41,6 @@ class CompileUI implements ShouldQueue
     public function handle()
     {
         $setting = Setting::byKey('css-override');
-        \Log::debug('*** Got setting: ' . json_encode($setting));
         if ($setting) {
             $this->writeColors(json_decode($setting->attributesToArray()['config']['variables'], true));
             $this->writeFonts(json_decode($setting->attributesToArray()['config']['sansSerifFont']));

--- a/ProcessMaker/Multitenancy/TenantBootstrapper.php
+++ b/ProcessMaker/Multitenancy/TenantBootstrapper.php
@@ -146,6 +146,7 @@ class TenantBootstrapper
         // Env::getRepository() is immutable but will use values from $_SERVER and $_ENV
         $_SERVER[$key] = $value;
         $_ENV[$key] = $value;
+        putenv("$key=$value");
     }
 
     private function decrypt($value)

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -299,6 +299,7 @@ class ProcessMakerServiceProvider extends ServiceProvider
         foreach (self::$landlordValues as $key => $value) {
             $_SERVER[$key] = $value;
             $_ENV[$key] = $value;
+            putenv("$key=$value");
         }
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
The automated data source generator was getting the URL with getenv

## Solution
- Also set vars with putenv

## How to Test
See ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-27846

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:multitenancy
ci:deploy