### PR TITLE
bugfix/FOUR-28509: The submit button does not validate the required input file.

### DIFF
--- a/ProcessMaker/Traits/TaskResourceIncludes.php
+++ b/ProcessMaker/Traits/TaskResourceIncludes.php
@@ -64,6 +64,10 @@ trait TaskResourceIncludes
             // but drafts are disabled so we need to delete it now that
             // it's been accessed.
             $draft->delete();
+
+            // Return null to prevent the frontend from trying to load
+            // files from the deleted draft
+            return ['draft' => null];
         }
 
         return ['draft' => $draft];


### PR DESCRIPTION
## Solution

A new validation was added to prevent the Trait method from attempting to obtain a file ID that was deleted from the draft when the draft environment variable TASK_DRAFTS_ENABLED=false

## How to Test
1. Create a screen that includes a required upload document field and a submit button.
2. Saved it and assign it to a task in a process.
3. Create a case.
4. Upload a file (do not submit the form)
5. Navigate to another section in ProcessMaker.
6. Return to the case open the task. 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-28509

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes draft handling in `TaskResourceIncludes`. When `TASK_DRAFTS_ENABLED=false` and a draft exists, the code now deletes the draft and explicitly returns `['draft' => null]` to prevent the frontend from attempting to load files from a deleted draft.
> 
> - Adjusts `includeDraft()` to return `null` for `draft` after deletion when drafts are disabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5133c6a6c1d3f246ff09f27746307548a4330517. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->