### PR TITLE
Data Connector uses incorrect Collection ID at runtime causing 500 error

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -195,12 +195,6 @@ trait MakeHttpRequests
         $method = $this->evalMustache($endpoint['method'], $requestData);
         $url = $this->addQueryStringsParamsToUrl($endpoint, $config, $requestData, $params);
 
-        // validate url have host
-        if (!parse_url($url, PHP_URL_HOST)) {
-            $host = $this->api_base_url ?? config('app.url');
-            $url = $host . $url;
-        }
-
         // Prepare Headers
         $headers = $this->addHeaders($endpoint, $config, $requestData);
 
@@ -487,6 +481,12 @@ trait MakeHttpRequests
         // If url does not include the protocol and server name complete it with the local server
         if (substr($url, 0, 1) === '/') {
             $url = url($url);
+        }
+
+        // validate url have host
+        if (!parse_url($url, PHP_URL_HOST)) {
+            $host = $this->api_base_url ?? config('app.url');
+            $url = $host . $url;
         }
 
         // Evaluate mustache expressions in URL

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -195,6 +195,12 @@ trait MakeHttpRequests
         $method = $this->evalMustache($endpoint['method'], $requestData);
         $url = $this->addQueryStringsParamsToUrl($endpoint, $config, $requestData, $params);
 
+        // validate url have host
+        if (!parse_url($url, PHP_URL_HOST)) {
+            $host = $this->api_base_url ?? config('app.url');
+            $url = $host . $url;
+        }
+
         // Prepare Headers
         $headers = $this->addHeaders($endpoint, $config, $requestData);
 

--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -483,6 +483,10 @@ trait MakeHttpRequests
             $url = url($url);
         }
 
+        if (strpos($url, '{{__api_base_url__}}') !== false) {
+            $url = str_replace('{{__api_base_url__}}', $this->api_base_url, $url);
+        }
+
         // validate url have host
         if (!parse_url($url, PHP_URL_HOST)) {
             $host = $this->api_base_url ?? config('app.url');


### PR DESCRIPTION
## Issue & Reproduction Steps
The host is not recognizable in the API call

## Solution
- Enhance URL validation in MakeHttpRequests trait to ensure a host is present. If the URL lacks a host, prepend the base URL from configuration or fallback to the app URL.

## How to Test

- Create a Collection
- Use the DC generated with the collection
- In a screen, use the DC; the call should work correctly and not give a 500 error.

## Related Tickets & Packages
- [FOUR-29133](https://processmaker.atlassian.net/browse/FOUR-29133)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy



[FOUR-29133]: https://processmaker.atlassian.net/browse/FOUR-29133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ