### PR TITLE
FOUR-28487: Fix pagination per-page selection resetting on page navigation

### DIFF
--- a/resources/js/processes-catalogue/components/home/CustomHomeTableSection/CustomHomeTableSection.vue
+++ b/resources/js/processes-catalogue/components/home/CustomHomeTableSection/CustomHomeTableSection.vue
@@ -112,6 +112,7 @@ const hookData = async () => {
 
 const onPerPage = async (perPage) => {
   dataPagination.value.perPage = perPage;
+  dataPagination.value.page = 1;
   await hookData();
 };
 

--- a/resources/js/processes-catalogue/components/home/CustomHomeTableSection/CustomHomeTableSection.vue
+++ b/resources/js/processes-catalogue/components/home/CustomHomeTableSection/CustomHomeTableSection.vue
@@ -19,7 +19,6 @@
     </FilterableTable>
     <Pagination
       ref="paginator"
-      :key="dataPagination.page"
       :class="{
         'tw-opacity-50':showPlaceholder,
         'tw-pt-3':true
@@ -27,6 +26,7 @@
       :total="dataPagination.total"
       :page="dataPagination.page"
       :pages="dataPagination.pages"
+      :per-page="dataPagination.perPage"
       @perPage="onPerPage"
       @go="onGo" />
   </div>

--- a/resources/jscomposition/cases/casesDetail/components/CompletedForms.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CompletedForms.vue
@@ -36,6 +36,7 @@
       :total="dataPagination.total"
       :page="dataPagination.page"
       :pages="dataPagination.pages"
+      :per-page="dataPagination.perPage"
       @perPage="onPerPage"
       @go="onGo" />
   </div>

--- a/resources/jscomposition/cases/casesDetail/components/CompletedForms.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CompletedForms.vue
@@ -123,6 +123,7 @@ const onGo = async (page) => {
 
 const onPerPage = async (perPage) => {
   dataPagination.value.perPage = perPage;
+  dataPagination.value.page = 1;
 
   await hookGetData();
 };

--- a/resources/jscomposition/cases/casesDetail/components/RequestTable.vue
+++ b/resources/jscomposition/cases/casesDetail/components/RequestTable.vue
@@ -96,6 +96,7 @@ const onGo = async (page) => {
 
 const onPerPage = async (perPage) => {
   dataPagination.value.perPage = perPage;
+  dataPagination.value.page = 1;
 
   await hookGetData();
 };

--- a/resources/jscomposition/cases/casesDetail/components/RequestTable.vue
+++ b/resources/jscomposition/cases/casesDetail/components/RequestTable.vue
@@ -18,6 +18,7 @@
       :total="dataPagination.total"
       :page="dataPagination.page"
       :pages="dataPagination.pages"
+      :per-page="dataPagination.perPage"
       @perPage="onPerPage"
       @go="onGo" />
   </div>

--- a/resources/jscomposition/cases/casesDetail/components/TaskTable.vue
+++ b/resources/jscomposition/cases/casesDetail/components/TaskTable.vue
@@ -17,6 +17,7 @@
       :total="dataPagination.total"
       :page="dataPagination.page"
       :pages="dataPagination.pages"
+      :per-page="dataPagination.perPage"
       @perPage="onPerPage"
       @go="onGo" />
   </div>

--- a/resources/jscomposition/cases/casesDetail/components/TaskTable.vue
+++ b/resources/jscomposition/cases/casesDetail/components/TaskTable.vue
@@ -98,6 +98,7 @@ const onGo = async (page) => {
 
 const onPerPage = async (perPage) => {
   dataPagination.value.perPage = perPage;
+  dataPagination.value.page = 1;
 
   await hookGetData();
 };

--- a/resources/jscomposition/cases/casesMain/CasesDataSection.vue
+++ b/resources/jscomposition/cases/casesMain/CasesDataSection.vue
@@ -145,6 +145,7 @@ const onGo = async (page) => {
 
 const onPerPage = async (perPage) => {
   dataPagination.value.perPage = perPage;
+  dataPagination.value.page = 1;
 
   await hookGetData();
 };

--- a/resources/jscomposition/cases/casesMain/CasesDataSection.vue
+++ b/resources/jscomposition/cases/casesMain/CasesDataSection.vue
@@ -36,7 +36,6 @@
     </FilterableTable>
     <Pagination
       ref="paginator"
-      :key="dataPagination.page"
       :class="{
         'tw-opacity-50':showPlaceholder,
         'tw-pt-3':true
@@ -44,6 +43,7 @@
       :total="dataPagination.total"
       :page="dataPagination.page"
       :pages="dataPagination.pages"
+      :per-page="dataPagination.perPage"
       @perPage="onPerPage"
       @go="onGo" />
   </div>

--- a/resources/jscomposition/system/table/Pagination.vue
+++ b/resources/jscomposition/system/table/Pagination.vue
@@ -127,7 +127,7 @@
   </div>
 </template>
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import { t } from "i18next";
 import { Dropdown } from "../../base/form";
 
@@ -144,6 +144,10 @@ const props = defineProps({
     type: Number,
     default: () => (0),
   },
+  perPage: {
+    type: Number,
+    default: () => (15),
+  },
   options: {
     type: Array,
     default: () => [],
@@ -159,7 +163,7 @@ const totalModelLabel = computed(() => {
   return `${t("{{count}} Items", { count: props.total })}`;
 });
 
-const pageModel = ref(props.page);
+const pageModel = ref(props.page || 1);
 const optionsPerPage = [
   {
     value: 15,
@@ -177,10 +181,12 @@ const optionsPerPage = [
 
 const optionsModel = ref(props.options.length ? props.options : optionsPerPage);
 
-const selectedOption = ref({
-  value: 15,
-  label: "15 items",
-});
+const resolveOption = (value) => {
+  const matched = optionsModel.value.find((option) => option.value === value);
+  return matched || { value, label: `${value} ${t("Per page")}` };
+};
+
+const selectedOption = ref(resolveOption(props.perPage || 15));
 
 const first = () => {
   if (pageModel.value > 1) {
@@ -226,6 +232,24 @@ const setPerPage = (value) => {
 defineExpose({
   setPerPage,
 });
+
+watch(
+  () => props.page,
+  (value) => {
+    if (value && value !== pageModel.value) {
+      pageModel.value = value;
+    }
+  }
+);
+
+watch(
+  () => props.perPage,
+  (value) => {
+    if (value && value !== selectedOption.value?.value) {
+      selectedOption.value = resolveOption(value);
+    }
+  }
+);
 </script>
 <style scoped>
 /* Chrome, Safari, Edge, Opera */


### PR DESCRIPTION
## Issue & Reproduction Steps
On the Cases list (/cases), selecting 50 items per page resets to 15 after navigating to the next/previous page, even though the table still renders 50 items.

1. Go to /cases.
2. Select 50 per page in the paginator.
3. Click next page, then previous page.
4. Observe the per‑page selector resets to 15.

## Solution
- Keep the pagination component’s selected per‑page value in sync with the parent via a new perPage prop and reactive watchers.
- Remove forced remounts (:key="dataPagination.page") so pagination state is not reset on page changes.
- Pass perPage from parent paginated views to the Pagination component.

## How to Test
1. Open /cases.
2. Select 50 per page.
3. Navigate to the next page and back.
4. Confirm the per‑page selector remains 50 and the table still shows 50 items.
**Optional:** Repeat on other screens that use the same pagination component (e.g., case detail tables and launchpad tables) to ensure the selection persists.

## Related Tickets & Packages
- [FOUR-28487](https://processmaker.atlassian.net/browse/FOUR-28487)

ci:deploy

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-28487]: https://processmaker.atlassian.net/browse/FOUR-28487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ