### PR TITLE
FOUR-28328: The "save as template" option should not be displayed for a screen template.

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -606,6 +606,7 @@ export default {
             value: "create-template",
             content: this.$t("Save as Template"),
             icon: "fas fa-file-image",
+            conditional: "if(is_template, false, true)",
           },
         ],
       },
@@ -1234,7 +1235,9 @@ export default {
           section: "right",
           options: {
             actions: [...this.ellipsisMenuOptions.actions],
-            data: {},
+            data: {
+              is_template: !!this.screen.is_template,
+            },
             divider: false,
             lauchpad: true,
           },


### PR DESCRIPTION
## Issue & Reproduction Steps
The Options menu in the screen builder shows “Save as Template” even when editing a screen that is already a template.

1. Go to Screens.
2. Click “My Templates”.
3. Edit a template.
4. Open Options.
5. Observe “Save as Template” is visible (should not be).

## Solution
- Hide the “Save as Template” action when the current screen is a template by adding a conditional and passing is_template to the ellipsis menu data.

<img width="1528" height="1057" alt="Screenshot 2026-01-14 at 14-48-52 Edit Screen - ProcessMaker" src="https://github.com/user-attachments/assets/7d2bc073-3612-46e4-843b-0fd28bafcb21" />

## How to Test
1. Open /designer/screen-builder/{id}/edit for a screen template.
2. Open Options.
3. Verify “Save as Template” is not shown.
4. Open a non-template screen in the builder and verify “Save as Template” is shown.

## Related Tickets & Packages
- [FOUR-28328](https://processmaker.atlassian.net/browse/FOUR-28328)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-28328]: https://processmaker.atlassian.net/browse/FOUR-28328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ