### PR TITLE
FOUR-28264 Make config cache run in subprocess

### DIFF
--- a/ProcessMaker/Jobs/RefreshArtisanCaches.php
+++ b/ProcessMaker/Jobs/RefreshArtisanCaches.php
@@ -39,7 +39,7 @@ class RefreshArtisanCaches implements ShouldQueue
             // Run in a separate process to avoid the tenant being set.
             // We do not use a tenant-specific config cache file.
             Process::path(base_path())
-                ->env(['TENANT' => ''])
+                ->env(['TENANT' => false, 'APP_URL' => false])
                 ->run(Application::formatCommandString('config:cache'))->throw();
         } else {
             Artisan::call('queue:restart', $options);

--- a/ProcessMaker/Jobs/RefreshArtisanCaches.php
+++ b/ProcessMaker/Jobs/RefreshArtisanCaches.php
@@ -3,12 +3,14 @@
 namespace ProcessMaker\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Console\Application;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Process;
 
 class RefreshArtisanCaches implements ShouldQueue
 {
@@ -34,7 +36,11 @@ class RefreshArtisanCaches implements ShouldQueue
         ];
 
         if (app()->configurationIsCached()) {
-            Artisan::call('config:cache', $options);
+            // Run in a separate process to avoid the tenant being set.
+            // We do not use a tenant-specific config cache file.
+            Process::path(base_path())
+                ->env(['TENANT' => ''])
+                ->run(Application::formatCommandString('config:cache'))->throw();
         } else {
             Artisan::call('queue:restart', $options);
 


### PR DESCRIPTION
The config cache needs to be rebuilt without a tenant set. The cleanest way to do this when the command is run dynamically is to do it in a subprocess.

https://processmaker.atlassian.net/browse/FOUR-28264

ci:deploy
ci:multitenancy