### PR TITLE
FOUR-28842 Coronation Registrars - 404 error when open Charts

### DIFF
--- a/database/migrations/2026_02_10_153533_add_index_process_request_tokens_ele_sta_self_pro_user.php
+++ b/database/migrations/2026_02_10_153533_add_index_process_request_tokens_ele_sta_self_pro_user.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('
+            ALTER TABLE `process_request_tokens`
+            ADD INDEX `process_request_tokens_ele_sta_self_pro_user` (`element_type`, `status`, `is_self_service`, `process_id`, `user_id`)
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('
+            ALTER TABLE `process_request_tokens`
+            DROP INDEX `process_request_tokens_ele_sta_self_pro_user`
+        ');
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
An error 404 is displayed in call to service /charts after 5 minutes, because a couple of queries are too slow

## Solution
A new index with 5 fields was added to improve the performance of the slow queries

## How to Test
In Coronation server go to saved search section and open the saved search with ID 921

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-28842

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
