### PR TITLE
Fix global URL helper

### DIFF
--- a/ProcessMaker/Multitenancy/SwitchTenant.php
+++ b/ProcessMaker/Multitenancy/SwitchTenant.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Multitenancy;
 
 use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Monolog\Handler\RotatingFileHandler;
@@ -135,6 +136,9 @@ class SwitchTenant implements SwitchTenantTask
         $this->setConfig('logging.channels.daily.path', storage_path('logs/processmaker.log'));
         $app->make('log')->reset();
         $app->forgetInstance('log');
+
+        // url() helper
+        app(UrlGenerator::class)->useOrigin($tenant->config['app.url']);
 
         // NOTE: Cache prefix and cache settings prefix are handled in PrefixCacheTask
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Using the global `url()` helper in queued jobs was returning the wrong host

## Solution
- Set the host has part of the SwitchTenant provider

## How to Test
Try exporting a collection from 2 different tenants on the same server. For example https://testtenant01.qa.processmaker.net and https://paos.qa.processmaker.net. Ensure they both export correctly

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-29220?focusedCommentId=492087

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
