### PR TITLE
FOUR-26243: Set Guided Template Process Owner to Authenticated User

### DIFF
--- a/ProcessMaker/Templates/ProcessTemplate.php
+++ b/ProcessMaker/Templates/ProcessTemplate.php
@@ -257,6 +257,7 @@ class ProcessTemplate implements TemplateInterface
                 $payload['export'][$key]['attributes']['name'] = $requestData['name'];
                 $payload['export'][$key]['attributes']['description'] = $requestData['description'];
                 $payload['export'][$key]['attributes']['process_category_id'] = $requestData['process_category_id'];
+                $payload['export'][$key]['attributes']['user_id'] = Auth::id();
                 // Store the wizard template uuid on the process to rerun the helper process
                 if (isset($requestData['wizardTemplateUuid'])) {
                     $properties = json_decode($payload['export'][$key]['attributes']['properties'], true);


### PR DESCRIPTION
## Issue & Reproduction Steps
Processes created from guided templates were assigned to the template owner instead of the authenticated user.

## Solution
- Set the root process user_id to Auth::id() during template import so the created process is owned by the authenticated user.

## How to Test

1. Create a process from any guided template.
2. Verify the new process owner is the logged‑in user (UI or DB processes.user_id).

## Related Tickets & Packages
- [FOUR-26243](https://processmaker.atlassian.net/browse/FOUR-26243)

ci:deploy

[FOUR-26243]: https://processmaker.atlassian.net/browse/FOUR-26243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ