### PR TITLE
FOUR-28469: Error with Subrocesses - Missing data between from child request to parent request

### DIFF
--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -114,6 +114,14 @@ class CallActivity implements CallActivityInterface
             $data = array_intersect_key($allData, array_flip($updatedKeys));
         }
 
+        $parentData = $token->getInstance()->getDataStore()->getData();
+
+        // Ensure new keys created in the subprocess are merged even if getUpdated() missed them.
+        $newKeys = array_diff(array_keys($allData ?? []), array_keys($parentData ?? []));
+        if (!empty($newKeys)) {
+            $data = $data + array_intersect_key($allData, array_flip($newKeys));
+        }
+
         $dataManager = new DataManager();
         $dataManager->updateData($token, $data);
         $token->getInstance()->getProcess()->getEngine()->runToNextState();

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -97,30 +97,10 @@ class CallActivity implements CallActivityInterface
         $store = $closedInstance->getDataStore();
         $allData = $store->getData();
 
-        // Determine which data should be merged back from the subprocess.
-        $updatedKeys = method_exists($store, 'getUpdated')
-            ? $store->getUpdated()
-            : null;
-
-        if ($updatedKeys === null) {
-            // Legacy behavior or no tracking available: copy all data.
-            $data = $allData;
-        } elseif ($updatedKeys === []) {
-            // Nothing was updated in the subprocess: do not merge anything.
-            $data = [];
-        } else {
-            // Merge only the explicitly updated keys.
-            $updatedKeys = array_values((array) $updatedKeys);
-            $data = array_intersect_key($allData, array_flip($updatedKeys));
-        }
-
+        $data = $this->resolveUpdatedData($store, $allData);
         $parentData = $token->getInstance()->getDataStore()->getData();
-
-        // Ensure new keys created in the subprocess are merged even if getUpdated() missed them.
-        $newKeys = array_diff(array_keys($allData ?? []), array_keys($parentData ?? []));
-        if (!empty($newKeys)) {
-            $data = $data + array_intersect_key($allData, array_flip($newKeys));
-        }
+        $data = $this->mergeNewKeys($data, $allData, $parentData);
+        $data = $this->mergeChangedKeys($data, $allData, $parentData);
 
         $dataManager = new DataManager();
         $dataManager->updateData($token, $data);
@@ -131,6 +111,62 @@ class CallActivity implements CallActivityInterface
         $this->synchronizeInstances($instance, $token->getInstance());
 
         return $this;
+    }
+
+    /**
+     * Decide which data from the subprocess should be merged based on updated keys.
+     */
+    private function resolveUpdatedData($store, array $allData): array
+    {
+        $updatedKeys = method_exists($store, 'getUpdated')
+            ? $store->getUpdated()
+            : null;
+
+        if ($updatedKeys === null) {
+            return $allData;
+        }
+
+        if ($updatedKeys === []) {
+            return [];
+        }
+
+        $updatedKeys = array_values((array) $updatedKeys);
+
+        return array_intersect_key($allData, array_flip($updatedKeys));
+    }
+
+    /**
+     * Merge keys that exist only in the subprocess data.
+     */
+    private function mergeNewKeys(array $data, array $allData, array $parentData): array
+    {
+        $newKeys = array_diff(array_keys($allData), array_keys($parentData));
+        if (empty($newKeys)) {
+            return $data;
+        }
+
+        return $data + array_intersect_key($allData, array_flip($newKeys));
+    }
+
+    /**
+     * Merge keys that changed in the subprocess but may not have been tracked.
+     */
+    private function mergeChangedKeys(array $data, array $allData, array $parentData): array
+    {
+        $changedKeys = [];
+        foreach ($allData as $key => $value) {
+            if (array_key_exists($key, $parentData) && $parentData[$key] !== $value) {
+                $changedKeys[] = $key;
+            }
+        }
+
+        if (empty($changedKeys)) {
+            return $data;
+        }
+
+        $pendingKeys = array_diff($changedKeys, array_keys($data));
+
+        return $data + array_intersect_key($allData, array_flip($pendingKeys));
     }
 
     /**

--- a/ProcessMaker/Models/CallActivity.php
+++ b/ProcessMaker/Models/CallActivity.php
@@ -116,7 +116,7 @@ class CallActivity implements CallActivityInterface
     /**
      * Decide which data from the subprocess should be merged based on updated keys.
      */
-    private function resolveUpdatedData($store, array $allData): array
+    protected function resolveUpdatedData($store, array $allData): array
     {
         $updatedKeys = method_exists($store, 'getUpdated')
             ? $store->getUpdated()
@@ -138,7 +138,7 @@ class CallActivity implements CallActivityInterface
     /**
      * Merge keys that exist only in the subprocess data.
      */
-    private function mergeNewKeys(array $data, array $allData, array $parentData): array
+    protected function mergeNewKeys(array $data, array $allData, array $parentData): array
     {
         $newKeys = array_diff(array_keys($allData), array_keys($parentData));
         if (empty($newKeys)) {
@@ -151,7 +151,7 @@ class CallActivity implements CallActivityInterface
     /**
      * Merge keys that changed in the subprocess but may not have been tracked.
      */
-    private function mergeChangedKeys(array $data, array $allData, array $parentData): array
+    protected function mergeChangedKeys(array $data, array $allData, array $parentData): array
     {
         $changedKeys = [];
         foreach ($allData as $key => $value) {

--- a/tests/unit/ProcessMaker/Models/CallActivityMergeTest.php
+++ b/tests/unit/ProcessMaker/Models/CallActivityMergeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Models;
+
+use PHPUnit\Framework\TestCase;
+use ProcessMaker\Models\CallActivity;
+
+class CallActivityMergeTest extends TestCase
+{
+    private function callActivity(): CallActivity
+    {
+        return new class extends CallActivity {
+            public function callResolveUpdatedData($store, array $allData): array
+            {
+                return $this->resolveUpdatedData($store, $allData);
+            }
+
+            public function callMergeNewKeys(array $data, array $allData, array $parentData): array
+            {
+                return $this->mergeNewKeys($data, $allData, $parentData);
+            }
+
+            public function callMergeChangedKeys(array $data, array $allData, array $parentData): array
+            {
+                return $this->mergeChangedKeys($data, $allData, $parentData);
+            }
+        };
+    }
+
+    public function testResolveUpdatedDataReturnsAllWhenUpdatedIsNull(): void
+    {
+        $store = new class {
+            public function getUpdated()
+            {
+                return null;
+            }
+        };
+
+        $callActivity = $this->callActivity();
+        $all = ['a' => 1, 'b' => 2];
+
+        $result = $callActivity->callResolveUpdatedData($store, $all);
+
+        $this->assertSame($all, $result);
+    }
+
+    public function testResolveUpdatedDataReturnsEmptyWhenUpdatedIsEmptyArray(): void
+    {
+        $store = new class {
+            public function getUpdated(): array
+            {
+                return [];
+            }
+        };
+
+        $callActivity = $this->callActivity();
+        $all = ['a' => 1, 'b' => 2];
+
+        $result = $callActivity->callResolveUpdatedData($store, $all);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testResolveUpdatedDataReturnsOnlyUpdatedKeys(): void
+    {
+        $store = new class {
+            public function getUpdated(): array
+            {
+                return ['b'];
+            }
+        };
+
+        $callActivity = $this->callActivity();
+        $all = ['a' => 1, 'b' => 2, 'c' => 3];
+
+        $result = $callActivity->callResolveUpdatedData($store, $all);
+
+        $this->assertSame(['b' => 2], $result);
+    }
+
+    public function testMergeNewKeysAddsKeysAbsentInParent(): void
+    {
+        $callActivity = $this->callActivity();
+        $data = ['a' => 1];
+        $all = ['a' => 1, 'b' => 2, 'c' => 3];
+        $parent = ['a' => 1];
+
+        $result = $callActivity->callMergeNewKeys($data, $all, $parent);
+
+        $this->assertSame(['a' => 1, 'b' => 2, 'c' => 3], $result);
+    }
+
+    public function testMergeChangedKeysAddsDifferencesNotTracked(): void
+    {
+        $callActivity = $this->callActivity();
+        $data = ['a' => 1]; // already tracked
+        $all = ['a' => 1, 'b' => 99, 'c' => 'new'];
+        $parent = ['a' => 1, 'b' => 2, 'c' => 'old'];
+
+        $result = $callActivity->callMergeChangedKeys($data, $all, $parent);
+
+        $this->assertSame(['a' => 1, 'b' => 99, 'c' => 'new'], $result);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Variables created or modified in a subprocess were not merged back into the parent request when getUpdated() was empty or incomplete; only the tracked keys were applied, so new or changed values could be lost.

Reproduce (manual): Create a parent with a Call Activity to a child process. In the child, write variables not initialized in the parent (e.g., via script/flow update). Complete the child and parent; the parent summary shows missing or stale values for those variables.

## Solution
- Refactored ProcessMaker/Models/CallActivity.php merge logic into smaller helpers:
  - resolveUpdatedData() keeps legacy behavior, handles empty getUpdated(), or uses the tracked keys.
  - mergeNewKeys() adds keys that exist only in the subprocess data.
  - mergeChangedKeys() adds keys that exist in both but have changed, even if getUpdated() didn’t track them.

The refactor reduces inline branching while ensuring new/changed subprocess variables are merged into the parent without overwriting untouched parent values.

## How to Test
Follow reproduction steps from the ticket.

## Related Tickets & Packages
- [FOUR-28469](https://processmaker.atlassian.net/browse/FOUR-28469)
 
ci:deploy
 


[FOUR-28469]: https://processmaker.atlassian.net/browse/FOUR-28469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ