### PR TITLE
[46535] Rollback in Sub-Process Does Not Allow Parent Process to Continue (FAILING State)

### DIFF
--- a/ProcessMaker/RollbackProcessRequest.php
+++ b/ProcessMaker/RollbackProcessRequest.php
@@ -127,6 +127,7 @@ class RollbackProcessRequest
                 break;
         }
 
+        // update the process request status to active
         $processRequest = $this->newTask->processRequest;
         $processRequest->status = 'ACTIVE';
         $process = $processRequest->process;
@@ -135,8 +136,11 @@ class RollbackProcessRequest
         )->id;
         $processRequest->saveOrFail();
 
+        // update the current task status to closed
         $currentTask->status = 'CLOSED';
         $currentTask->saveOrFail();
+
+        $this->syncParentProcessStatus($processRequest);
 
         return $this->newTask;
     }
@@ -208,5 +212,26 @@ class RollbackProcessRequest
             ]),
             'case_number' => isset($this->currentTask->case_number) ? $this->currentTask->case_number : null,
         ]);
+    }
+
+    /**
+     * When the rolled-back request is a subprocess, reactivate the parent request
+     * and the parent's call activity tokens that were in error.
+     */
+    private function syncParentProcessStatus(ProcessRequest $processRequest): void
+    {
+        $parentRequest = $processRequest->parentRequest;
+        if (!$parentRequest) {
+            return;
+        }
+
+        if (in_array($parentRequest->status, ['ERROR', 'FAILING'])) {
+            $parentRequest->status = 'ACTIVE';
+            $parentRequest->saveOrFail();
+        }
+
+        ProcessRequestToken::where('subprocess_request_id', $processRequest->id)
+            ->whereIn('status', ['ERROR', 'FAILING'])
+            ->update(['status' => 'ACTIVE']);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
When a task or script fails and is a SubProcess, this parent process is left in error, now the parent process is updated.

## Solution
- Implement process request status updates in RollbackProcessRequest class

## How to Test
The steps are on the ticket.

## Related Tickets & Packages
- [FOUR-25486](https://processmaker.atlassian.net/browse/FOUR-25486)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy

[FOUR-25486]: https://processmaker.atlassian.net/browse/FOUR-25486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ