### PR TITLE
The status filter in Processes I Manage stopped working

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -753,13 +753,35 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
 
         $value = mb_strtolower($value);
 
-        return function ($query) use ($value, $statusMap, $expression, $user) {
+        // Capture processManagerIds from the builder if it's available
+        // The $callback parameter is actually the $builder from ExtendedPMQL
+        $builder = $callback;
+        $processManagerIds = null;
+        if ($builder && method_exists($builder, 'getQuery')) {
+            $processManagerIds = $builder->getQuery()->processManagerIds ?? null;
+        }
+
+        return function ($query) use ($value, $statusMap, $expression, $user, $processManagerIds) {
+            // Also check in the current query in case it's available there
+            $currentProcessManagerIds = $query->getQuery()->processManagerIds ?? null;
+            $finalProcessManagerIds = $processManagerIds ?? $currentProcessManagerIds;
+            $isProcessManager = !empty($finalProcessManagerIds);
+
             if ($value === 'self service') {
                 if (!$user) {
                     $user = auth()->user();
                 }
 
-                if ($user) {
+                if ($isProcessManager) {
+                    // When processesIManage is active, include self-service tasks from managed processes
+                    $selfServiceTaskIds = ProcessRequestToken::select(['id'])
+                        ->whereIn('process_id', $finalProcessManagerIds)
+                        ->where('is_self_service', 1)
+                        ->whereNull('user_id')
+                        ->where('status', 'ACTIVE');
+
+                    $query->whereIn('process_request_tokens.id', $selfServiceTaskIds);
+                } elseif ($user) {
                     $taskIds = $user->availableSelfServiceTaskIds();
                     $query->whereIn('process_request_tokens.id', $taskIds);
                 } else {

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -289,27 +289,56 @@ trait TaskControllerIndexMethods
             } catch (SyntaxError $e) {
                 abort('Your PMQL contains invalid syntax.', 400);
             }
-
-            // After PMQL is applied, if processesIManage is active, add self-service tasks
-            // This is done after PMQL to avoid the is_self_service = 0 filter that PMQL might add
-            if ($request->input('processesIManage') === 'true' && isset($query->getQuery()->processManagerIds)) {
-                $ids = $query->getQuery()->processManagerIds;
-                $selfServiceTaskIds = ProcessRequestToken::select(['id'])
-                    ->whereIn('process_id', $ids)
-                    ->where('is_self_service', 1)
-                    ->whereNull('user_id')
-                    ->where('status', 'ACTIVE');
-
-                // Add self-service tasks using orWhereIn to override PMQL's is_self_service = 0 filter
-                $query->orWhereIn('process_request_tokens.id', $selfServiceTaskIds);
-            }
         }
     }
 
     private function applyAdvancedFilter($query, $request)
     {
         if ($advancedFilter = $request->input('advanced_filter', '')) {
-            Filter::filter($query, $advancedFilter);
+            // Parse the advanced filter
+            $filterArray = is_string($advancedFilter) ? json_decode($advancedFilter, true) : $advancedFilter;
+
+            // Check if processesIManage is active and we have processManagerIds
+            $processManagerIds = $query->getQuery()->processManagerIds ?? null;
+            $isProcessManager = !empty($processManagerIds) && $request->input('processesIManage') === 'true';
+
+            // If processesIManage is active, handle "Self Service" status filter specially
+            if ($isProcessManager && is_array($filterArray)) {
+                $hasSelfServiceFilter = false;
+                $filteredArray = [];
+
+                foreach ($filterArray as $filter) {
+                    // Check if this is a "Self Service" status filter
+                    if (isset($filter['subject']['type']) &&
+                        $filter['subject']['type'] === 'Status' &&
+                        isset($filter['value']) &&
+                        mb_strtolower($filter['value']) === 'self service') {
+                        $hasSelfServiceFilter = true;
+                        // Don't add this filter to the array - we'll handle it manually
+                        continue;
+                    }
+                    $filteredArray[] = $filter;
+                }
+
+                // Apply the filtered advanced_filter (without Self Service)
+                if (!empty($filteredArray)) {
+                    Filter::filter($query, $filteredArray);
+                }
+
+                // Manually apply the Self Service filter for process managers
+                if ($hasSelfServiceFilter) {
+                    $selfServiceTaskIds = ProcessRequestToken::select(['id'])
+                        ->whereIn('process_id', $processManagerIds)
+                        ->where('is_self_service', 1)
+                        ->whereNull('user_id')
+                        ->where('status', 'ACTIVE');
+
+                    $query->whereIn('process_request_tokens.id', $selfServiceTaskIds);
+                }
+            } else {
+                // Normal behavior - apply the filter as-is
+                Filter::filter($query, $advancedFilter);
+            }
         }
     }
 


### PR DESCRIPTION

## Issue & Reproduction Steps
The new manager query does not work correctly with the advanced filter.

## Solution
- Enhance self-service task filtering for process managers in ProcessRequestToken and TaskControllerIndexMethods. Capture processManagerIds from the builder and apply advanced filters accordingly, ensuring proper handling of "Self Service" status. This improves task accessibility for users managing processes.

## How to Test
Perform filtering on the ProcessIManage list.

## Related Tickets & Packages
- [FOUR-27966](urlhttps://processmaker.atlassian.net/browse/FOUR-27966)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy


[FOUR-27966]: https://processmaker.atlassian.net/browse/FOUR-27966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ