### PR TITLE
FOUR-29448: The PMQL to filter in select list control is not working

### DIFF
--- a/ProcessMaker/Traits/MakeHttpRequests.php
+++ b/ProcessMaker/Traits/MakeHttpRequests.php
@@ -499,18 +499,27 @@ trait MakeHttpRequests
         $parsedUrl = $this->parseUrl($url);
         $query = [];
         parse_str($parsedUrl['query'] ?? '', $query);
-        if (array_key_exists('params', $endpoint)) {
+        $hasEndpointParams = array_key_exists('params', $endpoint) && is_array($endpoint['params']);
+        if ($hasEndpointParams) {
             foreach ($endpoint['params'] as $param) {
+                if (!array_key_exists('key', $param)) {
+                    continue;
+                }
+
                 $key = $this->evalMustache($param['key'], $data);
                 // Get value from outbound configuration, if not defined get the default value
-                $value = $params[$key] ?? $this->evalMustache($param['value'], $data);
-                if ($value !== '' || $param['required']) {
+                $value = $params[$key] ?? $this->evalMustache($param['value'] ?? '', $data);
+                if ($value !== '' || ($param['required'] ?? false)) {
                     $query[$key] = $value;
                 }
             }
-        } else {
+        }
+
+        // Preserve legacy behavior for configured endpoint params, but when params are
+        // missing/empty allow dynamic PARAM values (e.g. pmql from screen select-list).
+        if (!$hasEndpointParams || empty($endpoint['params'])) {
             foreach ($params as $key => $value) {
-                if ($value !== '') {
+                if ($value !== '' && !array_key_exists($key, $query)) {
                     $query[$key] = $value;
                 }
             }

--- a/tests/Feature/MakeHttpRequestTest.php
+++ b/tests/Feature/MakeHttpRequestTest.php
@@ -128,6 +128,70 @@ class MakeHttpRequestTest extends TestCase
         $this->assertEquals('json', $bodyType);
     }
 
+    public function testRequestConstructionAddsDynamicParamsWhenEndpointParamsAreEmpty()
+    {
+        $testStub = new class {
+            use MakeHttpRequests;
+        };
+        $testStub->endpoints = json_decode('{"records":{"url":"https://example.test/api/1.0/collections/4/records","body":"","view":false,"method":"GET","params":[],"headers":[],"purpose":"records","body_type":"raw","outboundConfig":[]}}', true);
+        $testStub->credentials = ['verify_certificate' => true];
+        $testStub->authtype = 'NONE';
+
+        $endpointConfig = [
+            'dataSource' => 1,
+            'endpoint' => 'records',
+            'outboundConfig' => [
+                ['value' => '{{pmqlValue}}', 'type' => 'PARAM', 'key' => 'pmql', 'format' => 'mustache'],
+            ],
+        ];
+        $requestData = [
+            'pmqlValue' => 'data.form_input_1=Lorem',
+        ];
+
+        $request = $this->callMethod(
+            $testStub,
+            'prepareRequestWithOutboundConfig',
+            [$requestData, &$endpointConfig]
+        );
+        [$method, $url] = array_values($request);
+
+        $this->assertEquals('GET', $method);
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+        $this->assertArrayHasKey('pmql', $query);
+        $this->assertEquals('data.form_input_1=Lorem', $query['pmql']);
+    }
+
+    public function testRequestConstructionWithEmptyEndpointParamsDoesNotOverwriteExistingQueryParams()
+    {
+        $testStub = new class {
+            use MakeHttpRequests;
+        };
+        $testStub->endpoints = json_decode('{"records":{"url":"https://example.test/api/1.0/collections/4/records?pmql=data.form_input_1%3D%22Original%22","body":"","view":false,"method":"GET","params":[],"headers":[],"purpose":"records","body_type":"raw","outboundConfig":[]}}', true);
+        $testStub->credentials = ['verify_certificate' => true];
+        $testStub->authtype = 'NONE';
+
+        $endpointConfig = [
+            'dataSource' => 1,
+            'endpoint' => 'records',
+            'outboundConfig' => [
+                ['value' => '{{pmqlValue}}', 'type' => 'PARAM', 'key' => 'pmql', 'format' => 'mustache'],
+            ],
+        ];
+        $requestData = [
+            'pmqlValue' => 'data.form_input_1=Lorem',
+        ];
+
+        $request = $this->callMethod(
+            $testStub,
+            'prepareRequestWithOutboundConfig',
+            [$requestData, &$endpointConfig]
+        );
+        [, $url] = array_values($request);
+
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+        $this->assertEquals('data.form_input_1="Original"', html_entity_decode($query['pmql']));
+    }
+
     /**
      * Verifies that different Guzzle Http Responses are mapped correctly calling the function responseWithHeaderData
      */


### PR DESCRIPTION
## Issue & Reproduction Steps
PMQL in Screen Builder Select List was not applied when using a Data Connector endpoint with params: [].
The request returned all records because dynamic PARAM values (like pmql) were not added to the query string in that case.

## Solution
- Updated MakeHttpRequests.php to preserve legacy behavior for configured endpoint params, and also allow dynamic query params when endpoint params is missing or empty.
- Prevented overwriting already-defined query keys.
- Added regression tests in MakeHttpRequestTest.php:
testRequestConstructionAddsDynamicParamsWhenEndpointParamsAreEmpty
testRequestConstructionWithEmptyEndpointParamsDoesNotOverwriteExistingQueryParams

## How to Test
- Confirm the Select List is filtered by PMQL in Preview mode.

## Related Tickets & Packages
- [FOUR-29448](https://processmaker.atlassian.net/browse/FOUR-29448)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-29448]: https://processmaker.atlassian.net/browse/FOUR-29448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ