### PR TITLE
FOUR-27812 | Email / Conversation / Display Screens Show Bullet Point to Left of Screen Name

### DIFF
--- a/resources/sass/tailwind.css
+++ b/resources/sass/tailwind.css
@@ -25,8 +25,8 @@
   }
 
   /* Reset the list style for the vue-form-renderer and screen-container */
-  #screen-container ul,
-  #vue-form-renderer ul {
+  #screen-container ul:not(.nav-tabs):not(.nav-tabs ul),
+  #vue-form-renderer ul:not(.nav-tabs):not(.nav-tabs ul) {
     list-style: revert;
     margin: revert;
     padding: revert;


### PR DESCRIPTION
# Issue
Ticket: [FOUR-27812](https://processmaker.atlassian.net/browse/FOUR-27812)

When viewing Email, Conversational, or Display screens, an unwanted bullet point appears to the left of the Screen name. This occurs because the CSS rule that resets list styles for `#screen-container` and `#vue-form-renderer` was too broad and inadvertently affected `.nav-tabs` elements, overriding their intended `list-style: none` styling.

# Solution
1. In `tailwinds.css`, updated the CSS selectors to exclude `.nav-tabs` elements from the revert rule

# How To Test
1. Navigate to Screens
2. Create or edit an Email, Conversational, or Display screen
3. Verify that no bullet point appears to the left of the screen name
4. Verify that `.nav-tabs` elements throughout the application maintain their intended styling (no bullet points, proper padding)
  
ci:deploy

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-27812]: https://processmaker.atlassian.net/browse/FOUR-27812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ