### PR TITLE
FOUR-28353 Not all users in the reassigment list are listed if a proc…

### DIFF
--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1062,8 +1062,14 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
         $assignmentRule = $processRequestToken->getAssignmentRule();
         $managerIds = $processRequestToken->process->manager_id ?? [];
 
+        // For compatibility: when assignment rule is 'requester', return empty array
+        // to allow displaying all users instead of restricting to specific assignees.
+        if ($assignmentRule === 'requester') {
+            return [];
+        }
+
         // Rules that only return process managers
-        $managerOnlyRules = ['previous_task_assignee', 'requester', 'process_manager'];
+        $managerOnlyRules = ['previous_task_assignee', 'process_manager'];
         if (in_array($assignmentRule, $managerOnlyRules, true)) {
             return $this->normalizeUserIds($managerIds);
         }

--- a/tests/unit/ProcessMaker/Models/ProcessTest.php
+++ b/tests/unit/ProcessMaker/Models/ProcessTest.php
@@ -42,12 +42,12 @@ class ProcessTest extends TestCase
     {
         $manager1 = User::factory()->create(['status' => 'ACTIVE']);
         $manager2 = User::factory()->create(['status' => 'ACTIVE']);
-        
+
         // Create process with multiple managers (array)
         $process = Process::factory()->create([
-            'properties' => ['manager_id' => [$manager1->id, $manager2->id]]
+            'properties' => ['manager_id' => [$manager1->id, $manager2->id]],
         ]);
-        
+
         $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
         $token = ProcessRequestToken::factory()->create([
             'process_id' => $process->id,
@@ -56,14 +56,15 @@ class ProcessTest extends TestCase
         ]);
 
         // Mock getAssignmentRule to return different manager-only rules
-        $managerOnlyRules = ['previous_task_assignee', 'requester', 'process_manager'];
-        
+        // Note: 'requester' is excluded as it returns empty array for compatibility
+        $managerOnlyRules = ['previous_task_assignee', 'process_manager'];
+
         foreach ($managerOnlyRules as $rule) {
             $tokenMock = Mockery::mock($token)->makePartial();
             $tokenMock->shouldReceive('getAssignmentRule')->andReturn($rule);
-            
+
             $result = $process->getAssignableUsersByAssignmentType($tokenMock);
-            
+
             // Should return both managers
             $this->assertIsArray($result);
             $this->assertCount(2, $result);
@@ -78,12 +79,12 @@ class ProcessTest extends TestCase
     public function testGetAssignableUsersByAssignmentTypeWithSingleManager()
     {
         $manager = User::factory()->create(['status' => 'ACTIVE']);
-        
+
         // Create process with single manager (not array)
         $process = Process::factory()->create([
-            'properties' => ['manager_id' => $manager->id]
+            'properties' => ['manager_id' => $manager->id],
         ]);
-        
+
         $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
         $token = ProcessRequestToken::factory()->create([
             'process_id' => $process->id,
@@ -92,9 +93,9 @@ class ProcessTest extends TestCase
 
         $tokenMock = Mockery::mock($token)->makePartial();
         $tokenMock->shouldReceive('getAssignmentRule')->andReturn('process_manager');
-        
+
         $result = $process->getAssignableUsersByAssignmentType($tokenMock);
-        
+
         $this->assertIsArray($result);
         $this->assertCount(1, $result);
         $this->assertContains($manager->id, $result);
@@ -108,14 +109,14 @@ class ProcessTest extends TestCase
         $manager = User::factory()->create(['status' => 'ACTIVE']);
         $assignableUser1 = User::factory()->create(['status' => 'ACTIVE']);
         $assignableUser2 = User::factory()->create(['status' => 'ACTIVE']);
-        
+
         $process = Process::factory()->create([
-            'properties' => ['manager_id' => $manager->id]
+            'properties' => ['manager_id' => $manager->id],
         ]);
-        
+
         $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
         $elementId = 'test_element_' . uniqid();
-        
+
         // Create task assignments
         ProcessTaskAssignment::factory()->create([
             'process_id' => $process->id,
@@ -123,14 +124,14 @@ class ProcessTest extends TestCase
             'assignment_id' => $assignableUser1->id,
             'assignment_type' => User::class,
         ]);
-        
+
         ProcessTaskAssignment::factory()->create([
             'process_id' => $process->id,
             'process_task_id' => $elementId,
             'assignment_id' => $assignableUser2->id,
             'assignment_type' => User::class,
         ]);
-        
+
         $token = ProcessRequestToken::factory()->create([
             'process_id' => $process->id,
             'process_request_id' => $request->id,
@@ -138,13 +139,13 @@ class ProcessTest extends TestCase
         ]);
 
         $groupBasedRules = ['user_group', 'process_variable', 'rule_expression'];
-        
+
         foreach ($groupBasedRules as $rule) {
             $tokenMock = Mockery::mock($token)->makePartial();
             $tokenMock->shouldReceive('getAssignmentRule')->andReturn($rule);
-            
+
             $result = $process->getAssignableUsersByAssignmentType($tokenMock);
-            
+
             // Should return assignable users + manager
             $this->assertIsArray($result);
             $this->assertCount(3, $result);
@@ -160,11 +161,11 @@ class ProcessTest extends TestCase
     public function testGetAssignableUsersByAssignmentTypeWithEmptyElementId()
     {
         $manager = User::factory()->create(['status' => 'ACTIVE']);
-        
+
         $process = Process::factory()->create([
-            'properties' => ['manager_id' => $manager->id]
+            'properties' => ['manager_id' => $manager->id],
         ]);
-        
+
         $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
         $token = ProcessRequestToken::factory()->create([
             'process_id' => $process->id,
@@ -174,9 +175,9 @@ class ProcessTest extends TestCase
 
         $tokenMock = Mockery::mock($token)->makePartial();
         $tokenMock->shouldReceive('getAssignmentRule')->andReturn('user_group');
-        
+
         $result = $process->getAssignableUsersByAssignmentType($tokenMock);
-        
+
         // Should only return manager when element_id is empty
         $this->assertIsArray($result);
         $this->assertCount(1, $result);
@@ -189,9 +190,9 @@ class ProcessTest extends TestCase
     public function testGetAssignableUsersByAssignmentTypeWithNullManager()
     {
         $process = Process::factory()->create([
-            'properties' => ['manager_id' => null]
+            'properties' => ['manager_id' => null],
         ]);
-        
+
         $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
         $token = ProcessRequestToken::factory()->create([
             'process_id' => $process->id,
@@ -200,9 +201,9 @@ class ProcessTest extends TestCase
 
         $tokenMock = Mockery::mock($token)->makePartial();
         $tokenMock->shouldReceive('getAssignmentRule')->andReturn('process_manager');
-        
+
         $result = $process->getAssignableUsersByAssignmentType($tokenMock);
-        
+
         // Should return empty array when manager_id is null
         $this->assertIsArray($result);
         $this->assertEmpty($result);
@@ -214,11 +215,11 @@ class ProcessTest extends TestCase
     public function testGetAssignableUsersByAssignmentTypeWithUnknownRule()
     {
         $manager = User::factory()->create(['status' => 'ACTIVE']);
-        
+
         $process = Process::factory()->create([
-            'properties' => ['manager_id' => $manager->id]
+            'properties' => ['manager_id' => $manager->id],
         ]);
-        
+
         $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
         $token = ProcessRequestToken::factory()->create([
             'process_id' => $process->id,
@@ -227,9 +228,9 @@ class ProcessTest extends TestCase
 
         $tokenMock = Mockery::mock($token)->makePartial();
         $tokenMock->shouldReceive('getAssignmentRule')->andReturn('unknown_rule');
-        
+
         $result = $process->getAssignableUsersByAssignmentType($tokenMock);
-        
+
         // Should return empty array for unknown rules
         $this->assertIsArray($result);
         $this->assertEmpty($result);
@@ -242,13 +243,13 @@ class ProcessTest extends TestCase
     {
         $manager1 = User::factory()->create(['status' => 'ACTIVE']);
         $manager2 = User::factory()->create(['status' => 'ACTIVE']);
-        
+
         // Simulate nested array scenario (shouldn't happen but test the normalization)
         // Note: The accessor will normalize this, but we test the normalization logic
         $process = Process::factory()->create([
-            'properties' => ['manager_id' => [[$manager1->id], [$manager2->id]]]
+            'properties' => ['manager_id' => [[$manager1->id], [$manager2->id]]],
         ]);
-        
+
         $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
         $token = ProcessRequestToken::factory()->create([
             'process_id' => $process->id,
@@ -257,9 +258,9 @@ class ProcessTest extends TestCase
 
         $tokenMock = Mockery::mock($token)->makePartial();
         $tokenMock->shouldReceive('getAssignmentRule')->andReturn('process_manager');
-        
+
         $result = $process->getAssignableUsersByAssignmentType($tokenMock);
-        
+
         // Should flatten and return both managers
         $this->assertIsArray($result);
         $this->assertCount(2, $result);
@@ -278,14 +279,14 @@ class ProcessTest extends TestCase
     {
         $manager = User::factory()->create(['status' => 'ACTIVE']);
         $assignableUser = User::factory()->create(['status' => 'ACTIVE']);
-        
+
         $process = Process::factory()->create([
-            'properties' => ['manager_id' => $manager->id]
+            'properties' => ['manager_id' => $manager->id],
         ]);
-        
+
         $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
         $elementId = 'test_element_' . uniqid();
-        
+
         // Create task assignment with manager as assignable user (duplicate scenario)
         ProcessTaskAssignment::factory()->create([
             'process_id' => $process->id,
@@ -293,14 +294,14 @@ class ProcessTest extends TestCase
             'assignment_id' => $manager->id, // Same as manager
             'assignment_type' => User::class,
         ]);
-        
+
         ProcessTaskAssignment::factory()->create([
             'process_id' => $process->id,
             'process_task_id' => $elementId,
             'assignment_id' => $assignableUser->id,
             'assignment_type' => User::class,
         ]);
-        
+
         $token = ProcessRequestToken::factory()->create([
             'process_id' => $process->id,
             'process_request_id' => $request->id,
@@ -309,9 +310,9 @@ class ProcessTest extends TestCase
 
         $tokenMock = Mockery::mock($token)->makePartial();
         $tokenMock->shouldReceive('getAssignmentRule')->andReturn('user_group');
-        
+
         $result = $process->getAssignableUsersByAssignmentType($tokenMock);
-        
+
         // Should return unique values (manager should appear only once)
         $this->assertIsArray($result);
         $this->assertCount(2, $result); // manager + assignableUser (no duplicates)
@@ -319,5 +320,154 @@ class ProcessTest extends TestCase
         $this->assertContains($assignableUser->id, $result);
         // Verify no duplicates
         $this->assertEquals(count($result), count(array_unique($result)));
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with 'requester' rule returns empty array
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithRequesterRule()
+    {
+        $manager = User::factory()->create(['status' => 'ACTIVE']);
+
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id],
+        ]);
+
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'element_id' => 'test_element',
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('requester');
+
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+
+        // For compatibility, 'requester' rule should return empty array
+        // to allow displaying all users instead of restricting to managers
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with empty array manager_id
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithEmptyArrayManager()
+    {
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => []],
+        ]);
+
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('process_manager');
+
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+
+        // Should return empty array when manager_id is empty array
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with group assignments
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithGroupAssignments()
+    {
+        $manager = User::factory()->create(['status' => 'ACTIVE']);
+        $groupUser1 = User::factory()->create(['status' => 'ACTIVE']);
+        $groupUser2 = User::factory()->create(['status' => 'ACTIVE']);
+
+        $group = Group::factory()->create(['name' => 'Test Group', 'status' => 'ACTIVE']);
+        $group->groupMembers()->create(['member_id' => $groupUser1->id, 'member_type' => User::class]);
+        $group->groupMembers()->create(['member_id' => $groupUser2->id, 'member_type' => User::class]);
+
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id],
+        ]);
+
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $elementId = 'test_element_' . uniqid();
+
+        // Create task assignment with group
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $process->id,
+            'process_task_id' => $elementId,
+            'assignment_id' => $group->id,
+            'assignment_type' => Group::class,
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'element_id' => $elementId,
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('user_group');
+
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+
+        // Should return group users + manager
+        $this->assertIsArray($result);
+        $this->assertCount(3, $result); // manager + 2 group users
+        $this->assertContains($manager->id, $result);
+        $this->assertContains($groupUser1->id, $result);
+        $this->assertContains($groupUser2->id, $result);
+    }
+
+    /**
+     * Test getAssignableUsersByAssignmentType with group-based rules and no manager
+     */
+    public function testGetAssignableUsersByAssignmentTypeWithGroupBasedRulesNoManager()
+    {
+        $assignableUser1 = User::factory()->create(['status' => 'ACTIVE']);
+        $assignableUser2 = User::factory()->create(['status' => 'ACTIVE']);
+
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => null],
+        ]);
+
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+        $elementId = 'test_element_' . uniqid();
+
+        // Create task assignments
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $process->id,
+            'process_task_id' => $elementId,
+            'assignment_id' => $assignableUser1->id,
+            'assignment_type' => User::class,
+        ]);
+
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $process->id,
+            'process_task_id' => $elementId,
+            'assignment_id' => $assignableUser2->id,
+            'assignment_type' => User::class,
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'element_id' => $elementId,
+        ]);
+
+        $tokenMock = Mockery::mock($token)->makePartial();
+        $tokenMock->shouldReceive('getAssignmentRule')->andReturn('user_group');
+
+        $result = $process->getAssignableUsersByAssignmentType($tokenMock);
+
+        // Should return only assignable users (no manager)
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertContains($assignableUser1->id, $result);
+        $this->assertContains($assignableUser2->id, $result);
     }
 }


### PR DESCRIPTION
…ess manager has assigned on the process

 ## Description
Not all users in the reassigment list are listed if a process manager has been assigned to the process.
 ## Related tickets
https://processmaker.atlassian.net/browse/FOUR-28353
