### PR TITLE
FOUR-29250 End Event – External URL with Mustache Support

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1531,8 +1531,10 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                         $elementDestination = $elementDestinationProp['value']['url'] ?? null;
                     }
                 }
-                if ($elementDestinationType === 'externalURL' && is_string($elementDestination) && $elementDestination !== '') {
-                    $elementDestination = $this->resolveElementDestinationUrl($elementDestination);
+                if (is_string($elementDestination) && $elementDestination !== '') {
+                    if ($elementDestinationType === 'externalURL' || $elementDestinationType === 'customDashboard') {
+                        $elementDestination = $this->resolveElementDestinationUrl($elementDestination);
+                    }
                 }
                 break;
             case 'taskList':

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -24,6 +24,8 @@ use ProcessMaker\Nayra\Contracts\Bpmn\MultiInstanceLoopCharacteristicsInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Managers\WorkflowManagerDefault;
 use ProcessMaker\Nayra\Storage\BpmnDocument;
+use ProcessMaker\Managers\DataManager;
+use ProcessMaker\Models\MustacheExpressionEvaluator;
 use ProcessMaker\Notifications\ActivityActivatedNotification;
 use ProcessMaker\Notifications\TaskReassignmentNotification;
 use ProcessMaker\Query\Expression;
@@ -1441,6 +1443,49 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     }
 
     /**
+     * Build context for Mustache (end event external URL). Same as scripts/screens: _user, _request, process data, APP_URL.
+     */
+    private function getElementDestinationMustacheContext(): array
+    {
+        try {
+            $context = (new DataManager())->getData($this);
+        } catch (Throwable $e) {
+            $request = $this->processRequest;
+            $context = array_merge($request->data ?? [], $request ? (new DataManager())->updateRequestMagicVariable([], $request) : []);
+            $user = $this->user ?? \Illuminate\Support\Facades\Auth::user();
+            if ($user) {
+                $userData = $user->attributesToArray();
+                unset($userData['remember_token']);
+                $context['_user'] = $userData;
+            }
+        }
+
+        $context['APP_URL'] = config('app.url');
+
+        // Normalize to plain arrays/scalars so Mustache resolves all keys (common PHP idiom)
+        $normalized = json_decode(json_encode($context), true);
+
+        return is_array($normalized) ? $normalized : [];
+    }
+
+    /**
+     * Resolve Mustache in end event external URL. FEEL is not supported here; use Mustache only.
+     * Context: APP_URL, _request, _user, process variables (same as getElementDestinationMustacheContext).
+     *
+     * Example (Mustache):
+     *   {{APP_URL}}/admin/users/{{_request.id}}/edit     -> https://example.com/admin/users/123/edit
+     *   {{APP_URL}}/webentry/{{_request.id}}             -> https://example.com/webentry/123
+     *   {{APP_URL}}/path/{{my_process_var}}               -> uses process variable my_process_var
+     */
+    private function resolveElementDestinationUrl(string $url): string
+    {
+        $url = html_entity_decode($url, ENT_QUOTES | ENT_HTML401, 'UTF-8');
+        $context = $this->getElementDestinationMustacheContext();
+
+        return (new MustacheExpressionEvaluator())->render($url, $context);
+    }
+
+    /**
      * Determines the destination based on the type of element destination property
      *
      * @param elementDestinationType Used to determine the type of destination for an element.
@@ -1480,6 +1525,9 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                     } else {
                         $elementDestination = $elementDestinationProp['value']['url'] ?? null;
                     }
+                }
+                if ($elementDestinationType === 'externalURL' && is_string($elementDestination) && $elementDestination !== '') {
+                    $elementDestination = $this->resolveElementDestinationUrl($elementDestination);
                 }
                 break;
             case 'taskList':

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1450,6 +1450,10 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         try {
             $context = (new DataManager())->getData($this);
         } catch (Throwable $e) {
+            Log::warning('Failed to load Mustache context via DataManager, falling back to request data', [
+                'token_id' => $this->id,
+                'error' => $e->getMessage(),
+            ]);
             $request = $this->processRequest;
             $context = array_merge($request->data ?? [], $request ? (new DataManager())->updateRequestMagicVariable([], $request) : []);
             $user = $this->user ?? \Illuminate\Support\Facades\Auth::user();

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1456,7 +1456,8 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
             ]);
             $request = $this->processRequest;
             $context = array_merge($request->data ?? [], $request ? (new DataManager())->updateRequestMagicVariable([], $request) : []);
-            $user = $this->user ?? \Illuminate\Support\Facades\Auth::user();
+            $user = $this->user ?? auth()->user();
+
             if ($user) {
                 $userData = $user->attributesToArray();
                 unset($userData['remember_token']);

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1466,6 +1466,11 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
 
         $context['APP_URL'] = config('app.url');
 
+        // Never expose remember_token to Mustache (defense in depth; DataManager/fallback may already strip it)
+        if (isset($context['_user']) && is_array($context['_user'])) {
+            unset($context['_user']['remember_token']);
+        }
+
         // Normalize to plain arrays/scalars so Mustache resolves all keys (common PHP idiom)
         $json = json_encode($context, JSON_THROW_ON_ERROR);
         $normalized = json_decode($json, true, 512, JSON_THROW_ON_ERROR);

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -1468,7 +1468,8 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         $context['APP_URL'] = config('app.url');
 
         // Normalize to plain arrays/scalars so Mustache resolves all keys (common PHP idiom)
-        $normalized = json_decode(json_encode($context), true);
+        $json = json_encode($context, JSON_THROW_ON_ERROR);
+        $normalized = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
 
         return is_array($normalized) ? $normalized : [];
     }

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -17,6 +17,8 @@ use ProcessMaker\Contracts\ConditionalRedirectServiceInterface;
 use ProcessMaker\Events\ActivityAssigned;
 use ProcessMaker\Events\ActivityReassignment;
 use ProcessMaker\Facades\WorkflowUserManager;
+use ProcessMaker\Managers\DataManager;
+use ProcessMaker\Models\MustacheExpressionEvaluator;
 use ProcessMaker\Nayra\Bpmn\TokenTrait;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\FlowElementInterface;
@@ -24,8 +26,6 @@ use ProcessMaker\Nayra\Contracts\Bpmn\MultiInstanceLoopCharacteristicsInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
 use ProcessMaker\Nayra\Managers\WorkflowManagerDefault;
 use ProcessMaker\Nayra\Storage\BpmnDocument;
-use ProcessMaker\Managers\DataManager;
-use ProcessMaker\Models\MustacheExpressionEvaluator;
 use ProcessMaker\Notifications\ActivityActivatedNotification;
 use ProcessMaker\Notifications\TaskReassignmentNotification;
 use ProcessMaker\Query\Expression;
@@ -1457,7 +1457,6 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
             $request = $this->processRequest;
             $context = array_merge($request->data ?? [], $request ? (new DataManager())->updateRequestMagicVariable([], $request) : []);
             $user = $this->user ?? auth()->user();
-
             if ($user) {
                 $userData = $user->attributesToArray();
                 unset($userData['remember_token']);

--- a/ProcessMaker/Services/ConditionalRedirectService.php
+++ b/ProcessMaker/Services/ConditionalRedirectService.php
@@ -103,6 +103,8 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
     public function resolve(array $conditionalRedirect, array $data): ?array
     {
         $this->errors = [];
+        $data = $this->normalizeDataForFeel($data);
+
         foreach ($conditionalRedirect as $item) {
             if (!isset($item['condition'])) {
                 throw new InvalidArgumentException('Condition is required');
@@ -123,6 +125,29 @@ class ConditionalRedirectService implements ConditionalRedirectServiceInterface
         }
 
         return null;
+    }
+
+    /**
+     * Normalize data so FEEL comparisons like form_input_1==0 work when form sends string "0".
+     * Converts numeric strings to int/float so that the first matching condition is the intended one.
+     *
+     * @param array $data
+     * @return array
+     */
+    private function normalizeDataForFeel(array $data): array
+    {
+        $normalized = [];
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $normalized[$key] = $this->normalizeDataForFeel($value);
+            } elseif (is_string($value) && is_numeric($value)) {
+                $normalized[$key] = str_contains($value, '.') ? (float) $value : (int) $value;
+            } else {
+                $normalized[$key] = $value;
+            }
+        }
+
+        return $normalized;
     }
 
     /**

--- a/resources/js/tasks/edit.js
+++ b/resources/js/tasks/edit.js
@@ -217,11 +217,6 @@ const main = new Vue({
       if (this.task.component && this.task.component === "AdvancedScreenFrame") {
         return;
       }
-      // Conditional redirect: use external URL (Mustache already resolved by API) when present
-      if (elementDestination && elementDestination.type === "externalURL" && elementDestination.value) {
-        this.redirect(elementDestination.value);
-        return;
-      }
       this.redirect("/tasks");
     },
     claimTask() {
@@ -378,13 +373,9 @@ const main = new Vue({
         const taskId = task.id;
         this.submitting = true;
         ProcessMaker.apiClient
-          .put(`tasks/${taskId}?include=elementDestination`, { status: "COMPLETED", data: dataToSubmit })
-          .then((response) => {
+          .put(`tasks/${taskId}`, { status: "COMPLETED", data: dataToSubmit })
+          .then(() => {
             window.ProcessMaker.alert(message, "success", 5, true);
-            // Redirect using conditional redirect (e.g. external URL with Mustache resolved by API)
-            if (response.data && response.data.elementDestination) {
-              this.closed(taskId, response.data.elementDestination);
-            }
           })
           .catch((error) => {
           // If there are errors, the user will be redirected to the request page

--- a/resources/js/tasks/edit.js
+++ b/resources/js/tasks/edit.js
@@ -217,6 +217,11 @@ const main = new Vue({
       if (this.task.component && this.task.component === "AdvancedScreenFrame") {
         return;
       }
+      // Conditional redirect: use external URL (Mustache already resolved by API) when present
+      if (elementDestination && elementDestination.type === "externalURL" && elementDestination.value) {
+        this.redirect(elementDestination.value);
+        return;
+      }
       this.redirect("/tasks");
     },
     claimTask() {
@@ -373,9 +378,13 @@ const main = new Vue({
         const taskId = task.id;
         this.submitting = true;
         ProcessMaker.apiClient
-          .put(`tasks/${taskId}`, { status: "COMPLETED", data: dataToSubmit })
-          .then(() => {
+          .put(`tasks/${taskId}?include=elementDestination`, { status: "COMPLETED", data: dataToSubmit })
+          .then((response) => {
             window.ProcessMaker.alert(message, "success", 5, true);
+            // Redirect using conditional redirect (e.g. external URL with Mustache resolved by API)
+            if (response.data && response.data.elementDestination) {
+              this.closed(taskId, response.data.elementDestination);
+            }
           })
           .catch((error) => {
           // If there are errors, the user will be redirected to the request page

--- a/tests/unit/ProcessMaker/Models/ProcessRequestTokenElementDestinationTest.php
+++ b/tests/unit/ProcessMaker/Models/ProcessRequestTokenElementDestinationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Models;
+
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use ReflectionClass;
+use Tests\TestCase;
+
+class ProcessRequestTokenElementDestinationTest extends TestCase
+{
+    /**
+     * Invoke a private method on an object.
+     */
+    private function invokePrivateMethod(object $object, string $methodName, array $args = []): mixed
+    {
+        $reflection = new ReflectionClass($object);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $args);
+    }
+
+    /**
+     * Test getElementDestinationMustacheContext returns context with APP_URL, _request, _user and process data.
+     */
+    public function testGetElementDestinationMustacheContextReturnsExpectedKeys(): void
+    {
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => ['processVar' => 'value123'],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $context = $this->invokePrivateMethod($token, 'getElementDestinationMustacheContext');
+
+        $this->assertIsArray($context);
+        $this->assertArrayHasKey('APP_URL', $context);
+        $this->assertSame(config('app.url'), $context['APP_URL']);
+        $this->assertArrayHasKey('_request', $context);
+        $this->assertIsArray($context['_request']);
+        $this->assertArrayHasKey('id', $context['_request']);
+        $this->assertSame((string) $request->id, (string) $context['_request']['id']);
+        $this->assertArrayHasKey('case_number', $context['_request']);
+        $this->assertArrayHasKey('_user', $context);
+        $this->assertIsArray($context['_user']);
+        $this->assertArrayHasKey('id', $context['_user']);
+        $this->assertArrayHasKey('processVar', $context);
+        $this->assertSame('value123', $context['processVar']);
+    }
+
+    /**
+     * Test resolveElementDestinationUrl resolves Mustache placeholders APP_URL and _request.id.
+     */
+    public function testResolveElementDestinationUrlResolvesMustache(): void
+    {
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => [],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $urlTemplate = '{{APP_URL}}/path/{{_request.id}}';
+        $resolved = $this->invokePrivateMethod($token, 'resolveElementDestinationUrl', [$urlTemplate]);
+
+        $expectedUrl = config('app.url') . '/path/' . $request->id;
+        $this->assertSame($expectedUrl, $resolved);
+    }
+
+    /**
+     * Test resolveElementDestinationUrl resolves process variable in URL.
+     */
+    public function testResolveElementDestinationUrlResolvesProcessVariable(): void
+    {
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => ['segment' => 'admin'],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $urlTemplate = '{{APP_URL}}/{{segment}}/users';
+        $resolved = $this->invokePrivateMethod($token, 'resolveElementDestinationUrl', [$urlTemplate]);
+
+        $this->assertSame(config('app.url') . '/admin/users', $resolved);
+    }
+
+    /**
+     * Test resolveElementDestinationUrl decodes HTML entities in template.
+     */
+    public function testResolveElementDestinationUrlDecodesHtmlEntities(): void
+    {
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => [],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $urlWithEntities = '&#104;&#116;&#116;&#112;&#115;&#58;//example.com/{{_request.id}}';
+        $resolved = $this->invokePrivateMethod($token, 'resolveElementDestinationUrl', [$urlWithEntities]);
+
+        $this->assertStringContainsString((string) $request->id, $resolved);
+        $this->assertStringContainsString('https://example.com/', $resolved);
+    }
+}

--- a/tests/unit/ProcessMaker/Models/ProcessRequestTokenElementDestinationTest.php
+++ b/tests/unit/ProcessMaker/Models/ProcessRequestTokenElementDestinationTest.php
@@ -143,4 +143,176 @@ class ProcessRequestTokenElementDestinationTest extends TestCase
         $this->assertStringContainsString((string) $request->id, $resolved);
         $this->assertStringContainsString('https://example.com/', $resolved);
     }
+
+    /**
+     * Test getElementDestinationMustacheContext excludes remember_token from _user.
+     */
+    public function testGetElementDestinationMustacheContextExcludesRememberTokenFromUser(): void
+    {
+        $user = User::factory()->create([
+            'status' => 'ACTIVE',
+            'remember_token' => 'secret-token',
+        ]);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => [],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $context = $this->invokePrivateMethod($token, 'getElementDestinationMustacheContext');
+
+        $this->assertArrayHasKey('_user', $context);
+        $this->assertIsArray($context['_user']);
+        $this->assertArrayNotHasKey('remember_token', $context['_user']);
+    }
+
+    /**
+     * Test getElementDestinationMustacheContext returns normalized context (arrays and scalars only).
+     */
+    public function testGetElementDestinationMustacheContextReturnsNormalizedArray(): void
+    {
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => ['nested' => ['a' => 1, 'b' => 'two']],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $context = $this->invokePrivateMethod($token, 'getElementDestinationMustacheContext');
+
+        $this->assertIsArray($context);
+        $this->assertArrayHasKey('APP_URL', $context);
+        $this->assertIsString($context['APP_URL']);
+        $this->assertArrayHasKey('nested', $context);
+        $this->assertIsArray($context['nested']);
+        $this->assertSame(1, $context['nested']['a']);
+        $this->assertSame('two', $context['nested']['b']);
+    }
+
+    /**
+     * Test getElementDestinationMustacheContext includes APP_URL when token has no user.
+     */
+    public function testGetElementDestinationMustacheContextWhenTokenHasNoUser(): void
+    {
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => null,
+            'data' => ['foo' => 'bar'],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => null,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $context = $this->invokePrivateMethod($token, 'getElementDestinationMustacheContext');
+
+        $this->assertIsArray($context);
+        $this->assertSame(config('app.url'), $context['APP_URL']);
+        $this->assertArrayHasKey('_request', $context);
+        $this->assertSame('bar', $context['foo']);
+    }
+
+    /**
+     * Test resolveElementDestinationUrl resolves _user placeholder.
+     */
+    public function testResolveElementDestinationUrlResolvesUserPlaceholder(): void
+    {
+        $user = User::factory()->create(['status' => 'ACTIVE', 'username' => 'johndoe']);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => [],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $urlTemplate = '{{APP_URL}}/users/{{_user.id}}/{{_user.username}}';
+        $resolved = $this->invokePrivateMethod($token, 'resolveElementDestinationUrl', [$urlTemplate]);
+
+        $expectedUrl = config('app.url') . '/users/' . $user->id . '/johndoe';
+        $this->assertSame($expectedUrl, $resolved);
+    }
+
+    /**
+     * Test resolveElementDestinationUrl with empty string returns empty string.
+     */
+    public function testResolveElementDestinationUrlWithEmptyString(): void
+    {
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => [],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $resolved = $this->invokePrivateMethod($token, 'resolveElementDestinationUrl', ['']);
+
+        $this->assertSame('', $resolved);
+    }
+
+    /**
+     * Test resolveElementDestinationUrl with no placeholders returns URL unchanged (after entity decode).
+     */
+    public function testResolveElementDestinationUrlWithNoPlaceholders(): void
+    {
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'user_id' => $user->id,
+            'data' => [],
+        ]);
+
+        $token = ProcessRequestToken::factory()->create([
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'user_id' => $user->id,
+            'element_id' => 'end_1',
+            'element_type' => 'end_event',
+        ]);
+
+        $plainUrl = 'https://example.com/static/path';
+        $resolved = $this->invokePrivateMethod($token, 'resolveElementDestinationUrl', [$plainUrl]);
+
+        $this->assertSame($plainUrl, $resolved);
+    }
 }


### PR DESCRIPTION
Description:
feat(end event): support Mustache in external URL for element destination

- Resolve Mustache expressions in end event "External URL" when the token reaches the end event, using the same context as scripts/screens (APP_URL, _request, _user, process variables).
- Add getElementDestinationMustacheContext() to build context via DataManager with fallback; normalize to plain array for Mustache.
- Add resolveElementDestinationUrl() to decode HTML entities and render URL template with MustacheExpressionEvaluator. FEEL is not supported.
- Apply resolution only for externalURL type; conditional redirect URLs also go through Mustache when destination is external URL.
- Harden getElementDestinationAttribute(): ensure conditionalRedirectProp and elementDestinationProp are never null (json_decode ?? [], pass ?? []).
- Modeler: allow URL validation when string contains {{ (Mustache); update helper and error copy to document _request.id, _user.id, process vars. 
 

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-29250

ci:deploy
ci:modeler:feature/FOUR-29250

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime redirect URL generation and conditional redirect evaluation, which can alter navigation behavior and expose more process/user data via templating if misconfigured. Added normalization and new tests reduce risk but the redirect path is user-facing and sensitive to edge cases.
> 
> **Overview**
> End event `externalURL`/`customDashboard` element destinations now support Mustache placeholders (e.g. `{{APP_URL}}`, `{{_request.id}}`, process variables) by building a DataManager-based context (with fallback), HTML-entity decoding the template, and rendering via `MustacheExpressionEvaluator` while stripping `remember_token`.
> 
> Conditional redirect evaluation now normalizes numeric strings in process data to numbers before FEEL execution to avoid mismatched comparisons (e.g. `"0"` vs `0`). A new unit test suite covers Mustache context construction, URL rendering (request/user/process vars), entity decoding, and token/user edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cbf37b73d0dba9f988f70ba713d39a374210486. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->