### PR TITLE
FOUR-29304 Fix logging when name attribute is unknown

### DIFF
--- a/ProcessMaker/Models/EnvironmentVariable.php
+++ b/ProcessMaker/Models/EnvironmentVariable.php
@@ -60,9 +60,10 @@ class EnvironmentVariable extends ProcessMakerModel
         } catch (Exception $e) {
             Log::error(
                 'Can not decrypt environment variable: ' .
-                $this->attributes['name'] .
+                ($this->attributes['name'] ?? 'unknown') .
                 "\n" . $e->getMessage() .
-                "\n" . $e->getTraceAsString()
+                "\n" . $e->getTraceAsString(),
+                ['attributes' => $this->attributes]
             );
 
             return null;


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-29304

## Solution
- Check if name exists before using it in the log

## How to Test
See https://processmaker.atlassian.net/browse/FOUR-29304

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-29304

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
