### PR TITLE
FOUR-27111 | Implement Backend Logic to Call API → Submit Document for Extraction

### DIFF
--- a/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
@@ -136,6 +136,8 @@ class ScriptMicroserviceRunner
             $variablesParameter['API_HOST'] = config('app.docker_host_url') . '/api/1.0';
             $variablesParameter['APP_URL'] = config('app.docker_host_url');
             $variablesParameter['API_SSL_VERIFY'] = (config('app.api_ssl_verify') ? '1' : '0');
+            $variablesParameter['SMART_EXTRACT_API_HOST'] = config('app.smart_extract_api_host');
+            $variablesParameter['SMART_EXTRACT_PM_API_TOKEN'] = config('app.smart_extract_api_token');
         }
 
         return $variablesParameter;

--- a/config/app.php
+++ b/config/app.php
@@ -298,4 +298,7 @@ return [
     'multitenancy' => env('MULTITENANCY', false),
 
     'resources_core_path' => base_path('resources-core'),
+
+    'smart_extract_api_host' => env('SMART_EXTRACT_API_HOST', 'extract-api.processmaker.net'),
+    'smart_extract_api_token' => env('SMART_EXTRACT_PM_API_TOKEN', ''),
 ];


### PR DESCRIPTION
# Summary
This PR adds configuration support for Smart Extract API variables, making them available as environment variables to scripts running in the Script Microservice Runner.

# Solution
### 1. Configuration (`config/app.php`)
- Added `smart_extract_api_host` configuration option with default value `'extract-api.processmaker.net'`
- Added `smart_extract_api_token` configuration option (empty string by default)

### 2. Script Runner Environment Variables (`ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php`)
- Added `SMART_EXTRACT_API_HOST` to the environment variables passed to scripts
- Added `SMART_EXTRACT_PM_API_TOKEN` to the environment variables passed to scripts
- These variables are injected into the script execution environment alongside existing variables like `API_TOKEN`, `API_HOST`, etc.

# How To Test
- Verify that scripts can access `SMART_EXTRACT_API_HOST` and `SMART_EXTRACT_PM_API_TOKEN` as environment variables

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Smart Extract API host/token config and injects them as `SMART_EXTRACT_API_HOST` and `SMART_EXTRACT_PM_API_TOKEN` env vars to scripts.
> 
> - **Config**:
>   - Add `app.smart_extract_api_host` (default `extract-api.processmaker.net`).
>   - Add `app.smart_extract_api_token` (default empty).
> - **Script Runner** (`ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php`):
>   - Include `SMART_EXTRACT_API_HOST` and `SMART_EXTRACT_PM_API_TOKEN` in script environment variables alongside existing `API_*` vars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34840d31c56f6919212be4786bbf68e0c5d3f792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->