### PR TITLE
FOUR-28338: Hide PI import in Projects

### DIFF
--- a/resources/js/components/templates/SelectTemplateModal.vue
+++ b/resources/js/components/templates/SelectTemplateModal.vue
@@ -27,7 +27,8 @@
         @ai-process-button-clicked="createAiProcess()"
         @process-intelligence-clicked="importPI()"
         :showTemplateOptionsActionBar="true"
-        :package-ai="packageAi" />
+        :package-ai="packageAi"
+        :show-pi-import="showPiImport" />
     </modal>
     <create-process-modal ref="create-process-modal" 
       :blank-template="blankTemplate" 
@@ -55,7 +56,16 @@
 
   export default {
     components: { Modal, TemplateSearch, CreateProcessModal, ImportPIModal },
-    props: ['type', 'countCategories', 'packageAi', 'isProjectsInstalled', 'hideAddBtn', 'projectId', 'isAbTestingInstalled'],
+    props: {
+      type: String,
+      countCategories: [Number, String, Boolean],
+      packageAi: [Boolean, Number],
+      isProjectsInstalled: [Boolean, String, Number],
+      hideAddBtn: [Boolean, String, Number],
+      projectId: [Number, String],
+      isAbTestingInstalled: Boolean,
+      showPiImport: { type: Boolean, default: true },
+    },
     data: function() {
       return {
         title: '',

--- a/resources/js/components/templates/TemplateSearch.vue
+++ b/resources/js/components/templates/TemplateSearch.vue
@@ -36,7 +36,7 @@
           />
         </div>
 
-        <div v-if="packageAi" class="col-4 p-0">
+        <div v-if="packageAi && showPiImport" class="col-4 p-0">
           <button-card
             :button="processIntelligenceButton"
             @show-details="showDetails($event)"
@@ -129,7 +129,14 @@ import WizardTemplateDetails from "./WizardTemplateDetails.vue";
 export default {
   components: { ButtonCard, TemplateSelectCard, TemplateDetails, WizardTemplateDetails },
   mixins: [datatableMixin, dataLoadingMixin],
-  props: ["type", "component", "packageAi", 'showTemplateGalleryLink', 'showTemplateOptionsActionBar'],
+  props: {
+    type: String,
+    component: String,
+    packageAi: [Boolean, Number],
+    showTemplateGalleryLink: [Boolean, String, Number],
+    showTemplateOptionsActionBar: [Boolean, String, Number],
+    showPiImport: { type: Boolean, default: true },
+  },
   data() {
     return {
       filter: "",


### PR DESCRIPTION
## Issue & Reproduction Steps
The “Import a PI Process” option should not be available in the Projects flow.

Repro:

1. Go to Designer > Projects > Project A.
2. Click “+ Asset” → “Process”.
3. Observe “Import a PI Process” option is visible (should not be).

## Solution
- Added a showPiImport flag to the process template modal flow and disabled PI import in the Projects flow.

## How to Test
1. Go to Designer > Projects > Project A.
2. Click “+ Asset” → “Process”.
3. Verify “Import a PI Process” is NOT shown.

## Related Tickets & Packages
- [FOUR-28338](https://processmaker.atlassian.net/browse/FOUR-28338),
- [Projects PR](https://github.com/ProcessMaker/package-projects/pull/191)

ci:deploy
ci:package-projects:bugfix/FOUR-28338

[FOUR-28338]: https://processmaker.atlassian.net/browse/FOUR-28338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ