### PR TITLE
FOUR-26241: Fix process owner validation on update and show validation alert

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -19,6 +19,7 @@ use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Http\Controllers\Api\GroupController;
 use ProcessMaker\Http\Controllers\Api\TemplateController;
 use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Http\Requests\ProcessUpdateRequest;
 use ProcessMaker\Http\Resources\ApiCollection;
 use ProcessMaker\Http\Resources\ApiResource;
 use ProcessMaker\Http\Resources\Process as Resource;
@@ -463,7 +464,7 @@ class ProcessController extends Controller
     /**
      * Updates the current element.
      *
-     * @param Request $request
+     * @param ProcessUpdateRequest $request
      * @param Process $process
      * @return ResponseFactory|Response
      *
@@ -494,21 +495,13 @@ class ProcessController extends Controller
      *     ),
      * )
      */
-    public function update(Request $request, Process $process)
+    public function update(ProcessUpdateRequest $request, Process $process)
     {
         $lastVersion = $process->getDraftOrPublishedLatestVersion();
         $process->bpmn = $lastVersion->bpmn;
         $process->alternative = $lastVersion->alternative;
         $process->stages = $lastVersion->stages;
 
-        $rules = Process::rules($process);
-        if (!$request->has('name')) {
-            unset($rules['name']);
-        }
-        if ($request->has('default_for_anon_webentry')) {
-            $rules = ['language_code' => 'required_if:default_for_anon_webentry,true'];
-        }
-        $request->validate($rules);
         $original = $process->getOriginal();
 
         // Replace html entities with the correct characters

--- a/ProcessMaker/Http/Requests/ProcessUpdateRequest.php
+++ b/ProcessMaker/Http/Requests/ProcessUpdateRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ProcessMaker\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use ProcessMaker\Models\Process;
+
+class ProcessUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $process = $this->route('process');
+        $rules = Process::rules($process);
+
+        if (!$this->has('name')) {
+            unset($rules['name']);
+        }
+
+        if ($this->has('default_for_anon_webentry')) {
+            $rules = ['language_code' => 'required_if:default_for_anon_webentry,true'];
+        }
+
+        if ($this->has('user_id')) {
+            $rules['user_id'] = ['required', 'integer', 'exists:users,id'];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Get the validation messages that apply to the request.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'user_id.required' => __('Process owner is required.'),
+            'user_id.exists' => __('Selected process owner is invalid.'),
+        ];
+    }
+}

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -688,8 +688,15 @@
                     .catch(error => {
                         //define how display errors
                         if (error.response.status && error.response.status === 422) {
-                        // Validation error
-                        that.errors = error.response.data.errors;
+                            // Validation error
+                            that.errors = error.response.data.errors;
+                            const errors = that.errors || {};
+                            const firstFieldErrors = Object.values(errors).find(fieldErrors => Array.isArray(fieldErrors) && fieldErrors.length);
+                            const firstError = (firstFieldErrors && firstFieldErrors[0]) || error.response.data.message;
+
+                            if (firstError) {
+                                window.ProcessMaker.alert(that.$t(firstError), 'danger');
+                            }
                         }
                     });
                 },


### PR DESCRIPTION
## Issue & Reproduction Steps
Saving a process with an empty owner caused a server error because processes.user_id is not nullable.

## Solution
- Added a ProcessUpdateRequest FormRequest to validate updates and require user_id when provided.
- Switched ProcessController@update to use the FormRequest instead of inline validation.
- Added a generic 422 alert in the process edit UI to surface validation errors to the user.

## How to Test
1. Open any process and clear the “Process Owner”.
2. Click Save.
3. Verify you see a validation alert and an inline error and no server error occurs.
4. Set a valid owner and save again; confirm it saves successfully.

## Related Tickets & Packages
- [FOUR-26241](https://processmaker.atlassian.net/browse/FOUR-26241)

 ci:deploy

[FOUR-26241]: https://processmaker.atlassian.net/browse/FOUR-26241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ