### PR TITLE
bugfix/FOUR-28985 `Submit action` is not working when a `new Inbox rule` is created

### DIFF
--- a/resources/js/inbox-rules/components/InboxRuleFillData.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFillData.vue
@@ -1,90 +1,136 @@
 <template>
   <div>
     <b-embed
-      :src="linkTasks"
-      @load="loaded()"
-      :disable-interstitial="true"
       ref="preview"
-      :event-parent-id="_uid" /> 
+      :src="linkTasks"
+      :disable-interstitial="true"
+      :event-parent-id="_uid"
+      @load="loaded()"
+    />
   </div>
 </template>
 
-
 <script>
-  export default {
-    props: {
-      taskId: {
-        type: Number,
-        default: null
-      },
-      inboxRuleData: {
-        type: Object,
-        default: null
-      },
-      propInboxQuickFill: {
-        type: Object,
-        default: null
-      },
+export default {
+  props: {
+    taskId: {
+      type: Number,
+      default: null,
     },
-    data() {
-      return {
-        formData: {}
-      };
+    inboxRuleData: {
+      type: Object,
+      default: null,
     },
-    computed: {
-      linkTasks() {
-        return `/tasks/${this.taskId}/edit/preview?dispatchSubmit=1&alwaysAllowEditing=1&disableInterstitial=1`;
-      },
-      iframeContentWindow() {
-        return this.$refs['preview'].firstChild.contentWindow;
+    propInboxQuickFill: {
+      type: Object,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      formData: {},
+      lastClickedButton: null,
+    };
+  },
+  computed: {
+    linkTasks() {
+      return `/tasks/${this.taskId}/edit/preview?dispatchSubmit=1&alwaysAllowEditing=1&disableInterstitial=1`;
+    },
+    iframeContentWindow() {
+      return this.$refs.preview.firstChild.contentWindow;
+    },
+  },
+  watch: {
+    formData() {
+      this.$emit("data", this.formData);
+    },
+    propInboxQuickFill() {
+      this.formData = _.merge({}, this.formData, this.propInboxQuickFill);
+      this.iframeContentWindow.location.reload();
+    },
+  },
+  mounted() {
+    this.receiveEvent("dataUpdated", (data) => {
+      this.formData = data;
+    });
+    this.receiveEvent("formSubmit", (data) => {
+      // Use buttonInfo from event if it's a valid object, otherwise use lastClickedButton
+      // Note: There's a bug in screen-builder where buttonInfo arrives as `false` instead of the object
+      let submitData = null;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        submitData = data;
+      } else if (this.lastClickedButton && this.lastClickedButton.label) {
+        // Fallback: use button info captured from iframe click listener
+        submitData = {
+          name: this.lastClickedButton.name,
+          label: this.lastClickedButton.label,
+          value: this.lastClickedButton.value,
+        };
       }
-    },
-    watch: {
-      formData() {
-        this.$emit("data", this.formData);
-      },
-      propInboxQuickFill() {
-        this.formData = _.merge({}, this.formData, this.propInboxQuickFill);
-        this.iframeContentWindow.location.reload();
-      }
-    },
-    mounted() {
-      this.receiveEvent('dataUpdated', (data) => {
-        this.formData = data;
+      this.$emit("submit", submitData);
+    });
+    this.receiveEvent("taskReady", () => {
+      this.sendEvent("fillDataOverwriteExistingFields", this.inboxRuleData);
+      // Setup click listener for submit buttons in iframe after task is ready
+      this.$nextTick(() => {
+        this.setupButtonClickListener();
       });
-      this.receiveEvent('formSubmit', (data) => {
-        this.$emit("submit", data);
+    });
+  },
+  methods: {
+    eraseData() {
+      this.sendEvent("eraseData", true);
+    },
+    reload() {
+      this.formData = {};
+      this.iframeContentWindow.location.reload();
+    },
+    loaded() {
+      // eslint-disable-next-line no-underscore-dangle
+      this.iframeContentWindow.event_parent_id = this._uid;
+      this.sendEvent("sendValidateForm", false);
+    },
+    sendEvent(name, data) {
+      const event = new CustomEvent(name, {
+        detail: data,
       });
-      this.receiveEvent('taskReady', () => {
-        this.sendEvent("fillDataOverwriteExistingFields", this.inboxRuleData);
+      this.iframeContentWindow.dispatchEvent(event);
+    },
+    receiveEvent(name, callback) {
+      window.addEventListener(name, (event) => {
+        // eslint-disable-next-line no-underscore-dangle
+        if (event.detail.event_parent_id !== this._uid) {
+          return;
+        }
+        callback(event.detail.data);
       });
     },
-    methods: {
-      eraseData() {
-        this.sendEvent("eraseData", true);
-      },
-      reload() {
-        this.formData = {};
-        this.iframeContentWindow.location.reload();
-      },
-      loaded() {
-        this.iframeContentWindow.event_parent_id = this._uid;
-        this.sendEvent("sendValidateForm", false);
-      },
-      sendEvent(name, data) {
-        const event = new CustomEvent(name, {
-          detail: data
-        });
-        this.iframeContentWindow.dispatchEvent(event);
-      },
-      receiveEvent(name, callback) {
-        window.addEventListener(name, (event) => {
-          if (event.detail.event_parent_id !== this._uid) {
-            return;
+    setupButtonClickListener() {
+      try {
+        const iframeDoc = this.iframeContentWindow.document;
+        // Listen for clicks on submit buttons in the iframe
+        iframeDoc.addEventListener("click", (event) => {
+          const button = event.target.closest("button");
+          if (button) {
+            // Check if this is a submit button (has btn-primary class or is inside form-group)
+            const isSubmitButton = button.classList.contains("btn-primary")
+              || button.classList.contains("btn-secondary")
+              || button.closest(".form-group");
+            if (isSubmitButton) {
+              this.lastClickedButton = {
+                name: button.getAttribute("name") || null,
+                label: button.textContent?.trim() || null,
+                value: button.value || null,
+              };
+            }
           }
-          callback(event.detail.data);
-        });
-      },
-    }
-  }
+        }, true);
+      } catch (e) {
+        // Cross-origin restrictions may prevent access to iframe content
+        // eslint-disable-next-line no-console
+        console.warn("Could not setup button click listener in iframe:", e.message);
+      }
+    },
+  },
+};
 </script>

--- a/resources/js/inbox-rules/components/InboxRuleFillData.vue
+++ b/resources/js/inbox-rules/components/InboxRuleFillData.vue
@@ -55,7 +55,6 @@ export default {
     });
     this.receiveEvent("formSubmit", (data) => {
       // Use buttonInfo from event if it's a valid object, otherwise use lastClickedButton
-      // Note: There's a bug in screen-builder where buttonInfo arrives as `false` instead of the object
       let submitData = null;
       if (data && typeof data === "object" && !Array.isArray(data)) {
         submitData = data;


### PR DESCRIPTION
## Issue & Reproduction Steps
`Submit action` is not working when a `new Inbox rule` is created

## Solution
submit button listener

## How to Test

Create a simple process (start event - task - task - end event)
Create a simple screen
Add a line input control
Add a submit button
Assign this screen in both tasks
Run a Case
Fill fields
Press submit button
Run other Case
Press Create rule button when screen is displaying
Check Save and reuse filled data field
Add a date in the deactivation date field
Press Next button
Check Submit after filling field
Select a submit button on the screen

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-28985


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-window iframe event handling and adds DOM click interception, which can be brittle (cross-origin, timing) and may affect submit behavior across embedded task previews.
> 
> **Overview**
> Fixes cases where creating a new Inbox rule caused the **Submit action** to emit unusable data by adding a fallback path that captures submit-button metadata directly from the embedded task preview iframe.
> 
> `InboxRuleFillData.vue` now tracks the last clicked submit button (name/label/value), emits that data when `formSubmit` events arrive without valid button info, and hooks an iframe click listener after `taskReady` to populate this fallback (with a guarded cross-origin warning).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f19c0348ae84bed88037e952cac5efa969c3e6b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->