### PR TITLE
FOUR-28311 The search for reassignment is not working

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -253,10 +253,10 @@ class UserController extends Controller
             $include_ids = explode(',', $include_ids_string);
         } elseif ($request->has('assignable_for_task_id')) {
             $processRequestToken = ProcessRequestToken::findOrFail($request->input('assignable_for_task_id'));
-            $assignmentRule = $processRequestToken->getAssignmentRule();
             if (config('app.reassign_restrict_to_assignable_users')) {
                 $include_ids = $processRequestToken->process->getAssignableUsersByAssignmentType($processRequestToken);
             }
+            $assignmentRule = $processRequestToken->getAssignmentRule();
             if ($assignmentRule === 'rule_expression' && $request->has('form_data')) {
                 $include_ids = $processRequestToken->getAssigneesFromExpression($request->input('form_data'));
             }

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1053,29 +1053,65 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
      * - previous_task_assignee: would assign it to the Process Manager.
      * - requester: would assign it to the Process Manager.
      * - process_manager: would assign it to the same Process Manager.
-     * 
+     *
      * @param ProcessRequestToken $processRequestToken
-     * @return array
+     * @return array Array of user IDs, always returns a flat array (never nested)
      */
     public function getAssignableUsersByAssignmentType(ProcessRequestToken $processRequestToken): array
     {
-        $users = [];
-        switch ($processRequestToken->getAssignmentRule()) {
-            case 'user_group':
-            case 'process_variable':
-            case 'rule_expression':
-                $users = $this->getAssignableUsers($processRequestToken->element_id);
-                $users[] = $processRequestToken->process->properties["manager_id"];
-                break;
-            case 'previous_task_assignee':
-            case 'requester':
-                $users[] = $processRequestToken->process->properties["manager_id"];
-                break;
-            case 'process_manager':
-                $users[] = $processRequestToken->process->properties["manager_id"];
-                break;
+        $assignmentRule = $processRequestToken->getAssignmentRule();
+        $managerIds = $processRequestToken->process->manager_id ?? [];
+        
+        // Rules that only return process managers
+        $managerOnlyRules = ['previous_task_assignee', 'requester', 'process_manager'];
+        if (in_array($assignmentRule, $managerOnlyRules, true)) {
+            return $this->normalizeUserIds($managerIds);
         }
-        return $users;
+        
+        // Rules that return assignable users plus process managers
+        $groupBasedRules = ['user_group', 'process_variable', 'rule_expression'];
+        if (in_array($assignmentRule, $groupBasedRules, true)) {
+            $users = [];
+            
+            // Get assignable users from task assignments
+            if (!empty($processRequestToken->element_id)) {
+                $users = $this->getAssignableUsers($processRequestToken->element_id);
+            }
+            
+            // Merge with manager IDs
+            if (!empty($managerIds)) {
+                $users = array_merge($users, $managerIds);
+            }
+            
+            return $this->normalizeUserIds($users);
+        }
+        
+        // Default: return empty array for unknown rules
+        return [];
+    }
+    
+    /**
+     * Normalize user IDs to ensure a flat array of unique numeric values.
+     *
+     * @param array|null $userIds
+     * @return array
+     */
+    private function normalizeUserIds($userIds): array
+    {
+        if (empty($userIds)) {
+            return [];
+        }
+        
+        // Flatten nested arrays and filter out invalid values
+        $normalized = array_filter(
+            array_values(Arr::flatten($userIds)),
+            function ($id) {
+                return !empty($id) && is_numeric($id);
+            }
+        );
+        
+        // Remove duplicates and return
+        return array_values(array_unique($normalized));
     }
 
     /**

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1061,35 +1061,35 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
     {
         $assignmentRule = $processRequestToken->getAssignmentRule();
         $managerIds = $processRequestToken->process->manager_id ?? [];
-        
+
         // Rules that only return process managers
         $managerOnlyRules = ['previous_task_assignee', 'requester', 'process_manager'];
         if (in_array($assignmentRule, $managerOnlyRules, true)) {
             return $this->normalizeUserIds($managerIds);
         }
-        
+
         // Rules that return assignable users plus process managers
         $groupBasedRules = ['user_group', 'process_variable', 'rule_expression'];
         if (in_array($assignmentRule, $groupBasedRules, true)) {
             $users = [];
-            
+
             // Get assignable users from task assignments
             if (!empty($processRequestToken->element_id)) {
                 $users = $this->getAssignableUsers($processRequestToken->element_id);
             }
-            
+
             // Merge with manager IDs
             if (!empty($managerIds)) {
                 $users = array_merge($users, $managerIds);
             }
-            
+
             return $this->normalizeUserIds($users);
         }
-        
+
         // Default: return empty array for unknown rules
         return [];
     }
-    
+
     /**
      * Normalize user IDs to ensure a flat array of unique numeric values.
      *
@@ -1101,7 +1101,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         if (empty($userIds)) {
             return [];
         }
-        
+
         // Flatten nested arrays and filter out invalid values
         $normalized = array_filter(
             array_values(Arr::flatten($userIds)),
@@ -1109,7 +1109,7 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
                 return !empty($id) && is_numeric($id);
             }
         );
-        
+
         // Remove duplicates and return
         return array_values(array_unique($normalized));
     }

--- a/resources/js/common/reassignMixin.js
+++ b/resources/js/common/reassignMixin.js
@@ -37,7 +37,7 @@ export default {
         }
       }
 
-      ProcessMaker.apiClient.post('users_task_count', { params }).then(response => {
+      ProcessMaker.apiClient.post('users_task_count',  params ).then(response => {
         this.reassignUsers = [];
         response.data.data.forEach((user) => {
           this.reassignUsers.push({

--- a/tests/unit/ProcessMaker/Models/ProcessTest.php
+++ b/tests/unit/ProcessMaker/Models/ProcessTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Unit\ProcessMaker\Models;
 
+use Mockery;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\ProcessTaskAssignment;
 use ProcessMaker\Models\User;
 use Tests\TestCase;
 
@@ -29,5 +33,291 @@ class ProcessTest extends TestCase
         $process->getConsolidatedUsers($groupA->id, $users);
 
         $this->assertEquals([$groupAUser->id, $groupBUser->id], $users);
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with manager-only rules
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithManagerOnlyRules()
+    {
+        $manager1 = User::factory()->create(['status' => 'ACTIVE']);
+        $manager2 = User::factory()->create(['status' => 'ACTIVE']);
+        
+        // Create process with multiple managers (array)
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => [$manager1->id, $manager2->id]]
+        ]);
+        
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'element_id' => 'test_element',
+        ]);
+
+        // Mock getAssignmentRule to return different manager-only rules
+        $managerOnlyRules = ['previous_task_assignee', 'requester', 'process_manager'];
+        
+        foreach ($managerOnlyRules as $rule) {
+            $tokenMock = Mockery::mock($token)->makePartial();
+            $tokenMock->shouldReceive('getAssignmentRule')->andReturn($rule);
+            
+            $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+            
+            // Should return both managers
+            $this->assertIsArray($result);
+            $this->assertCount(2, $result);
+            $this->assertContains($manager1->id, $result);
+            $this->assertContains($manager2->id, $result);
+        }
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with single manager
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithSingleManager()
+    {
+        $manager = User::factory()->create(['status' => 'ACTIVE']);
+        
+        // Create process with single manager (not array)
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id]
+        ]);
+        
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('process_manager');
+        
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+        
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertContains($manager->id, $result);
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with group-based rules
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithGroupBasedRules()
+    {
+        $manager = User::factory()->create(['status' => 'ACTIVE']);
+        $assignableUser1 = User::factory()->create(['status' => 'ACTIVE']);
+        $assignableUser2 = User::factory()->create(['status' => 'ACTIVE']);
+        
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id]
+        ]);
+        
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $elementId = 'test_element_' . uniqid();
+        
+        // Create task assignments
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $process->id,
+            'process_task_id' => $elementId,
+            'assignment_id' => $assignableUser1->id,
+            'assignment_type' => User::class,
+        ]);
+        
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $process->id,
+            'process_task_id' => $elementId,
+            'assignment_id' => $assignableUser2->id,
+            'assignment_type' => User::class,
+        ]);
+        
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'element_id' => $elementId,
+        ]);
+
+        $groupBasedRules = ['user_group', 'process_variable', 'rule_expression'];
+        
+        foreach ($groupBasedRules as $rule) {
+            $tokenMock = Mockery::mock($token)->makePartial();
+            $tokenMock->shouldReceive('getAssignmentRule')->andReturn($rule);
+            
+            $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+            
+            // Should return assignable users + manager
+            $this->assertIsArray($result);
+            $this->assertCount(3, $result);
+            $this->assertContains($manager->id, $result);
+            $this->assertContains($assignableUser1->id, $result);
+            $this->assertContains($assignableUser2->id, $result);
+        }
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with empty element_id
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithEmptyElementId()
+    {
+        $manager = User::factory()->create(['status' => 'ACTIVE']);
+        
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id]
+        ]);
+        
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'element_id' => '', // Use empty string instead of null
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('user_group');
+        
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+        
+        // Should only return manager when element_id is empty
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertContains($manager->id, $result);
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with null manager_id
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithNullManager()
+    {
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => null]
+        ]);
+        
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('process_manager');
+        
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+        
+        // Should return empty array when manager_id is null
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with unknown rule
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithUnknownRule()
+    {
+        $manager = User::factory()->create(['status' => 'ACTIVE']);
+        
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id]
+        ]);
+        
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('unknown_rule');
+        
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+        
+        // Should return empty array for unknown rules
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType handles nested arrays correctly
+     */
+    public function testGetAssignableUsersByAssignmentTypeHandlesNestedArrays()
+    {
+        $manager1 = User::factory()->create(['status' => 'ACTIVE']);
+        $manager2 = User::factory()->create(['status' => 'ACTIVE']);
+        
+        // Simulate nested array scenario (shouldn't happen but test the normalization)
+        // Note: The accessor will normalize this, but we test the normalization logic
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => [[$manager1->id], [$manager2->id]]]
+        ]);
+        
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('process_manager');
+        
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+        
+        // Should flatten and return both managers
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertContains($manager1->id, $result);
+        $this->assertContains($manager2->id, $result);
+        // Verify it's a flat array (not nested)
+        foreach ($result as $item) {
+            $this->assertIsInt($item);
+        }
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType removes duplicates
+     */
+    public function testGetAssignableUsersByAssignmentTypeRemovesDuplicates()
+    {
+        $manager = User::factory()->create(['status' => 'ACTIVE']);
+        $assignableUser = User::factory()->create(['status' => 'ACTIVE']);
+        
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id]
+        ]);
+        
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $elementId = 'test_element_' . uniqid();
+        
+        // Create task assignment with manager as assignable user (duplicate scenario)
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $process->id,
+            'process_task_id' => $elementId,
+            'assignment_id' => $manager->id, // Same as manager
+            'assignment_type' => User::class,
+        ]);
+        
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $process->id,
+            'process_task_id' => $elementId,
+            'assignment_id' => $assignableUser->id,
+            'assignment_type' => User::class,
+        ]);
+        
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'element_id' => $elementId,
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('user_group');
+        
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+        
+        // Should return unique values (manager should appear only once)
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result); // manager + assignableUser (no duplicates)
+        $this->assertContains($manager->id, $result);
+        $this->assertContains($assignableUser->id, $result);
+        // Verify no duplicates
+        $this->assertEquals(count($result), count(array_unique($result)));
     }
 }


### PR DESCRIPTION
 ## Description
In version 4.15.11, when we perform a user search in the dropdown of the reassignment, it does not work.
 ## Related tickets
https://processmaker.atlassian.net/browse/FOUR-28311
