### PR TITLE
FOUR-28840: Available self service tasks not displayed for non-admin users due to inefficient query for filtering

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -139,6 +139,10 @@ class TaskController extends Controller
         $fields = $request->input('fields', '');
         if ($fields) {
             $selectedFields = explode(',', $fields);
+            // Ensure 'id' is always included for internal logic (e.g., inOverdueQuery at line ~186)
+            if (!in_array('id', $selectedFields)) {
+                $selectedFields[] = 'id';
+            }
             $query = $query->select($selectedFields);
         }
 

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -134,6 +134,14 @@ class TaskController extends Controller
 
         $query = $this->indexBaseQuery($request);
 
+        // Get fields from request (sent by frontend)
+        // If not provided, don't apply select() to maintain backward compatibility (returns all columns)
+        $fields = $request->input('fields', '');
+        if ($fields) {
+            $selectedFields = explode(',', $fields);
+            $query = $query->select($selectedFields);
+        }
+
         $this->applyFilters($query, $request);
 
         $this->excludeNonVisibleTasks($query, $request);

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -782,8 +782,7 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
 
                     $query->whereIn('process_request_tokens.id', $selfServiceTaskIds);
                 } elseif ($user) {
-                    $taskIds = $user->availableSelfServiceTaskIds();
-                    $query->whereIn('process_request_tokens.id', $taskIds);
+                    $query->whereIn('process_request_tokens.id', $user->availableSelfServiceTasksQuery());
                 } else {
                     $query->where('process_request_tokens.is_self_service', 1);
                 }

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -466,11 +466,11 @@ class User extends Authenticatable implements HasMedia
         $this->groups()->detach();
     }
 
-    public function availableSelfServiceTaskIds()
+    public function availableSelfServiceTasksQuery()
     {
         $groupIds = $this->groups()->pluck('groups.id');
 
-        $taskQuery = ProcessRequestToken::select(['id'])
+        $taskQuery = ProcessRequestToken::select(['process_request_tokens.id'])
         ->where([
             'is_self_service' => true,
             'status' => 'ACTIVE',
@@ -490,7 +490,12 @@ class User extends Authenticatable implements HasMedia
             $query->orWhereJsonContains('self_service_groups->users', (string) $this->id);
         });
 
-        return $taskQuery->pluck('id');
+        return $taskQuery;
+    }
+
+    public function availableSelfServiceTaskIds()
+    {
+        return $this->availableSelfServiceTasksQuery()->pluck('id');
     }
 
     /**

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -383,7 +383,7 @@ trait TaskControllerIndexMethods
 
         $query->where(function ($query) use ($user) {
             $query->where('user_id', $user->id)
-                ->orWhereIn('id', $user->availableSelfServiceTaskIds());
+                ->orWhereIn('id', $user->availableSelfServiceTasksQuery());
         });
     }
 

--- a/public/builds/login/js/app-login.js
+++ b/public/builds/login/js/app-login.js
@@ -2944,13 +2944,13 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _modules_lang_js__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ./modules/lang.js */ "./resources/js/modules/lang.js");
 /* harmony import */ var _components_common_mixins_accessibility__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! ./components/common/mixins/accessibility */ "./resources/js/components/common/mixins/accessibility.js");
 var _document$head$queryS;
-function cov_2337h25edu() {
-  var path = "/Users/sanjacornelius/Documents/processmaker/resources/js/app-login.js";
-  var hash = "195e5558a5d99dbe9490879ad07aabe07e89bf1c";
+function cov_uea4ftz59() {
+  var path = "/Users/rodrigoquelca/Herd/processmaker/resources/js/app-login.js";
+  var hash = "a1fb3675012b262c56bd713cf2e624ea3fc864f6";
   var global = new Function("return this")();
   var gcv = "__coverage__";
   var coverageData = {
-    path: "/Users/sanjacornelius/Documents/processmaker/resources/js/app-login.js",
+    path: "/Users/rodrigoquelca/Herd/processmaker/resources/js/app-login.js",
     statementMap: {
       "0": {
         start: {
@@ -3928,7 +3928,7 @@ function cov_2337h25edu() {
       "7": [0, 0]
     },
     _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
-    hash: "195e5558a5d99dbe9490879ad07aabe07e89bf1c"
+    hash: "a1fb3675012b262c56bd713cf2e624ea3fc864f6"
   };
   var coverage = global[gcv] || (global[gcv] = {});
   if (!coverage[path] || coverage[path].hash !== hash) {
@@ -3937,13 +3937,13 @@ function cov_2337h25edu() {
   var actualCoverage = coverage[path];
   {
     // @ts-ignore
-    cov_2337h25edu = function () {
+    cov_uea4ftz59 = function () {
       return actualCoverage;
     };
   }
   return actualCoverage;
 }
-cov_2337h25edu();
+cov_uea4ftz59();
 
 
 
@@ -3959,35 +3959,35 @@ cov_2337h25edu();
 
 
 
-cov_2337h25edu().s[0]++;
+cov_uea4ftz59().s[0]++;
 window.__ = _modules_lang_js__WEBPACK_IMPORTED_MODULE_7__["default"];
-cov_2337h25edu().s[1]++;
+cov_uea4ftz59().s[1]++;
 window._ = __webpack_require__(/*! lodash */ "./node_modules/lodash/lodash.js");
-cov_2337h25edu().s[2]++;
+cov_uea4ftz59().s[2]++;
 window.Popper = (__webpack_require__(/*! popper.js */ "./node_modules/popper.js/dist/esm/popper.js")["default"]);
-cov_2337h25edu().s[3]++;
+cov_uea4ftz59().s[3]++;
 window.$ = window.jQuery = __webpack_require__(/*! jquery */ "./node_modules/jquery/dist/jquery.js");
-cov_2337h25edu().s[4]++;
+cov_uea4ftz59().s[4]++;
 window.Vue = vue__WEBPACK_IMPORTED_MODULE_9__["default"];
-cov_2337h25edu().s[5]++;
+cov_uea4ftz59().s[5]++;
 window.vue = vue__WEBPACK_IMPORTED_MODULE_9__;
-cov_2337h25edu().s[6]++;
+cov_uea4ftz59().s[6]++;
 window.bootstrap = bootstrap__WEBPACK_IMPORTED_MODULE_0__;
-cov_2337h25edu().s[7]++;
+cov_uea4ftz59().s[7]++;
 window.Vue.use((vue_cookies__WEBPACK_IMPORTED_MODULE_6___default()));
-cov_2337h25edu().s[8]++;
+cov_uea4ftz59().s[8]++;
 window.Vue.use(_panter_vue_i18next__WEBPACK_IMPORTED_MODULE_5__["default"]);
-var translationsLoaded = (cov_2337h25edu().s[9]++, false);
-var mdates = (cov_2337h25edu().s[10]++, JSON.parse((_document$head$queryS = document.head.querySelector("meta[name=\"i18n-mdate\"]")) === null || _document$head$queryS === void 0 ? void 0 : _document$head$queryS.content));
+var translationsLoaded = (cov_uea4ftz59().s[9]++, false);
+var mdates = (cov_uea4ftz59().s[10]++, JSON.parse((_document$head$queryS = document.head.querySelector("meta[name=\"i18n-mdate\"]")) === null || _document$head$queryS === void 0 ? void 0 : _document$head$queryS.content));
 
 // Make $t available to all vue instances
-cov_2337h25edu().s[11]++;
+cov_uea4ftz59().s[11]++;
 vue__WEBPACK_IMPORTED_MODULE_9__["default"].mixin({
   i18n: new _panter_vue_i18next__WEBPACK_IMPORTED_MODULE_5__["default"](i18next__WEBPACK_IMPORTED_MODULE_1__["default"])
 });
-cov_2337h25edu().s[12]++;
+cov_uea4ftz59().s[12]++;
 vue__WEBPACK_IMPORTED_MODULE_9__["default"].mixin(_components_common_mixins_accessibility__WEBPACK_IMPORTED_MODULE_8__["default"]);
-cov_2337h25edu().s[13]++;
+cov_uea4ftz59().s[13]++;
 window.ProcessMaker = {
   i18n: i18next__WEBPACK_IMPORTED_MODULE_1__["default"],
   /**
@@ -3997,25 +3997,25 @@ window.ProcessMaker = {
   packages: [],
   missingTranslations: new Set(),
   missingTranslation: function missingTranslation(value) {
-    cov_2337h25edu().f[0]++;
-    cov_2337h25edu().s[14]++;
+    cov_uea4ftz59().f[0]++;
+    cov_uea4ftz59().s[14]++;
     if (this.missingTranslations.has(value)) {
-      cov_2337h25edu().b[0][0]++;
-      cov_2337h25edu().s[15]++;
+      cov_uea4ftz59().b[0][0]++;
+      cov_uea4ftz59().s[15]++;
       return;
     } else {
-      cov_2337h25edu().b[0][1]++;
+      cov_uea4ftz59().b[0][1]++;
     }
-    cov_2337h25edu().s[16]++;
+    cov_uea4ftz59().s[16]++;
     this.missingTranslations.add(value);
-    cov_2337h25edu().s[17]++;
+    cov_uea4ftz59().s[17]++;
     console.warn("Missing Translation:", value);
   },
   $notifications: {
     icons: {}
   }
 };
-cov_2337h25edu().s[18]++;
+cov_uea4ftz59().s[18]++;
 window.ProcessMaker.i18nPromise = i18next__WEBPACK_IMPORTED_MODULE_1__["default"].use((i18next_chained_backend__WEBPACK_IMPORTED_MODULE_2___default())).init({
   lng: document.documentElement.lang,
   fallbackLng: "en",
@@ -4025,20 +4025,20 @@ window.ProcessMaker.i18nPromise = i18next__WEBPACK_IMPORTED_MODULE_1__["default"
   nsSeparator: false,
   keySeparator: false,
   parseMissingKeyHandler: function parseMissingKeyHandler(value) {
-    cov_2337h25edu().f[1]++;
-    cov_2337h25edu().s[19]++;
+    cov_uea4ftz59().f[1]++;
+    cov_uea4ftz59().s[19]++;
     if (!translationsLoaded) {
-      cov_2337h25edu().b[1][0]++;
-      cov_2337h25edu().s[20]++;
+      cov_uea4ftz59().b[1][0]++;
+      cov_uea4ftz59().s[20]++;
       return value;
     } else {
-      cov_2337h25edu().b[1][1]++;
+      cov_uea4ftz59().b[1][1]++;
     }
     // Report that a translation is missing
-    cov_2337h25edu().s[21]++;
+    cov_uea4ftz59().s[21]++;
     window.ProcessMaker.missingTranslation(value);
     // Fallback to showing the english version
-    cov_2337h25edu().s[22]++;
+    cov_uea4ftz59().s[22]++;
     return value;
   },
   backend: {
@@ -4052,10 +4052,10 @@ window.ProcessMaker.i18nPromise = i18next__WEBPACK_IMPORTED_MODULE_1__["default"
     }]
   }
 });
-cov_2337h25edu().s[23]++;
+cov_uea4ftz59().s[23]++;
 window.ProcessMaker.i18nPromise.then(function () {
-  cov_2337h25edu().f[2]++;
-  cov_2337h25edu().s[24]++;
+  cov_uea4ftz59().f[2]++;
+  cov_uea4ftz59().s[24]++;
   translationsLoaded = true;
 });
 
@@ -4064,85 +4064,85 @@ window.ProcessMaker.i18nPromise.then(function () {
  * REST api endpoints through oauth authentication
  *
  */
-cov_2337h25edu().s[25]++;
+cov_uea4ftz59().s[25]++;
 window.ProcessMaker.apiClient = __webpack_require__(/*! axios */ "./node_modules/axios/index.js");
-cov_2337h25edu().s[26]++;
+cov_uea4ftz59().s[26]++;
 window.ProcessMaker.apiClient.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
 
 // Setup api versions
-var apiVersionConfig = (cov_2337h25edu().s[27]++, [{
+var apiVersionConfig = (cov_uea4ftz59().s[27]++, [{
   version: "1.0",
   baseURL: "/api/1.0/"
 }, {
   version: "1.1",
   baseURL: "/api/1.1/"
 }]);
-cov_2337h25edu().s[28]++;
+cov_uea4ftz59().s[28]++;
 window.ProcessMaker.apiClient.defaults.baseURL = apiVersionConfig[0].baseURL;
-cov_2337h25edu().s[29]++;
+cov_uea4ftz59().s[29]++;
 window.ProcessMaker.apiClient.interceptors.request.use(function (config) {
-  cov_2337h25edu().f[3]++;
-  cov_2337h25edu().s[30]++;
-  if ((cov_2337h25edu().b[3][0]++, typeof config.url !== "string") || (cov_2337h25edu().b[3][1]++, !config.url)) {
-    cov_2337h25edu().b[2][0]++;
-    cov_2337h25edu().s[31]++;
+  cov_uea4ftz59().f[3]++;
+  cov_uea4ftz59().s[30]++;
+  if ((cov_uea4ftz59().b[3][0]++, typeof config.url !== "string") || (cov_uea4ftz59().b[3][1]++, !config.url)) {
+    cov_uea4ftz59().b[2][0]++;
+    cov_uea4ftz59().s[31]++;
     throw new Error("Invalid URL in the request configuration");
   } else {
-    cov_2337h25edu().b[2][1]++;
+    cov_uea4ftz59().b[2][1]++;
   }
-  cov_2337h25edu().s[32]++;
+  cov_uea4ftz59().s[32]++;
   apiVersionConfig.forEach(function (_ref) {
     var version = _ref.version,
       baseURL = _ref.baseURL;
-    cov_2337h25edu().f[4]++;
-    var versionPrefix = (cov_2337h25edu().s[33]++, "/api/".concat(version, "/"));
-    cov_2337h25edu().s[34]++;
+    cov_uea4ftz59().f[4]++;
+    var versionPrefix = (cov_uea4ftz59().s[33]++, "/api/".concat(version, "/"));
+    cov_uea4ftz59().s[34]++;
     if (config.url.startsWith(versionPrefix)) {
-      cov_2337h25edu().b[4][0]++;
-      cov_2337h25edu().s[35]++;
+      cov_uea4ftz59().b[4][0]++;
+      cov_uea4ftz59().s[35]++;
       // eslint-disable-next-line no-param-reassign
       config.baseURL = baseURL;
       // eslint-disable-next-line no-param-reassign
-      cov_2337h25edu().s[36]++;
+      cov_uea4ftz59().s[36]++;
       config.url = config.url.replace(versionPrefix, "");
     } else {
-      cov_2337h25edu().b[4][1]++;
+      cov_uea4ftz59().b[4][1]++;
     }
   });
-  cov_2337h25edu().s[37]++;
+  cov_uea4ftz59().s[37]++;
   return config;
 });
 
 // Set the default API timeout
-var apiTimeout = (cov_2337h25edu().s[38]++, 5000);
-cov_2337h25edu().s[39]++;
-if ((cov_2337h25edu().b[6][0]++, window.Processmaker) && (cov_2337h25edu().b[6][1]++, window.Processmaker.apiTimeout !== undefined)) {
-  cov_2337h25edu().b[5][0]++;
-  cov_2337h25edu().s[40]++;
+var apiTimeout = (cov_uea4ftz59().s[38]++, 5000);
+cov_uea4ftz59().s[39]++;
+if ((cov_uea4ftz59().b[6][0]++, window.Processmaker) && (cov_uea4ftz59().b[6][1]++, window.Processmaker.apiTimeout !== undefined)) {
+  cov_uea4ftz59().b[5][0]++;
+  cov_uea4ftz59().s[40]++;
   apiTimeout = window.Processmaker.apiTimeout;
 } else {
-  cov_2337h25edu().b[5][1]++;
+  cov_uea4ftz59().b[5][1]++;
 }
-cov_2337h25edu().s[41]++;
+cov_uea4ftz59().s[41]++;
 window.ProcessMaker.apiClient.defaults.timeout = apiTimeout;
 
 // click an active tab after all components have mounted
-cov_2337h25edu().s[42]++;
+cov_uea4ftz59().s[42]++;
 vue__WEBPACK_IMPORTED_MODULE_9__["default"].use({
   install: function install(vue) {
-    cov_2337h25edu().f[5]++;
-    cov_2337h25edu().s[43]++;
+    cov_uea4ftz59().f[5]++;
+    cov_uea4ftz59().s[43]++;
     vue.mixin({
       mounted: function mounted() {
-        cov_2337h25edu().f[6]++;
-        cov_2337h25edu().s[44]++;
+        cov_uea4ftz59().f[6]++;
+        cov_uea4ftz59().s[44]++;
         if (this.$parent) {
-          cov_2337h25edu().b[7][0]++;
-          cov_2337h25edu().s[45]++;
+          cov_uea4ftz59().b[7][0]++;
+          cov_uea4ftz59().s[45]++;
           // only run on root
           return;
         } else {
-          cov_2337h25edu().b[7][1]++;
+          cov_uea4ftz59().b[7][1]++;
         }
       }
     });
@@ -4150,7 +4150,7 @@ vue__WEBPACK_IMPORTED_MODULE_9__["default"].use({
 });
 
 // Send an event when the global Vue and ProcessMaker instance is available
-cov_2337h25edu().s[46]++;
+cov_uea4ftz59().s[46]++;
 window.dispatchEvent(new Event("app-bootstrapped"));
 
 /***/ }),
@@ -4168,13 +4168,13 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ });
 /* harmony import */ var _babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/slicedToArray */ "./node_modules/@babel/runtime/helpers/esm/slicedToArray.js");
 
-function cov_20gejcf4ab() {
-  var path = "/Users/sanjacornelius/Documents/processmaker/resources/js/components/common/mixins/accessibility.js";
-  var hash = "32ff012b53571eb61942410b27f8a8c856256151";
+function cov_1m92uxlif6() {
+  var path = "/Users/rodrigoquelca/Herd/processmaker/resources/js/components/common/mixins/accessibility.js";
+  var hash = "0e9d2f7988eca41f690710783b46356cf01e01f4";
   var global = new Function("return this")();
   var gcv = "__coverage__";
   var coverageData = {
-    path: "/Users/sanjacornelius/Documents/processmaker/resources/js/components/common/mixins/accessibility.js",
+    path: "/Users/rodrigoquelca/Herd/processmaker/resources/js/components/common/mixins/accessibility.js",
     statementMap: {
       "0": {
         start: {
@@ -5413,7 +5413,7 @@ function cov_20gejcf4ab() {
       "14": [0, 0]
     },
     _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
-    hash: "32ff012b53571eb61942410b27f8a8c856256151"
+    hash: "0e9d2f7988eca41f690710783b46356cf01e01f4"
   };
   var coverage = global[gcv] || (global[gcv] = {});
   if (!coverage[path] || coverage[path].hash !== hash) {
@@ -5422,48 +5422,48 @@ function cov_20gejcf4ab() {
   var actualCoverage = coverage[path];
   {
     // @ts-ignore
-    cov_20gejcf4ab = function () {
+    cov_1m92uxlif6 = function () {
       return actualCoverage;
     };
   }
   return actualCoverage;
 }
-cov_20gejcf4ab();
+cov_1m92uxlif6();
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({
   data: function data() {
-    cov_20gejcf4ab().f[0]++;
-    cov_20gejcf4ab().s[0]++;
+    cov_1m92uxlif6().f[0]++;
+    cov_1m92uxlif6().s[0]++;
     return {
       focusErrors: null
     };
   },
   mounted: function mounted() {
-    cov_20gejcf4ab().f[1]++;
-    cov_20gejcf4ab().s[1]++;
+    cov_1m92uxlif6().f[1]++;
+    cov_1m92uxlif6().s[1]++;
     // Listen only on the root Vue instance
     if (!this.$parent) {
-      cov_20gejcf4ab().b[0][0]++;
-      cov_20gejcf4ab().s[2]++;
+      cov_1m92uxlif6().b[0][0]++;
+      cov_1m92uxlif6().s[2]++;
       // Set the focus within any modal or popover that is instantiated
       this.$root.$on("bv::modal::shown", this.setFocusWithin);
-      cov_20gejcf4ab().s[3]++;
+      cov_1m92uxlif6().s[3]++;
       this.$root.$on("bv::popover::shown", this.setFocusWithin);
     } else {
-      cov_20gejcf4ab().b[0][1]++;
+      cov_1m92uxlif6().b[0][1]++;
     }
-    cov_20gejcf4ab().s[4]++;
+    cov_1m92uxlif6().s[4]++;
     if (this.focusErrors) {
-      cov_20gejcf4ab().b[1][0]++;
-      cov_20gejcf4ab().s[5]++;
+      cov_1m92uxlif6().b[1][0]++;
+      cov_1m92uxlif6().s[5]++;
       // watch an object for form errors
       this.$watch(this.focusErrors, this.focusErrorsChanged, {
         deep: true
       });
-      cov_20gejcf4ab().s[6]++;
+      cov_1m92uxlif6().s[6]++;
       this.dontListenForApiClientError();
     } else {
-      cov_20gejcf4ab().b[1][1]++;
-      cov_20gejcf4ab().s[7]++;
+      cov_1m92uxlif6().b[1][1]++;
+      cov_1m92uxlif6().s[7]++;
       // default api error focusing
       this.listenForApiClientError();
     }
@@ -5476,144 +5476,144 @@ cov_20gejcf4ab();
      * @param modalId
      */
     setFocusWithin: function setFocusWithin(shownEvent, modalId) {
-      cov_20gejcf4ab().f[2]++;
-      cov_20gejcf4ab().s[8]++;
-      if ((cov_20gejcf4ab().b[3][0]++, !(shownEvent.target instanceof HTMLElement)) && (cov_20gejcf4ab().b[3][1]++, !(shownEvent.relatedTarget instanceof HTMLElement))) {
-        cov_20gejcf4ab().b[2][0]++;
-        cov_20gejcf4ab().s[9]++;
+      cov_1m92uxlif6().f[2]++;
+      cov_1m92uxlif6().s[8]++;
+      if ((cov_1m92uxlif6().b[3][0]++, !(shownEvent.target instanceof HTMLElement)) && (cov_1m92uxlif6().b[3][1]++, !(shownEvent.relatedTarget instanceof HTMLElement))) {
+        cov_1m92uxlif6().b[2][0]++;
+        cov_1m92uxlif6().s[9]++;
         return;
       } else {
-        cov_20gejcf4ab().b[2][1]++;
+        cov_1m92uxlif6().b[2][1]++;
       }
 
       // If relatedTarget is present and an HTMLElement,
       // then we know we're working with a popover,
       // otherwise it's a modal
-      var target = (cov_20gejcf4ab().s[10]++, shownEvent.relatedTarget instanceof HTMLElement ? (cov_20gejcf4ab().b[4][0]++, shownEvent.relatedTarget) : (cov_20gejcf4ab().b[4][1]++, shownEvent.target));
+      var target = (cov_1m92uxlif6().s[10]++, shownEvent.relatedTarget instanceof HTMLElement ? (cov_1m92uxlif6().b[4][0]++, shownEvent.relatedTarget) : (cov_1m92uxlif6().b[4][1]++, shownEvent.target));
 
       // Find the first focusable element that isn't the
       // modal/popover close button
-      var focusableElement = (cov_20gejcf4ab().s[11]++, target.querySelector("input, select, textarea, button:not(.close), a"));
+      var focusableElement = (cov_1m92uxlif6().s[11]++, target.querySelector("input, select, textarea, button:not(.close), a"));
 
       // If there is an element to focus on, then do so
-      cov_20gejcf4ab().s[12]++;
+      cov_1m92uxlif6().s[12]++;
       if (focusableElement instanceof HTMLElement) {
-        cov_20gejcf4ab().b[5][0]++;
+        cov_1m92uxlif6().b[5][0]++;
         //do not set focus() if it is a vue-multiselect
-        var parentVue = (cov_20gejcf4ab().s[13]++, this.findHtmlElementParentVueComponent(focusableElement));
-        cov_20gejcf4ab().s[14]++;
-        if ((cov_20gejcf4ab().b[7][0]++, parentVue !== null) && (cov_20gejcf4ab().b[7][1]++, parentVue.$options.name == 'vue-multiselect')) {
-          cov_20gejcf4ab().b[6][0]++;
-          cov_20gejcf4ab().s[15]++;
+        var parentVue = (cov_1m92uxlif6().s[13]++, this.findHtmlElementParentVueComponent(focusableElement));
+        cov_1m92uxlif6().s[14]++;
+        if ((cov_1m92uxlif6().b[7][0]++, parentVue !== null) && (cov_1m92uxlif6().b[7][1]++, parentVue.$options.name == 'vue-multiselect')) {
+          cov_1m92uxlif6().b[6][0]++;
+          cov_1m92uxlif6().s[15]++;
           return;
         } else {
-          cov_20gejcf4ab().b[6][1]++;
+          cov_1m92uxlif6().b[6][1]++;
         }
-        cov_20gejcf4ab().s[16]++;
+        cov_1m92uxlif6().s[16]++;
         focusableElement.focus();
       } else {
-        cov_20gejcf4ab().b[5][1]++;
+        cov_1m92uxlif6().b[5][1]++;
       }
     },
     findHtmlElementParentVueComponent: function findHtmlElementParentVueComponent(element) {
-      cov_20gejcf4ab().f[3]++;
-      cov_20gejcf4ab().s[17]++;
+      cov_1m92uxlif6().f[3]++;
+      cov_1m92uxlif6().s[17]++;
       if (element === undefined) {
-        cov_20gejcf4ab().b[8][0]++;
-        cov_20gejcf4ab().s[18]++;
+        cov_1m92uxlif6().b[8][0]++;
+        cov_1m92uxlif6().s[18]++;
         return null;
       } else {
-        cov_20gejcf4ab().b[8][1]++;
+        cov_1m92uxlif6().b[8][1]++;
       }
-      cov_20gejcf4ab().s[19]++;
+      cov_1m92uxlif6().s[19]++;
       if ('__vue__' in element) {
-        cov_20gejcf4ab().b[9][0]++;
-        cov_20gejcf4ab().s[20]++;
+        cov_1m92uxlif6().b[9][0]++;
+        cov_1m92uxlif6().s[20]++;
         return element.__vue__;
       } else {
-        cov_20gejcf4ab().b[9][1]++;
-        cov_20gejcf4ab().s[21]++;
+        cov_1m92uxlif6().b[9][1]++;
+        cov_1m92uxlif6().s[21]++;
         return this.findHtmlElementParentVueComponent(element.parentNode);
       }
     },
     hasCustomFocusErrors: function hasCustomFocusErrors() {
-      cov_20gejcf4ab().f[4]++;
-      cov_20gejcf4ab().s[22]++;
+      cov_1m92uxlif6().f[4]++;
+      cov_1m92uxlif6().s[22]++;
       if (this.$root._hasCustomFocusErrors) {
-        cov_20gejcf4ab().b[10][0]++;
-        cov_20gejcf4ab().s[23]++;
+        cov_1m92uxlif6().b[10][0]++;
+        cov_1m92uxlif6().s[23]++;
         this.$off;
       } else {
-        cov_20gejcf4ab().b[10][1]++;
+        cov_1m92uxlif6().b[10][1]++;
       }
     },
     listenForApiClientError: function listenForApiClientError() {
-      cov_20gejcf4ab().f[5]++;
-      cov_20gejcf4ab().s[24]++;
+      cov_1m92uxlif6().f[5]++;
+      cov_1m92uxlif6().s[24]++;
       if (typeof window.ProcessMaker._focusErrorsIntitalized === "undefined") {
-        cov_20gejcf4ab().b[11][0]++;
-        cov_20gejcf4ab().s[25]++;
+        cov_1m92uxlif6().b[11][0]++;
+        cov_1m92uxlif6().s[25]++;
         window.ProcessMaker.EventBus.$on("api-client-error", this.onApiClientError);
-        cov_20gejcf4ab().s[26]++;
+        cov_1m92uxlif6().s[26]++;
         window.ProcessMaker._focusErrorsIntitalized = true;
       } else {
-        cov_20gejcf4ab().b[11][1]++;
+        cov_1m92uxlif6().b[11][1]++;
       }
     },
     dontListenForApiClientError: function dontListenForApiClientError() {
-      cov_20gejcf4ab().f[6]++;
-      cov_20gejcf4ab().s[27]++;
+      cov_1m92uxlif6().f[6]++;
+      cov_1m92uxlif6().s[27]++;
       window.ProcessMaker.EventBus.$off("api-client-error", this.onApiClientError);
-      cov_20gejcf4ab().s[28]++;
+      cov_1m92uxlif6().s[28]++;
       window.ProcessMaker._focusErrorsIntitalized = true;
     },
     onApiClientError: function onApiClientError(error) {
-      cov_20gejcf4ab().f[7]++;
-      var errors = (cov_20gejcf4ab().s[29]++, _.get(error, "response.data.errors", false));
-      cov_20gejcf4ab().s[30]++;
+      cov_1m92uxlif6().f[7]++;
+      var errors = (cov_1m92uxlif6().s[29]++, _.get(error, "response.data.errors", false));
+      cov_1m92uxlif6().s[30]++;
       if (errors) {
-        cov_20gejcf4ab().b[12][0]++;
-        cov_20gejcf4ab().s[31]++;
+        cov_1m92uxlif6().b[12][0]++;
+        cov_1m92uxlif6().s[31]++;
         this.focusErrorsChanged(errors);
       } else {
-        cov_20gejcf4ab().b[12][1]++;
+        cov_1m92uxlif6().b[12][1]++;
       }
     },
     focusErrorsChanged: function focusErrorsChanged(newValue) {
-      cov_20gejcf4ab().f[8]++;
-      var selector = (cov_20gejcf4ab().s[32]++, Object.entries(newValue).filter(function (_ref) {
+      cov_1m92uxlif6().f[8]++;
+      var selector = (cov_1m92uxlif6().s[32]++, Object.entries(newValue).filter(function (_ref) {
         var _ref2 = (0,_babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__["default"])(_ref, 2),
           _ = _ref2[0],
           value = _ref2[1];
-        cov_20gejcf4ab().f[9]++;
-        cov_20gejcf4ab().s[33]++;
+        cov_1m92uxlif6().f[9]++;
+        cov_1m92uxlif6().s[33]++;
         return value !== null;
       }) // Filter out null values
       .map(function (_ref3) {
         var _ref4 = (0,_babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__["default"])(_ref3, 2),
           field = _ref4[0],
           _ = _ref4[1];
-        cov_20gejcf4ab().f[10]++;
-        cov_20gejcf4ab().s[34]++;
+        cov_1m92uxlif6().f[10]++;
+        cov_1m92uxlif6().s[34]++;
         return "[name='".concat(field, "']");
       }) // Select elements matching the name attribute
       .join(", "));
-      cov_20gejcf4ab().s[35]++;
+      cov_1m92uxlif6().s[35]++;
       if (!selector) {
-        cov_20gejcf4ab().b[13][0]++;
-        cov_20gejcf4ab().s[36]++;
+        cov_1m92uxlif6().b[13][0]++;
+        cov_1m92uxlif6().s[36]++;
         return;
       } else {
-        cov_20gejcf4ab().b[13][1]++;
+        cov_1m92uxlif6().b[13][1]++;
       }
-      var firstInput = (cov_20gejcf4ab().s[37]++, document.querySelector(selector)); // Find the first match
-      cov_20gejcf4ab().s[38]++;
+      var firstInput = (cov_1m92uxlif6().s[37]++, document.querySelector(selector)); // Find the first match
+      cov_1m92uxlif6().s[38]++;
       if (firstInput) {
-        cov_20gejcf4ab().b[14][0]++;
-        cov_20gejcf4ab().s[39]++;
+        cov_1m92uxlif6().b[14][0]++;
+        cov_1m92uxlif6().s[39]++;
         firstInput.focus();
       } else {
-        cov_20gejcf4ab().b[14][1]++;
+        cov_1m92uxlif6().b[14][1]++;
       }
     }
   }
@@ -5632,13 +5632,13 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (/* binding */ translate)
 /* harmony export */ });
-function cov_kcsn6du19() {
-  var path = "/Users/sanjacornelius/Documents/processmaker/resources/js/modules/lang.js";
-  var hash = "2cc2f52cbb98903a23b86bcdba9de5ccc6934daa";
+function cov_2rmq8yqjks() {
+  var path = "/Users/rodrigoquelca/Herd/processmaker/resources/js/modules/lang.js";
+  var hash = "60dd3571884a36549a21e4082aea36122067deab";
   var global = new Function("return this")();
   var gcv = "__coverage__";
   var coverageData = {
-    path: "/Users/sanjacornelius/Documents/processmaker/resources/js/modules/lang.js",
+    path: "/Users/rodrigoquelca/Herd/processmaker/resources/js/modules/lang.js",
     statementMap: {
       "0": {
         start: {
@@ -5686,7 +5686,7 @@ function cov_kcsn6du19() {
     },
     b: {},
     _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
-    hash: "2cc2f52cbb98903a23b86bcdba9de5ccc6934daa"
+    hash: "60dd3571884a36549a21e4082aea36122067deab"
   };
   var coverage = global[gcv] || (global[gcv] = {});
   if (!coverage[path] || coverage[path].hash !== hash) {
@@ -5695,16 +5695,16 @@ function cov_kcsn6du19() {
   var actualCoverage = coverage[path];
   {
     // @ts-ignore
-    cov_kcsn6du19 = function () {
+    cov_2rmq8yqjks = function () {
       return actualCoverage;
     };
   }
   return actualCoverage;
 }
-cov_kcsn6du19();
+cov_2rmq8yqjks();
 function translate(value) {
-  cov_kcsn6du19().f[0]++;
-  cov_kcsn6du19().s[0]++;
+  cov_2rmq8yqjks().f[0]++;
+  cov_2rmq8yqjks().s[0]++;
   return value;
 }
 

--- a/public/builds/login/js/app-login.js
+++ b/public/builds/login/js/app-login.js
@@ -2944,13 +2944,13 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _modules_lang_js__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ./modules/lang.js */ "./resources/js/modules/lang.js");
 /* harmony import */ var _components_common_mixins_accessibility__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! ./components/common/mixins/accessibility */ "./resources/js/components/common/mixins/accessibility.js");
 var _document$head$queryS;
-function cov_uea4ftz59() {
-  var path = "/Users/rodrigoquelca/Herd/processmaker/resources/js/app-login.js";
-  var hash = "a1fb3675012b262c56bd713cf2e624ea3fc864f6";
+function cov_2337h25edu() {
+  var path = "/Users/sanjacornelius/Documents/processmaker/resources/js/app-login.js";
+  var hash = "195e5558a5d99dbe9490879ad07aabe07e89bf1c";
   var global = new Function("return this")();
   var gcv = "__coverage__";
   var coverageData = {
-    path: "/Users/rodrigoquelca/Herd/processmaker/resources/js/app-login.js",
+    path: "/Users/sanjacornelius/Documents/processmaker/resources/js/app-login.js",
     statementMap: {
       "0": {
         start: {
@@ -3928,7 +3928,7 @@ function cov_uea4ftz59() {
       "7": [0, 0]
     },
     _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
-    hash: "a1fb3675012b262c56bd713cf2e624ea3fc864f6"
+    hash: "195e5558a5d99dbe9490879ad07aabe07e89bf1c"
   };
   var coverage = global[gcv] || (global[gcv] = {});
   if (!coverage[path] || coverage[path].hash !== hash) {
@@ -3937,13 +3937,13 @@ function cov_uea4ftz59() {
   var actualCoverage = coverage[path];
   {
     // @ts-ignore
-    cov_uea4ftz59 = function () {
+    cov_2337h25edu = function () {
       return actualCoverage;
     };
   }
   return actualCoverage;
 }
-cov_uea4ftz59();
+cov_2337h25edu();
 
 
 
@@ -3959,35 +3959,35 @@ cov_uea4ftz59();
 
 
 
-cov_uea4ftz59().s[0]++;
+cov_2337h25edu().s[0]++;
 window.__ = _modules_lang_js__WEBPACK_IMPORTED_MODULE_7__["default"];
-cov_uea4ftz59().s[1]++;
+cov_2337h25edu().s[1]++;
 window._ = __webpack_require__(/*! lodash */ "./node_modules/lodash/lodash.js");
-cov_uea4ftz59().s[2]++;
+cov_2337h25edu().s[2]++;
 window.Popper = (__webpack_require__(/*! popper.js */ "./node_modules/popper.js/dist/esm/popper.js")["default"]);
-cov_uea4ftz59().s[3]++;
+cov_2337h25edu().s[3]++;
 window.$ = window.jQuery = __webpack_require__(/*! jquery */ "./node_modules/jquery/dist/jquery.js");
-cov_uea4ftz59().s[4]++;
+cov_2337h25edu().s[4]++;
 window.Vue = vue__WEBPACK_IMPORTED_MODULE_9__["default"];
-cov_uea4ftz59().s[5]++;
+cov_2337h25edu().s[5]++;
 window.vue = vue__WEBPACK_IMPORTED_MODULE_9__;
-cov_uea4ftz59().s[6]++;
+cov_2337h25edu().s[6]++;
 window.bootstrap = bootstrap__WEBPACK_IMPORTED_MODULE_0__;
-cov_uea4ftz59().s[7]++;
+cov_2337h25edu().s[7]++;
 window.Vue.use((vue_cookies__WEBPACK_IMPORTED_MODULE_6___default()));
-cov_uea4ftz59().s[8]++;
+cov_2337h25edu().s[8]++;
 window.Vue.use(_panter_vue_i18next__WEBPACK_IMPORTED_MODULE_5__["default"]);
-var translationsLoaded = (cov_uea4ftz59().s[9]++, false);
-var mdates = (cov_uea4ftz59().s[10]++, JSON.parse((_document$head$queryS = document.head.querySelector("meta[name=\"i18n-mdate\"]")) === null || _document$head$queryS === void 0 ? void 0 : _document$head$queryS.content));
+var translationsLoaded = (cov_2337h25edu().s[9]++, false);
+var mdates = (cov_2337h25edu().s[10]++, JSON.parse((_document$head$queryS = document.head.querySelector("meta[name=\"i18n-mdate\"]")) === null || _document$head$queryS === void 0 ? void 0 : _document$head$queryS.content));
 
 // Make $t available to all vue instances
-cov_uea4ftz59().s[11]++;
+cov_2337h25edu().s[11]++;
 vue__WEBPACK_IMPORTED_MODULE_9__["default"].mixin({
   i18n: new _panter_vue_i18next__WEBPACK_IMPORTED_MODULE_5__["default"](i18next__WEBPACK_IMPORTED_MODULE_1__["default"])
 });
-cov_uea4ftz59().s[12]++;
+cov_2337h25edu().s[12]++;
 vue__WEBPACK_IMPORTED_MODULE_9__["default"].mixin(_components_common_mixins_accessibility__WEBPACK_IMPORTED_MODULE_8__["default"]);
-cov_uea4ftz59().s[13]++;
+cov_2337h25edu().s[13]++;
 window.ProcessMaker = {
   i18n: i18next__WEBPACK_IMPORTED_MODULE_1__["default"],
   /**
@@ -3997,25 +3997,25 @@ window.ProcessMaker = {
   packages: [],
   missingTranslations: new Set(),
   missingTranslation: function missingTranslation(value) {
-    cov_uea4ftz59().f[0]++;
-    cov_uea4ftz59().s[14]++;
+    cov_2337h25edu().f[0]++;
+    cov_2337h25edu().s[14]++;
     if (this.missingTranslations.has(value)) {
-      cov_uea4ftz59().b[0][0]++;
-      cov_uea4ftz59().s[15]++;
+      cov_2337h25edu().b[0][0]++;
+      cov_2337h25edu().s[15]++;
       return;
     } else {
-      cov_uea4ftz59().b[0][1]++;
+      cov_2337h25edu().b[0][1]++;
     }
-    cov_uea4ftz59().s[16]++;
+    cov_2337h25edu().s[16]++;
     this.missingTranslations.add(value);
-    cov_uea4ftz59().s[17]++;
+    cov_2337h25edu().s[17]++;
     console.warn("Missing Translation:", value);
   },
   $notifications: {
     icons: {}
   }
 };
-cov_uea4ftz59().s[18]++;
+cov_2337h25edu().s[18]++;
 window.ProcessMaker.i18nPromise = i18next__WEBPACK_IMPORTED_MODULE_1__["default"].use((i18next_chained_backend__WEBPACK_IMPORTED_MODULE_2___default())).init({
   lng: document.documentElement.lang,
   fallbackLng: "en",
@@ -4025,20 +4025,20 @@ window.ProcessMaker.i18nPromise = i18next__WEBPACK_IMPORTED_MODULE_1__["default"
   nsSeparator: false,
   keySeparator: false,
   parseMissingKeyHandler: function parseMissingKeyHandler(value) {
-    cov_uea4ftz59().f[1]++;
-    cov_uea4ftz59().s[19]++;
+    cov_2337h25edu().f[1]++;
+    cov_2337h25edu().s[19]++;
     if (!translationsLoaded) {
-      cov_uea4ftz59().b[1][0]++;
-      cov_uea4ftz59().s[20]++;
+      cov_2337h25edu().b[1][0]++;
+      cov_2337h25edu().s[20]++;
       return value;
     } else {
-      cov_uea4ftz59().b[1][1]++;
+      cov_2337h25edu().b[1][1]++;
     }
     // Report that a translation is missing
-    cov_uea4ftz59().s[21]++;
+    cov_2337h25edu().s[21]++;
     window.ProcessMaker.missingTranslation(value);
     // Fallback to showing the english version
-    cov_uea4ftz59().s[22]++;
+    cov_2337h25edu().s[22]++;
     return value;
   },
   backend: {
@@ -4052,10 +4052,10 @@ window.ProcessMaker.i18nPromise = i18next__WEBPACK_IMPORTED_MODULE_1__["default"
     }]
   }
 });
-cov_uea4ftz59().s[23]++;
+cov_2337h25edu().s[23]++;
 window.ProcessMaker.i18nPromise.then(function () {
-  cov_uea4ftz59().f[2]++;
-  cov_uea4ftz59().s[24]++;
+  cov_2337h25edu().f[2]++;
+  cov_2337h25edu().s[24]++;
   translationsLoaded = true;
 });
 
@@ -4064,85 +4064,85 @@ window.ProcessMaker.i18nPromise.then(function () {
  * REST api endpoints through oauth authentication
  *
  */
-cov_uea4ftz59().s[25]++;
+cov_2337h25edu().s[25]++;
 window.ProcessMaker.apiClient = __webpack_require__(/*! axios */ "./node_modules/axios/index.js");
-cov_uea4ftz59().s[26]++;
+cov_2337h25edu().s[26]++;
 window.ProcessMaker.apiClient.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
 
 // Setup api versions
-var apiVersionConfig = (cov_uea4ftz59().s[27]++, [{
+var apiVersionConfig = (cov_2337h25edu().s[27]++, [{
   version: "1.0",
   baseURL: "/api/1.0/"
 }, {
   version: "1.1",
   baseURL: "/api/1.1/"
 }]);
-cov_uea4ftz59().s[28]++;
+cov_2337h25edu().s[28]++;
 window.ProcessMaker.apiClient.defaults.baseURL = apiVersionConfig[0].baseURL;
-cov_uea4ftz59().s[29]++;
+cov_2337h25edu().s[29]++;
 window.ProcessMaker.apiClient.interceptors.request.use(function (config) {
-  cov_uea4ftz59().f[3]++;
-  cov_uea4ftz59().s[30]++;
-  if ((cov_uea4ftz59().b[3][0]++, typeof config.url !== "string") || (cov_uea4ftz59().b[3][1]++, !config.url)) {
-    cov_uea4ftz59().b[2][0]++;
-    cov_uea4ftz59().s[31]++;
+  cov_2337h25edu().f[3]++;
+  cov_2337h25edu().s[30]++;
+  if ((cov_2337h25edu().b[3][0]++, typeof config.url !== "string") || (cov_2337h25edu().b[3][1]++, !config.url)) {
+    cov_2337h25edu().b[2][0]++;
+    cov_2337h25edu().s[31]++;
     throw new Error("Invalid URL in the request configuration");
   } else {
-    cov_uea4ftz59().b[2][1]++;
+    cov_2337h25edu().b[2][1]++;
   }
-  cov_uea4ftz59().s[32]++;
+  cov_2337h25edu().s[32]++;
   apiVersionConfig.forEach(function (_ref) {
     var version = _ref.version,
       baseURL = _ref.baseURL;
-    cov_uea4ftz59().f[4]++;
-    var versionPrefix = (cov_uea4ftz59().s[33]++, "/api/".concat(version, "/"));
-    cov_uea4ftz59().s[34]++;
+    cov_2337h25edu().f[4]++;
+    var versionPrefix = (cov_2337h25edu().s[33]++, "/api/".concat(version, "/"));
+    cov_2337h25edu().s[34]++;
     if (config.url.startsWith(versionPrefix)) {
-      cov_uea4ftz59().b[4][0]++;
-      cov_uea4ftz59().s[35]++;
+      cov_2337h25edu().b[4][0]++;
+      cov_2337h25edu().s[35]++;
       // eslint-disable-next-line no-param-reassign
       config.baseURL = baseURL;
       // eslint-disable-next-line no-param-reassign
-      cov_uea4ftz59().s[36]++;
+      cov_2337h25edu().s[36]++;
       config.url = config.url.replace(versionPrefix, "");
     } else {
-      cov_uea4ftz59().b[4][1]++;
+      cov_2337h25edu().b[4][1]++;
     }
   });
-  cov_uea4ftz59().s[37]++;
+  cov_2337h25edu().s[37]++;
   return config;
 });
 
 // Set the default API timeout
-var apiTimeout = (cov_uea4ftz59().s[38]++, 5000);
-cov_uea4ftz59().s[39]++;
-if ((cov_uea4ftz59().b[6][0]++, window.Processmaker) && (cov_uea4ftz59().b[6][1]++, window.Processmaker.apiTimeout !== undefined)) {
-  cov_uea4ftz59().b[5][0]++;
-  cov_uea4ftz59().s[40]++;
+var apiTimeout = (cov_2337h25edu().s[38]++, 5000);
+cov_2337h25edu().s[39]++;
+if ((cov_2337h25edu().b[6][0]++, window.Processmaker) && (cov_2337h25edu().b[6][1]++, window.Processmaker.apiTimeout !== undefined)) {
+  cov_2337h25edu().b[5][0]++;
+  cov_2337h25edu().s[40]++;
   apiTimeout = window.Processmaker.apiTimeout;
 } else {
-  cov_uea4ftz59().b[5][1]++;
+  cov_2337h25edu().b[5][1]++;
 }
-cov_uea4ftz59().s[41]++;
+cov_2337h25edu().s[41]++;
 window.ProcessMaker.apiClient.defaults.timeout = apiTimeout;
 
 // click an active tab after all components have mounted
-cov_uea4ftz59().s[42]++;
+cov_2337h25edu().s[42]++;
 vue__WEBPACK_IMPORTED_MODULE_9__["default"].use({
   install: function install(vue) {
-    cov_uea4ftz59().f[5]++;
-    cov_uea4ftz59().s[43]++;
+    cov_2337h25edu().f[5]++;
+    cov_2337h25edu().s[43]++;
     vue.mixin({
       mounted: function mounted() {
-        cov_uea4ftz59().f[6]++;
-        cov_uea4ftz59().s[44]++;
+        cov_2337h25edu().f[6]++;
+        cov_2337h25edu().s[44]++;
         if (this.$parent) {
-          cov_uea4ftz59().b[7][0]++;
-          cov_uea4ftz59().s[45]++;
+          cov_2337h25edu().b[7][0]++;
+          cov_2337h25edu().s[45]++;
           // only run on root
           return;
         } else {
-          cov_uea4ftz59().b[7][1]++;
+          cov_2337h25edu().b[7][1]++;
         }
       }
     });
@@ -4150,7 +4150,7 @@ vue__WEBPACK_IMPORTED_MODULE_9__["default"].use({
 });
 
 // Send an event when the global Vue and ProcessMaker instance is available
-cov_uea4ftz59().s[46]++;
+cov_2337h25edu().s[46]++;
 window.dispatchEvent(new Event("app-bootstrapped"));
 
 /***/ }),
@@ -4168,13 +4168,13 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ });
 /* harmony import */ var _babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/slicedToArray */ "./node_modules/@babel/runtime/helpers/esm/slicedToArray.js");
 
-function cov_1m92uxlif6() {
-  var path = "/Users/rodrigoquelca/Herd/processmaker/resources/js/components/common/mixins/accessibility.js";
-  var hash = "0e9d2f7988eca41f690710783b46356cf01e01f4";
+function cov_20gejcf4ab() {
+  var path = "/Users/sanjacornelius/Documents/processmaker/resources/js/components/common/mixins/accessibility.js";
+  var hash = "32ff012b53571eb61942410b27f8a8c856256151";
   var global = new Function("return this")();
   var gcv = "__coverage__";
   var coverageData = {
-    path: "/Users/rodrigoquelca/Herd/processmaker/resources/js/components/common/mixins/accessibility.js",
+    path: "/Users/sanjacornelius/Documents/processmaker/resources/js/components/common/mixins/accessibility.js",
     statementMap: {
       "0": {
         start: {
@@ -5413,7 +5413,7 @@ function cov_1m92uxlif6() {
       "14": [0, 0]
     },
     _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
-    hash: "0e9d2f7988eca41f690710783b46356cf01e01f4"
+    hash: "32ff012b53571eb61942410b27f8a8c856256151"
   };
   var coverage = global[gcv] || (global[gcv] = {});
   if (!coverage[path] || coverage[path].hash !== hash) {
@@ -5422,48 +5422,48 @@ function cov_1m92uxlif6() {
   var actualCoverage = coverage[path];
   {
     // @ts-ignore
-    cov_1m92uxlif6 = function () {
+    cov_20gejcf4ab = function () {
       return actualCoverage;
     };
   }
   return actualCoverage;
 }
-cov_1m92uxlif6();
+cov_20gejcf4ab();
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({
   data: function data() {
-    cov_1m92uxlif6().f[0]++;
-    cov_1m92uxlif6().s[0]++;
+    cov_20gejcf4ab().f[0]++;
+    cov_20gejcf4ab().s[0]++;
     return {
       focusErrors: null
     };
   },
   mounted: function mounted() {
-    cov_1m92uxlif6().f[1]++;
-    cov_1m92uxlif6().s[1]++;
+    cov_20gejcf4ab().f[1]++;
+    cov_20gejcf4ab().s[1]++;
     // Listen only on the root Vue instance
     if (!this.$parent) {
-      cov_1m92uxlif6().b[0][0]++;
-      cov_1m92uxlif6().s[2]++;
+      cov_20gejcf4ab().b[0][0]++;
+      cov_20gejcf4ab().s[2]++;
       // Set the focus within any modal or popover that is instantiated
       this.$root.$on("bv::modal::shown", this.setFocusWithin);
-      cov_1m92uxlif6().s[3]++;
+      cov_20gejcf4ab().s[3]++;
       this.$root.$on("bv::popover::shown", this.setFocusWithin);
     } else {
-      cov_1m92uxlif6().b[0][1]++;
+      cov_20gejcf4ab().b[0][1]++;
     }
-    cov_1m92uxlif6().s[4]++;
+    cov_20gejcf4ab().s[4]++;
     if (this.focusErrors) {
-      cov_1m92uxlif6().b[1][0]++;
-      cov_1m92uxlif6().s[5]++;
+      cov_20gejcf4ab().b[1][0]++;
+      cov_20gejcf4ab().s[5]++;
       // watch an object for form errors
       this.$watch(this.focusErrors, this.focusErrorsChanged, {
         deep: true
       });
-      cov_1m92uxlif6().s[6]++;
+      cov_20gejcf4ab().s[6]++;
       this.dontListenForApiClientError();
     } else {
-      cov_1m92uxlif6().b[1][1]++;
-      cov_1m92uxlif6().s[7]++;
+      cov_20gejcf4ab().b[1][1]++;
+      cov_20gejcf4ab().s[7]++;
       // default api error focusing
       this.listenForApiClientError();
     }
@@ -5476,144 +5476,144 @@ cov_1m92uxlif6();
      * @param modalId
      */
     setFocusWithin: function setFocusWithin(shownEvent, modalId) {
-      cov_1m92uxlif6().f[2]++;
-      cov_1m92uxlif6().s[8]++;
-      if ((cov_1m92uxlif6().b[3][0]++, !(shownEvent.target instanceof HTMLElement)) && (cov_1m92uxlif6().b[3][1]++, !(shownEvent.relatedTarget instanceof HTMLElement))) {
-        cov_1m92uxlif6().b[2][0]++;
-        cov_1m92uxlif6().s[9]++;
+      cov_20gejcf4ab().f[2]++;
+      cov_20gejcf4ab().s[8]++;
+      if ((cov_20gejcf4ab().b[3][0]++, !(shownEvent.target instanceof HTMLElement)) && (cov_20gejcf4ab().b[3][1]++, !(shownEvent.relatedTarget instanceof HTMLElement))) {
+        cov_20gejcf4ab().b[2][0]++;
+        cov_20gejcf4ab().s[9]++;
         return;
       } else {
-        cov_1m92uxlif6().b[2][1]++;
+        cov_20gejcf4ab().b[2][1]++;
       }
 
       // If relatedTarget is present and an HTMLElement,
       // then we know we're working with a popover,
       // otherwise it's a modal
-      var target = (cov_1m92uxlif6().s[10]++, shownEvent.relatedTarget instanceof HTMLElement ? (cov_1m92uxlif6().b[4][0]++, shownEvent.relatedTarget) : (cov_1m92uxlif6().b[4][1]++, shownEvent.target));
+      var target = (cov_20gejcf4ab().s[10]++, shownEvent.relatedTarget instanceof HTMLElement ? (cov_20gejcf4ab().b[4][0]++, shownEvent.relatedTarget) : (cov_20gejcf4ab().b[4][1]++, shownEvent.target));
 
       // Find the first focusable element that isn't the
       // modal/popover close button
-      var focusableElement = (cov_1m92uxlif6().s[11]++, target.querySelector("input, select, textarea, button:not(.close), a"));
+      var focusableElement = (cov_20gejcf4ab().s[11]++, target.querySelector("input, select, textarea, button:not(.close), a"));
 
       // If there is an element to focus on, then do so
-      cov_1m92uxlif6().s[12]++;
+      cov_20gejcf4ab().s[12]++;
       if (focusableElement instanceof HTMLElement) {
-        cov_1m92uxlif6().b[5][0]++;
+        cov_20gejcf4ab().b[5][0]++;
         //do not set focus() if it is a vue-multiselect
-        var parentVue = (cov_1m92uxlif6().s[13]++, this.findHtmlElementParentVueComponent(focusableElement));
-        cov_1m92uxlif6().s[14]++;
-        if ((cov_1m92uxlif6().b[7][0]++, parentVue !== null) && (cov_1m92uxlif6().b[7][1]++, parentVue.$options.name == 'vue-multiselect')) {
-          cov_1m92uxlif6().b[6][0]++;
-          cov_1m92uxlif6().s[15]++;
+        var parentVue = (cov_20gejcf4ab().s[13]++, this.findHtmlElementParentVueComponent(focusableElement));
+        cov_20gejcf4ab().s[14]++;
+        if ((cov_20gejcf4ab().b[7][0]++, parentVue !== null) && (cov_20gejcf4ab().b[7][1]++, parentVue.$options.name == 'vue-multiselect')) {
+          cov_20gejcf4ab().b[6][0]++;
+          cov_20gejcf4ab().s[15]++;
           return;
         } else {
-          cov_1m92uxlif6().b[6][1]++;
+          cov_20gejcf4ab().b[6][1]++;
         }
-        cov_1m92uxlif6().s[16]++;
+        cov_20gejcf4ab().s[16]++;
         focusableElement.focus();
       } else {
-        cov_1m92uxlif6().b[5][1]++;
+        cov_20gejcf4ab().b[5][1]++;
       }
     },
     findHtmlElementParentVueComponent: function findHtmlElementParentVueComponent(element) {
-      cov_1m92uxlif6().f[3]++;
-      cov_1m92uxlif6().s[17]++;
+      cov_20gejcf4ab().f[3]++;
+      cov_20gejcf4ab().s[17]++;
       if (element === undefined) {
-        cov_1m92uxlif6().b[8][0]++;
-        cov_1m92uxlif6().s[18]++;
+        cov_20gejcf4ab().b[8][0]++;
+        cov_20gejcf4ab().s[18]++;
         return null;
       } else {
-        cov_1m92uxlif6().b[8][1]++;
+        cov_20gejcf4ab().b[8][1]++;
       }
-      cov_1m92uxlif6().s[19]++;
+      cov_20gejcf4ab().s[19]++;
       if ('__vue__' in element) {
-        cov_1m92uxlif6().b[9][0]++;
-        cov_1m92uxlif6().s[20]++;
+        cov_20gejcf4ab().b[9][0]++;
+        cov_20gejcf4ab().s[20]++;
         return element.__vue__;
       } else {
-        cov_1m92uxlif6().b[9][1]++;
-        cov_1m92uxlif6().s[21]++;
+        cov_20gejcf4ab().b[9][1]++;
+        cov_20gejcf4ab().s[21]++;
         return this.findHtmlElementParentVueComponent(element.parentNode);
       }
     },
     hasCustomFocusErrors: function hasCustomFocusErrors() {
-      cov_1m92uxlif6().f[4]++;
-      cov_1m92uxlif6().s[22]++;
+      cov_20gejcf4ab().f[4]++;
+      cov_20gejcf4ab().s[22]++;
       if (this.$root._hasCustomFocusErrors) {
-        cov_1m92uxlif6().b[10][0]++;
-        cov_1m92uxlif6().s[23]++;
+        cov_20gejcf4ab().b[10][0]++;
+        cov_20gejcf4ab().s[23]++;
         this.$off;
       } else {
-        cov_1m92uxlif6().b[10][1]++;
+        cov_20gejcf4ab().b[10][1]++;
       }
     },
     listenForApiClientError: function listenForApiClientError() {
-      cov_1m92uxlif6().f[5]++;
-      cov_1m92uxlif6().s[24]++;
+      cov_20gejcf4ab().f[5]++;
+      cov_20gejcf4ab().s[24]++;
       if (typeof window.ProcessMaker._focusErrorsIntitalized === "undefined") {
-        cov_1m92uxlif6().b[11][0]++;
-        cov_1m92uxlif6().s[25]++;
+        cov_20gejcf4ab().b[11][0]++;
+        cov_20gejcf4ab().s[25]++;
         window.ProcessMaker.EventBus.$on("api-client-error", this.onApiClientError);
-        cov_1m92uxlif6().s[26]++;
+        cov_20gejcf4ab().s[26]++;
         window.ProcessMaker._focusErrorsIntitalized = true;
       } else {
-        cov_1m92uxlif6().b[11][1]++;
+        cov_20gejcf4ab().b[11][1]++;
       }
     },
     dontListenForApiClientError: function dontListenForApiClientError() {
-      cov_1m92uxlif6().f[6]++;
-      cov_1m92uxlif6().s[27]++;
+      cov_20gejcf4ab().f[6]++;
+      cov_20gejcf4ab().s[27]++;
       window.ProcessMaker.EventBus.$off("api-client-error", this.onApiClientError);
-      cov_1m92uxlif6().s[28]++;
+      cov_20gejcf4ab().s[28]++;
       window.ProcessMaker._focusErrorsIntitalized = true;
     },
     onApiClientError: function onApiClientError(error) {
-      cov_1m92uxlif6().f[7]++;
-      var errors = (cov_1m92uxlif6().s[29]++, _.get(error, "response.data.errors", false));
-      cov_1m92uxlif6().s[30]++;
+      cov_20gejcf4ab().f[7]++;
+      var errors = (cov_20gejcf4ab().s[29]++, _.get(error, "response.data.errors", false));
+      cov_20gejcf4ab().s[30]++;
       if (errors) {
-        cov_1m92uxlif6().b[12][0]++;
-        cov_1m92uxlif6().s[31]++;
+        cov_20gejcf4ab().b[12][0]++;
+        cov_20gejcf4ab().s[31]++;
         this.focusErrorsChanged(errors);
       } else {
-        cov_1m92uxlif6().b[12][1]++;
+        cov_20gejcf4ab().b[12][1]++;
       }
     },
     focusErrorsChanged: function focusErrorsChanged(newValue) {
-      cov_1m92uxlif6().f[8]++;
-      var selector = (cov_1m92uxlif6().s[32]++, Object.entries(newValue).filter(function (_ref) {
+      cov_20gejcf4ab().f[8]++;
+      var selector = (cov_20gejcf4ab().s[32]++, Object.entries(newValue).filter(function (_ref) {
         var _ref2 = (0,_babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__["default"])(_ref, 2),
           _ = _ref2[0],
           value = _ref2[1];
-        cov_1m92uxlif6().f[9]++;
-        cov_1m92uxlif6().s[33]++;
+        cov_20gejcf4ab().f[9]++;
+        cov_20gejcf4ab().s[33]++;
         return value !== null;
       }) // Filter out null values
       .map(function (_ref3) {
         var _ref4 = (0,_babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__["default"])(_ref3, 2),
           field = _ref4[0],
           _ = _ref4[1];
-        cov_1m92uxlif6().f[10]++;
-        cov_1m92uxlif6().s[34]++;
+        cov_20gejcf4ab().f[10]++;
+        cov_20gejcf4ab().s[34]++;
         return "[name='".concat(field, "']");
       }) // Select elements matching the name attribute
       .join(", "));
-      cov_1m92uxlif6().s[35]++;
+      cov_20gejcf4ab().s[35]++;
       if (!selector) {
-        cov_1m92uxlif6().b[13][0]++;
-        cov_1m92uxlif6().s[36]++;
+        cov_20gejcf4ab().b[13][0]++;
+        cov_20gejcf4ab().s[36]++;
         return;
       } else {
-        cov_1m92uxlif6().b[13][1]++;
+        cov_20gejcf4ab().b[13][1]++;
       }
-      var firstInput = (cov_1m92uxlif6().s[37]++, document.querySelector(selector)); // Find the first match
-      cov_1m92uxlif6().s[38]++;
+      var firstInput = (cov_20gejcf4ab().s[37]++, document.querySelector(selector)); // Find the first match
+      cov_20gejcf4ab().s[38]++;
       if (firstInput) {
-        cov_1m92uxlif6().b[14][0]++;
-        cov_1m92uxlif6().s[39]++;
+        cov_20gejcf4ab().b[14][0]++;
+        cov_20gejcf4ab().s[39]++;
         firstInput.focus();
       } else {
-        cov_1m92uxlif6().b[14][1]++;
+        cov_20gejcf4ab().b[14][1]++;
       }
     }
   }
@@ -5632,13 +5632,13 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (/* binding */ translate)
 /* harmony export */ });
-function cov_2rmq8yqjks() {
-  var path = "/Users/rodrigoquelca/Herd/processmaker/resources/js/modules/lang.js";
-  var hash = "60dd3571884a36549a21e4082aea36122067deab";
+function cov_kcsn6du19() {
+  var path = "/Users/sanjacornelius/Documents/processmaker/resources/js/modules/lang.js";
+  var hash = "2cc2f52cbb98903a23b86bcdba9de5ccc6934daa";
   var global = new Function("return this")();
   var gcv = "__coverage__";
   var coverageData = {
-    path: "/Users/rodrigoquelca/Herd/processmaker/resources/js/modules/lang.js",
+    path: "/Users/sanjacornelius/Documents/processmaker/resources/js/modules/lang.js",
     statementMap: {
       "0": {
         start: {
@@ -5686,7 +5686,7 @@ function cov_2rmq8yqjks() {
     },
     b: {},
     _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
-    hash: "60dd3571884a36549a21e4082aea36122067deab"
+    hash: "2cc2f52cbb98903a23b86bcdba9de5ccc6934daa"
   };
   var coverage = global[gcv] || (global[gcv] = {});
   if (!coverage[path] || coverage[path].hash !== hash) {
@@ -5695,16 +5695,16 @@ function cov_2rmq8yqjks() {
   var actualCoverage = coverage[path];
   {
     // @ts-ignore
-    cov_2rmq8yqjks = function () {
+    cov_kcsn6du19 = function () {
       return actualCoverage;
     };
   }
   return actualCoverage;
 }
-cov_2rmq8yqjks();
+cov_kcsn6du19();
 function translate(value) {
-  cov_2rmq8yqjks().f[0]++;
-  cov_2rmq8yqjks().s[0]++;
+  cov_kcsn6du19().f[0]++;
+  cov_kcsn6du19().s[0]++;
   return value;
 }
 

--- a/resources/js/requests/components/RequestDetail.vue
+++ b/resources/js/requests/components/RequestDetail.vue
@@ -207,6 +207,7 @@ export default {
         'due_at',
         'is_self_service',
         'is_actionbyemail',
+        'self_service_groups',  // Required by Task resource's addAssignableUsers() method when recalculating assignable users
       ];
       return `&fields=${fields.join(',')}`;
     },

--- a/resources/js/requests/components/RequestDetail.vue
+++ b/resources/js/requests/components/RequestDetail.vue
@@ -184,12 +184,30 @@ export default {
               this.status
             }&per_page=${
               this.perPage
-            }${this.getSortParam()}`,
+            }${this.getSortParam()}${this.getColumnsParam()}`,
         )
         .then((response) => {
           this.data = this.transform(response.data);
           this.loading = false;
         });
+    },
+    /**
+     * Get the fields parameter for the API request
+     * @returns {string} The fields parameter for the API request
+     */
+    getColumnsParam() {
+      const fields = [
+        'id',
+        'element_name',
+        'user_id',
+        'process_id',
+        'process_request_id',
+        'status',
+        'due_at',
+        'is_self_service',
+        'is_actionbyemail',
+      ];
+      return `&fields=${fields.join(',')}`;
     },
     getSortParam() {
       if (this.sortOrder instanceof Array && this.sortOrder.length > 0) {

--- a/resources/js/requests/components/RequestDetail.vue
+++ b/resources/js/requests/components/RequestDetail.vue
@@ -198,6 +198,7 @@ export default {
     getColumnsParam() {
       const fields = [
         'id',
+        'element_id',           // Required by assignableUsers relationship (TokenAssignableUsers::match uses element_id)
         'element_name',
         'user_id',
         'process_id',

--- a/tests/Feature/SelfServiceOptimizationTest.php
+++ b/tests/Feature/SelfServiceOptimizationTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use ProcessMaker\Models\Group;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class SelfServiceOptimizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * BULLETPROOF TEST: Verifies that the Subquery approach is 100% equivalent
+     * to the Array approach across all possible edge cases and legacy formats.
+     */
+    public function test_subquery_optimization_is_bulletproof()
+    {
+        // 1. Setup Environment
+        $user = User::factory()->create();
+        $groupA = Group::factory()->create(['name' => 'Group A']);
+        $groupB = Group::factory()->create(['name' => 'Group B']);
+        $user->groups()->attach([$groupA->id, $groupB->id]);
+
+        $otherUser = User::factory()->create();
+        $otherGroup = Group::factory()->create(['name' => 'Other Group']);
+
+        // 2. CREATE SCENARIOS
+
+        // Scenario 1: New Format - Int ID in groups array
+        $t1 = $this->createSelfServiceTask(['groups' => [$groupA->id]]);
+
+        // Scenario 2: New Format - String ID in groups array (Legacy/JSON inconsistency)
+        $t2 = $this->createSelfServiceTask(['groups' => [(string) $groupB->id]]);
+
+        // Scenario 3: Old Format - Direct ID in array (Very old processes)
+        $t3 = $this->createSelfServiceTask([$groupA->id]);
+
+        // Scenario 4: Direct User Assignment (Int)
+        $t4 = $this->createSelfServiceTask(['users' => [$user->id]]);
+
+        // Scenario 5: Direct User Assignment (String)
+        $t5 = $this->createSelfServiceTask(['users' => [(string) $user->id]]);
+
+        // --- NEGATIVE SCENARIOS (Should NEVER be returned) ---
+
+        // Scenario 6: Task for another group
+        $t6 = $this->createSelfServiceTask(['groups' => [$otherGroup->id]]);
+
+        // Scenario 7: Task for another user
+        $t7 = $this->createSelfServiceTask(['users' => [$otherUser->id]]);
+
+        // Scenario 8: Task is not ACTIVE
+        $t8 = $this->createSelfServiceTask(['users' => [$user->id]], 'COMPLETED');
+
+        // Scenario 9: Task is already assigned to someone
+        $t9 = $this->createSelfServiceTask(['users' => [$user->id]], 'ACTIVE', $otherUser->id);
+
+        // 3. THE COMPARISON ENGINE
+
+        // Method A: Array Pluck (Memory intensive, prone to crash)
+        $oldWayIds = $user->availableSelfServiceTaskIds()->sort()->values()->toArray();
+
+        // Method B: Subquery (Optimized, safe)
+        $newWayQuery = $user->availableSelfServiceTasksQuery();
+        $resultsNewWay = ProcessRequestToken::whereIn('id', $newWayQuery)
+            ->orderBy('id')
+            ->pluck('id')
+            ->toArray();
+
+        // 4. ASSERTIONS
+
+        // A. Integrity check: Both lists must be identical
+        $this->assertEquals($oldWayIds, $resultsNewWay, 'FATAL: Subquery results differ from Array results!');
+
+        // B. Coverage check: Ensure all positive scenarios are present
+        $expectedIds = [$t1->id, $t2->id, $t3->id, $t4->id, $t5->id];
+        sort($expectedIds);
+        $this->assertEquals($expectedIds, $resultsNewWay, 'Subquery missed one of the valid scenarios.');
+
+        // C. Exclusion check: Ensure none of the negative scenarios leaked in
+        $forbiddenIds = [$t6->id, $t7->id, $t8->id, $t9->id];
+        foreach ($forbiddenIds as $id) {
+            $this->assertNotContains($id, $resultsNewWay, "Security breach: Task $id should not be visible.");
+        }
+
+        // D. Performance Logic check: Subquery must be an instance of Eloquent Builder
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, $newWayQuery);
+    }
+
+    /**
+     * STRESS TEST: Demonstrates the performance and stability gap.
+     * This test creates 10,000 tasks to show how the old way struggles vs the new way.
+     */
+    public function test_large_data_performance_and_stability()
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create();
+        $user->groups()->attach($group);
+
+        // Crear dependencias reales para evitar errores de Foreign Key
+        $process = \ProcessMaker\Models\Process::factory()->create();
+        $request = \ProcessMaker\Models\ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+        ]);
+
+        echo "\n--- STRESS TEST (10,000 Self-Service Tasks) ---\n";
+
+        // 1. Seed 10,000 tasks efficiently using bulk insert
+        $count = 10000;
+        $now = now()->toDateTimeString();
+        $chunkSize = 1000;
+
+        for ($i = 0; $i < $count / $chunkSize; $i++) {
+            $tasks = [];
+            for ($j = 0; $j < $chunkSize; $j++) {
+                $tasks[] = [
+                    'process_id' => $process->id,
+                    'process_request_id' => $request->id,
+                    'element_id' => 'node_1',
+                    'element_type' => 'task',
+                    'status' => 'ACTIVE',
+                    'is_self_service' => 1,
+                    'self_service_groups' => json_encode(['groups' => [$group->id]]),
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+            DB::table('process_request_tokens')->insert($tasks);
+        }
+
+        // 2. Measure OLD WAY (Array of IDs)
+        $startMemOld = memory_get_usage();
+        $startTimeOld = microtime(true);
+
+        $ids = $user->availableSelfServiceTaskIds();
+        $resultOld = ProcessRequestToken::whereIn('id', $ids)->count();
+
+        $timeOld = microtime(true) - $startTimeOld;
+        $memOld = (memory_get_usage() - $startMemOld) / 1024 / 1024;
+
+        // 3. Measure NEW WAY (Subquery)
+        $startMemNew = memory_get_usage();
+        $startTimeNew = microtime(true);
+
+        $query = $user->availableSelfServiceTasksQuery();
+        $resultNew = ProcessRequestToken::whereIn('id', $query)->count();
+
+        $timeNew = microtime(true) - $startTimeNew;
+        $memNew = (memory_get_usage() - $startMemNew) / 1024 / 1024;
+
+        // OUTPUT RESULTS
+        echo 'OLD WAY (Array):    Time: ' . number_format($timeOld, 4) . 's | Mem: ' . number_format($memOld, 2) . "MB | Found: $resultOld\n";
+        echo 'NEW WAY (Subquery): Time: ' . number_format($timeNew, 4) . 's | Mem: ' . number_format($memNew, 2) . "MB | Found: $resultNew\n";
+
+        // ASSERTIONS
+        $this->assertEquals($resultOld, $resultNew, 'Results must be identical!');
+
+        // En base de datos reales (no en memoria), la subconsulta suele ser más rápida
+        // Pero lo más importante es que no tiene límites de placeholders
+        $this->assertTrue($resultNew > 0);
+
+        echo "----------------------------------------------\n";
+        if ($timeNew > 0) {
+            echo 'Optimization: ' . number_format(($timeOld / $timeNew), 1) . "x faster\n";
+        }
+    }
+
+    private function createSelfServiceTask($groups, $status = 'ACTIVE', $userId = null)
+    {
+        return ProcessRequestToken::factory()->create([
+            'is_self_service' => true,
+            'status' => $status,
+            'user_id' => $userId,
+            'self_service_groups' => $groups,
+        ]);
+    }
+}

--- a/tests/unit/ProcessMaker/FilterTest.php
+++ b/tests/unit/ProcessMaker/FilterTest.php
@@ -227,10 +227,10 @@ class FilterTest extends TestCase
             ],
         ], ProcessRequestToken::class);
 
-        $this->assertEquals(
-            "select * from `process_request_tokens` where ((`process_request_tokens`.`id` in ({$selfServiceTask->id})))",
-            $sql
-        );
+        $this->assertStringContainsString('select * from `process_request_tokens` where ((`process_request_tokens`.`id` in (select `process_request_tokens`.`id` from `process_request_tokens` where', $sql);
+        $this->assertStringContainsString('`is_self_service` = 1', $sql);
+        $this->assertStringContainsString("`status` = 'ACTIVE'", $sql);
+        $this->assertStringContainsString('json_contains(`self_service_groups`', $sql);
     }
 
     public function testTaskStatusActive()

--- a/tests/unit/ProcessMaker/Models/SelfServiceComparisonTest.php
+++ b/tests/unit/ProcessMaker/Models/SelfServiceComparisonTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Models;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ProcessMaker\Models\Group;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class SelfServiceComparisonTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Verifies that the results obtained using the ID list (Array)
+     * and the subquery (Query Builder) are exactly the same.
+     *
+     * @return void
+     */
+    public function test_self_service_results_are_identical_between_array_and_subquery()
+    {
+        // 1. Scenario configuration
+        $user = User::factory()->create();
+        $group = Group::factory()->create();
+        $user->groups()->attach($group);
+
+        // Task 1: Available by GROUP (Should appear)
+        $task1 = ProcessRequestToken::factory()->create([
+            'is_self_service' => true,
+            'status' => 'ACTIVE',
+            'user_id' => null,
+            'self_service_groups' => ['groups' => [$group->id]],
+        ]);
+
+        // Task 2: Available by direct USER (Should appear)
+        $task2 = ProcessRequestToken::factory()->create([
+            'is_self_service' => true,
+            'status' => 'ACTIVE',
+            'user_id' => null,
+            'self_service_groups' => ['users' => [$user->id]],
+        ]);
+
+        // Task 3: NOT available (Another group)
+        ProcessRequestToken::factory()->create([
+            'is_self_service' => true,
+            'status' => 'ACTIVE',
+            'user_id' => null,
+            'self_service_groups' => ['groups' => [9999]],
+        ]);
+
+        // Task 4: NOT available (Already completed)
+        ProcessRequestToken::factory()->create([
+            'is_self_service' => true,
+            'status' => 'COMPLETED',
+            'user_id' => null,
+            'self_service_groups' => ['groups' => [$group->id]],
+        ]);
+
+        // 2. Execution of both methods
+
+        // Method A: Using the IDs array (Preserved behavior)
+        $idsArray = $user->availableSelfServiceTaskIds();
+        $resultsFromArray = ProcessRequestToken::whereIn('id', $idsArray)
+            ->pluck('id')
+            ->sort()
+            ->values()
+            ->toArray();
+
+        // Method B: Using the subquery (New optimization)
+        $subqueryBuilder = $user->availableSelfServiceTasksQuery();
+        $resultsFromSubquery = ProcessRequestToken::whereIn('id', $subqueryBuilder)
+            ->pluck('id')
+            ->sort()
+            ->values()
+            ->toArray();
+
+        // 3. Verification
+
+        // Check that tasks were found
+        $this->assertCount(2, $resultsFromArray, 'Exactly 2 tasks should have been found with the old method.');
+
+        // Check that both methods return exactly the same results
+        $this->assertEquals(
+            $resultsFromArray,
+            $resultsFromSubquery,
+            'Task IDs found by both methods MUST be identical.'
+        );
+
+        // Verify specific IDs are correct
+        $this->assertContains($task1->id, $resultsFromSubquery);
+        $this->assertContains($task2->id, $resultsFromSubquery);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Available self service tasks not displayed for non-admin users due to inefficient query for filtering

## Solution
-  create availableSelfServiceTasksQuery
<img width="986" height="398" alt="image" src="https://github.com/user-attachments/assets/e2492d14-a880-432e-ad90-91b4e7e0b7b0" />

## How to Test
described in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-28840

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves performance and correctness of self-service task visibility while reducing payloads from the tasks API.
> 
> - Introduces `User::availableSelfServiceTasksQuery()` (subquery) and refactors call sites to use it instead of plucked ID arrays (in PMQL `Status = Self Service`, `applyForCurrentUser`, and related filters)
> - Adds optional `fields` param to `TaskController@index`; ensures `id` is always selected; `RequestDetail.vue` now requests only required columns
> - Updates PMQL/self-service SQL expectations and adds comprehensive tests: equivalence and stress tests for the subquery vs array approach, plus adjusted `FilterTest` assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a556cebe566b80b55a64b5329c6672833bf3a75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->