### PR TITLE
Add Detailed Logging to Cases Retention Evaluation Job

### DIFF
--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -5,6 +5,7 @@ namespace ProcessMaker\Console\Commands;
 use Illuminate\Console\Command;
 use ProcessMaker\Jobs\EvaluateProcessRetentionJob;
 use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessCategory;
 
 class EvaluateCaseRetention extends Command
 {
@@ -39,10 +40,30 @@ class EvaluateCaseRetention extends Command
         $this->info('Case retention policy is enabled');
         $this->info('Dispatching retention evaluation jobs for all processes');
 
+        // Get system category IDs to exclude
+        $systemCategoryIds = ProcessCategory::where('is_system', true)->pluck('id');
+
         // Process all processes when retention policy is enabled
+        // Exclude processes that are templates or in system categories
         // Processes without retention_period will default to 1_year
         $jobCount = 0;
-        Process::chunkById(100, function ($processes) use (&$jobCount) {
+        $query = Process::where('is_template', '!=', 1);
+
+        // Exclude processes in system categories
+        if ($systemCategoryIds->isNotEmpty()) {
+            $query->where(function ($q) use ($systemCategoryIds) {
+                $q->where(function ($subQuery) use ($systemCategoryIds) {
+                    $subQuery->whereNotIn('process_category_id', $systemCategoryIds)
+                        ->orWhereNull('process_category_id');
+                });
+            })
+            ->whereDoesntHave('categories', function ($q) use ($systemCategoryIds) {
+                // Exclude processes with any category assignment to system categories
+                $q->whereIn('id', $systemCategoryIds);
+            });
+        }
+
+        $query->chunkById(100, function ($processes) use (&$jobCount) {
             foreach ($processes as $process) {
                 dispatch(new EvaluateProcessRetentionJob($process->id));
                 $jobCount++;

--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -59,7 +59,7 @@ class EvaluateCaseRetention extends Command
             })
             ->whereDoesntHave('categories', function ($q) use ($systemCategoryIds) {
                 // Exclude processes with any category assignment to system categories
-                $q->whereIn('id', $systemCategoryIds);
+                $q->whereIn('process_categories.id', $systemCategoryIds);
             });
         }
 

--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -44,7 +44,6 @@ class EvaluateCaseRetention extends Command
         $systemCategoryIds = ProcessCategory::where('is_system', true)->pluck('id');
 
         // Exclude processes that are templates or in system categories
-        // Processes without retention_period will default to one_year
         $jobCount = 0;
         $query = Process::where('is_template', '!=', 1);
 
@@ -62,7 +61,6 @@ class EvaluateCaseRetention extends Command
             });
         }
 
-        // Processes without retention_period will default to one_year
         $query->chunkById(100, function ($processes) use (&$jobCount) {
             foreach ($processes as $process) {
                 dispatch(new EvaluateProcessRetentionJob($process->id));

--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -37,16 +37,19 @@ class EvaluateCaseRetention extends Command
         }
 
         $this->info('Case retention policy is enabled');
-        $this->info('Evaluating and deleting cases past their retention period');
+        $this->info('Dispatching retention evaluation jobs for all processes');
 
         // Process all processes when retention policy is enabled
         // Processes without retention_period will default to 1_year
-        Process::chunkById(100, function ($processes) {
+        $jobCount = 0;
+        Process::chunkById(100, function ($processes) use (&$jobCount) {
             foreach ($processes as $process) {
                 dispatch(new EvaluateProcessRetentionJob($process->id));
+                $jobCount++;
             }
         });
 
-        $this->info('Cases retention evaluation complete');
+        $this->info("Dispatched {$jobCount} retention evaluation job(s) to the queue");
+        $this->info('Jobs will be processed asynchronously by queue workers');
     }
 }

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -26,15 +26,27 @@ class EvaluateProcessRetentionJob implements ShouldQueue
      */
     public function handle(): void
     {
+        $startTime = microtime(true);
+
+        Log::info('EvaluateProcessRetentionJob: Starting evaluation', [
+            'process_id' => $this->processId,
+        ]);
+
         // Only run if case retention policy is enabled
         $enabled = config('app.case_retention_policy_enabled', false);
         if (!$enabled) {
+            Log::info('EvaluateProcessRetentionJob: Case retention policy is disabled, skipping', [
+                'process_id' => $this->processId,
+            ]);
+
             return;
         }
 
         $process = Process::find($this->processId);
         if (!$process) {
-            Log::error('CaseRetentionJob: Process not found', ['process_id' => $this->processId]);
+            Log::error('EvaluateProcessRetentionJob: Process not found', [
+                'process_id' => $this->processId,
+            ]);
 
             return;
         }
@@ -49,6 +61,13 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             default => 12, // Default to 1_year
         };
 
+        Log::info('EvaluateProcessRetentionJob: Retention configuration loaded', [
+            'process_id' => $this->processId,
+            'process_name' => $process->name,
+            'retention_period' => $retentionPeriod,
+            'retention_months' => $retentionMonths,
+        ]);
+
         // Default retention_updated_at to now if not set
         // This means the retention policy applies from now for processes without explicit retention settings
         $retentionUpdatedAt = isset($process->properties['retention_updated_at'])
@@ -56,10 +75,19 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             : Carbon::now();
 
         // Check if there are any process requests for this process
-        // If not, nothing to delete
-        if (!ProcessRequest::where('process_id', $this->processId)->exists()) {
+        $processRequestCount = ProcessRequest::where('process_id', $this->processId)->count();
+        if ($processRequestCount === 0) {
+            Log::info('EvaluateProcessRetentionJob: No process requests found, nothing to evaluate', [
+                'process_id' => $this->processId,
+            ]);
+
             return;
         }
+
+        Log::info('EvaluateProcessRetentionJob: Process request count', [
+            'process_id' => $this->processId,
+            'total_process_requests' => $processRequestCount,
+        ]);
 
         // Handle two scenarios:
         // 1. Cases created BEFORE retention_updated_at: Delete if older than retention period from retention_updated_at
@@ -75,8 +103,20 @@ class EvaluateProcessRetentionJob implements ShouldQueue
         // For cases created after retention_updated_at: cutoff is now - retention_period
         $newCasesCutoff = $now->copy()->subMonths($retentionMonths);
 
+        Log::info('EvaluateProcessRetentionJob: Retention cutoff dates calculated', [
+            'process_id' => $this->processId,
+            'retention_updated_at' => $retentionUpdatedAt->toIso8601String(),
+            'old_cases_cutoff' => $oldCasesCutoff->toIso8601String(),
+            'new_cases_cutoff' => $newCasesCutoff->toIso8601String(),
+            'current_time' => $now->toIso8601String(),
+        ]);
+
         // Use subquery to get process request IDs
         $processRequestSubquery = ProcessRequest::where('process_id', $this->processId)->select('id');
+
+        $totalDeleted = 0;
+        $chunkCount = 0;
+        $processId = $this->processId;
 
         CaseNumber::whereIn('process_request_id', $processRequestSubquery)
             ->where(function ($query) use ($retentionUpdatedAt, $oldCasesCutoff, $newCasesCutoff) {
@@ -91,15 +131,30 @@ class EvaluateProcessRetentionJob implements ShouldQueue
                     ->where('created_at', '<', $newCasesCutoff);
                 });
             })
-            ->chunkById(100, function ($cases) {
+            ->chunkById(100, function ($cases) use (&$totalDeleted, &$chunkCount, $processId) {
                 $caseIds = $cases->pluck('id');
+                $chunkSize = $caseIds->count();
+
                 // Delete the cases
                 CaseNumber::whereIn('id', $caseIds)->delete();
 
-                // TODO: Add logs to track the number of cases deleted
-                // Get deleted timestamp
-                // $deletedAt = Carbon::now();
-                // RetentionPolicyLog::record($process->id, $caseIds, $deletedAt);
+                $totalDeleted += $chunkSize;
+                $chunkCount++;
+
+                Log::info('EvaluateProcessRetentionJob: Deleted chunk of cases', [
+                    'process_id' => $processId,
+                    'chunk_number' => $chunkCount,
+                    'cases_deleted' => $chunkSize,
+                ]);
             });
+
+        $executionTime = round((microtime(true) - $startTime) * 1000, 2);
+
+        Log::info('EvaluateProcessRetentionJob: Evaluation completed', [
+            'process_id' => $this->processId,
+            'total_cases_deleted' => $totalDeleted,
+            'total_chunks_processed' => $chunkCount,
+            'execution_time_ms' => $executionTime,
+        ]);
     }
 }

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -51,6 +51,24 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             return;
         }
 
+        // Skip template processes
+        if ($process->is_template) {
+            Log::info('EvaluateProcessRetentionJob: Skipping template process', [
+                'process_id' => $this->processId,
+            ]);
+
+            return;
+        }
+
+        // Skip processes in system categories
+        if ($process->categories()->where('is_system', true)->exists()) {
+            Log::info('EvaluateProcessRetentionJob: Skipping process in system category', [
+                'process_id' => $this->processId,
+            ]);
+
+            return;
+        }
+
         // Default to 1_year if retention_period is not set
         $retentionPeriod = $process->properties['retention_period'] ?? '1_year';
         $retentionMonths = match ($retentionPeriod) {

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -165,7 +165,6 @@ class EvaluateProcessRetentionJob implements ShouldQueue
 
                 $this->deleteTaskDraftMedia($draftIds);
                 $this->deleteTaskDrafts($processRequestTokenIds);
-                
 
                 $chunkCount++;
                 $chunkSize = count($caseIds);

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -75,19 +75,13 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             : Carbon::now();
 
         // Check if there are any process requests for this process
-        $processRequestCount = ProcessRequest::where('process_id', $this->processId)->count();
-        if ($processRequestCount === 0) {
+        if (!ProcessRequest::where('process_id', $this->processId)->exists()) {
             Log::info('EvaluateProcessRetentionJob: No process requests found, nothing to evaluate', [
                 'process_id' => $this->processId,
             ]);
 
             return;
         }
-
-        Log::info('EvaluateProcessRetentionJob: Process request count', [
-            'process_id' => $this->processId,
-            'total_process_requests' => $processRequestCount,
-        ]);
 
         // Handle two scenarios:
         // 1. Cases created BEFORE retention_updated_at: Delete if older than retention period from retention_updated_at

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Config;
 use ProcessMaker\Jobs\EvaluateProcessRetentionJob;
 use ProcessMaker\Models\CaseNumber;
 use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessRequest;
 use Tests\TestCase;
 
@@ -327,5 +328,46 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $this->assertNull(CaseNumber::find($oldCase->id), 'The 13-month-old case should be deleted with default 1 year retention');
         $this->assertNotNull(CaseNumber::find($newCase->id), 'The 5-month-old case should NOT be deleted with default 1 year retention');
         $this->assertDatabaseCount('case_numbers', 2);
+    }
+
+    public function testItDoesNotRunForTemplates()
+    {
+        // Create a template process
+        $process = Process::factory()->create([
+            'is_template' => 1,
+        ]);
+        $process->save();
+        $process->refresh();
+
+        // Dispatch the job
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // The case should NOT be deleted because the process is a template
+        $this->assertDatabaseCount('case_numbers', 0);
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+    }
+
+    public function testItDoesNotRunForProcessesInSystemCategories()
+    {
+        $category = ProcessCategory::factory()->create([
+            'is_system' => 1,
+        ]);
+        // Create a process in a system category
+        $process = Process::factory()->create([
+            'process_category_id' => $category->id,
+        ]);
+        $process->save();
+        $process->refresh();
+
+        // Dispatch the job
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // The case should NOT be deleted because the process is in a system category
+        $this->assertDatabaseCount('case_numbers', 0);
     }
 }

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -335,21 +335,34 @@ class EvaluateProcessRetentionJobTest extends TestCase
         // Create a template process
         $process = Process::factory()->create([
             'is_template' => 1,
+            'properties' => [
+                'retention_period' => self::RETENTION_PERIOD,
+            ],
         ]);
         $process->save();
         $process->refresh();
-
-        // Dispatch the job
-        EvaluateProcessRetentionJob::dispatchSync($process->id);
-
-        // The case should NOT be deleted because the process is a template
-        $this->assertDatabaseCount('case_numbers', 0);
 
         // Create a process request
         $processRequest = ProcessRequest::factory()->create();
         $processRequest->process_id = $process->id;
         $processRequest->save();
         $processRequest->refresh();
+
+        // Create an old case that should be deleted if this wasn't a template
+        // 13 months ago is older than 1 year retention period
+        $oldCaseDate = Carbon::now()->subMonths(13);
+        $oldCase = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+        ]);
+        $oldCase->created_at = $oldCaseDate;
+        $oldCase->save();
+
+        // Dispatch the job
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // The case should NOT be deleted because the process is a template
+        $this->assertNotNull(CaseNumber::find($oldCase->id), 'The case should NOT be deleted because the process is a template');
+        $this->assertDatabaseCount('case_numbers', 2);
     }
 
     public function testItDoesNotRunForProcessesInSystemCategories()
@@ -360,14 +373,33 @@ class EvaluateProcessRetentionJobTest extends TestCase
         // Create a process in a system category
         $process = Process::factory()->create([
             'process_category_id' => $category->id,
+            'properties' => [
+                'retention_period' => self::RETENTION_PERIOD,
+            ],
         ]);
         $process->save();
         $process->refresh();
+
+        // Create a process request
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+
+        // Create an old case that should be deleted if this wasn't in a system category
+        // 13 months ago is older than 1 year retention period
+        $oldCaseDate = Carbon::now()->subMonths(13);
+        $oldCase = CaseNumber::factory()->create([
+            'process_request_id' => $processRequest->id,
+        ]);
+        $oldCase->created_at = $oldCaseDate;
+        $oldCase->save();
 
         // Dispatch the job
         EvaluateProcessRetentionJob::dispatchSync($process->id);
 
         // The case should NOT be deleted because the process is in a system category
-        $this->assertDatabaseCount('case_numbers', 0);
+        $this->assertNotNull(CaseNumber::find($oldCase->id), 'The case should NOT be deleted because the process is in a system category');
+        $this->assertDatabaseCount('case_numbers', 2);
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR enhances observability of the Cases Retention evaluation job by introducing structured logging throughout its execution. Both informational messages and error conditions are now logged to improve traceability, debugging, and operational monitoring.

## Solution
- Added logging for key execution steps within the `cases:retention:evaluate` job
- Added error logging to capture and surface failures during job execution

## How to Test
1. Execute the retention evaluation job for a tenant:
`TENANT=[tenant_id] php artisan cases:retention:evaluate`

2. Open the corresponding tenant logs.

3. Verify that:
 - Execution progress messages are logged.
 - Any errors (if triggered) are properly recorded.
 - Logs provide sufficient context for troubleshooting.

## Related Tickets & Packages
- [FOUR-29113](https://processmaker.atlassian.net/browse/FOUR-29113)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-29113]: https://processmaker.atlassian.net/browse/FOUR-29113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches case-retention deletion execution by excluding template and system-category processes and adding additional early-exit conditions, which could change what data is eligible for deletion. The rest is primarily structured logging/metrics, but it runs in a background job and could affect operations if the filtering is incorrect.
> 
> **Overview**
> **Case retention evaluation now avoids system/template processes and is more observable.** The `cases:retention:evaluate` command filters out template processes and any process assigned to *system* categories (via `process_category_id` or category assignments), then reports how many `EvaluateProcessRetentionJob`s were queued.
> 
> `EvaluateProcessRetentionJob` adds structured start/end logging (including retention settings, cutoff dates, per-chunk deletion counts, and execution time) and explicitly skips template and system-category processes; tests add coverage to ensure retention does not run for those excluded process types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9579d012d8bb28887502eceedb4b312019179728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->