### PR TITLE
Task/FOUR-28207: Build iframeSrc in TaskController with fileId and documentToken received from Apply Model response

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -190,6 +190,25 @@ class TaskController extends Controller
                 'datetime_format',
             ]);
             $userConfiguration = (new UserConfigurationController())->index();
+            $hitlEnabled = config('smart-extract.hitl_enabled', false) && $isSmartExtractTask;
+            
+            // Build the iframe source
+            $iframeSrc = null;
+            if ($hitlEnabled) {
+                $dashboardUrl = config('smart-extract.dashboard_url');
+                $requestData = $task->processRequest->data ?? [];
+   
+                $documentToken = $requestData['documentToken'] ?? null;
+                $fileId = $requestData['fileId'] ?? null;
+                
+                if ($documentToken && $fileId) {
+                    $queryParams = http_build_query([
+                        'documentToken' => $documentToken,
+                        'fileId' => $fileId,
+                    ]);
+                    $iframeSrc = $dashboardUrl . '?' . $queryParams;
+                }
+            }
 
             return view('tasks.edit', [
                 'task' => $task,
@@ -204,7 +223,8 @@ class TaskController extends Controller
                 'screenFields' => $screenFields,
                 'taskDraftsEnabled' => $taskDraftsEnabled,
                 'userConfiguration' => $userConfiguration,
-                'hitlEnabled' => config('smart-extract.hitl_enabled', false) && $isSmartExtractTask,
+                'hitlEnabled' => $hitlEnabled,
+                'iframeSrc' => $iframeSrc,
             ]);
         }
     }

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -108,7 +108,7 @@
                       @redirect="redirectToTask"
                       @form-data-changed="handleFormDataChange" />
                   @else
-                    @include('tasks.partials.hitl-iframe')
+                    @include('tasks.partials.hitl-iframe', ['iframeSrc' => $iframeSrc ?? null])
                   @endunless
                 @endcan
                 <div v-if="taskHasComments">

--- a/resources/views/tasks/partials/hitl-iframe.blade.php
+++ b/resources/views/tasks/partials/hitl-iframe.blade.php
@@ -1,7 +1,7 @@
 {{-- Smart Extract Manual Edit content when HITL is enabled --}}
 @php
-  // Note: This URL will be obtained from request data in future implementation.
-  $iframeSrc = null
+  // The $iframeSrc variable is received as a parameter from edit.blade.php
+  $iframeSrc = $iframeSrc ?? null;
 @endphp
 
 @if (!empty($iframeSrc))


### PR DESCRIPTION
## Solution
- This ticket implements last part of HITL process, building the Smart Extract URL for the iframe.

## How to Test
1. Enable HITL flag TRUE in .env file
2. Create Process Start Event -> Task (with upload file control) -> Smart Extract NODE -> End Event
3. Run and upload Transcript PDF File
4. Check if process worked creating a new TASK called Manual Document Review
5.  Go To Tasks and click in HITL task
6. Complete de verification in iframe
7. An alert message should be displayed with message "Document has being verified"
8. Click on OK
9. Process should end without problems.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-28207

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
