### PR TITLE
FOUR-29144: Fix 404 on Process Information chart when no saved search is configured

### DIFF
--- a/resources/js/processes-catalogue/components/BaseChart.vue
+++ b/resources/js/processes-catalogue/components/BaseChart.vue
@@ -172,7 +172,8 @@ export default {
      * Both packages go always together
      */
     fetchChart() {
-      if (!ProcessMaker.packages.includes("package-collections") && this.chartId === null && this.chartId === 0) {
+      const hasCollections = ProcessMaker.packages.includes("package-collections");
+      if (!hasCollections || !this.chartId) {
         this.getDefaultData();
         return;
       }
@@ -297,7 +298,7 @@ export default {
           const launchpadProperties = unparseProperties
             ? JSON.parse(unparseProperties)
             : "";
-          this.chartId = launchpadProperties.saved_chart_id;
+          this.chartId = launchpadProperties?.saved_chart_id || 0;
           this.fetchChart();
         })
         .catch((error) => {


### PR DESCRIPTION
## Issue & Reproduction Steps
When opening Process Information for a process without a saved search chart configured, the UI attempts to call `saved-searches/charts/undefined`, which returns a 404.

1. Log in.
2. Go to Processes.
3. Open any process without a saved search chart configured.
4. Click the info (“i”) button to open Process Information.
5. Observe the 404 in the network tab for `saved-searches/charts/undefined`.

## Solution
- Guard the chart fetch to only run when `package-collections` is installed and a valid `chartId` exists.
- Default `chartId` to `0` when launchpad properties do not include `saved_chart_id`.

## How to Test
1. Open a process without a saved search chart configured.
2. Click the info (“i”) button.
3. Confirm no request is made to `saved-searches/charts/undefined` and no 404 appears.
4. (Optional) Configure a saved search chart for the process and confirm the chart loads via `saved-searches/charts/{id}`.

ci:deploy