### PR TITLE
FOUR-25055: Fix process owner when creating from default templates

### DIFF
--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -293,6 +293,8 @@ class ProcessTemplate implements TemplateInterface
         $processId = $rootLog['newId'];
 
         $process = Process::findOrFail($processId);
+        $process->user_id = Auth::id();
+        $process->save();
 
         $this->syncLaunchpadAssets($request, $process);
 

--- a/tests/Feature/Templates/Api/ProcessTemplateTest.php
+++ b/tests/Feature/Templates/Api/ProcessTemplateTest.php
@@ -342,6 +342,53 @@ class ProcessTemplateTest extends TestCase
         $this->assertEquals('Description of the process', $newProcess->description);
     }
 
+    public function testProcessCreatedFromTemplateUsesAuthenticatedUserAsOwner()
+    {
+        $this->addGlobalSignalProcess();
+        $templateOwner = User::factory()->create(['is_administrator' => true]);
+        $this->user = User::factory()->create(['is_administrator' => false]);
+
+        $processCategory = ProcessCategory::factory()->create(['status' => 'ACTIVE']);
+
+        $process = $this->createProcess('process-with-task-screen', [
+            'name' => 'Template Owned Process',
+            'description' => 'Template Owned Description',
+            'user_id' => $templateOwner->getKey(),
+            'process_category_id' => $processCategory->getKey(),
+        ]);
+
+        $manifest = $this->getManifest('process', $process->id);
+
+        $template = ProcessTemplates::factory()->create([
+            'name' => 'Owner Override Template',
+            'description' => 'Owner Override Template Description',
+            'process_id' => $process->id,
+            'process_category_id' => $processCategory->getKey(),
+            'manifest' => json_encode($manifest),
+            'user_id' => $templateOwner->getKey(),
+            'version' => '1.0.0',
+        ]);
+
+        $route = route('api.template.create', ['type' => 'process', 'id' => $template->id]);
+        $response = $this->apiCall('POST', $route, [
+            'user_id' => $this->user->getKey(),
+            'name' => 'New Process From Template',
+            'description' => 'New Process Description',
+            'process_category_id' => $processCategory->getKey(),
+            'mode' => 'copy',
+            'version' => $template->version,
+            'saveAssetMode' => 'saveAllAssets',
+        ]);
+
+        $response->assertStatus(200);
+
+        $processId = $response->json('processId');
+        $newProcess = Process::findOrFail($processId);
+
+        $this->assertEquals($this->user->getKey(), $newProcess->user_id);
+        $this->assertNotEquals($templateOwner->getKey(), $newProcess->user_id);
+    }
+
     /**
      * Tests the fixtures of the private PHP function.
      *


### PR DESCRIPTION
## Issue & Reproduction Steps

Creating a process from a default template assigns ownership to the template’s author/admin instead of the logged-in user. Reproduce by logging in as a non-admin user, calling POST /api/1.0/template/create/process/{id} with any default template id, and observing processes.user_id matches the template author rather than the requester.

## Solution
- Override the root asset’s user_id to the authenticated user during template-based process creation.
- Persist the newly created process with user_id set to the authenticated user (no inheritance from the template author).
- Add a regression test ensuring a process created from a template is owned by the logged-in user.

## How to Test
1. As a non-admin user, call POST /api/1.0/template/create/process/{id} using a default template id; confirm the new row in processes has user_id equal to the caller.
2. Run the regression test: php artisan test --filter=ProcessTemplateTest::testProcessCreatedFromTemplateUsesAuthenticatedUserAsOwner

## Related Tickets & Packages
- [FOUR-25055](https://processmaker.atlassian.net/browse/FOUR-25055)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-25055]: https://processmaker.atlassian.net/browse/FOUR-25055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ