### PR TITLE
FOUR-27394: Fix Case Title/Case # links in Requests table

### DIFF
--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -353,6 +353,12 @@ export default {
     openRequest(data, index) {
       return `/requests/${data.id}`;
     },
+    openCase(data) {
+      if (data && data.case_number) {
+        return `/cases/${data.case_number}`;
+      }
+      return this.openRequest(data, 1);
+    },
     openTask(task) {
       return `/tasks/${task.id}/edit`;
     },
@@ -406,14 +412,14 @@ export default {
     },
     formatCaseNumber(value) {
       return `
-      <a href="${this.openRequest(value, 1)}"
+      <a href="${this.openCase(value)}"
          class="text-nowrap">
          # ${value.case_number}
       </a>`;
     },
     formatCaseTitle(value) {
       return `
-      <a href="${this.openRequest(value, 1)}"
+      <a href="${this.openCase(value)}"
          class="text-nowrap">
          ${value.case_title_formatted || value.case_title || value.name}
       </a>`;
@@ -457,8 +463,8 @@ export default {
       data.data = this.jsonRows(data.data);
       for (let record of data.data) {
         //format Status
-        record["case_number"] = this.formatCaseNumber(record);
         record["case_title"] = this.formatCaseTitle(record);
+        record["case_number"] = this.formatCaseNumber(record);
         if (record["active_tasks"]) {
           record["active_tasks"] = this.formatActiveTasks(record["active_tasks"]);
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
In the Requests list (/requests), the “Case Title” and “Case #” columns link to /requests/{id} but should link to /cases/{case_number}.

## Solution
- Updated Requests list links for Case Title and Case # to use /cases/{case_number} with fallback to /requests/{id}.

## How to Test
1. Open /requests.
2. Click a Case Title and Case #; confirm they go to /cases/{case_number}.
3. If a row has no case_number, confirm it falls back to /requests/{id}.

## Related Tickets & Packages
- [FOUR-27394](https://processmaker.atlassian.net/browse/FOUR-27394)

ci:deploy

[FOUR-27394]: https://processmaker.atlassian.net/browse/FOUR-27394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ