### PR TITLE
FOUR-25963: Guard missing setting keys when rendering admin settings

### DIFF
--- a/resources/js/admin/settings/components/SettingText.vue
+++ b/resources/js/admin/settings/components/SettingText.vue
@@ -150,7 +150,8 @@ export default {
       if (this.setting?.ui?.isNotEmpty) {
         return this.transformed !== "" && this.transformed !== null;
       }
-      if (this.setting.key.startsWith("white_list.")) {
+      const settingKey = this.setting?.key ?? "";
+      if (settingKey.startsWith("white_list.")) {
         return this.validateURL(this.transformed);
       }
       return true;
@@ -190,7 +191,8 @@ export default {
       if (this.setting.ui?.isNotEmpty && (this.transformed === "" || this.transformed === null)) {
         return;
       }
-      if (this.setting.key.startsWith("white_list.")) {
+      const settingKey = this.setting?.key ?? "";
+      if (settingKey.startsWith("white_list.")) {
         if (!this.validateURL(this.transformed)) {
           return;
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
When disabling the SCIM switch at https://processmaker.test/admin/settings, the console logs a Vue render error: TypeError: can't access property "startsWith", this.setting.key is undefined.

## Solution
- Added safe fallback for setting.key before calling startsWith in SettingText.vue.

## How to Test
1. Visit https://processmaker.test/admin/settings.
2. Toggle the SCIM switch off.
3. Confirm no console error is emitted and the setting renders normally.

## Related Tickets & Packages
- [FOUR-25963](https://processmaker.atlassian.net/browse/FOUR-25963)

ci:deploy

[FOUR-25963]: https://processmaker.atlassian.net/browse/FOUR-25963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ