### PR TITLE
FOUR-28838: Fix case detail error when case is deleted via API

### DIFF
--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -65,6 +65,9 @@ class CasesController extends Controller
 
         // Get all the request related to this case number
         $allRequests = ProcessRequest::where('case_number', $case_number)->get();
+        if ($allRequests->isEmpty()) {
+            abort(404);
+        }
         $parentRequest = null;
         $requestCount = $allRequests->count();
         // Search the parent request parent_request_id and load $request
@@ -74,6 +77,7 @@ class CasesController extends Controller
                 break;
             }
         }
+        $request = $parentRequest ?: $allRequests->first();
         $request->participants;
         $request->user;
         // Load the data and key values


### PR DESCRIPTION
## Issue & Reproduction Steps
When a case is deleted via the API, visiting the case detail route (including cases/{case_number}/files/{file}) triggers an Undefined variable $request error in CasesController::show.

## Solution
- Add a guard in CasesController.php to return 404 when no requests exist for the case.

## How to Test

1. Delete a case via DELETE /cases/{case_number}.
2. Visit /cases/{case_number} and /cases/{case_number}/files/{file}.
3. Confirm you get a 404 and no Undefined variable $request error is logged.
4. Visit an existing case and confirm the detail view still loads normally.

## Related Tickets & Packages
- [FOUR-28838](https://processmaker.atlassian.net/browse/FOUR-28838)

[FOUR-28838]: https://processmaker.atlassian.net/browse/FOUR-28838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ