### PR TITLE
FOUR-29322: Artisan commands fail with SQLite "unable to open database…

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -75,6 +75,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Job Batching
+    |--------------------------------------------------------------------------
+    |
+    | The following options configure the database and table that store job
+    | batching information. Uses the same database connection as the app
+    | so we do not fall back to Laravel's default 'sqlite'.
+    |
+    */
+
+    'batching' => [
+        'database' => env('DB_CONNECTION', 'processmaker'),
+        'table' => 'job_batches',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Failed Queue Jobs
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
… file" when queue batching is not configured

Description:
Add queue.batching config so job batching uses app DB connection

Without this, Laravel falls back to env('DB_CONNECTION','sqlite'). When DB_CONNECTION is unset, BusServiceProvider requests the 'sqlite' connection and php artisan route:list fails with "unable to open database file".

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-29322
