### PR TITLE
FOUR-27727: Fix Process Information button after Launch Screen change

### DIFF
--- a/resources/js/processes-catalogue/components/ProcessScreen.vue
+++ b/resources/js/processes-catalogue/components/ProcessScreen.vue
@@ -3,7 +3,9 @@
     <process-header-start
         :process="process"
         :ellipsis-permission="ellipsisPermission"
+        :show-process-info="showProcessInfo"
         @goBack="goBack()"
+        @toggle-info="toggleInfo"
         @onProcessNavigate="onProcessNavigate"
         v-if="!mobileApp"
       />
@@ -11,6 +13,30 @@
       v-if="showScreen"
       :screen="screen"
     />
+    <slide-process-info
+      :show="showProcessInfo"
+      :title="title"
+      :process="process"
+      :full-carousel="fullCarousel"
+      :is-wizard-template="createdFromWizardTemplate"
+      @getHelperProcess="getHelperProcess"
+      @closeCarousel="closeFullCarousel"
+      @close="closeProcessInfo"
+    >
+      <div class="tw-flex tw-flex-col tw-gap-4 tw-pl-10 tw-pr-10">
+        <carousel-slide
+          :process="process"
+          @full-carousel="showFullCarousel"
+        />
+        <div v-show="!fullCarousel">
+          <process-options
+            class="tw-w-full"
+            :process="process"
+            :collapsed="collapsed"
+          />
+        </div>
+      </div>
+    </slide-process-info>
     <create-template-modal
       id="create-template-modal"
       ref="create-template-modal"
@@ -42,6 +68,13 @@
       :description-settings="process.description"
       :process="process"
     />
+    <wizard-helper-process-modal
+      v-if="createdFromWizardTemplate"
+      id="wizardHelperProcessModal"
+      ref="wizardHelperProcessModal"
+      :process-launchpad-id="process.id"
+      :wizard-template-uuid="wizardTemplateUuid"
+    />
   </div>
 </template>
 
@@ -57,6 +90,10 @@ import ellipsisMenuMixin from "../../components/shared/ellipsisMenuActions";
 import processNavigationMixin from "../../components/shared/processNavigation";
 import ProcessesMixin from "./mixins/ProcessesMixin";
 import ProcessHeaderStart from "./ProcessHeaderStart.vue";
+import SlideProcessInfo from "./slideProcessInfo/SlideProcessInfo.vue";
+import CarouselSlide from "./CarouselSlide.vue";
+import ProcessOptions from "./ProcessOptions.vue";
+import WizardHelperProcessModal from "../../components/templates/WizardHelperProcessModal.vue";
 
 const tceValidScreen = ["tce-student", "tce-college", "tce-grants"];
 
@@ -70,6 +107,10 @@ export default {
     AddToProjectModal,
     LaunchpadSettingsModal,
     ProcessHeaderStart,
+    SlideProcessInfo,
+    CarouselSlide,
+    ProcessOptions,
+    WizardHelperProcessModal,
   },
   mixins: [ellipsisMenuMixin, processNavigationMixin, ProcessesMixin],
   props: ["process", "currentUserId", "ellipsisPermission"],
@@ -79,7 +120,23 @@ export default {
       screen_id: "",
       showScreen: false,
       mobileApp: window.ProcessMaker.mobileApp,
+      showProcessInfo: false,
+      fullCarousel: false,
+      collapsed: true,
     };
+  },
+  computed: {
+    title() {
+      return this.fullCarousel
+        ? this.process.name
+        : this.$t("Process Information");
+    },
+    createdFromWizardTemplate() {
+      return !!this.process?.properties?.wizardTemplateUuid;
+    },
+    wizardTemplateUuid() {
+      return this.process?.properties?.wizardTemplateUuid;
+    },
   },
   mounted() {
     this.getScreen();
@@ -104,6 +161,23 @@ export default {
             window.ProcessMaker.alert(this.$t("TCE dashboards are currently unavailable, please contact with the administrator in order to enable"), "danger");
           }
         });
+    },
+    toggleInfo() {
+      this.showProcessInfo = !this.showProcessInfo;
+    },
+    closeProcessInfo() {
+      this.showProcessInfo = false;
+    },
+    showFullCarousel() {
+      this.fullCarousel = true;
+    },
+    closeFullCarousel() {
+      this.fullCarousel = false;
+    },
+    getHelperProcess() {
+      if (this.$refs.wizardHelperProcessModal) {
+        this.$refs.wizardHelperProcessModal.getHelperProcessStartEvent();
+      }
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
When a process uses a Launch Screen (non-default), the Process Information “i” button in the header stops working after saving Launchpad settings. The button remains visible but no longer opens the information panel.

## Solution
- Wire the header “i” button in the Launch Screen view to the same Process Information panel used in the default view.

## How to Test
1. Open a process with Launchpad default and verify the “i” button opens the Process Information panel.
2. Edit Launchpad, select a Launch Screen, click Save.
3. After reload, click the “i” button; the Process Information panel should open.
4. Verify close behavior and full carousel navigation still work.

## Related Tickets & Packages
- [FOUR-27727](https://processmaker.atlassian.net/browse/FOUR-27727)

ci:deploy

[FOUR-27727]: https://processmaker.atlassian.net/browse/FOUR-27727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ