### PR TITLE
Web Entry Forms Missing from Form History

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -31,6 +31,7 @@ use ProcessMaker\Managers\DataManager;
 use ProcessMaker\Models\Comment;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\User;
 use ProcessMaker\Nayra\Contracts\Bpmn\CatchEventInterface;
 use ProcessMaker\Notifications\ProcessCanceledNotification;
@@ -779,8 +780,8 @@ class ProcessRequestController extends Controller
         $query = ProcessRequestToken::query();
         $query->select('id', 'element_id', 'process_id', 'process_request_id', 'data')
             ->where('process_request_id', $request->id)
-            ->whereNotIn('element_type', ['startEvent', 'end_event', 'scriptTask'])
-            ->where('status', 'CLOSED')
+            ->whereNotIn('element_type', ['end_event', 'scriptTask'])
+            ->whereIn('status', ['CLOSED', 'TRIGGERED'])
             ->orderBy('completed_at');
 
         $response =
@@ -792,16 +793,24 @@ class ProcessRequestController extends Controller
         $collection = $response->getCollection()
             ->transform(function ($token): ?object {
                 $definition = $token->getDefinition();
+                $screen = null;
                 if (array_key_exists('screenRef', $definition)) {
                     $screen = $token->getScreenVersion();
-                    if ($screen) {
-                        $dataManager = new DataManager();
-                        $screen->data = $dataManager->getData($token, true);
-                        $screen->screen_id = $screen->id;
-                        $screen->id = $token->id;
-
-                        return $screen;
+                } else {
+                    $config = json_decode($definition['config']);
+                    // verify the object config has a web_entry property
+                    if (isset($config->web_entry)) {
+                        $screen = Screen::find($config->web_entry->screen_id);
                     }
+                }
+
+                if ($screen) {
+                    $dataManager = new DataManager();
+                    $screen->data = $dataManager->getData($token, true);
+                    $screen->screen_id = $screen->id;
+                    $screen->id = $token->id;
+
+                    return $screen;
                 }
 
                 return null;

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -792,6 +792,14 @@ class ProcessRequestController extends Controller
 
         $collection = $response->getCollection()
             ->transform(function ($token): ?object {
+                $definition = $token->getDefinition();
+                if (!array_key_exists('screenRef', $definition)) {
+                    $config = isset($definition['config']) ? json_decode($definition['config']) : null;
+                    $screenRef = (isset($config) && isset($config->web_entry)) ? $config->web_entry->screen_id ?? null : null;
+                    if (!$screenRef) {
+                        return null;
+                    }
+                }
                 $screen = $token->getScreenVersion() ?? null;
 
                 if ($screen) {

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -792,28 +792,16 @@ class ProcessRequestController extends Controller
 
         $collection = $response->getCollection()
             ->transform(function ($token): ?object {
-                $definition = $token->getDefinition();
-                $screen = null;
-                if (array_key_exists('screenRef', $definition)) {
-                    $screen = $token->getScreenVersion();
-                } else {
-                    $config = json_decode($definition['config']);
-                    // verify the object config has a web_entry property
-                    if (isset($config->web_entry)) {
-                        $screen = Screen::find($config->web_entry->screen_id);
-                    }
-                }
+                $screen = $token->getScreenVersion() ?? null;
 
                 if ($screen) {
                     $dataManager = new DataManager();
                     $screen->data = $dataManager->getData($token, true);
                     $screen->screen_id = $screen->id;
                     $screen->id = $token->id;
-
-                    return $screen;
                 }
 
-                return null;
+                return $screen;
             })
             ->reject(fn ($item) => $item === null)
             ->values();

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -208,9 +208,27 @@ class TaskController extends Controller
         }
 
         // Validate the inputs, including optional ones
+        $allowedStatuses = ['ACTIVE', 'CLOSED', 'TRIGGERED'];
         $request->validate([
             'case_number' => 'required|integer',
-            'status' => 'nullable|string|in:ACTIVE,CLOSED',
+            'status' => [
+                'nullable',
+                'string',
+                function ($attribute, $value, $fail) use ($allowedStatuses) {
+                    $statuses = array_map(fn ($v) => mb_strtoupper(trim($v)), explode(',', $value));
+                    $statuses = array_filter($statuses);
+                    foreach ($statuses as $status) {
+                        if (!in_array($status, $allowedStatuses)) {
+                            $fail(__('The :attribute must contain only valid statuses: :values. Multiple statuses can be comma-separated.', [
+                                'attribute' => $attribute,
+                                'values' => implode(', ', $allowedStatuses),
+                            ]));
+
+                            return;
+                        }
+                    }
+                },
+            ],
             'order_by' => 'nullable|string|in:id,element_name,due_at,user.lastname,process.name',
             'order_direction' => 'nullable|string|in:asc,desc',
             'page' => 'nullable|integer|min:1',

--- a/ProcessMaker/Http/Resources/ScreenVersion.php
+++ b/ProcessMaker/Http/Resources/ScreenVersion.php
@@ -63,7 +63,7 @@ class ScreenVersion extends ApiResource
      */
     private function setDefaultScreenForNestedScreens(array &$screenVersion): void
     {
-        $configArray = $screenVersion['config'];
+        $configArray = $screenVersion['config'] ?? [];
         foreach ($configArray as $key => $config) {
             foreach ($config['items'] as $itemKey => $item) {
                 if (isset($item['component']) && $item['component'] === 'FormNestedScreen') {

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -448,8 +448,10 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     public function getScreen(): ?Screen
     {
         $definition = $this->getDefinition();
-
-        $config = json_decode($definition['config']);
+        $config = null;
+        if (isset($definition['config'])) {
+            $config = json_decode($definition['config']);
+        }
         if (isset($config) and isset($config->web_entry)) {
             $screenRef = $config->web_entry->screen_id ?? null;
         } else {

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -312,13 +312,20 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     }
 
     /**
-     * Scope to filter by status
+     * Scope to filter by status.
+     * Supports single value (e.g. ACTIVE) or comma-separated values (e.g. CLOSED,TRIGGERED).
      */
     public function scopeFilterByStatus($query, $request)
     {
         $status = $request->input('status', 'ACTIVE');
+        $statuses = array_map(fn ($v) => mb_strtoupper(trim($v)), explode(',', $status));
+        $statuses = array_filter($statuses);
 
-        return $query->where('status', $status);
+        if (count($statuses) === 1) {
+            return $query->where('status', $statuses[0]);
+        }
+
+        return $query->whereIn('status', $statuses);
     }
 
     /**
@@ -441,7 +448,14 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     public function getScreen(): ?Screen
     {
         $definition = $this->getDefinition();
-        $screenRef = $definition['screenRef'] ?? null;
+
+        $config = json_decode($definition['config']);
+        if (isset($config) and isset($config->web_entry)) {
+            $screenRef = $config->web_entry->screen_id ?? null;
+        } else {
+            $screenRef = $definition['screenRef'] ?? null;
+        }
+
         $screen = Screen::find($screenRef);
 
         if ($screen === null) {

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -448,15 +448,12 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     public function getScreen(): ?Screen
     {
         $definition = $this->getDefinition();
-        $config = null;
-        if (isset($definition['config'])) {
-            $config = json_decode($definition['config']);
-        }
+        $screenRef = isset($definition['screenRef']) ? $definition['screenRef'] : null;
 
-        $screenRef = $definition['screenRef'] ?? null;
+        if (!$screenRef) {
+            $config = isset($definition['config']) ? json_decode($definition['config']) : null;
 
-        if (!$screenRef && isset($config) && isset($config->web_entry)) {
-            $screenRef = $config->web_entry->screen_id ?? null;
+            $screenRef = (isset($config) && isset($config->web_entry)) ? $config->web_entry->screen_id ?? null : null;
         }
 
         $screen = Screen::find($screenRef);

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -452,10 +452,11 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         if (isset($definition['config'])) {
             $config = json_decode($definition['config']);
         }
-        if (isset($config) and isset($config->web_entry)) {
+
+        $screenRef = $definition['screenRef'] ?? null;
+
+        if (!$screenRef && isset($config) && isset($config->web_entry)) {
             $screenRef = $config->web_entry->screen_id ?? null;
-        } else {
-            $screenRef = $definition['screenRef'] ?? null;
         }
 
         $screen = Screen::find($screenRef);

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -135,8 +135,12 @@ trait TaskControllerIndexMethods
     private function applyDefaultFiltering($query, $column, $filterByFields, $fieldFilter)
     {
         $key = array_search($column, $filterByFields);
-        $operator = is_numeric($fieldFilter) ? '=' : 'like';
-        $query->where(is_string($key) ? $key : $column, $operator, $fieldFilter);
+        if (str_contains($fieldFilter, ',')) {
+            $query->whereIn(is_string($key) ? $key : $column, explode(',', $fieldFilter));
+        } else {
+            $operator = is_numeric($fieldFilter) ? '=' : 'like';
+            $query->where(is_string($key) ? $key : $column, $operator, $fieldFilter);
+        }
     }
 
     private function addTaskData($response)
@@ -158,7 +162,8 @@ trait TaskControllerIndexMethods
         $hitlEnabled = filter_var(config('smart-extract.hitl_enabled'), FILTER_VALIDATE_BOOLEAN);
         $query->when(!$allTasks, function ($query) {
             $query->where(function ($query) {
-                $query->where('element_type', '=', 'task');
+                $query->orWhere('element_type', '=', 'task');
+                $query->orWhere('element_type', '=', 'startEvent');
                 $query->orWhere(function ($query) {
                     $query->where('element_type', '=', 'serviceTask');
                     $query->where('element_name', '=', 'AI Assistant');

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -160,10 +160,15 @@ trait TaskControllerIndexMethods
         $nonSystem = filter_var($request->input('non_system'), FILTER_VALIDATE_BOOLEAN);
         $allTasks = filter_var($request->input('all_tasks'), FILTER_VALIDATE_BOOLEAN);
         $hitlEnabled = filter_var(config('smart-extract.hitl_enabled'), FILTER_VALIDATE_BOOLEAN);
-        $query->when(!$allTasks, function ($query) {
-            $query->where(function ($query) {
-                $query->orWhere('element_type', '=', 'task');
-                $query->orWhere('element_type', '=', 'startEvent');
+        $includeScreen = filter_var($request->input('includeScreen'), FILTER_VALIDATE_BOOLEAN);
+        $query->when(!$allTasks, function ($query) use ($includeScreen) {
+            $query->where(function ($query) use ($includeScreen) {
+                if ($includeScreen) {
+                    $query->orWhere('element_type', '=', 'task');
+                    $query->orWhere('element_type', '=', 'startEvent');
+                } else {
+                    $query->where('element_type', '=', 'task');
+                }
                 $query->orWhere(function ($query) {
                     $query->where('element_type', '=', 'serviceTask');
                     $query->where('element_name', '=', 'AI Assistant');

--- a/resources/jscomposition/cases/casesDetail/components/CompletedForms.vue
+++ b/resources/jscomposition/cases/casesDetail/components/CompletedForms.vue
@@ -76,7 +76,7 @@ const getData = async () => {
   const response = await getDataTask({
     params: {
       case_number: getCaseNumber(),
-      status: "CLOSED",
+      status: "CLOSED,TRIGGERED",
       includeScreen: 1,
       order_by: filter.value?.field,
       order_direction: filter.value?.filter,


### PR DESCRIPTION
## Issue & Reproduction Steps
Allow StartEvent forms with WebEntry to be displayed in the list of completed forms.

## Solution
- Add the Start Event element with Triggered status to the filtered lists.

## How to Test
Reviews all lists cases, requests

## Related Tickets & Packages
- [FOUR-6304)](url[)](https://processmaker.atlassian.net/browse/FOUR-6304)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
