### PR TITLE
It is not possible edit configuration an imported process that is old.

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -113,6 +113,13 @@ class ProcessController extends Controller
             $isDraft = $lastDraftOrPublishedVersion->draft;
         }
 
+        // search if user  exists
+        $user = User::where('id', $process->user_id)->exists();
+        if (!$user) {
+            // if user not exists, set the first administrator as the process owner
+            $process->user_id = User::where('is_administrator', true)->first()->id;
+        }
+
         return view('processes.edit', compact([
             'process',
             'categories',

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -117,7 +117,7 @@ class ProcessController extends Controller
         $user = User::where('id', $process->user_id)->exists();
         if (!$user) {
             // if user not exists, set the first administrator as the process owner
-            $process->user_id = User::where('is_administrator', true)->first()->id;
+            $process->user_id = User::where('is_administrator', true)->where('status', 'ACTIVE')->first()->id;
         }
 
         return view('processes.edit', compact([


### PR DESCRIPTION
## Issue & Reproduction Steps
Assign process ownership to the first administrator if the user does not exist.

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Import the test process into the ticket.
Go to the process configuration option.
On this screen, if a user does not exist in the Owner field, the first active administrator will be selected. You must save the changes for them to appear in the process list.

## Related Tickets & Packages
- [FOUR-27829](https://processmaker.atlassian.net/browse/FOUR-27829)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-27829]: https://processmaker.atlassian.net/browse/FOUR-27829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ