### PR TITLE
FOUR-28341: Improve Error Handling for Smart Extract Subprocess

### DIFF
--- a/ProcessMaker/Jobs/ErrorHandling.php
+++ b/ProcessMaker/Jobs/ErrorHandling.php
@@ -210,10 +210,59 @@ class ErrorHandling
     public static function convertResponseToException($result)
     {
         if ($result['status'] === 'error') {
-            if (str_starts_with($result['message'], 'Command exceeded timeout of')) {
-                throw new ScriptTimeoutException($result['message']);
+            $rawMessage = $result['message'] ?? '';
+            if (str_starts_with((string) $rawMessage, 'Command exceeded timeout of')) {
+                throw new ScriptTimeoutException((string) $rawMessage);
             }
-            throw new ScriptException($result['message']);
+
+            $message = self::extractScriptErrorMessage($result);
+
+            if (empty($message)) {
+                $message = $rawMessage ?: 'Script execution failed with unknown error';
+            }
+
+            throw new ScriptException($message);
         }
+    }
+
+    /**
+     * Extract a concise error message from the microservice response.
+     */
+    private static function extractScriptErrorMessage(array $result): string
+    {
+        $candidates = [
+            $result['output']['error'] ?? null,
+            $result['output']['exception'] ?? null,
+            $result['output']['stderr'] ?? null,
+            $result['output']['stdout'] ?? null,
+            $result['message'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) || is_numeric($candidate)) {
+                $short = self::shortenMessage((string) $candidate);
+                if (!empty($short)) {
+                    return $short;
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Keep only the first line of the error and limit its length to avoid noisy traces.
+     */
+    private static function shortenMessage(string $message): string
+    {
+        $firstLine = strtok($message, "\n");
+        $firstLine = $firstLine === false ? $message : $firstLine;
+        $trimmed = trim($firstLine);
+
+        if (strlen($trimmed) > 400) {
+            return substr($trimmed, 0, 400) . '…';
+        }
+
+        return $trimmed;
     }
 }

--- a/tests/unit/ErrorHandlingTest.php
+++ b/tests/unit/ErrorHandlingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ProcessMaker\Exception\ScriptException;
+use ProcessMaker\Exception\ScriptTimeoutException;
+use ProcessMaker\Jobs\ErrorHandling;
+
+class ErrorHandlingTest extends TestCase
+{
+    public function testUsesOutputErrorOverGenericMessage(): void
+    {
+        $result = [
+            'status' => 'error',
+            'message' => 'Generic failure',
+            'output' => [
+                'error' => 'SMART_EXTRACT_API_HOST is required but could not be resolved',
+            ],
+        ];
+
+        $this->expectException(ScriptException::class);
+        $this->expectExceptionMessage('SMART_EXTRACT_API_HOST is required but could not be resolved');
+
+        ErrorHandling::convertResponseToException($result);
+    }
+
+    public function testPrefersStderrAndKeepsOnlyFirstLine(): void
+    {
+        $result = [
+            'status' => 'error',
+            'message' => 'fallback message',
+            'output' => [
+                'stderr' => "First line of error\nstack trace line 2\nstack trace line 3",
+            ],
+        ];
+
+        $this->expectException(ScriptException::class);
+        $this->expectExceptionMessage('First line of error');
+
+        ErrorHandling::convertResponseToException($result);
+    }
+
+    public function testTimeoutErrorThrowsScriptTimeoutException(): void
+    {
+        $result = [
+            'status' => 'error',
+            'message' => 'Command exceeded timeout of 120 seconds',
+        ];
+
+        $this->expectException(ScriptTimeoutException::class);
+        $this->expectExceptionMessage('Command exceeded timeout of 120 seconds');
+
+        ErrorHandling::convertResponseToException($result);
+    }
+
+    public function testFallsBackToRawMessageWhenNoOutputPresent(): void
+    {
+        $result = [
+            'status' => 'error',
+            'message' => 'Plain failure',
+        ];
+
+        $this->expectException(ScriptException::class);
+        $this->expectExceptionMessage('Plain failure');
+
+        ErrorHandling::convertResponseToException($result);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps

The Smart Extract subprocess surfaced only “Script execution failed with exit code: 1” in the Errors tab, hiding the actual root cause.

Reproduce: run Smart Extract subprocess with an invalid/missing SMART_EXTRACT_API_HOST; the UI shows only the generic exit code and no actionable message.

## Solution
- Enhanced error extraction in ProcessMaker/Jobs/ErrorHandling.php to surface concise, meaningful messages from microservice responses (prefers output error/exception/stderr/stdout; trims to first line and limits length; keeps timeout handling intact).
- Added PHPUnit coverage in tests/Unit/ErrorHandlingTest.php for output precedence, stderr first-line trimming, timeout handling and fallback to raw message.

Before:
<img width="2321" height="1229" alt="before" src="https://github.com/user-attachments/assets/759ebd2a-2d2c-43c4-9e94-343ba19ecc47" />

After:
<img width="2321" height="1229" alt="after" src="https://github.com/user-attachments/assets/b3ba37f5-558f-426a-83fb-7ad0b22e6e29" />

## How to Test
1. Functional UI check: trigger the Smart Extract subprocess with SMART_EXTRACT_API_HOST blank/invalid. In the request Errors tab, you should see the specific message (e.g., “SMART_EXTRACT_API_HOST is required but could not be resolved”) instead of a generic exit code.
2. Unit tests: run php artisan test --filter=ErrorHandlingTest to verify the new error-handling cases.

## Related Tickets & Packages
- [FOUR-28341](https://processmaker.atlassian.net/browse/FOUR-28341)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-28341]: https://processmaker.atlassian.net/browse/FOUR-28341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ