### PR TITLE
FOUR-27537 Home Page as Element Destination in End Event Results in Error

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1414,8 +1414,8 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                 $elementDestination = route('tasks.index');
                 break;
             case 'homepageDashboard':
-                if (hasPackage('package-dynamic-ui')) {
-                    $user = auth()->user();
+                $user = auth()->user();
+                if (hasPackage('package-dynamic-ui') && $user) {
                     $elementDestination = \ProcessMaker\Package\PackageDynamicUI\Models\DynamicUI::getHomePage($user);
                 } else {
                     $elementDestination = route('home');


### PR DESCRIPTION
## Home Page as Element Destination in End Event Results in Error

## Solution
Use home route when an automated task completes a process or when the user is empty


https://github.com/user-attachments/assets/7b21cde5-e588-4454-8fcf-ef1ce0aa060c

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-27537

ci:deploy
