### PR TITLE
FOUR-28723 | Store Logs For Deleting Cases via API

### DIFF
--- a/ProcessMaker/Events/CaseDeleted.php
+++ b/ProcessMaker/Events/CaseDeleted.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ProcessMaker\Events;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Events\Dispatchable;
+use ProcessMaker\Contracts\SecurityLogEventInterface;
+use ProcessMaker\Traits\FormatSecurityLogChanges;
+
+class CaseDeleted implements SecurityLogEventInterface
+{
+    use Dispatchable;
+    use FormatSecurityLogChanges;
+
+    private int $caseNumber;
+
+    private string $caseTitle;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(int $caseNumber, string $caseTitle)
+    {
+        $this->caseNumber = $caseNumber;
+        $this->caseTitle = $caseTitle;
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getData(): array
+    {
+        return [
+            'case_title' => $this->caseTitle,
+            'case_number' => $this->caseNumber,
+            'deleted_at' => Carbon::now(),
+        ];
+    }
+
+    /**
+     * Get specific data related to the event
+     *
+     * @return array
+     */
+    public function getChanges(): array
+    {
+        return [
+            'case_number' => $this->caseNumber,
+        ];
+    }
+
+    /**
+     * Get the Event name
+     *
+     * @return string
+     */
+    public function getEventName(): string
+    {
+        return 'CaseDeleted';
+    }
+}

--- a/ProcessMaker/Events/CaseDeleted.php
+++ b/ProcessMaker/Events/CaseDeleted.php
@@ -12,7 +12,7 @@ class CaseDeleted implements SecurityLogEventInterface
     use Dispatchable;
     use FormatSecurityLogChanges;
 
-    private int $caseNumber;
+    private string $caseNumber;
 
     private string $caseTitle;
 
@@ -21,7 +21,7 @@ class CaseDeleted implements SecurityLogEventInterface
      *
      * @return void
      */
-    public function __construct(int $caseNumber, string $caseTitle)
+    public function __construct(string $caseNumber, string $caseTitle)
     {
         $this->caseNumber = $caseNumber;
         $this->caseTitle = $caseTitle;

--- a/ProcessMaker/Events/CaseDeleted.php
+++ b/ProcessMaker/Events/CaseDeleted.php
@@ -35,7 +35,7 @@ class CaseDeleted implements SecurityLogEventInterface
     public function getData(): array
     {
         return [
-            'case_title' => $this->caseTitle,
+            'name' => $this->caseTitle,
             'case_number' => $this->caseNumber,
             'deleted_at' => Carbon::now(),
         ];

--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
@@ -21,9 +21,7 @@ class DeleteCase
             abort(404);
         }
 
-        // Get case title before deletion for event logging
         $caseTitle = $this->getCaseTitle($caseNumber);
-
         $tokenIds = $this->getRequestTokenIds($requestIds);
 
         DB::transaction(function () use ($caseNumber, $requestIds, $tokenIds) {
@@ -68,7 +66,7 @@ class DeleteCase
             return $caseStarted->case_title;
         }
 
-        // Get case title from the first ProcessRequest if CaseStarted doesn't exist
+        // If CaseStarted doesn't exist, get case title from the first ProcessRequest
         $firstRequest = ProcessRequest::query()
             ->where('case_number', $caseNumber)
             ->whereNull('parent_request_id')

--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
@@ -64,15 +64,15 @@ class DeleteCase
 
         if ($caseStarted) {
             return $caseStarted->case_title ?? "Case #{$caseNumber}";
-        }
-
-        // If CaseStarted doesn't exist, get case title from the first ProcessRequest
-        $firstRequest = ProcessRequest::query()
+        } else {
+            // If CaseStarted doesn't exist, get case title from the first ProcessRequest
+            $firstRequest = ProcessRequest::query()
             ->where('case_number', $caseNumber)
             ->whereNull('parent_request_id')
             ->first();
 
-        return $firstRequest?->case_title ?? "Case #{$caseNumber}";
+            return $firstRequest?->case_title ?? "Case #{$caseNumber}";
+        }
     }
 
     private function getRequestTokenIds(array $requestIds): array

--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
@@ -63,7 +63,7 @@ class DeleteCase
             ->first();
 
         if ($caseStarted) {
-            return $caseStarted->case_title;
+            return $caseStarted->case_title ?? "Case #{$caseNumber}";
         }
 
         // If CaseStarted doesn't exist, get case title from the first ProcessRequest

--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
@@ -3,23 +3,16 @@
 namespace ProcessMaker\Http\Controllers\Api\Actions\Cases;
 
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
-use ProcessMaker\Models\CaseNumber;
-use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Events\CaseDeleted;
 use ProcessMaker\Models\CaseStarted;
-use ProcessMaker\Models\Comment;
-use ProcessMaker\Models\InboxRule;
-use ProcessMaker\Models\InboxRuleLog;
-use ProcessMaker\Models\Media;
-use ProcessMaker\Models\ProcessAbeRequestToken;
 use ProcessMaker\Models\ProcessRequest;
-use ProcessMaker\Models\ProcessRequestLock;
 use ProcessMaker\Models\ProcessRequestToken;
-use ProcessMaker\Models\ScheduledTask;
 use ProcessMaker\Models\TaskDraft;
 
 class DeleteCase
 {
+    use DeletesCaseRecords;
+
     public function __invoke(string $caseNumber): void
     {
         $requestIds = $this->getRequestIds($caseNumber);
@@ -27,6 +20,9 @@ class DeleteCase
         if ($requestIds === []) {
             abort(404);
         }
+
+        // Get case title before deletion for event logging
+        $caseTitle = $this->getCaseTitle($caseNumber);
 
         $tokenIds = $this->getRequestTokenIds($requestIds);
 
@@ -49,6 +45,8 @@ class DeleteCase
             $this->deleteProcessRequests($requestIds);
         });
 
+        CaseDeleted::dispatch($caseNumber, $caseTitle);
+
         $this->dispatchSavedSearchRecount();
     }
 
@@ -58,6 +56,25 @@ class DeleteCase
             ->where('case_number', $caseNumber)
             ->pluck('id')
             ->all();
+    }
+
+    private function getCaseTitle(string $caseNumber): string
+    {
+        $caseStarted = CaseStarted::query()
+            ->where('case_number', $caseNumber)
+            ->first();
+
+        if ($caseStarted) {
+            return $caseStarted->case_title;
+        }
+
+        // Get case title from the first ProcessRequest if CaseStarted doesn't exist
+        $firstRequest = ProcessRequest::query()
+            ->where('case_number', $caseNumber)
+            ->whereNull('parent_request_id')
+            ->first();
+
+        return $firstRequest?->case_title ?? "Case #{$caseNumber}";
     }
 
     private function getRequestTokenIds(array $requestIds): array
@@ -82,186 +99,6 @@ class DeleteCase
             ->whereIn('task_id', $tokenIds)
             ->pluck('id')
             ->all();
-    }
-
-    private function deleteCasesStarted(string $caseNumber): void
-    {
-        CaseStarted::query()
-            ->where('case_number', $caseNumber)
-            ->delete();
-    }
-
-    private function deleteCasesParticipated(string $caseNumber): void
-    {
-        CaseParticipated::query()
-            ->where('case_number', $caseNumber)
-            ->delete();
-    }
-
-    private function deleteCaseNumbers(array $requestIds): void
-    {
-        if ($requestIds === []) {
-            return;
-        }
-
-        CaseNumber::query()
-            ->whereIn('process_request_id', $requestIds)
-            ->delete();
-    }
-
-    private function deleteProcessRequests(array $requestIds): void
-    {
-        if ($requestIds === []) {
-            return;
-        }
-
-        ProcessRequest::query()
-            ->whereIn('id', $requestIds)
-            ->get()
-            ->each
-            ->delete();
-    }
-
-    private function deleteProcessRequestTokens(array $requestIds): void
-    {
-        if ($requestIds === []) {
-            return;
-        }
-
-        ProcessRequestToken::query()
-            ->whereIn('process_request_id', $requestIds)
-            ->delete();
-    }
-
-    private function deleteProcessRequestLocks(array $requestIds, array $tokenIds): void
-    {
-        ProcessRequestLock::query()
-            ->whereIn('process_request_id', $requestIds)
-            ->delete();
-
-        if ($tokenIds !== []) {
-            ProcessRequestLock::query()
-                ->whereIn('process_request_token_id', $tokenIds)
-                ->delete();
-        }
-    }
-
-    private function deleteProcessAbeRequestTokens(array $requestIds, array $tokenIds): void
-    {
-        ProcessAbeRequestToken::query()
-            ->whereIn('process_request_id', $requestIds)
-            ->delete();
-
-        if ($tokenIds !== []) {
-            ProcessAbeRequestToken::query()
-                ->whereIn('process_request_token_id', $tokenIds)
-                ->delete();
-        }
-    }
-
-    private function deleteScheduledTasks(array $requestIds, array $tokenIds): void
-    {
-        ScheduledTask::query()
-            ->whereIn('process_request_id', $requestIds)
-            ->delete();
-
-        if ($tokenIds !== []) {
-            ScheduledTask::query()
-                ->whereIn('process_request_token_id', $tokenIds)
-                ->delete();
-        }
-    }
-
-    private function deleteInboxRules(array $tokenIds): void
-    {
-        if ($tokenIds === []) {
-            return;
-        }
-
-        InboxRule::query()
-            ->whereIn('process_request_token_id', $tokenIds)
-            ->get()
-            ->each
-            ->delete();
-    }
-
-    private function deleteInboxRuleLogs(array $tokenIds): void
-    {
-        if ($tokenIds === []) {
-            return;
-        }
-
-        InboxRuleLog::query()
-            ->whereIn('process_request_token_id', $tokenIds)
-            ->delete();
-    }
-
-    private function deleteEllucianEthosSyncTasks(array $tokenIds): void
-    {
-        if ($tokenIds === [] || !Schema::hasTable('ellucian_ethos_sync_global_task_list')) {
-            return;
-        }
-
-        DB::table('ellucian_ethos_sync_global_task_list')
-            ->whereIn('process_request_token_id', $tokenIds)
-            ->delete();
-    }
-
-    private function deleteTaskDrafts(array $tokenIds): void
-    {
-        if ($tokenIds === []) {
-            return;
-        }
-
-        TaskDraft::query()
-            ->whereIn('task_id', $tokenIds)
-            ->delete();
-    }
-
-    private function deleteTaskDraftMedia(array $draftIds): void
-    {
-        if ($draftIds === []) {
-            return;
-        }
-
-        Media::query()
-            ->where('model_type', TaskDraft::class)
-            ->whereIn('model_id', $draftIds)
-            ->get()
-            ->each
-            ->delete();
-    }
-
-    private function deleteRequestMedia(array $requestIds): void
-    {
-        if ($requestIds === []) {
-            return;
-        }
-
-        Media::query()
-            ->where('model_type', ProcessRequest::class)
-            ->whereIn('model_id', $requestIds)
-            ->get()
-            ->each
-            ->delete();
-    }
-
-    private function deleteComments(string $caseNumber, array $requestIds, array $tokenIds): void
-    {
-        Comment::query()
-            ->where('case_number', $caseNumber)
-            ->orWhere(function ($query) use ($requestIds, $tokenIds) {
-                $query->where('commentable_type', ProcessRequest::class)
-                    ->whereIn('commentable_id', $requestIds);
-
-                if ($tokenIds !== []) {
-                    $query->orWhere(function ($nestedQuery) use ($tokenIds) {
-                        $nestedQuery->where('commentable_type', ProcessRequestToken::class)
-                            ->whereIn('commentable_id', $tokenIds);
-                    });
-                }
-            })
-            ->delete();
     }
 
     private function dispatchSavedSearchRecount(): void

--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeletesCaseRecords.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeletesCaseRecords.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Api\Actions\Cases;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use ProcessMaker\Models\CaseNumber;
+use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Models\CaseStarted;
+use ProcessMaker\Models\Comment;
+use ProcessMaker\Models\InboxRule;
+use ProcessMaker\Models\InboxRuleLog;
+use ProcessMaker\Models\Media;
+use ProcessMaker\Models\ProcessAbeRequestToken;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestLock;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\ScheduledTask;
+use ProcessMaker\Models\TaskDraft;
+
+trait DeletesCaseRecords
+{
+    private function deleteCasesStarted(string $caseNumber): void
+    {
+        CaseStarted::query()
+            ->where('case_number', $caseNumber)
+            ->delete();
+    }
+
+    private function deleteCasesParticipated(string $caseNumber): void
+    {
+        CaseParticipated::query()
+            ->where('case_number', $caseNumber)
+            ->delete();
+    }
+
+    private function deleteCaseNumbers(array $requestIds): void
+    {
+        if ($requestIds === []) {
+            return;
+        }
+
+        CaseNumber::query()
+            ->whereIn('process_request_id', $requestIds)
+            ->delete();
+    }
+
+    private function deleteProcessRequests(array $requestIds): void
+    {
+        if ($requestIds === []) {
+            return;
+        }
+
+        ProcessRequest::query()
+            ->whereIn('id', $requestIds)
+            ->get()
+            ->each
+            ->delete();
+    }
+
+    private function deleteProcessRequestTokens(array $requestIds): void
+    {
+        if ($requestIds === []) {
+            return;
+        }
+
+        ProcessRequestToken::query()
+            ->whereIn('process_request_id', $requestIds)
+            ->delete();
+    }
+
+    private function deleteProcessRequestLocks(array $requestIds, array $tokenIds): void
+    {
+        ProcessRequestLock::query()
+            ->whereIn('process_request_id', $requestIds)
+            ->delete();
+
+        if ($tokenIds !== []) {
+            ProcessRequestLock::query()
+                ->whereIn('process_request_token_id', $tokenIds)
+                ->delete();
+        }
+    }
+
+    private function deleteProcessAbeRequestTokens(array $requestIds, array $tokenIds): void
+    {
+        ProcessAbeRequestToken::query()
+            ->whereIn('process_request_id', $requestIds)
+            ->delete();
+
+        if ($tokenIds !== []) {
+            ProcessAbeRequestToken::query()
+                ->whereIn('process_request_token_id', $tokenIds)
+                ->delete();
+        }
+    }
+
+    private function deleteScheduledTasks(array $requestIds, array $tokenIds): void
+    {
+        ScheduledTask::query()
+            ->whereIn('process_request_id', $requestIds)
+            ->delete();
+
+        if ($tokenIds !== []) {
+            ScheduledTask::query()
+                ->whereIn('process_request_token_id', $tokenIds)
+                ->delete();
+        }
+    }
+
+    private function deleteInboxRules(array $tokenIds): void
+    {
+        if ($tokenIds === []) {
+            return;
+        }
+
+        InboxRule::query()
+            ->whereIn('process_request_token_id', $tokenIds)
+            ->get()
+            ->each
+            ->delete();
+    }
+
+    private function deleteInboxRuleLogs(array $tokenIds): void
+    {
+        if ($tokenIds === []) {
+            return;
+        }
+
+        InboxRuleLog::query()
+            ->whereIn('process_request_token_id', $tokenIds)
+            ->delete();
+    }
+
+    private function deleteEllucianEthosSyncTasks(array $tokenIds): void
+    {
+        if ($tokenIds === [] || !Schema::hasTable('ellucian_ethos_sync_global_task_list')) {
+            return;
+        }
+
+        DB::table('ellucian_ethos_sync_global_task_list')
+            ->whereIn('process_request_token_id', $tokenIds)
+            ->delete();
+    }
+
+    private function deleteTaskDrafts(array $tokenIds): void
+    {
+        if ($tokenIds === []) {
+            return;
+        }
+
+        TaskDraft::query()
+            ->whereIn('task_id', $tokenIds)
+            ->delete();
+    }
+
+    private function deleteTaskDraftMedia(array $draftIds): void
+    {
+        if ($draftIds === []) {
+            return;
+        }
+
+        Media::query()
+            ->where('model_type', TaskDraft::class)
+            ->whereIn('model_id', $draftIds)
+            ->get()
+            ->each
+            ->delete();
+    }
+
+    private function deleteRequestMedia(array $requestIds): void
+    {
+        if ($requestIds === []) {
+            return;
+        }
+
+        Media::query()
+            ->where('model_type', ProcessRequest::class)
+            ->whereIn('model_id', $requestIds)
+            ->get()
+            ->each
+            ->delete();
+    }
+
+    private function deleteComments(string $caseNumber, array $requestIds, array $tokenIds): void
+    {
+        Comment::query()
+            ->where('case_number', $caseNumber)
+            ->orWhere(function ($query) use ($requestIds, $tokenIds) {
+                $query->where('commentable_type', ProcessRequest::class)
+                    ->whereIn('commentable_id', $requestIds);
+
+                if ($tokenIds !== []) {
+                    $query->orWhere(function ($nestedQuery) use ($tokenIds) {
+                        $nestedQuery->where('commentable_type', ProcessRequestToken::class)
+                            ->whereIn('commentable_id', $tokenIds);
+                    });
+                }
+            })
+            ->delete();
+    }
+}

--- a/ProcessMaker/Providers/EventServiceProvider.php
+++ b/ProcessMaker/Providers/EventServiceProvider.php
@@ -9,6 +9,7 @@ use ProcessMaker\Events\ActivityReassignment;
 use ProcessMaker\Events\AuthClientCreated;
 use ProcessMaker\Events\AuthClientDeleted;
 use ProcessMaker\Events\AuthClientUpdated;
+use ProcessMaker\Events\CaseDeleted;
 use ProcessMaker\Events\CategoryCreated;
 use ProcessMaker\Events\CategoryDeleted;
 use ProcessMaker\Events\CategoryUpdated;
@@ -139,6 +140,7 @@ class EventServiceProvider extends ServiceProvider
             $this->app['events']->listen(AuthClientCreated::class, SecurityLogger::class);
             $this->app['events']->listen(AuthClientDeleted::class, SecurityLogger::class);
             $this->app['events']->listen(AuthClientUpdated::class, SecurityLogger::class);
+            $this->app['events']->listen(CaseDeleted::class, SecurityLogger::class);
             $this->app['events']->listen(CategoryCreated::class, SecurityLogger::class);
             $this->app['events']->listen(CategoryDeleted::class, SecurityLogger::class);
             $this->app['events']->listen(CategoryUpdated::class, SecurityLogger::class);

--- a/tests/Feature/Api/SecurityLogsTest.php
+++ b/tests/Feature/Api/SecurityLogsTest.php
@@ -43,12 +43,14 @@ use ProcessMaker\Events\UserCreated;
 use ProcessMaker\Events\UserDeleted;
 use ProcessMaker\Events\UserRestored;
 use ProcessMaker\Events\UserUpdated;
+use ProcessMaker\Http\Controllers\Api\Actions\Cases\DeleteCase;
 use ProcessMaker\Managers\SignalManager;
 use ProcessMaker\Models\EnvironmentVariable;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
+use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessTemplates;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\Script;
@@ -246,6 +248,24 @@ class SecurityLogsTest extends TestCase
         } else {
             $this->assertCount(0, $collection);
         }
+    }
+
+    /**
+     * This tests Case Deleted
+     */
+    public function testCaseDeleted()
+    {
+        $caseNumber = 12345;
+
+        // Create a ProcessRequest with a case number
+        ProcessRequest::factory()
+            ->withCaseNumber($caseNumber)
+            ->create();
+
+        // Use the DeleteCase action to delete the case and dispatch the CaseDeleted event
+        (new DeleteCase)($caseNumber);
+
+        $this->checkAssertsSegurityLog('CaseDeleted', 'deleted_at');
     }
 
     /**

--- a/tests/Feature/Api/SecurityLogsTest.php
+++ b/tests/Feature/Api/SecurityLogsTest.php
@@ -43,7 +43,6 @@ use ProcessMaker\Events\UserCreated;
 use ProcessMaker\Events\UserDeleted;
 use ProcessMaker\Events\UserRestored;
 use ProcessMaker\Events\UserUpdated;
-use ProcessMaker\Http\Controllers\Api\Actions\Cases\DeleteCase;
 use ProcessMaker\Managers\SignalManager;
 use ProcessMaker\Models\EnvironmentVariable;
 use ProcessMaker\Models\Group;
@@ -257,13 +256,13 @@ class SecurityLogsTest extends TestCase
     {
         $caseNumber = 12345;
 
-        // Create a ProcessRequest with a case number
         ProcessRequest::factory()
             ->withCaseNumber($caseNumber)
             ->create();
 
-        // Use the DeleteCase action to delete the case and dispatch the CaseDeleted event
-        (new DeleteCase)($caseNumber);
+        $response = $this->apiCall('DELETE', route('api.cases.destroy', ['case_number' => $caseNumber]));
+
+        $response->assertStatus(204);
 
         $this->checkAssertsSegurityLog('CaseDeleted', 'deleted_at');
     }


### PR DESCRIPTION
# Issue
Ticket: [FOUR-28723](https://processmaker.atlassian.net/browse/FOUR-28723)

This PR implements security logging for case deletions performed via the API, ensuring that all case deletion activities are traceable and auditable through ProcessMaker's existing security log infrastructure.

# Solution
1. Created `CaseDeleted` Event (`ProcessMaker/Events/CaseDeleted.php`)
	- **New event class** that implements `SecurityLogEventInterface` to enable security logging for case deletions
2. Refactored `DeleteCase` Action (`ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php`)
	- **Refactored to use `DeletesCaseRecords` trait** to reduce class complexity
3. Created `DeletesCaseRecords` Trait (`ProcessMaker/Http/Controllers/Api/Actions/Cases/DeletesCaseRecords.php`)
	- **New trait** containing all case deletion logic methods
4. Added Test Coverage (`tests/Feature/Api/SecurityLogsTest.php`)
	- **Created `testCaseDeleted()` test** to verify that case deletions are properly logged

# How To Test
1. Delete a Case via API
2. Log in to ProcessMaker. Go to **Admin** → **Users** → **Security Logs**
3. Verify the `CaseDeleted` log entry appears in the list
4. Click on the `CaseDeleted` log entry to view detailed information
   - Verify the following information is displayed accurately:
     - **Name**: Should display the case title
     - **Case Number**: Should display the case number
     - **Deleted At**: Should show the timestamp when the deletion occurred
5. Run the Unit Test:
     `tests/Feature/Api/SecurityLogsTest.php --filter=testCaseDeleted`

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-28723]: https://processmaker.atlassian.net/browse/FOUR-28723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Security logging for case deletions**
> 
> - Introduces `CaseDeleted` event implementing `SecurityLogEventInterface` with `name`, `case_number`, and `deleted_at` in `data` and `case_number` in `changes`.
> - `DeleteCase` now uses `DeletesCaseRecords` trait (extracted all record-deletion helpers) and dispatches `CaseDeleted` after a successful transaction; adds `getCaseTitle` to resolve a human-readable title from `CaseStarted` or the first `ProcessRequest`.
> - Registers `CaseDeleted` in `EventServiceProvider` to be handled by `SecurityLogger` when `app.security_log` is enabled.
> - Adds `testCaseDeleted` in `SecurityLogsTest` to verify a `CaseDeleted` security log is emitted on `DELETE /api/cases/{case_number}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e8b89f1484fc31c53e664ad0be1c1f034ecda3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->