### PR TITLE
FOUR-29161 - Use correct context for notifications

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -142,8 +142,8 @@ window.ProcessMaker = {
      * @returns {void}
      */
   pushNotification(notification) {
-    if (this.notifications.filter((x) => x.id === notification).length === 0) {
-      this.notifications.push(notification);
+    if (window.ProcessMaker.notifications.filter((x) => x.id === notification).length === 0) {
+      window.ProcessMaker.notifications.push(notification);
     }
   },
 


### PR DESCRIPTION
## Issue & Reproduction Steps
CSS Notification didn't clear because of bug in subscriber callback.

This was caused by https://github.com/ProcessMaker/processmaker/commit/df25a80b39d8277df85878f86cdb7a1b0113141b
```
pushNotification: window.ProcessMaker.pushNotification,
```
Which removes the context from the method

## Solution
- Call the global object from inside the method to preserve context

## How to Test
See jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-29161

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
