### PR TITLE
Bugfix/FOUR-27831: The percentage of Started Cases in Launchpad isn't updating.

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
@@ -28,14 +28,14 @@
                 </div>
                 <div class="d-flex align-items-center flex-shrink-0 tw-text-xs">
                   <mini-pie-chart
-                    :count="process.counts.in_progress"
-                    :total="process.counts.total"
+                    :count="inProgress"
+                    :total="total"
                     :name="$t('In Progress')"
                     color="#4EA075"
                   />
                   <mini-pie-chart
-                    :count="process.counts.completed"
-                    :total="process.counts.total"
+                    :count="completed"
+                    :total="total"
                     :name="$t('Completed')"
                     color="#478FCC"
                   />
@@ -148,6 +148,9 @@ export default {
       infoCollapsed: true,
       processEvents: [],
       singleStartEvent: null,
+      inProgress: 0,
+      completed: 0,
+      total: 0,
     };
   },
   computed: {
@@ -166,7 +169,18 @@ export default {
     ProcessMaker.EventBus.$on("reloadByNewScreen", () => {
       window.location.reload();
     });
+    ProcessMaker.EventBus.$on("chartDataUpdated", (data) => {
+      if (data.processId === this.process.id) {
+        this.completed = data.completed;
+        this.inProgress = data.inProgress;
+        this.total = data.total;
+      }
+    });
     this.getStartEvents();
+    this.fetchChartData();
+  },
+  beforeDestroy() {
+    ProcessMaker.EventBus.$off("chartDataUpdated");
   },
   methods: {
     /**
@@ -226,6 +240,24 @@ export default {
         })
         .catch((err) => {
           ProcessMaker.alert(err, "danger");
+        });
+    },
+    /**
+     * Fetch chart data for mini pie charts
+     */
+    fetchChartData() {
+      ProcessMaker.apiClient
+        .get(`requests/${this.process.id}/default-chart`)
+        .then((response) => {
+          const { data: { datasets: { data: [completedCount, inProgressCount] } } } = response.data;
+          this.completed = completedCount;
+          this.inProgress = inProgressCount;
+          this.total = this.completed + this.inProgress;
+        })
+        .catch(() => {
+          this.inProgress = 0;
+          this.completed = 0;
+          this.total = 0;
         });
     },
   },

--- a/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
+++ b/resources/js/processes-catalogue/components/ProcessCollapseInfo.vue
@@ -166,6 +166,10 @@ export default {
   },
   mounted() {
     this.verifyDescription();
+    // Initialize chart data from process.counts
+    this.inProgress = this.process.counts?.in_progress || 0;
+    this.completed = this.process.counts?.completed || 0;
+    this.total = this.process.counts?.total || 0;
     ProcessMaker.EventBus.$on("reloadByNewScreen", () => {
       window.location.reload();
     });
@@ -177,7 +181,6 @@ export default {
       }
     });
     this.getStartEvents();
-    this.fetchChartData();
   },
   beforeDestroy() {
     ProcessMaker.EventBus.$off("chartDataUpdated");
@@ -240,24 +243,6 @@ export default {
         })
         .catch((err) => {
           ProcessMaker.alert(err, "danger");
-        });
-    },
-    /**
-     * Fetch chart data for mini pie charts
-     */
-    fetchChartData() {
-      ProcessMaker.apiClient
-        .get(`requests/${this.process.id}/default-chart`)
-        .then((response) => {
-          const { data: { datasets: { data: [completedCount, inProgressCount] } } } = response.data;
-          this.completed = completedCount;
-          this.inProgress = inProgressCount;
-          this.total = this.completed + this.inProgress;
-        })
-        .catch(() => {
-          this.inProgress = 0;
-          this.completed = 0;
-          this.total = 0;
         });
     },
   },

--- a/resources/js/processes-catalogue/components/optionsMenu/ProcessCounter.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ProcessCounter.vue
@@ -69,6 +69,13 @@ export default {
           this.completed = completedCount;
           this.inProgress = inProgressCount;
           this.total = this.completed + this.inProgress;
+          // Emit event to update other components
+          ProcessMaker.EventBus.$emit("chartDataUpdated", {
+            processId: this.process.id,
+            completed: this.completed,
+            inProgress: this.inProgress,
+            total: this.total,
+          });
         })
         .catch(() => {
           this.inProgress = 0;

--- a/resources/js/processes-catalogue/components/optionsMenu/ProcessCounter.vue
+++ b/resources/js/processes-catalogue/components/optionsMenu/ProcessCounter.vue
@@ -13,14 +13,14 @@
       class="charts"
     >
       <mini-pie-chart
-        :count="process.counts.in_progress"
-        :total="process.counts.total"
+        :count="inProgress"
+        :total="total"
         :name="$t('In Progress')"
         color="#4EA075"
       />
       <mini-pie-chart
-        :count="process.counts.completed"
-        :total="process.counts.total"
+        :count="completed"
+        :total="total"
         :name="$t('Completed')"
         color="#478FCC"
       />
@@ -38,6 +38,9 @@ export default {
   data() {
     return {
       count: 0,
+      inProgress: 0,
+      completed: 0,
+      total: 0,
     };
   },
   computed: {
@@ -57,6 +60,20 @@ export default {
         })
         .catch(() => {
           this.count = 0;
+        });
+
+      ProcessMaker.apiClient
+        .get(`requests/${this.process.id}/default-chart`)
+        .then((response) => {
+          const { data: { datasets: { data: [completedCount, inProgressCount] } } } = response.data;
+          this.completed = completedCount;
+          this.inProgress = inProgressCount;
+          this.total = this.completed + this.inProgress;
+        })
+        .catch(() => {
+          this.inProgress = 0;
+          this.completed = 0;
+          this.total = 0;
         });
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
The percentage of started/completed cases isn't changing.

## Solution
The percentage of started/completed cases now is changing when Process Information display is opened.

## How to Test
1. Go to /process-browser
2. Open a process and click on Process Information
3. In another tab, create a case for the selected process.
4. Return to /process-browser and open Process Information

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-27831

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
