### PR TITLE
FOUR-27641: CSS: The data from the select list is being displayed with a space on the left side.

### DIFF
--- a/resources/sass/tailwind.css
+++ b/resources/sass/tailwind.css
@@ -18,9 +18,9 @@
       with no bullets/numbers and no margin or padding. */
     .form-group ol,
     .form-group ul {
-      list-style: revert-layer !important;
-      margin: 0 !important;
-      padding: revert-layer !important;
+      list-style: revert-layer;
+      margin: 0;
+      padding: revert-layer;
     }
   }
 

--- a/resources/sass/tailwind.css
+++ b/resources/sass/tailwind.css
@@ -16,18 +16,18 @@
 
     /* Ordered and unordered lists are unstyled by default,
       with no bullets/numbers and no margin or padding. */
-    ol,
-    ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
+    .form-group ol,
+    .form-group ul {
+      list-style: revert-layer !important;
+      margin: 0 !important;
+      padding: revert-layer !important;
     }
   }
 
   /* Reset the list style for the vue-form-renderer and screen-container */
-  #screen-container ul,
-  #vue-form-renderer ul {
-    list-style: revert;
-    margin: revert;
-    padding: revert;
+  .multiselect__content-wrapper ul,
+  .multiselect__content-wrapper ol {
+    list-style: revert-layer;
+    margin: revert-layer;
+    padding: 0px;
   }


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-27641

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy