### PR TITLE
Persist and Display updated_by / updated_at for Cases Retention Policy

### DIFF
--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -407,7 +407,7 @@
                                         <div class="retention-text retention-body default-retention p-2">
                                             <span v-if="!retentionUpdatedBy.id && !retentionUpdatedBy.fullname" class="d-flex align-items-center font-italic"><i class="fp-check-circle-outline default-retention-icon"></i><span class="ml-1">{{ __('The default retention period is in effect.')}}</span></span>
                                             <!-- This should display the retention updated by and the retention updated at in the format of "Updated by <fullname> on <date>" -->
-                                            <span v-if="retentionUpdatedBy.id && retentionUpdatedBy.fullname" class="d-flex align-items-center"><strong class="mr-1">{{ __('Last modified by: ') }}</strong>@{{ retentionUpdatedBy.fullname.trim() }}{{ __(', at') }} @{{ retentionUpdatedBy.date | formatDate('datetime') }}</strong></span>
+                                            <span v-if="retentionUpdatedBy.id && retentionUpdatedBy.fullname" class="d-flex align-items-center"><strong class="mr-1">{{ __('Last modified by: ') }}</strong>@{{ retentionUpdatedBy.fullname.trim() }}{{ __(', at') }} @{{formatDateUser(retentionUpdatedBy.date) }}</span>
                                         </div>
                                         <b-modal
                                             v-model="showRetentionConfirmModal"
@@ -902,7 +902,7 @@
                     return allowed.includes('one_year') ? 'one_year' : (allowed[0] || null);
                 },
                 onRetentionPeriodSelect(newVal) {
-                        if (!newVal || !this.lastConfirmedRetentionPeriod) {
+                    if (!newVal || !this.lastConfirmedRetentionPeriod) {
                         return;
                     }
 
@@ -915,15 +915,15 @@
                     this.showRetentionConfirmModal = true;
                 },
                 confirmRetentionChange() {
-                if (this.pendingRetentionPeriod) {
-                    this.canSelectRetentionPeriod = this.pendingRetentionPeriod;
-                    this.lastConfirmedRetentionPeriod = this.pendingRetentionPeriod;
+                    if (this.pendingRetentionPeriod) {
+                        this.canSelectRetentionPeriod = this.pendingRetentionPeriod;
+                        this.lastConfirmedRetentionPeriod = this.pendingRetentionPeriod;
 
-                    this.formData.properties = this.formData.properties || {};
-                    this.formData.properties.retention_period = this.pendingRetentionPeriod.id;
-                }
+                        this.formData.properties = this.formData.properties || {};
+                        this.formData.properties.retention_period = this.pendingRetentionPeriod.id;
+                    }
 
-                this.retentionModalStep = 'success';
+                    this.retentionModalStep = 'success';
                 },
                 cancelRetentionChange() {
                     this.canSelectRetentionPeriod = this.lastConfirmedRetentionPeriod;
@@ -939,11 +939,26 @@
                     if (this.retentionModalStep === 'confirm') {
                         this.cancelRetentionChange();
                     }
+                },
+                formatDateUser(value) {
+                    let config = "";
+                    if (typeof ProcessMaker !== "undefined" && ProcessMaker.user && ProcessMaker.user.datetime_format) {
+                        config = ProcessMaker.user.datetime_format;
+                    }
+
+                    if (value) {
+                        if (moment(value).isValid()) {
+                            return window.moment(value)
+                                .format(config);
+                        }
+                        return value;
+                    }
+                    return "n/a";
                 }
                 },
+               
             });
         });
-
     </script>
 @endsection
 

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -405,7 +405,9 @@
                                             </multiselect>
                                         </div>
                                         <div class="retention-text retention-body default-retention p-2">
-                                            <span class="d-flex align-items-center"><i class="fp-check-circle-outline default-retention-icon"></i><span class="ml-1">{{ __('The default retention period is in effect.')}}</span></span>
+                                            <span v-if="!retentionUpdatedBy.id && !retentionUpdatedBy.fullname" class="d-flex align-items-center font-italic"><i class="fp-check-circle-outline default-retention-icon"></i><span class="ml-1">{{ __('The default retention period is in effect.')}}</span></span>
+                                            <!-- This should display the retention updated by and the retention updated at in the format of "Updated by <fullname> on <date>" -->
+                                            <span v-if="retentionUpdatedBy.id && retentionUpdatedBy.fullname" class="d-flex align-items-center"><strong class="mr-1">{{ __('Last modified by: ') }}</strong>@{{ retentionUpdatedBy.fullname.trim() }}{{ __(', at') }} @{{ retentionUpdatedBy.date | formatDate('datetime') }}</strong></span>
                                         </div>
                                         <b-modal
                                             v-model="showRetentionConfirmModal"
@@ -689,6 +691,11 @@
                     caseRetentionPolicyEnabled: @json(config('app.case_retention_policy_enabled')),
                     lastConfirmedRetentionPeriod: null,
                     originalRetentionPeriodId: null,
+                    retentionUpdatedBy: {
+                        id: null,
+                        fullname: null,
+                        date: null,
+                    },
                 }
                 },
                 mounted() {
@@ -725,6 +732,11 @@
 
                     this.lastConfirmedRetentionPeriod = this.canSelectRetentionPeriod;
                     this.originalRetentionPeriodId = this.canSelectRetentionPeriod ? this.canSelectRetentionPeriod.id : null;
+                    this.retentionUpdatedBy = {
+                        id: _.get(this.formData, 'properties.retention_updated_by.id'),
+                        fullname: _.get(this.formData, 'properties.retention_updated_by.fullname'),
+                        date: _.get(this.formData, 'properties.retention_updated_at'),
+                    };
                 },
                 computed: {
                     retentionPeriodSelectOptions() {
@@ -846,7 +858,13 @@
                                 id: userID.content,
                                 fullname: userFullName.content,
                             };
-                            this.formData.properties.retention_updated_at = new Date().toISOString();
+                            const updatedAt = new Date().toISOString();
+                            this.formData.properties.retention_updated_at = updatedAt;
+                            this.retentionUpdatedBy = {
+                                id: parseInt(userID?.content ?? 0),
+                                fullname: userFullName?.content ?? '',
+                                date: updatedAt,
+                            };
                         }
                     }
                     
@@ -1108,7 +1126,6 @@
         }
 
         .default-retention {
-            font-style: italic;
             background-color: #F1F2F4;
             border-radius: 8px;
         }

--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -688,6 +688,7 @@
                     pendingRetentionPeriod: null,
                     caseRetentionPolicyEnabled: @json(config('app.case_retention_policy_enabled')),
                     lastConfirmedRetentionPeriod: null,
+                    originalRetentionPeriodId: null,
                 }
                 },
                 mounted() {
@@ -723,6 +724,7 @@
                     }
 
                     this.lastConfirmedRetentionPeriod = this.canSelectRetentionPeriod;
+                    this.originalRetentionPeriodId = this.canSelectRetentionPeriod ? this.canSelectRetentionPeriod.id : null;
                 },
                 computed: {
                     retentionPeriodSelectOptions() {
@@ -835,6 +837,17 @@
                             ? this.canSelectRetentionPeriod.id
                             : this.getDefaultRetentionPeriodId();
                         this.formData.properties.retention_period = retentionPeriod;
+                        // Log retention period update only if the retention period is changed from the original value
+                        if (this.formData.properties.retention_period !== this.originalRetentionPeriodId) {
+                            // The logged in user is the one who updated the retention period
+                            const userID = document.head.querySelector("meta[name=\"user-id\"]");
+                            const userFullName = document.head.querySelector("meta[name=\"user-full-name\"]");
+                            this.formData.properties.retention_updated_by = {
+                                id: userID.content,
+                                fullname: userFullName.content,
+                            };
+                            this.formData.properties.retention_updated_at = new Date().toISOString();
+                        }
                     }
                     
                     ProcessMaker.apiClient.put('processes/' + that.formData.id, that.formData)


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR adds audit tracking for Cases Retention Policy configurations at the process level. Specifically, it persists the user and timestamp associated with retention policy updates and surfaces this information in the UI.

When a retention policy is modified and saved, the system now stores the metadata and displays a “Last Modified By” indicator to improve traceability and configuration transparency.

## Solution
- Persist `retention_updated_by` and `retention_updated_at` in `processes.properties`
- Update the UI to display:
      -  `Last Modified By: [USER] [DATE_TIME]`
      - Only when the retention policy value has been changed
- Ensure unrelated configuration updates do not modify retention audit metadata

## How to Test

1. Confirm the appropriate .env variables for Cases Retention Policy are configured.
2. Navigate to a Process → Configuration → Cases Retention settings.
3. Observe the default helper text displayed beneath the retention selection field.
4. Change the retention value and click Save.
5. Verify the helper text updates to:
     `Last Modified By: [USER] [DATE_TIME]`
6. Modify a different, unrelated process configuration setting and save.
7. Confirm that Last Modified By does not change unless the retention policy itself is modified.

## Related Tickets & Packages
- [FOUR-29108](https://processmaker.atlassian.net/browse/FOUR-29108)
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-29108]: https://processmaker.atlassian.net/browse/FOUR-29108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ