### PR TITLE
FOUR-27709: ABE does not work correctly when a parallel gateway is part of the flow

### DIFF
--- a/ProcessMaker/Jobs/CompleteActivity.php
+++ b/ProcessMaker/Jobs/CompleteActivity.php
@@ -8,6 +8,7 @@ use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\Process as Definitions;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\CallActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Contracts\Engine\ExecutionInstanceInterface;
 
@@ -42,8 +43,10 @@ class CompleteActivity extends BpmnAction implements ShouldQueue
     public function action(ProcessRequestToken $token, ActivityInterface $element, array $data)
     {
         //@todo requires a class to manage the data access and control the updates
-        $manager = new DataManager();
-        $manager->updateData($token, $data);
+        if (!($element instanceof CallActivityInterface)) {
+            $manager = new DataManager();
+            $manager->updateData($token, $data);
+        }
         $this->engine->runToNextState();
         $element->complete($token);
 

--- a/ProcessMaker/Jobs/ThrowMessageEvent.php
+++ b/ProcessMaker/Jobs/ThrowMessageEvent.php
@@ -48,16 +48,19 @@ class ThrowMessageEvent extends BpmnAction implements ShouldQueue
         $message->setId($this->messageRef);
         $eventDefinition->setPayload($message);
         $eventDefinition->setProperty('messageRef', $this->messageRef);
+        $eventDefinition->setProperty('target_catch_event_id', $this->elementId);
+        $eventDefinition->setProperty('target_instance_id', $this->instanceId);
+
+        if ($this->payload) {
+            foreach ($this->payload as $key => $value) {
+                $instance->getDataStore()->putData($key, $value);
+            }
+        }
 
         $this->engine->getEventDefinitionBus()->dispatchEventDefinition(
             null,
             $eventDefinition,
             null
         );
-        if ($this->payload) {
-            foreach ($this->payload as $key => $value) {
-                $instance->getDataStore()->putData($key, $value);
-            }
-        }
     }
 }

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -94,8 +94,13 @@ class CallActivity implements CallActivityInterface
      */
     protected function completeSubprocess(TokenInterface $token, ExecutionInstanceInterface $closedInstance, ExecutionInstanceInterface $instance)
     {
-        // Copy data from subprocess to main process
-        $data = $closedInstance->getDataStore()->getData();
+        // Copy only the data updated by the subprocess
+        $store = $closedInstance->getDataStore();
+        $data = $store->getData();
+        $updatedKeys = method_exists($store, 'getUpdated') ? $store->getUpdated() : array_keys($data);
+        if (!empty($updatedKeys)) {
+            $data = array_intersect_key($data, array_flip($updatedKeys));
+        }
         $dataManager = new DataManager();
         $dataManager->updateData($token, $data);
         $token->getInstance()->getProcess()->getEngine()->runToNextState();

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -94,13 +94,26 @@ class CallActivity implements CallActivityInterface
      */
     protected function completeSubprocess(TokenInterface $token, ExecutionInstanceInterface $closedInstance, ExecutionInstanceInterface $instance)
     {
-        // Copy only the data updated by the subprocess
         $store = $closedInstance->getDataStore();
-        $data = $store->getData();
-        $updatedKeys = method_exists($store, 'getUpdated') ? $store->getUpdated() : array_keys($data);
-        if (!empty($updatedKeys)) {
-            $data = array_intersect_key($data, array_flip($updatedKeys));
+        $allData = $store->getData();
+
+        // Determine which data should be merged back from the subprocess.
+        $updatedKeys = method_exists($store, 'getUpdated')
+            ? $store->getUpdated()
+            : null;
+
+        if ($updatedKeys === null) {
+            // Legacy behavior or no tracking available: copy all data.
+            $data = $allData;
+        } elseif ($updatedKeys === []) {
+            // Nothing was updated in the subprocess: do not merge anything.
+            $data = [];
+        } else {
+            // Merge only the explicitly updated keys.
+            $updatedKeys = array_values((array) $updatedKeys);
+            $data = array_intersect_key($allData, array_flip($updatedKeys));
         }
+
         $dataManager = new DataManager();
         $dataManager->updateData($token, $data);
         $token->getInstance()->getProcess()->getEngine()->runToNextState();


### PR DESCRIPTION
## Issue & Reproduction Steps.
When a process includes a parallel gateway that launches two “Actions By Email” call activities, the flow continues as soon as one email reply is received. Because the package fired a broadcast abe_processed message, both call activities were closed at once—so the parent request proceeded to the final Form Task even though one ABE remained unanswered.
Repro: Run the provided BPMN (parallel gateway → two ABE call activities → converging gateway). Start a case and reply to only one of the two ABE emails. The second branch closes automatically and the flow reaches the final Form Task.

## Solution
- Made CallActivity::completeSubprocess() merge only the fields actually updated by the subprocess to avoid overwriting sibling data.
- Prevented CompleteActivity from re‑merging data for call activities (that merge already happens inside CallActivity).
- Added targeted delivery in ThrowMessageEvent + Nayra’s EventDefinitionBus so abe_processed messages wake only the intended abe_task_node. Parallel call activities now wait for their own replies.

<img width="1550" height="861" alt="1" src="https://github.com/user-attachments/assets/c832c5e4-6546-418a-b68d-0991a7837bbb" />
<img width="1550" height="861" alt="2" src="https://github.com/user-attachments/assets/371c71a3-bbd6-42ce-a46b-80806996718a" />
<img width="1550" height="861" alt="3" src="https://github.com/user-attachments/assets/7aa20725-53a5-4c8c-ab18-2566bc558c8c" />
<img width="1550" height="861" alt="4" src="https://github.com/user-attachments/assets/11ebf79e-005b-4b01-8bb9-8580da5e8ced" />

## How to Test
1. Run the ABE process with the parallel gateway (same BPMN provided in the issue).
2. Start a case, reply to only the first ABE email.
Confirm:
- Only the corresponding call activity shows result = "yes" in the subprocess data.
- The second branch remains waiting (case stays at the converging gateway).
- Reply to the second email; verify the flow advances to the final Form Task and both result/result1 are saved in the parent request.

## Related Tickets & Packages
- [FOUR-27709](https://processmaker.atlassian.net/browse/FOUR-27709)
- [Nayra PR]()


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits subprocess data merging to updated fields, avoids double-merge for call activities, and targets message events to specific catch events/instances.
> 
> - **Call Activity data handling**:
>   - In `ProcessMaker/Models/CallActivity::completeSubprocess`, merge back only updated fields from the subprocess data store (using `getUpdated` when available), falling back to legacy copy-all if not tracked.
> - **Activity completion**:
>   - In `ProcessMaker/Jobs/CompleteActivity`, skip `DataManager->updateData` when the element is a `CallActivityInterface` to prevent duplicate merging.
> - **Message event targeting**:
>   - In `ProcessMaker/Jobs/ThrowMessageEvent`, add `target_catch_event_id` and `target_instance_id` to the message event definition and dispatch after applying payload to the instance datastore.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 725ffe42b79764f141c62c9c02c3439b32bfb554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[FOUR-27709]: https://processmaker.atlassian.net/browse/FOUR-27709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ