### PR TITLE
FOUR-28753: [TCE] Military V1 - Phase 1: Update Script Executor for Intake

### DIFF
--- a/ProcessMaker/Console/Commands/BuildScriptExecutors.php
+++ b/ProcessMaker/Console/Commands/BuildScriptExecutors.php
@@ -18,7 +18,11 @@ class BuildScriptExecutors extends Command
      *
      * @var string
      */
-    protected $signature = 'processmaker:build-script-executor {lang} {user?} {--rebuild}';
+    protected $signature = 'processmaker:build-script-executor
+                            {lang : The ID or language of the script executor}
+                            {user? : The user ID to send the broadcast event to}
+                            {--rebuild : Rebuild the docker image}
+                            {--build-args= : The build arguments for the docker build command}';
 
     /**
      * The console command description.
@@ -159,12 +163,41 @@ class BuildScriptExecutors extends Command
         $command = Docker::command() .
             " build --build-arg SDK_DIR=./sdk -t {$image} -f {$packagePath}/Dockerfile.custom {$packagePath}";
 
+        $buildArgs = $this->getBuildArgs();
+
+        foreach ($buildArgs as $buildArg) {
+            $command .= ' ' . $buildArg;
+        }
+
         $this->execCommand($command);
 
         $isNayra = $scriptExecutor->language === Base::NAYRA_LANG;
         if ($isNayra) {
             Base::bringUpNayraExecutor($this, $image);
         }
+    }
+
+    /**
+     * Get the build arguments for the docker build command.
+     *
+     * @return array
+     *   - '--build-arg <key>=<value>'
+     */
+    public function getBuildArgs(): array
+    {
+        $args = $this->option('build-args');
+
+        if ($args) {
+            $buildArgs = [];
+
+            foreach (explode(',', $args) as $arg) {
+                $buildArgs[] = '--build-arg ' . $arg;
+            }
+
+            return $buildArgs;
+        }
+
+        return [];
     }
 
     public function getDockerfileContent(ScriptExecutor $scriptExecutor): string

--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -130,12 +130,13 @@ trait ScriptDockerNayraTrait
         if ($status) {
             $this->bringUpNayraContainer();
         } else {
-
+            $isHost = config('app.nayra_docker_network') === 'host';
+            $portMapping = $isHost ? '-e PORT=' . $this->getNayraPort() . ' ' : '-p ' . $this->getNayraPort() . ':8080 ';
             exec($docker . " stop {$instanceName}_nayra 2>&1 || true");
             exec($docker . " rm {$instanceName}_nayra 2>&1 || true");
             exec(
                 $docker . ' run -d '
-                . ($this->getNayraPort() !== 8080 ? '-p ' . $this->getNayraPort() . ':8080 ' : '')
+                . ($this->getNayraPort() !== 8080 ? $portMapping : '')
                 . '--name ' . $instanceName . '_nayra '
                 . (config('app.nayra_docker_network')
                     ? '--network=' . config('app.nayra_docker_network') . ' '

--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -134,9 +134,9 @@ trait ScriptDockerNayraTrait
             exec($docker . " stop {$instanceName}_nayra 2>&1 || true");
             exec($docker . " rm {$instanceName}_nayra 2>&1 || true");
             exec(
-                $docker . ' run -d --name '
-                . '-p ' . $this->getNayraPort() . ':8080 '
-                . $instanceName . '_nayra '
+                $docker . ' run -d '
+                . ($this->getNayraPort() !== 8080 ? '-p ' . $this->getNayraPort() . ':8080 ' : '')
+                . '--name ' . $instanceName . '_nayra '
                 . (config('app.nayra_docker_network')
                     ? '--network=' . config('app.nayra_docker_network') . ' '
                     : '')

--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -23,7 +23,6 @@ trait ScriptDockerNayraTrait
 {
 
     private $schema = 'http';
-    public static $nayraPort = 8080;
 
     /**
      * Execute the script task using Nayra Docker.
@@ -82,7 +81,7 @@ trait ScriptDockerNayraTrait
     private function getNayraInstanceUrl()
     {
         $servers = self::getNayraAddresses();
-        return $this->schema . '://' . $servers[0] . ':' . static::$nayraPort;
+        return $this->schema . '://' . $servers[0] . ':' . $this->getNayraPort();
     }
 
     private function getDockerLogs($instanceName)
@@ -135,7 +134,9 @@ trait ScriptDockerNayraTrait
             exec($docker . " stop {$instanceName}_nayra 2>&1 || true");
             exec($docker . " rm {$instanceName}_nayra 2>&1 || true");
             exec(
-                $docker . ' run -d --name ' . $instanceName . '_nayra '
+                $docker . ' run -d --name '
+                . '-p ' . $this->getNayraPort() . ':8080 '
+                . $instanceName . '_nayra '
                 . (config('app.nayra_docker_network')
                     ? '--network=' . config('app.nayra_docker_network') . ' '
                     : '')
@@ -321,5 +322,10 @@ trait ScriptDockerNayraTrait
                 throw new UnexpectedValueException('Could not create docker network');
             }
         }
+    }
+
+    private function getNayraPort()
+    {
+        return config('app.nayra_port', 8080);
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -257,6 +257,7 @@ return [
     'force_https' => env('FORCE_HTTPS', true),
 
     'nayra_docker_network' => env('NAYRA_DOCKER_NETWORK', 'host'),
+    'nayra_port' => env('NAYRA_PORT', 8080),
 
     // Process Request security log rate limit: 1 per day (86400 seconds)
     'process_request_errors_rate_limit' => env('PROCESS_REQUEST_ERRORS_RATE_LIMIT', 1),


### PR DESCRIPTION
## Issue & Reproduction Steps
TCE Military V1 - Phase 1: Update Script Executor for Intake

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-28753

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces flexibility in executor builds and Nayra runtime configuration.
> 
> - Extends `processmaker:build-script-executor` to accept `--build-args` and appends them to `docker build` (e.g., `--build-arg key=value`).
> - Makes Nayra port configurable via `config('app.nayra_port')` (defaults to `8080`); removes static port usage and uses `getNayraPort()` in URLs and container startup.
> - Updates Nayra container run logic to set `-e PORT=<port>` on host network or `-p <port>:8080` on other networks, applied when port != 8080.
> - Adds `nayra_port` to `config/app.php` and uses it throughout Nayra Docker handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb21d76b47d7253d6c06b28b58a4234f04408059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->