### PR TITLE
FOUR-29010 Redis Client Requirement for Installation

### DIFF
--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -52,7 +52,7 @@ class Install extends Command
             {--data-username=                   : The data database username}
             {--data-password=                   : The data database password}
             {--data-schema=                     : The data database schema (if pgsql)}
-            {--redis-client=predis              : The Redis client (predis or phpredis)}
+            {--redis-client=phpredis            : The Redis client (predis or phpredis)}
             {--redis-host=                      : The Redis host, default is 127.0.0.1}
             {--redis-prefix=                    : The prefix to be appended to Redis entries}
             {--horizon-prefix=horizon:          : The prefix to be appended to Horizon queue entries}


### PR DESCRIPTION
## Description
Default redis-client to phpredis so processmaker:install completes; MetricsService requires phpredis, not predis
## Related tickets
https://processmaker.atlassian.net/browse/FOUR-29010

ci:deploy