### PR TITLE
FOUR-28794: Delete notifications tied to case on delete and add test

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
@@ -35,6 +35,7 @@ class DeleteCase
             $this->deleteTaskDraftMedia($draftIds);
             $this->deleteTaskDrafts($tokenIds);
             $this->deleteComments($caseNumber, $requestIds, $tokenIds);
+            $this->deleteNotifications($requestIds);
             $this->deleteRequestMedia($requestIds);
             $this->deleteCaseNumbers($requestIds);
             $this->deleteCasesStarted($caseNumber);

--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeletesCaseRecords.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeletesCaseRecords.php
@@ -11,6 +11,7 @@ use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\InboxRule;
 use ProcessMaker\Models\InboxRuleLog;
 use ProcessMaker\Models\Media;
+use ProcessMaker\Models\Notification;
 use ProcessMaker\Models\ProcessAbeRequestToken;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestLock;
@@ -197,6 +198,26 @@ trait DeletesCaseRecords
                     });
                 }
             })
+            ->delete();
+    }
+
+    private function deleteNotifications(array $requestIds): void
+    {
+        if ($requestIds === []) {
+            return;
+        }
+
+        $notificationTypes = [
+            'COMMENT',
+            'FILE_SHARED',
+            'TASK_CREATED',
+            'TASK_COMPLETED',
+            'TASK_REASSIGNED',
+        ];
+
+        Notification::query()
+            ->whereIn('data->request_id', $requestIds)
+            ->whereIn('data->type', $notificationTypes)
             ->delete();
     }
 }

--- a/tests/Feature/Api/CaseDeleteTest.php
+++ b/tests/Feature/Api/CaseDeleteTest.php
@@ -12,6 +12,7 @@ use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\InboxRule;
 use ProcessMaker\Models\InboxRuleLog;
 use ProcessMaker\Models\Media;
+use ProcessMaker\Models\Notification;
 use ProcessMaker\Models\ProcessAbeRequestToken;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestLock;
@@ -150,6 +151,70 @@ class CaseDeleteTest extends TestCase
         if (Schema::hasTable('ellucian_ethos_sync_global_task_list')) {
             $this->assertDatabaseMissing('ellucian_ethos_sync_global_task_list', ['process_request_token_id' => $token->id]);
         }
+    }
+
+    public function testDeleteCaseRemovesCaseNotifications(): void
+    {
+        $caseNumber = 13579;
+        $request = ProcessRequest::factory()
+            ->withCaseNumber($caseNumber)
+            ->create();
+        $otherRequest = ProcessRequest::factory()
+            ->withCaseNumber($caseNumber + 1)
+            ->create();
+
+        $notificationTypes = [
+            'COMMENT',
+            'FILE_SHARED',
+            'TASK_CREATED',
+            'TASK_COMPLETED',
+            'TASK_REASSIGNED',
+        ];
+
+        $deletedNotificationIds = [];
+        foreach ($notificationTypes as $type) {
+            $deletedNotificationIds[] = Notification::factory()->create([
+                'notifiable_type' => get_class($this->user),
+                'notifiable_id' => $this->user->getKey(),
+                'data' => json_encode([
+                    'type' => $type,
+                    'request_id' => $request->id,
+                    'url' => "/requests/{$request->id}",
+                ]),
+                'url' => "/requests/{$request->id}",
+            ])->id;
+        }
+
+        $keptDifferentRequest = Notification::factory()->create([
+            'notifiable_type' => get_class($this->user),
+            'notifiable_id' => $this->user->getKey(),
+            'data' => json_encode([
+                'type' => 'TASK_CREATED',
+                'request_id' => $otherRequest->id,
+                'url' => "/requests/{$otherRequest->id}",
+            ]),
+            'url' => "/requests/{$otherRequest->id}",
+        ]);
+
+        $keptDifferentType = Notification::factory()->create([
+            'notifiable_type' => get_class($this->user),
+            'notifiable_id' => $this->user->getKey(),
+            'data' => json_encode([
+                'type' => 'MESSAGE',
+                'request_id' => $request->id,
+                'url' => "/requests/{$request->id}",
+            ]),
+            'url' => "/requests/{$request->id}",
+        ]);
+
+        $response = $this->apiCall('DELETE', route('api.cases.destroy', ['case_number' => $caseNumber]));
+
+        $response->assertStatus(204);
+        foreach ($deletedNotificationIds as $notificationId) {
+            $this->assertDatabaseMissing('notifications', ['id' => $notificationId]);
+        }
+        $this->assertDatabaseHas('notifications', ['id' => $keptDifferentRequest->id]);
+        $this->assertDatabaseHas('notifications', ['id' => $keptDifferentType->id]);
     }
 
     public function testDeleteCaseReturnsNotFoundWhenMissing(): void


### PR DESCRIPTION
## Issue & Reproduction Steps
Deleting a case leaves stale notifications (comments, file shares, task created/completed, reassigned) that link to deleted requests, resulting in OOPS/404 when opened.

## Solution
- Delete notifications by data->request_id for the case and by data->type (COMMENT, FILE_SHARED, TASK_CREATED, TASK_COMPLETED, TASK_REASSIGNED) during case deletion.

## How to Test
1. Run phpunit --filter CaseDeleteTest.
2. Optionally reproduce manually: create a case with comment/file share/task/reassignment notifications, delete the case, verify those notifications are removed.

## Related Tickets & Packages
- [FOUR-28794](https://processmaker.atlassian.net/browse/FOUR-28794)

[FOUR-28794]: https://processmaker.atlassian.net/browse/FOUR-28794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ