### PR TITLE
Implement Scheduled Case Retention Evaluation and Automated Case Deletion

### DIFF
--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -28,7 +28,7 @@ class EvaluateCaseRetention extends Command
     public function handle()
     {
         // Only run if case retention policy is enabled
-        $enabled = getenv('CASE_RETENTION_POLICY_ENABLED');
+        $enabled = env('CASE_RETENTION_POLICY_ENABLED', false);
         if (!$enabled) {
             $this->info('Case retention policy is disabled');
             $this->error('Skipping case retention evaluation');

--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -30,7 +30,7 @@ class EvaluateCaseRetention extends Command
         $this->info('Evaluating and deleting cases past their retention period');
 
         // Process all processes when retention policy is enabled
-        // Processes without retention_period will default to 6 months
+        // Processes without retention_period will default to 1_year
         Process::chunkById(100, function ($processes) {
             foreach ($processes as $process) {
                 dispatch(new EvaluateProcessRetentionJob($process->id));

--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -28,7 +28,7 @@ class EvaluateCaseRetention extends Command
     public function handle()
     {
         // Only run if case retention policy is enabled
-        $enabled = env('CASE_RETENTION_POLICY_ENABLED', false);
+        $enabled = config('app.case_retention_policy_enabled', false);
         if (!$enabled) {
             $this->info('Case retention policy is disabled');
             $this->error('Skipping case retention evaluation');

--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -27,6 +27,16 @@ class EvaluateCaseRetention extends Command
      */
     public function handle()
     {
+        // Only run if case retention policy is enabled
+        $enabled = getenv('CASE_RETENTION_POLICY_ENABLED');
+        if (!$enabled) {
+            $this->info('Case retention policy is disabled');
+            $this->error('Skipping case retention evaluation');
+
+            return;
+        }
+
+        $this->info('Case retention policy is enabled');
         $this->info('Evaluating and deleting cases past their retention period');
 
         // Process all processes when retention policy is enabled

--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use ProcessMaker\Jobs\EvaluateProcessRetentionJob;
+use ProcessMaker\Models\Process;
+
+class EvaluateCaseRetention extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cases:retention:evaluate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Evaluate and delete cases past their retention period';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Evaluating and deleting cases past their retention period');
+
+        Process::whereNotNull('properties->retention_period')->chunkById(100, function ($processes) {
+            foreach ($processes as $process) {
+                dispatch(new EvaluateProcessRetentionJob($process->id));
+            }
+        });
+
+        $this->info('Cases retention evaluation complete');
+    }
+}

--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -29,7 +29,9 @@ class EvaluateCaseRetention extends Command
     {
         $this->info('Evaluating and deleting cases past their retention period');
 
-        Process::whereNotNull('properties->retention_period')->chunkById(100, function ($processes) {
+        // Process all processes when retention policy is enabled
+        // Processes without retention_period will default to 6 months
+        Process::chunkById(100, function ($processes) {
             foreach ($processes as $process) {
                 dispatch(new EvaluateProcessRetentionJob($process->id));
             }

--- a/ProcessMaker/Console/Kernel.php
+++ b/ProcessMaker/Console/Kernel.php
@@ -89,6 +89,13 @@ class Kernel extends ConsoleKernel
                 break;
         }
 
+        // evaluate cases retention policy
+        $schedule->command('cases:retention:evaluate')
+            ->daily()
+            ->onOneServer()
+            ->withoutOverlapping()
+            ->runInBackground();
+
         // 5 minutes is recommended in https://laravel.com/docs/12.x/horizon#metrics
         $schedule->command('horizon:snapshot')->everyFiveMinutes();
     }

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -26,6 +26,13 @@ class EvaluateProcessRetentionJob implements ShouldQueue
      */
     public function handle(): void
     {
+        // Only run if case retention policy is enabled
+        // Use getenv() to read directly from environment (works better in tests)
+        $enabled = getenv('CASE_RETENTION_POLICY_ENABLED');
+        if ($enabled === false || $enabled === 'false' || $enabled === '0' || $enabled === '') {
+            return;
+        }
+
         $process = Process::find($this->processId);
         if (!$process) {
             Log::error('CaseRetentionJob: Process not found', ['process_id' => $this->processId]);

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -2,10 +2,13 @@
 
 namespace ProcessMaker\Jobs;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 use ProcessMaker\Models\CaseNumber;
 use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
 
 class EvaluateProcessRetentionJob implements ShouldQueue
 {
@@ -37,10 +40,43 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             '5_years' => 60,
         };
 
-        $cutoffDate = $process->retention_updated_at->addMonths($retentionMonths);
+        $retentionUpdatedAt = Carbon::parse($process->properties['retention_updated_at']);
 
-        CaseNumber::where('process_id', $this->processId)
-            ->where('created_at', '<', $cutoffDate)
+        // Get all process request IDs for this process
+        $processRequestIds = ProcessRequest::where('process_id', $this->processId)->pluck('id');
+
+        // If there are no process requests, nothing to delete
+        if ($processRequestIds->isEmpty()) {
+            return;
+        }
+
+        // Handle two scenarios:
+        // 1. Cases created BEFORE retention_updated_at: Delete if older than retention period from retention_updated_at
+        //    (These cases were subject to the old retention policy, but we apply current retention from update date)
+        // 2. Cases created AFTER retention_updated_at: Delete if older than retention period from their creation date
+        //    (These cases are subject to the new retention policy)
+
+        $now = Carbon::now();
+
+        // For cases created before retention_updated_at: cutoff is retention_updated_at - retention_period
+        $oldCasesCutoff = $retentionUpdatedAt->copy()->subMonths($retentionMonths);
+
+        // For cases created after retention_updated_at: cutoff is now - retention_period
+        $newCasesCutoff = $now->copy()->subMonths($retentionMonths);
+
+        CaseNumber::whereIn('process_request_id', $processRequestIds)
+            ->where(function ($query) use ($retentionUpdatedAt, $oldCasesCutoff, $newCasesCutoff) {
+                // Cases created before retention_updated_at: delete if created before (retention_updated_at - retention_period)
+                $query->where(function ($q) use ($retentionUpdatedAt, $oldCasesCutoff) {
+                    $q->where('created_at', '<', $retentionUpdatedAt)
+                    ->where('created_at', '<', $oldCasesCutoff);
+                })
+                // Cases created after retention_updated_at: delete if created before (now - retention_period)
+                ->orWhere(function ($q) use ($retentionUpdatedAt, $newCasesCutoff) {
+                    $q->where('created_at', '>=', $retentionUpdatedAt)
+                    ->where('created_at', '<', $newCasesCutoff);
+                });
+            })
             ->chunkById(100, function ($cases) {
                 $caseIds = $cases->pluck('id');
                 // Delete the cases

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -27,9 +27,8 @@ class EvaluateProcessRetentionJob implements ShouldQueue
     public function handle(): void
     {
         // Only run if case retention policy is enabled
-        // Use getenv() to read directly from environment (works better in tests)
-        $enabled = getenv('CASE_RETENTION_POLICY_ENABLED');
-        if ($enabled === false || $enabled === 'false' || $enabled === '0' || $enabled === '') {
+        $enabled = config('app.case_retention_policy_enabled');
+        if (!$enabled) {
             return;
         }
 
@@ -40,14 +39,14 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             return;
         }
 
-        // Default to 6 months if retention_period is not set
-        $retentionPeriod = $process->properties['retention_period'] ?? '6_months';
+        // Default to 1_year if retention_period is not set
+        $retentionPeriod = $process->properties['retention_period'] ?? '1_year';
         $retentionMonths = match ($retentionPeriod) {
             '6_months' => 6,
             '1_year' => 12,
             '3_years' => 36,
             '5_years' => 60,
-            default => 6, // Default to 6 months
+            default => 12, // Default to 1_year
         };
 
         // Default retention_updated_at to now if not set

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ProcessMaker\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use ProcessMaker\Models\CaseNumber;
+use ProcessMaker\Models\Process;
+
+class EvaluateProcessRetentionJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public int $processId)
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $process = Process::find($this->processId);
+        if (!$process) {
+            Log::error('CaseRetentionJob: Process not found', ['process_id' => $this->processId]);
+
+            return;
+        }
+
+        $retentionMonths = match ($process->properties['retention_period']) {
+            '6_months' => 6,
+            '1_year' => 12,
+            '3_years' => 36,
+            '5_years' => 60,
+        };
+
+        $cutoffDate = $process->retention_updated_at->addMonths($retentionMonths);
+
+        CaseNumber::where('process_id', $this->processId)
+            ->where('created_at', '<', $cutoffDate)
+            ->chunkById(100, function ($cases) {
+                $caseIds = $cases->pluck('id');
+                // Delete the cases
+                CaseNumber::whereIn('id', $caseIds)->delete();
+
+                // TODO: Add logs to track the number of cases deleted
+                // Get deleted timestamp
+                // $deletedAt = Carbon::now();
+                // RetentionPolicyLog::record($process->id, $caseIds, $deletedAt);
+            });
+    }
+}

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -27,7 +27,7 @@ class EvaluateProcessRetentionJob implements ShouldQueue
     public function handle(): void
     {
         // Only run if case retention policy is enabled
-        $enabled = getenv('CASE_RETENTION_POLICY_ENABLED');
+        $enabled = env('CASE_RETENTION_POLICY_ENABLED', false);
         if (!$enabled) {
             return;
         }

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -40,14 +40,21 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             return;
         }
 
-        $retentionMonths = match ($process->properties['retention_period']) {
+        // Default to 6 months if retention_period is not set
+        $retentionPeriod = $process->properties['retention_period'] ?? '6_months';
+        $retentionMonths = match ($retentionPeriod) {
             '6_months' => 6,
             '1_year' => 12,
             '3_years' => 36,
             '5_years' => 60,
+            default => 6, // Default to 6 months
         };
 
-        $retentionUpdatedAt = Carbon::parse($process->properties['retention_updated_at']);
+        // Default retention_updated_at to now if not set
+        // This means the retention policy applies from now for processes without explicit retention settings
+        $retentionUpdatedAt = isset($process->properties['retention_updated_at'])
+            ? Carbon::parse($process->properties['retention_updated_at'])
+            : Carbon::now();
 
         // Get all process request IDs for this process
         $processRequestIds = ProcessRequest::where('process_id', $this->processId)->pluck('id');

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -55,11 +55,9 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             ? Carbon::parse($process->properties['retention_updated_at'])
             : Carbon::now();
 
-        // Get all process request IDs for this process
-        $processRequestIds = ProcessRequest::where('process_id', $this->processId)->pluck('id');
-
-        // If there are no process requests, nothing to delete
-        if ($processRequestIds->isEmpty()) {
+        // Check if there are any process requests for this process
+        // If not, nothing to delete
+        if (!ProcessRequest::where('process_id', $this->processId)->exists()) {
             return;
         }
 
@@ -77,7 +75,10 @@ class EvaluateProcessRetentionJob implements ShouldQueue
         // For cases created after retention_updated_at: cutoff is now - retention_period
         $newCasesCutoff = $now->copy()->subMonths($retentionMonths);
 
-        CaseNumber::whereIn('process_request_id', $processRequestIds)
+        // Use subquery to get process request IDs
+        $processRequestSubquery = ProcessRequest::where('process_id', $this->processId)->select('id');
+
+        CaseNumber::whereIn('process_request_id', $processRequestSubquery)
             ->where(function ($query) use ($retentionUpdatedAt, $oldCasesCutoff, $newCasesCutoff) {
                 // Cases created before retention_updated_at: delete if created before (retention_updated_at - retention_period)
                 $query->where(function ($q) use ($retentionUpdatedAt, $oldCasesCutoff) {

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -27,7 +27,7 @@ class EvaluateProcessRetentionJob implements ShouldQueue
     public function handle(): void
     {
         // Only run if case retention policy is enabled
-        $enabled = config('app.case_retention_policy_enabled');
+        $enabled = getenv('CASE_RETENTION_POLICY_ENABLED');
         if (!$enabled) {
             return;
         }

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -27,7 +27,7 @@ class EvaluateProcessRetentionJob implements ShouldQueue
     public function handle(): void
     {
         // Only run if case retention policy is enabled
-        $enabled = env('CASE_RETENTION_POLICY_ENABLED', false);
+        $enabled = config('app.case_retention_policy_enabled', false);
         if (!$enabled) {
             return;
         }

--- a/ProcessMaker/Models/CaseNumber.php
+++ b/ProcessMaker/Models/CaseNumber.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Models;
 
+use Database\Factories\ProcessMaker\Models\CaseNumberFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 

--- a/ProcessMaker/Models/CaseNumber.php
+++ b/ProcessMaker/Models/CaseNumber.php
@@ -2,7 +2,6 @@
 
 namespace ProcessMaker\Models;
 
-use Database\Factories\ProcessMaker\Models\CaseNumberFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 

--- a/config/app.php
+++ b/config/app.php
@@ -288,6 +288,9 @@ return [
     // Enable or disable TCE customization feature
     'tce_customization_enable' => env('TCE_CUSTOMIZATION_ENABLED', false),
 
+    // Enable or disable case retention policy
+    'case_retention_policy_enabled' => env('CASE_RETENTION_POLICY_ENABLED', false),
+
     'prometheus_namespace' => env('PROMETHEUS_NAMESPACE', strtolower(preg_replace('/[^a-zA-Z0-9_]+/', '_', env('APP_NAME', 'processmaker')))),
 
     'server_timing' => [

--- a/database/factories/ProcessMaker/Models/CaseNumberFactory.php
+++ b/database/factories/ProcessMaker/Models/CaseNumberFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories\ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use ProcessMaker\Models\CaseNumber;
+use ProcessMaker\Models\ProcessRequest;
+
+class CaseNumberFactory extends Factory
+{
+    protected $model = CaseNumber::class;
+
+    public function definition(): array
+    {
+        return [
+            'process_request_id' => function () {
+                return ProcessRequest::factory()->create()->getKey();
+            },
+        ];
+    }
+}

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -33,20 +33,17 @@ class EvaluateProcessRetentionJobTest extends TestCase
 
     public function testItDeletesCasesThatExceedRetentionPeriod()
     {
-        // Create a process with a 6 month retention period
-        // retention_updated_at is 6 months ago, so old cases cutoff is 12 months ago (6 months ago - 6 months)
-        $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
+        // Create a process with a 1 year retention period
+        // retention_updated_at defaults to now, so cutoff is 12 months ago (now - 12 months)
         $process = Process::factory()->create([
             'properties' => [
                 'retention_period' => self::RETENTION_PERIOD,
-                'retention_updated_at' => $retentionUpdatedAt,
             ],
         ]);
 
         $process->save();
         $process->refresh();
         $this->assertEquals(self::RETENTION_PERIOD, $process->properties['retention_period']);
-        $this->assertEquals($retentionUpdatedAt, $process->properties['retention_updated_at']);
 
         // Create a process request
         $processRequest = ProcessRequest::factory()->create();
@@ -55,8 +52,8 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $processRequest->refresh();
         $this->assertEquals($process->id, $processRequest->process_id);
 
-        // Create a case number created 13 months ago (before retention_updated_at)
-        // Old cases cutoff = 6 months ago - 6 months = 12 months ago
+        // Create a case number created 13 months ago
+        // Cutoff = now - 12 months = 12 months ago
         // 13 months ago < 12 months ago, so it should be deleted
         $oldCaseCreatedAt = Carbon::now()->subMonths(13)->toIso8601String();
         $caseOld = CaseNumber::factory()->create([
@@ -75,19 +72,16 @@ class EvaluateProcessRetentionJobTest extends TestCase
 
     public function testItDoesNotDeleteCasesThatAreWithinRetentionPeriod()
     {
-        // Create a process with a 6 month retention period
-        // retention_updated_at is 6 months ago, so old cases cutoff is 12 months ago (6 months ago - 6 months)
-        $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
+        // Create a process with a 1 year retention period
+        // retention_updated_at defaults to now, so cutoff is 12 months ago (now - 12 months)
         $process = Process::factory()->create([
             'properties' => [
                 'retention_period' => self::RETENTION_PERIOD,
-                'retention_updated_at' => $retentionUpdatedAt,
             ],
         ]);
         $process->save();
         $process->refresh();
         $this->assertEquals(self::RETENTION_PERIOD, $process->properties['retention_period']);
-        $this->assertEquals($retentionUpdatedAt, $process->properties['retention_updated_at']);
 
         // Create a process request
         $processRequest = ProcessRequest::factory()->create();
@@ -96,8 +90,9 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $processRequest->refresh();
         $this->assertEquals($process->id, $processRequest->process_id);
 
-        // Create a case number created 5 months ago (before retention_updated_at)
-        // This case is NOT older than the old cases cutoff (12 months ago), so it should NOT be deleted
+        // Create a case number created 5 months ago
+        // Cutoff = now - 12 months = 12 months ago
+        // 5 months ago is NOT < 12 months ago, so it should NOT be deleted
         $caseCreatedAt = Carbon::now()->subMonths(5)->toIso8601String();
         $case = CaseNumber::factory()->create([
             'created_at' => $caseCreatedAt,
@@ -115,17 +110,16 @@ class EvaluateProcessRetentionJobTest extends TestCase
 
     public function testItHandlesMultipleCasesInBatches()
     {
-        // Create a process with a 6 month retention period
+        // Create a process with a 1 year retention period
+        // retention_updated_at defaults to now, so cutoff is 12 months ago (now - 12 months)
         $process = Process::factory()->create([
             'properties' => [
                 'retention_period' => self::RETENTION_PERIOD,
-                'retention_updated_at' => Carbon::now()->subMonths(6)->toIso8601String(),
             ],
         ]);
         $process->save();
         $process->refresh();
         $this->assertEquals(self::RETENTION_PERIOD, $process->properties['retention_period']);
-        $this->assertEquals(Carbon::now()->subMonths(6)->toIso8601String(), $process->properties['retention_updated_at']);
 
         // Create a process request
         $processRequest = ProcessRequest::factory()->create();
@@ -135,8 +129,8 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $this->assertEquals($process->id, $processRequest->process_id);
 
         // Create 1200 cases (to test chunking/batch deletion)
-        // These cases are created 13 months ago (before retention_updated_at)
-        // Old cases cutoff = 6 months ago - 6 months = 12 months ago
+        // These cases are created 13 months ago
+        // Cutoff = now - 12 months = 12 months ago
         // 13 months ago < 12 months ago, so these should be deleted
         $cases = CaseNumber::factory()->count(1200)->create([
             'process_request_id' => $processRequest->id,
@@ -150,7 +144,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
 
         // Assert all old cases are deleted
         // There should be 1 case left (the auto-created case from ProcessRequestObserver)
-        // because it was created after retention_updated_at and is within the retention period
+        // because it was created recently and is within the retention period
         $this->assertDatabaseCount('case_numbers', 1);
     }
 

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -137,8 +137,6 @@ class EvaluateProcessRetentionJobTest extends TestCase
         // There should be 1 case left (the auto-created case from ProcessRequestObserver)
         // because it was created after retention_updated_at and is within the retention period
         $this->assertDatabaseCount('case_numbers', 1);
-
-        // TODO: Assert log entry is created
     }
 
     public function testItHandlesRetentionPolicyUpdate()

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -16,6 +16,24 @@ class EvaluateProcessRetentionJobTest extends TestCase
 
     const RETENTION_PERIOD = '6_months';
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Enable case retention policy for all tests
+        putenv('CASE_RETENTION_POLICY_ENABLED=true');
+        $_ENV['CASE_RETENTION_POLICY_ENABLED'] = 'true';
+        $_SERVER['CASE_RETENTION_POLICY_ENABLED'] = 'true';
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up environment variable
+        putenv('CASE_RETENTION_POLICY_ENABLED');
+        unset($_ENV['CASE_RETENTION_POLICY_ENABLED']);
+        unset($_SERVER['CASE_RETENTION_POLICY_ENABLED']);
+        parent::tearDown();
+    }
+
     public function testItDeletesCasesThatExceedRetentionPeriod()
     {
         // Create a process with a 6 month retention period
@@ -231,5 +249,51 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $this->assertNull(CaseNumber::find($oldCase->id), 'The 20-month-old case should be deleted');
         $this->assertNotNull(CaseNumber::find($oldCaseNotDeleted->id), 'The 7-month-old case should NOT be deleted');
         $this->assertDatabaseCount('case_numbers', 2);
+    }
+
+    public function testItDoesNotRunWhenRetentionPolicyIsDisabled()
+    {
+        // Disable case retention policy
+        putenv('CASE_RETENTION_POLICY_ENABLED=false');
+        $_ENV['CASE_RETENTION_POLICY_ENABLED'] = 'false';
+        $_SERVER['CASE_RETENTION_POLICY_ENABLED'] = 'false';
+
+        // Create a process with a 6 month retention period
+        $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
+        $process = Process::factory()->create([
+            'properties' => [
+                'retention_period' => self::RETENTION_PERIOD,
+                'retention_updated_at' => $retentionUpdatedAt,
+            ],
+        ]);
+        $process->save();
+        $process->refresh();
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+
+        // Create an old case that should be deleted if retention was enabled
+        $oldCaseDate = Carbon::now()->subMonths(13);
+        $oldCase = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+        ]);
+        $oldCase->created_at = $oldCaseDate;
+        $oldCase->save();
+
+        // Dispatch the job
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // The case should NOT be deleted because retention policy is disabled
+        // Plus the auto-created case = 2 total
+        $this->assertNotNull(CaseNumber::find($oldCase->id), 'The case should NOT be deleted when retention policy is disabled');
+        $this->assertDatabaseCount('case_numbers', 2);
+
+        // Re-enable for other tests
+        putenv('CASE_RETENTION_POLICY_ENABLED=true');
+        $_ENV['CASE_RETENTION_POLICY_ENABLED'] = 'true';
+        $_SERVER['CASE_RETENTION_POLICY_ENABLED'] = 'true';
     }
 }

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -296,4 +296,49 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $_ENV['CASE_RETENTION_POLICY_ENABLED'] = 'true';
         $_SERVER['CASE_RETENTION_POLICY_ENABLED'] = 'true';
     }
+
+    public function testItDefaultsToSixMonthsForProcessesWithoutRetentionPeriod()
+    {
+        // Create a process WITHOUT retention_period property (should default to 6 months)
+        $process = Process::factory()->create([
+            'properties' => [], // No retention_period set
+        ]);
+        $process->save();
+        $process->refresh();
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+
+        // Create a case created 7 months ago (older than default 6 months retention)
+        // Since retention_updated_at defaults to now, old cases cutoff = now - 6 months
+        // 7 months ago < (now - 6 months), so it should be deleted
+        $oldCaseDate = Carbon::now()->subMonths(7);
+        $oldCase = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+        ]);
+        $oldCase->created_at = $oldCaseDate;
+        $oldCase->save();
+
+        // Create a case created 5 months ago (within default 6 months retention)
+        // 5 months ago is NOT < (now - 6 months), so it should NOT be deleted
+        $newCaseDate = Carbon::now()->subMonths(5);
+        $newCase = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+        ]);
+        $newCase->created_at = $newCaseDate;
+        $newCase->save();
+
+        // Dispatch the job
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // The 7-month-old case should be deleted (older than 6 months default)
+        // The 5-month-old case should NOT be deleted (within 6 months default)
+        // Plus the auto-created case = 2 total
+        $this->assertNull(CaseNumber::find($oldCase->id), 'The 7-month-old case should be deleted with default 6-month retention');
+        $this->assertNotNull(CaseNumber::find($newCase->id), 'The 5-month-old case should NOT be deleted with default 6-month retention');
+        $this->assertDatabaseCount('case_numbers', 2);
+    }
 }

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -14,7 +14,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
 {
     use RefreshDatabase;
 
-    const RETENTION_PERIOD = '6_months';
+    const RETENTION_PERIOD = '1_year';
 
     protected function setUp(): void
     {
@@ -297,9 +297,9 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $_SERVER['CASE_RETENTION_POLICY_ENABLED'] = 'true';
     }
 
-    public function testItDefaultsToSixMonthsForProcessesWithoutRetentionPeriod()
+    public function testItDefaultsToOneYearForProcessesWithoutRetentionPeriod()
     {
-        // Create a process WITHOUT retention_period property (should default to 6 months)
+        // Create a process WITHOUT retention_period property (should default to 1 year)
         $process = Process::factory()->create([
             'properties' => [], // No retention_period set
         ]);
@@ -312,18 +312,18 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $processRequest->save();
         $processRequest->refresh();
 
-        // Create a case created 7 months ago (older than default 6 months retention)
-        // Since retention_updated_at defaults to now, old cases cutoff = now - 6 months
-        // 7 months ago < (now - 6 months), so it should be deleted
-        $oldCaseDate = Carbon::now()->subMonths(7);
+        // Create a case created 13 months ago (older than default 1 year retention)
+        // Since retention_updated_at defaults to now, old cases cutoff = now - 1 year
+        // 13 months ago < (now - 1 year), so it should be deleted
+        $oldCaseDate = Carbon::now()->subMonths(13);
         $oldCase = CaseNumber::factory()->create([
             'process_request_id' => $processRequest->id,
         ]);
         $oldCase->created_at = $oldCaseDate;
         $oldCase->save();
 
-        // Create a case created 5 months ago (within default 6 months retention)
-        // 5 months ago is NOT < (now - 6 months), so it should NOT be deleted
+        // Create a case created 5 months ago (within default 1 year retention)
+        // 5 months ago is NOT < (now - 1 year), so it should NOT be deleted
         $newCaseDate = Carbon::now()->subMonths(5);
         $newCase = CaseNumber::factory()->create([
             'process_request_id' => $processRequest->id,
@@ -334,11 +334,11 @@ class EvaluateProcessRetentionJobTest extends TestCase
         // Dispatch the job
         EvaluateProcessRetentionJob::dispatchSync($process->id);
 
-        // The 7-month-old case should be deleted (older than 6 months default)
-        // The 5-month-old case should NOT be deleted (within 6 months default)
+        // The 13-month-old case should be deleted (older than 1 year default)
+        // The 5-month-old case should NOT be deleted (within 1 year default)
         // Plus the auto-created case = 2 total
-        $this->assertNull(CaseNumber::find($oldCase->id), 'The 7-month-old case should be deleted with default 6-month retention');
-        $this->assertNotNull(CaseNumber::find($newCase->id), 'The 5-month-old case should NOT be deleted with default 6-month retention');
+        $this->assertNull(CaseNumber::find($oldCase->id), 'The 13-month-old case should be deleted with default 1 year retention');
+        $this->assertNotNull(CaseNumber::find($newCase->id), 'The 5-month-old case should NOT be deleted with default 1 year retention');
         $this->assertDatabaseCount('case_numbers', 2);
     }
 }

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Jobs;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ProcessMaker\Jobs\EvaluateProcessRetentionJob;
+use ProcessMaker\Models\CaseNumber;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use Tests\TestCase;
+
+class EvaluateProcessRetentionJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    const RETENTION_PERIOD = '6_months';
+
+    public function testItDeletesCasesThatExceedRetentionPeriod()
+    {
+        // Create a process with a 6 month retention period
+        $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
+        $process = Process::factory()->create([
+            'properties' => [
+                'retention_period' => self::RETENTION_PERIOD,
+                'retention_updated_at' => $retentionUpdatedAt,
+            ],
+        ]);
+
+        $process->save();
+        $process->refresh();
+        $this->assertEquals(self::RETENTION_PERIOD, $process->properties['retention_period']);
+        $this->assertEquals($retentionUpdatedAt, $process->properties['retention_updated_at']);
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+        $this->assertEquals($process->id, $processRequest->process_id);
+
+        // Create a case number with a creation date that is past the retention period
+        $oldCaseCreatedAt = Carbon::now()->subMonths(7)->toIso8601String();
+        $caseOld = CaseNumber::factory()->create([
+            'created_at' => $oldCaseCreatedAt,
+            'process_request_id' => $processRequest->id,
+        ]);
+        $this->assertEquals($processRequest->id, $caseOld->process_request_id);
+        $this->assertEquals($oldCaseCreatedAt, $caseOld->created_at->toIso8601String());
+
+        // Dispatch the job to evaluate the retention period
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // Check that the case old has been deleted
+        $this->assertNull(CaseNumber::find($caseOld->id));
+    }
+
+    public function testItDoesNotDeleteCasesThatAreWithinRetentionPeriod()
+    {
+        // Create a process with a 6 month retention period
+        $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
+        $process = Process::factory()->create([
+            'properties' => [
+                'retention_period' => self::RETENTION_PERIOD,
+                'retention_updated_at' => $retentionUpdatedAt,
+            ],
+        ]);
+        $process->save();
+        $process->refresh();
+        $this->assertEquals(self::RETENTION_PERIOD, $process->properties['retention_period']);
+        $this->assertEquals($retentionUpdatedAt, $process->properties['retention_updated_at']);
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+        $this->assertEquals($process->id, $processRequest->process_id);
+
+        // Create a case number with a creation date that is within the retention period
+        $caseCreatedAt = Carbon::now()->subMonths(5)->toIso8601String();
+        $case = CaseNumber::factory()->create([
+            'created_at' => $caseCreatedAt,
+            'process_request_id' => $processRequest->id,
+        ]);
+        $this->assertEquals($processRequest->id, $case->process_request_id);
+        $this->assertEquals($caseCreatedAt, $case->created_at->toIso8601String());
+
+        // Dispatch the job to evaluate the retention period
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // Check that the case has not been deleted
+        $this->assertNotNull(CaseNumber::find($case->id));
+    }
+
+    public function testItHandlesMultipleCasesInBatches()
+    {
+        // Create a process with a 6 month retention period
+        $process = Process::factory()->create([
+            'properties' => [
+                'retention_period' => self::RETENTION_PERIOD,
+                'retention_updated_at' => Carbon::now()->subMonths(6)->toIso8601String(),
+            ],
+        ]);
+        $process->save();
+        $process->refresh();
+        $this->assertEquals(self::RETENTION_PERIOD, $process->properties['retention_period']);
+        $this->assertEquals(Carbon::now()->subMonths(6)->toIso8601String(), $process->properties['retention_updated_at']);
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+        $this->assertEquals($process->id, $processRequest->process_id);
+
+        // Create 1200 cases (to test chunking/batch deletion)
+        // These cases should be deleted because they're older than the retention period
+        // retention_updated_at is 6 months ago, so cases created 7+ months ago should be deleted
+        $cases = CaseNumber::factory()->count(1200)->create([
+            'process_request_id' => $processRequest->id,
+            'created_at' => Carbon::now()->subMonths(7)->toIso8601String(),
+        ]);
+        $this->assertEquals($processRequest->id, $cases->first()->process_request_id);
+        $this->assertEquals(Carbon::now()->subMonths(7)->toIso8601String(), $cases->first()->created_at->toIso8601String());
+
+        // Dispatch the job to evaluate the retention period
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // Assert all old cases are deleted
+        // There should be 1 case left (due to the creation of the process request) because the new case is within the retention period
+        $this->assertDatabaseCount('case_numbers', 1);
+
+        // TODO: Assert log entry is created
+    }
+}

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -4,6 +4,7 @@ namespace Tests\Jobs;
 
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 use ProcessMaker\Jobs\EvaluateProcessRetentionJob;
 use ProcessMaker\Models\CaseNumber;
 use ProcessMaker\Models\Process;
@@ -20,17 +21,13 @@ class EvaluateProcessRetentionJobTest extends TestCase
     {
         parent::setUp();
         // Enable case retention policy for all tests
-        putenv('CASE_RETENTION_POLICY_ENABLED=true');
-        $_ENV['CASE_RETENTION_POLICY_ENABLED'] = 'true';
-        $_SERVER['CASE_RETENTION_POLICY_ENABLED'] = 'true';
+        Config::set('app.case_retention_policy_enabled', true);
     }
 
     protected function tearDown(): void
     {
-        // Clean up environment variable
-        putenv('CASE_RETENTION_POLICY_ENABLED');
-        unset($_ENV['CASE_RETENTION_POLICY_ENABLED']);
-        unset($_SERVER['CASE_RETENTION_POLICY_ENABLED']);
+        // Clean up config
+        Config::set('app.case_retention_policy_enabled', false);
         parent::tearDown();
     }
 
@@ -254,9 +251,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
     public function testItDoesNotRunWhenRetentionPolicyIsDisabled()
     {
         // Disable case retention policy
-        putenv('CASE_RETENTION_POLICY_ENABLED=false');
-        $_ENV['CASE_RETENTION_POLICY_ENABLED'] = 'false';
-        $_SERVER['CASE_RETENTION_POLICY_ENABLED'] = 'false';
+        Config::set('app.case_retention_policy_enabled', false);
 
         // Create a process with a 6 month retention period
         $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
@@ -292,9 +287,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $this->assertDatabaseCount('case_numbers', 2);
 
         // Re-enable for other tests
-        putenv('CASE_RETENTION_POLICY_ENABLED=true');
-        $_ENV['CASE_RETENTION_POLICY_ENABLED'] = 'true';
-        $_SERVER['CASE_RETENTION_POLICY_ENABLED'] = 'true';
+        Config::set('app.case_retention_policy_enabled', true);
     }
 
     public function testItDefaultsToOneYearForProcessesWithoutRetentionPeriod()

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -19,6 +19,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
     public function testItDeletesCasesThatExceedRetentionPeriod()
     {
         // Create a process with a 6 month retention period
+        // retention_updated_at is 6 months ago, so old cases cutoff is 12 months ago (6 months ago - 6 months)
         $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
         $process = Process::factory()->create([
             'properties' => [
@@ -39,8 +40,10 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $processRequest->refresh();
         $this->assertEquals($process->id, $processRequest->process_id);
 
-        // Create a case number with a creation date that is past the retention period
-        $oldCaseCreatedAt = Carbon::now()->subMonths(7)->toIso8601String();
+        // Create a case number created 13 months ago (before retention_updated_at)
+        // Old cases cutoff = 6 months ago - 6 months = 12 months ago
+        // 13 months ago < 12 months ago, so it should be deleted
+        $oldCaseCreatedAt = Carbon::now()->subMonths(13)->toIso8601String();
         $caseOld = CaseNumber::factory()->create([
             'created_at' => $oldCaseCreatedAt,
             'process_request_id' => $processRequest->id,
@@ -58,6 +61,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
     public function testItDoesNotDeleteCasesThatAreWithinRetentionPeriod()
     {
         // Create a process with a 6 month retention period
+        // retention_updated_at is 6 months ago, so old cases cutoff is 12 months ago (6 months ago - 6 months)
         $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
         $process = Process::factory()->create([
             'properties' => [
@@ -77,7 +81,8 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $processRequest->refresh();
         $this->assertEquals($process->id, $processRequest->process_id);
 
-        // Create a case number with a creation date that is within the retention period
+        // Create a case number created 5 months ago (before retention_updated_at)
+        // This case is NOT older than the old cases cutoff (12 months ago), so it should NOT be deleted
         $caseCreatedAt = Carbon::now()->subMonths(5)->toIso8601String();
         $case = CaseNumber::factory()->create([
             'created_at' => $caseCreatedAt,
@@ -115,22 +120,118 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $this->assertEquals($process->id, $processRequest->process_id);
 
         // Create 1200 cases (to test chunking/batch deletion)
-        // These cases should be deleted because they're older than the retention period
-        // retention_updated_at is 6 months ago, so cases created 7+ months ago should be deleted
+        // These cases are created 13 months ago (before retention_updated_at)
+        // Old cases cutoff = 6 months ago - 6 months = 12 months ago
+        // 13 months ago < 12 months ago, so these should be deleted
         $cases = CaseNumber::factory()->count(1200)->create([
             'process_request_id' => $processRequest->id,
-            'created_at' => Carbon::now()->subMonths(7)->toIso8601String(),
+            'created_at' => Carbon::now()->subMonths(13)->toIso8601String(),
         ]);
         $this->assertEquals($processRequest->id, $cases->first()->process_request_id);
-        $this->assertEquals(Carbon::now()->subMonths(7)->toIso8601String(), $cases->first()->created_at->toIso8601String());
+        $this->assertEquals(Carbon::now()->subMonths(13)->toIso8601String(), $cases->first()->created_at->toIso8601String());
 
         // Dispatch the job to evaluate the retention period
         EvaluateProcessRetentionJob::dispatchSync($process->id);
 
         // Assert all old cases are deleted
-        // There should be 1 case left (due to the creation of the process request) because the new case is within the retention period
+        // There should be 1 case left (the auto-created case from ProcessRequestObserver)
+        // because it was created after retention_updated_at and is within the retention period
         $this->assertDatabaseCount('case_numbers', 1);
 
         // TODO: Assert log entry is created
+    }
+
+    public function testItHandlesRetentionPolicyUpdate()
+    {
+        // Create a process with retention updated 6 months ago (was 6 months, now 1 year)
+        $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
+        $process = Process::factory()->create([
+            'properties' => [
+                'retention_period' => '1_year', // Updated to 1 year
+                'retention_updated_at' => $retentionUpdatedAt,
+            ],
+        ]);
+        $process->save();
+        $process->refresh();
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+
+        // Create an old case (7 months ago, before retention_updated_at)
+        // Old cases cutoff = 6 months ago - 1 year = 18 months ago
+        // 7 months ago is NOT < 18 months ago, so it should NOT be deleted
+        $oldCase = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+            'created_at' => Carbon::now()->subMonths(7)->toIso8601String(),
+        ]);
+
+        // Create a new case (1 month ago, after retention_updated_at)
+        // New cases cutoff = now - 1 year = 12 months ago
+        // 1 month ago is NOT < 12 months ago, so it should NOT be deleted
+        $newCase = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+            'created_at' => Carbon::now()->subMonths(1)->toIso8601String(),
+        ]);
+
+        // Dispatch the job
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // Both cases should still exist (plus the auto-created one = 3 total)
+        $this->assertNotNull(CaseNumber::find($oldCase->id));
+        $this->assertNotNull(CaseNumber::find($newCase->id));
+        $this->assertDatabaseCount('case_numbers', 3);
+    }
+
+    public function testItDeletesOldCasesAfterRetentionPolicyUpdate()
+    {
+        // Create a process with retention updated 6 months ago (was 6 months, now 1 year)
+        $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
+        $process = Process::factory()->create([
+            'properties' => [
+                'retention_period' => '1_year', // Updated to 1 year
+                'retention_updated_at' => $retentionUpdatedAt,
+            ],
+        ]);
+        $process->save();
+        $process->refresh();
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+
+        // Create an old case (20 months ago, before retention_updated_at which is 6 months ago)
+        // Old cases cutoff = 6 months ago - 1 year = 18 months ago
+        // 20 months ago < 18 months ago (earlier date), so it SHOULD be deleted
+        $oldCaseDate = Carbon::now()->subMonths(20);
+        $oldCase = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+        ]);
+        $oldCase->created_at = $oldCaseDate;
+        $oldCase->save();
+
+        // Create a case 7 months ago (before retention_updated_at) that should NOT be deleted
+        // Old cases cutoff = 6 months ago - 1 year = 18 months ago
+        // 7 months ago is NOT < 18 months ago (7 months ago is more recent), so it should NOT be deleted
+        $oldCaseNotDeletedDate = Carbon::now()->subMonths(7);
+        $oldCaseNotDeleted = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+        ]);
+        $oldCaseNotDeleted->created_at = $oldCaseNotDeletedDate;
+        $oldCaseNotDeleted->save();
+
+        // Dispatch the job
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // The 20-month-old case should be deleted (older than 18 months cutoff)
+        // The 7-month-old case should NOT be deleted (newer than 18 months cutoff)
+        // Plus the auto-created case = 2 total
+        $this->assertNull(CaseNumber::find($oldCase->id), 'The 20-month-old case should be deleted');
+        $this->assertNotNull(CaseNumber::find($oldCaseNotDeleted->id), 'The 7-month-old case should NOT be deleted');
+        $this->assertDatabaseCount('case_numbers', 2);
     }
 }


### PR DESCRIPTION
This PR introduces a scheduled background job that evaluates case retention rules and automatically deletes cases that exceed their configured retention period.

## Solution
- Added a new command: cases:retention:evaluate
    - Dispatches the `EvaluateProcessRetentionJob`
- Implemented chunked processing (default chunk size: 100) to improve performance and scalability
- Added a feature flag (CASE_RETENTION_POLICY_ENABLED)
     - The job will not execute unless the flag is enabled
- Set a default case retention period of 1 year
- Added unit tests to validate retention evaluation and deletion logic

## How to Test
1. Run`tests/Jobs/EvaluateCaseRetentionJobTest.php`
2. Verify all tests pass successfully

## Related Tickets & Packages
- [FOUR-29110](https://processmaker.atlassian.net/browse/FOUR-29110)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates background deletion of case records on a schedule, so misconfiguration or cutoff logic bugs could lead to unintended data loss. Guarded by a feature flag and chunked queries, but still touches production data lifecycle.
> 
> **Overview**
> Adds a new feature-flagged case retention evaluator: a daily scheduled `cases:retention:evaluate` command dispatches `EvaluateProcessRetentionJob` per process to delete `CaseNumber` records past the process’s configured retention window (defaulting to 1 year and accounting for `retention_updated_at`).
> 
> Introduces `CASE_RETENTION_POLICY_ENABLED`/`app.case_retention_policy_enabled`, adds a `CaseNumberFactory`, and includes a comprehensive `EvaluateProcessRetentionJobTest` suite covering deletion cutoffs, batching, policy updates, and the disabled-flag no-op behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 888d7a9acd0a8067e79e045403e9e30cbaf4b702. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[FOUR-29110]: https://processmaker.atlassian.net/browse/FOUR-29110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ