### PR TITLE
FOUR-28331:DASHBOARD>> The images in the interstitial screens are not centered.

### DIFF
--- a/resources/sass/tailwind.css
+++ b/resources/sass/tailwind.css
@@ -53,3 +53,8 @@
     margin: revert-layer;
     padding: 0px;
   }
+
+  /* Set Images in form-group in the center */
+  .form-group img {
+    display: inline-flex;
+  }


### PR DESCRIPTION
## Issue & Reproduction Steps
The images in the interstitial screens are not centered

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-28331

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy