### PR TITLE
FOUR-25084: Fix sidebar SVG icons so they inherit nav text color

### DIFF
--- a/resources/js/components/Sidebaricon.vue
+++ b/resources/js/components/Sidebaricon.vue
@@ -3,7 +3,12 @@
       <a :href="item.url" class="nav-link"  @click="toggle" :target="item.attributes.target" :aria-label="ariaLabel">
         <i v-if="item.attributes.icon" class="fas nav-icon" :class="item.attributes.icon" ></i>
         <i v-if="item.attributes.customicon" :class="item.attributes.customicon" ></i>
-        <img v-if="item.attributes.file" :src="item.attributes.file" class="nav-icon" id="custom_icon">
+        <span
+          v-if="item.attributes.file"
+          class="nav-icon custom-icon"
+          :style="maskStyle(item.attributes.file)"
+          id="custom_icon"
+        />
         <span class="nav-text" v-show="expanded()" v-cloak >
           {{item.title}}
           <i v-if="item.children && item.children.length" class="float-right fas" :class="{'fa-caret-right': !isOpen, 'fa-caret-down': isOpen}"></i>
@@ -19,7 +24,12 @@
                 </span>
             </a>
             <a :href="item.url" class="nav-link" v-show="item.attributes.file">
-              <img :src="item.attributes.file" class="nav-icon" id="custom_icon"><span class="nav-text" v-if="expanded()" v-cloak>{{item.title}}<span v-if="count !== null" class="nav-badge float-right">{{ count }}</span></span>
+              <span
+                :style="maskStyle(item.attributes.file)"
+                class="nav-icon custom-icon"
+                id="custom_icon"
+              />
+              <span class="nav-text" v-if="expanded()" v-cloak>{{item.title}}<span v-if="count !== null" class="nav-badge float-right">{{ count }}</span></span>
                 <span class="nav-text" v-if="expanded()" v-cloak>{{item.title}}
                   <span v-if="count !== null" class="nav-badge float-right" :aria-label="ariaLabel">{{ count }}</span>
                 </span>
@@ -73,7 +83,20 @@
       },
       expanded() {
         return this.$parent.expanded
-     }
+     },
+      maskStyle(file) {
+        return {
+          backgroundColor: 'currentColor',
+          WebkitMaskImage: `url(${file})`,
+          maskImage: `url(${file})`,
+          WebkitMaskRepeat: 'no-repeat',
+          maskRepeat: 'no-repeat',
+          WebkitMaskPosition: 'center',
+          maskPosition: 'center',
+          WebkitMaskSize: 'contain',
+          maskSize: 'contain',
+        };
+      }
     }
   }
 </script>

--- a/resources/sass/sidebar/sidebar.scss
+++ b/resources/sass/sidebar/sidebar.scss
@@ -43,6 +43,24 @@
     font-size: 14px;
     color: $light;
     height: 43px;
+
+    .nav-icon {
+      color: inherit;
+
+      &.custom-icon {
+        display: inline-block;
+        width: 24px;
+        height: 24px;
+        background-color: currentColor;
+      }
+
+      svg {
+        width: 1em;
+        height: 1em;
+        fill: currentColor;
+        stroke: currentColor;
+      }
+    }
   }
 
   .logo {


### PR DESCRIPTION
## Issue & Reproduction Steps

Sidebar menu SVG icons (base64 images) were rendering white instead of inheriting the nav text color.
Reproduce:
1. Open the sidebar with any item using a custom SVG icon and customized UI.
2. Note that font-awesome icons render red ($light), but SVG icons render white.

## Solution
- Swapped <img> tags for base64 SVGs to <span> elements using CSS masks so icons use currentColor.
- Added .nav-icon.custom-icon styles to size the masked icons and inherit the nav link color in resources/sass/sidebar/sidebar.scss.
- Kept existing font-awesome behavior unchanged.

## How to Test
1. Rebuild assets if needed (npm run dev or npm run build).
2. Open the sidebar; confirm custom SVG icons now display in the same red as font-awesome icons in both expanded and collapsed states.
3. Verify hover/active states still behave as before.

## Related Tickets & Packages
- [FOUR-25084](https://processmaker.atlassian.net/browse/FOUR-25084)

ci:deploy

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-25084]: https://processmaker.atlassian.net/browse/FOUR-25084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ