### PR TITLE
FOUR-25827: Fix launchpad import to refresh screen references after process import

### DIFF
--- a/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
+++ b/ProcessMaker/ImportExport/Exporters/ProcessLaunchpadExporter.php
@@ -46,6 +46,8 @@ class ProcessLaunchpadExporter extends ExporterBase
         foreach ($this->getDependents('screen') as $dependent) {
             $properties = json_decode($this->model->properties, true);
             $properties['screen_uuid'] = $dependent->model->uuid;
+            $properties['screen_id'] = $dependent->model->id;
+            $properties['screen_title'] = $dependent->model->title;
             $this->model->properties = json_encode($properties);
         }
 

--- a/tests/Feature/ImportExport/Exporters/ProcessLaunchpadExporterTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessLaunchpadExporterTest.php
@@ -116,10 +116,15 @@ class ProcessLaunchpadExporterTest extends TestCase
         $properties = json_decode($newProcess->launchpad->properties, true);
         $newSavedSearch1Id = Arr::get($properties, 'tabs.0.idSavedSearch');
         $newSavedSearch2Id = Arr::get($properties, 'tabs.1.idSavedSearch');
+        $cancelScreen = $newProcess->cancelScreen;
 
         $this->assertNotEquals($originalSavedSearch1Id, $savedSearch1->id);
         $this->assertEquals($savedSearch1->id, $newSavedSearch1Id);
         $this->assertEquals($savedSearch2->id, $newSavedSearch2Id);
+        $this->assertNotNull($cancelScreen);
+        $this->assertEquals($cancelScreen->id, Arr::get($properties, 'screen_id'));
+        $this->assertEquals($cancelScreen->uuid, Arr::get($properties, 'screen_uuid'));
+        $this->assertEquals($cancelScreen->title, Arr::get($properties, 'screen_title'));
 
         // Re-import the same process.
         $importer = new Importer($payload, $options);


### PR DESCRIPTION
## Issue & Reproduction Steps
When importing a process with launchpad settings, the stored screen_id in process_launchpad.properties can point to a non‑existent screen in the new environment, causing a 404 on GET /api/1.0/screens/:id when opening /process-browser/{processId}.

## Solution
- Update ProcessLaunchpadExporter::import() to also set screen_id and screen_title based on the imported screen (in addition to screen_uuid).
- Add coverage in ProcessLaunchpadExporterTest to assert the launchpad properties map to the new screen after import.

## How to Test
1. Run ./vendor/bin/phpunit --filter ProcessLaunchpadExporterTest 
2. Import a process with launchpad settings into a new environment and open /process-browser/{processId}.
3. Confirm the launchpad screen loads and GET /api/1.0/screens/:id returns 200.

## Related Tickets & Packages
- [FOUR-25827](https://processmaker.atlassian.net/browse/FOUR-25827)

ci:deploy

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-25827]: https://processmaker.atlassian.net/browse/FOUR-25827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures launchpad screen references are valid after import.
> 
> - In `ProcessLaunchpadExporter::import()`, now sets `screen_uuid`, `screen_id`, and `screen_title` from the imported `screen` dependent
> - Updates `ProcessLaunchpadExporterTest` to assert launchpad properties point to the new process cancel screen and that saved search IDs are remapped
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb782c5e52dd993d33cd032728aba154dd9f5e9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->