### PR TITLE
FOUR-27977: [48377] DevLink does not import Data Connector dependencies inside PM Blocks

### DIFF
--- a/ProcessMaker/Traits/HideSystemResources.php
+++ b/ProcessMaker/Traits/HideSystemResources.php
@@ -92,7 +92,11 @@ trait HideSystemResources
             return $query
                 ->where('is_template', false)
                 ->when(CachedSchema::hasColumn('data_sources', 'asset_type'), function ($query) {
-                    return $query->whereNull('asset_type');
+                    // Allow PM Block data connectors to be listed alongside regular ones.
+                    return $query->where(function ($query) {
+                        $query->whereNull('asset_type')
+                            ->orWhere('asset_type', 'PM_BLOCK');
+                    });
                 })
                 ->whereDoesntHave('categories', function ($query) {
                     $query->where('is_system', true);


### PR DESCRIPTION
## Issue & Reproduction Steps

When using “Save as PM Block”, the Select List inside the cloned Screen loses its Data Connector selection: the dropdown shows no selected connector/endpoint.

**Repro:** create a process with a Screen containing a Select List bound to a Data Connector; click “Save as PM Block”; open the generated PM Block’s Screen in the Screen Builder—Data Connector and End Point are unselected.

## Solution
- Allow PM Block Data Connectors (asset_type = PM_BLOCK) to be included in the nonSystem scope so they are returned by /api/data_sources and visible in the builder.
- Ensure the Select List import remaps selectedDataSource as an integer ID so the builder pre-selects the cloned Data Connector.
- Added targeted tests to prevent regressions for both the scope change and the Select List remap.

## How to Test
1. Create a process with a Screen that has a Select List configured to a Data Connector and save it as a PM Block.
2. Open the PM Block’s Screen in the Screen Builder: the Data Connector should already be selected and the End Point set to GET.
3. API check: GET /api/1.0/data_sources should list both regular and PM Block Data Connectors.

**Run focused tests:**
- php artisan test --filter=SelectedDataSourceIsStoredAsInteger
- php artisan test --filter=DataSourceNonSystemScopeTest

## Related Tickets & Packages
- [FOUR-27977](https://processmaker.atlassian.net/browse/FOUR-27977)
- [Package Data Source PR](https://github.com/ProcessMaker/package-data-sources/pull/454)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-27977]: https://processmaker.atlassian.net/browse/FOUR-27977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ac320fe83dd3b74eb4618cfda71ccb78b1bd4a52. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->