### PR TITLE
FOUR-29112 | Ensure Deleted Cases Are Fully Removed From System Views and APIs

### DIFF
--- a/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
+++ b/ProcessMaker/Console/Commands/EvaluateCaseRetention.php
@@ -40,7 +40,7 @@ class EvaluateCaseRetention extends Command
         $this->info('Evaluating and deleting cases past their retention period');
 
         // Process all processes when retention policy is enabled
-        // Processes without retention_period will default to 1_year
+        // Processes without retention_period will default to one_year
         Process::chunkById(100, function ($processes) {
             foreach ($processes as $process) {
                 dispatch(new EvaluateProcessRetentionJob($process->id));

--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeleteCase.php
@@ -99,20 +99,4 @@ class DeleteCase
             ->pluck('id')
             ->all();
     }
-
-    private function dispatchSavedSearchRecount(): void
-    {
-        if (!config('savedsearch.count', false)) {
-            return;
-        }
-
-        $jobClass = 'ProcessMaker\\Package\\SavedSearch\\Jobs\\RecountAllSavedSearches';
-        if (!class_exists($jobClass)) {
-            return;
-        }
-
-        DB::afterCommit(static function () use ($jobClass): void {
-            $jobClass::dispatch(['request', 'task']);
-        });
-    }
 }

--- a/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeletesCaseRecords.php
+++ b/ProcessMaker/Http/Controllers/Api/Actions/Cases/DeletesCaseRecords.php
@@ -220,4 +220,20 @@ trait DeletesCaseRecords
             ->whereIn('data->type', $notificationTypes)
             ->delete();
     }
+
+    private function dispatchSavedSearchRecount(): void
+    {
+        if (!config('savedsearch.count', false)) {
+            return;
+        }
+
+        $jobClass = 'ProcessMaker\\Package\\SavedSearch\\Jobs\\RecountAllSavedSearches';
+        if (!class_exists($jobClass)) {
+            return;
+        }
+
+        DB::afterCommit(static function () use ($jobClass): void {
+            $jobClass::dispatch(['request', 'task']);
+        });
+    }
 }

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -44,14 +44,14 @@ class EvaluateProcessRetentionJob implements ShouldQueue
             return;
         }
 
-        // Default to 1_year if retention_period is not set
-        $retentionPeriod = $process->properties['retention_period'] ?? '1_year';
+        // Default to one_year if retention_period is not set
+        $retentionPeriod = $process->properties['retention_period'] ?? 'one_year';
         $retentionMonths = match ($retentionPeriod) {
             'six_months' => 6,
             'one_year' => 12,
             'three_years' => 36,
             'five_years' => 60,
-            default => 12, // Default to 1_year
+            default => 12, // Default to one_year
         };
 
         // Default retention_updated_at to now if not set
@@ -104,6 +104,19 @@ class EvaluateProcessRetentionJob implements ShouldQueue
                     ->all();
 
                 if ($requestIds === []) {
+                    // If no ProcessRequest has case_number matching these CaseNumber ids, still remove case_numbers and UI entries
+                    Log::warning('CaseRetentionJob: No process requests found for case numbers, removing case_numbers and cases_started/participated', [
+                        'case_numbers' => $caseNumbers,
+                        'process_id' => $this->processId,
+                    ]);
+                    DB::transaction(function () use ($caseNumbers) {
+                        CaseNumber::whereIn('id', $caseNumbers)->delete();
+                        foreach ($caseNumbers as $caseNumber) {
+                            $this->deleteCasesStarted((string) $caseNumber);
+                            $this->deleteCasesParticipated((string) $caseNumber);
+                        }
+                    });
+
                     return;
                 }
 

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -138,5 +138,7 @@ class EvaluateProcessRetentionJob implements ShouldQueue
                     $this->deleteProcessRequests($requestIds);
                 });
             });
+
+        $this->dispatchSavedSearchRecount();
     }
 }

--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -5,13 +5,18 @@ namespace ProcessMaker\Jobs;
 use Carbon\Carbon;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use ProcessMaker\Http\Controllers\Api\Actions\Cases\DeletesCaseRecords;
 use ProcessMaker\Models\CaseNumber;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\TaskDraft;
 
 class EvaluateProcessRetentionJob implements ShouldQueue
 {
+    use DeletesCaseRecords;
     use Queueable;
 
     /**
@@ -42,10 +47,10 @@ class EvaluateProcessRetentionJob implements ShouldQueue
         // Default to 1_year if retention_period is not set
         $retentionPeriod = $process->properties['retention_period'] ?? '1_year';
         $retentionMonths = match ($retentionPeriod) {
-            '6_months' => 6,
-            '1_year' => 12,
-            '3_years' => 36,
-            '5_years' => 60,
+            'six_months' => 6,
+            'one_year' => 12,
+            'three_years' => 36,
+            'five_years' => 60,
             default => 12, // Default to 1_year
         };
 
@@ -92,14 +97,46 @@ class EvaluateProcessRetentionJob implements ShouldQueue
                 });
             })
             ->chunkById(100, function ($cases) {
-                $caseIds = $cases->pluck('id');
-                // Delete the cases
-                CaseNumber::whereIn('id', $caseIds)->delete();
+                $caseNumbers = $cases->pluck('id')->all();
+                $requestIds = ProcessRequest::query()
+                    ->whereIn('case_number', $caseNumbers)
+                    ->pluck('id')
+                    ->all();
 
-                // TODO: Add logs to track the number of cases deleted
-                // Get deleted timestamp
-                // $deletedAt = Carbon::now();
-                // RetentionPolicyLog::record($process->id, $caseIds, $deletedAt);
+                if ($requestIds === []) {
+                    return;
+                }
+
+                $tokenIds = ProcessRequestToken::query()
+                    ->whereIn('process_request_id', $requestIds)
+                    ->pluck('id')
+                    ->all();
+                $draftIds = $tokenIds !== []
+                    ? TaskDraft::query()->whereIn('task_id', $tokenIds)->pluck('id')->all()
+                    : [];
+
+                DB::transaction(function () use ($requestIds, $tokenIds, $caseNumbers, $draftIds) {
+                    $this->deleteInboxRuleLogs($tokenIds);
+                    $this->deleteInboxRules($tokenIds);
+                    $this->deleteProcessRequestLocks($requestIds, $tokenIds);
+                    $this->deleteProcessAbeRequestTokens($requestIds, $tokenIds);
+                    $this->deleteScheduledTasks($requestIds, $tokenIds);
+                    $this->deleteEllucianEthosSyncTasks($tokenIds);
+                    $this->deleteTaskDraftMedia($draftIds);
+                    $this->deleteTaskDrafts($tokenIds);
+                    foreach ($caseNumbers as $caseNumber) {
+                        $this->deleteComments((string) $caseNumber, $requestIds, $tokenIds);
+                    }
+                    $this->deleteNotifications($requestIds);
+                    $this->deleteRequestMedia($requestIds);
+                    $this->deleteCaseNumbers($requestIds);
+                    foreach ($caseNumbers as $caseNumber) {
+                        $this->deleteCasesStarted((string) $caseNumber);
+                        $this->deleteCasesParticipated((string) $caseNumber);
+                    }
+                    $this->deleteProcessRequestTokens($requestIds);
+                    $this->deleteProcessRequests($requestIds);
+                });
             });
     }
 }

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -5,15 +5,20 @@ namespace Tests\Jobs;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Jobs\EvaluateProcessRetentionJob;
 use ProcessMaker\Models\CaseNumber;
+use ProcessMaker\Models\CaseStarted;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\User;
+use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
 class EvaluateProcessRetentionJobTest extends TestCase
 {
     use RefreshDatabase;
+    use RequestHelper;
 
     const RETENTION_PERIOD = '1_year';
 
@@ -22,6 +27,11 @@ class EvaluateProcessRetentionJobTest extends TestCase
         parent::setUp();
         // Enable case retention policy for all tests
         Config::set('app.case_retention_policy_enabled', true);
+        // RequestHelper expects $this->user for apiCall (used in integration test)
+        $this->user = User::factory()->create([
+            'password' => Hash::make('password'),
+            'is_administrator' => true,
+        ]);
     }
 
     protected function tearDown(): void
@@ -136,12 +146,13 @@ class EvaluateProcessRetentionJobTest extends TestCase
         // These cases are created 13 months ago
         // Cutoff = now - 12 months = 12 months ago
         // 13 months ago < 12 months ago, so these should be deleted
+        $oldCaseCreatedAt = Carbon::now()->subMonths(13)->toIso8601String();
         $cases = CaseNumber::factory()->count(1200)->create([
             'process_request_id' => $processRequest->id,
-            'created_at' => Carbon::now()->subMonths(13)->toIso8601String(),
+            'created_at' => $oldCaseCreatedAt,
         ]);
         $this->assertEquals($processRequest->id, $cases->first()->process_request_id);
-        $this->assertEquals(Carbon::now()->subMonths(13)->toIso8601String(), $cases->first()->created_at->toIso8601String());
+        $this->assertEquals($oldCaseCreatedAt, $cases->first()->created_at->toIso8601String());
 
         // Link process request to one of the case numbers so the job can resolve request IDs for full delete
         $processRequest->case_number = $cases->first()->id;
@@ -353,5 +364,52 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $this->assertNull(CaseNumber::find($oldCase->id), 'The 13-month-old case should be deleted with default 1 year retention');
         $this->assertNotNull(CaseNumber::find($newCase->id), 'The 5-month-old case should NOT be deleted with default 1 year retention');
         $this->assertDatabaseCount('case_numbers', 2);
+    }
+
+    public function testDeletedCaseIsFullyInaccessibleViaApi(): void
+    {
+        $process = Process::factory()->create([
+            'properties' => [
+                'retention_period' => self::RETENTION_PERIOD,
+            ],
+        ]);
+        $process->save();
+        $process->refresh();
+
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+
+        $oldCaseCreatedAt = Carbon::now()->subMonths(13)->toIso8601String();
+        $caseOld = CaseNumber::factory()->create([
+            'created_at' => $oldCaseCreatedAt,
+            'process_request_id' => $processRequest->id,
+        ]);
+        $processRequest->case_number = $caseOld->id;
+        $processRequest->save();
+
+        CaseStarted::factory()->create([
+            'case_number' => $caseOld->id,
+            'user_id' => $this->user->id,
+        ]);
+
+        // Case should appear in the list before retention runs
+        $listBefore = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['userId' => $this->user->id]));
+        $listBefore->assertStatus(200);
+        $caseNumbersBefore = collect($listBefore->json('data'))->pluck('case_number')->all();
+        $this->assertContains($caseOld->id, $caseNumbersBefore, 'Case should appear in list before retention job runs');
+
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        // DELETE case by number should return 404 (case already removed)
+        $deleteResponse = $this->apiCall('DELETE', route('api.cases.destroy', ['case_number' => $caseOld->id]));
+        $deleteResponse->assertStatus(404);
+
+        // GET all_cases should not include the deleted case
+        $listAfter = $this->apiCall('GET', route('api.1.1.cases.all_cases', ['userId' => $this->user->id]));
+        $listAfter->assertStatus(200);
+        $caseNumbersAfter = collect($listAfter->json('data'))->pluck('case_number')->all();
+        $this->assertNotContains($caseOld->id, $caseNumbersAfter, 'Deleted case must not appear in All Cases API');
     }
 }

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -20,7 +20,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
     use RefreshDatabase;
     use RequestHelper;
 
-    const RETENTION_PERIOD = '1_year';
+    const RETENTION_PERIOD = 'one_year';
 
     protected function setUp(): void
     {
@@ -171,7 +171,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
         $process = Process::factory()->create([
             'properties' => [
-                'retention_period' => '1_year', // Updated to 1 year
+                'retention_period' => 'one_year', // Updated to 1 year
                 'retention_updated_at' => $retentionUpdatedAt,
             ],
         ]);
@@ -215,7 +215,7 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $retentionUpdatedAt = Carbon::now()->subMonths(6)->toIso8601String();
         $process = Process::factory()->create([
             'properties' => [
-                'retention_period' => '1_year', // Updated to 1 year
+                'retention_period' => 'one_year', // Updated to 1 year
                 'retention_updated_at' => $retentionUpdatedAt,
             ],
         ]);

--- a/tests/Jobs/EvaluateProcessRetentionJobTest.php
+++ b/tests/Jobs/EvaluateProcessRetentionJobTest.php
@@ -63,6 +63,10 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $this->assertEquals($processRequest->id, $caseOld->process_request_id);
         $this->assertEquals($oldCaseCreatedAt, $caseOld->created_at->toIso8601String());
 
+        // Link process request to this case number so the job can resolve request IDs for full delete
+        $processRequest->case_number = $caseOld->id;
+        $processRequest->save();
+
         // Dispatch the job to evaluate the retention period
         EvaluateProcessRetentionJob::dispatchSync($process->id);
 
@@ -139,13 +143,15 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $this->assertEquals($processRequest->id, $cases->first()->process_request_id);
         $this->assertEquals(Carbon::now()->subMonths(13)->toIso8601String(), $cases->first()->created_at->toIso8601String());
 
+        // Link process request to one of the case numbers so the job can resolve request IDs for full delete
+        $processRequest->case_number = $cases->first()->id;
+        $processRequest->save();
+
         // Dispatch the job to evaluate the retention period
         EvaluateProcessRetentionJob::dispatchSync($process->id);
 
-        // Assert all old cases are deleted
-        // There should be 1 case left (the auto-created case from ProcessRequestObserver)
-        // because it was created recently and is within the retention period
-        $this->assertDatabaseCount('case_numbers', 1);
+        // Assert all old cases are deleted (full delete removes the process request and all its case numbers)
+        $this->assertDatabaseCount('case_numbers', 0);
     }
 
     public function testItHandlesRetentionPolicyUpdate()
@@ -205,38 +211,48 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $process->save();
         $process->refresh();
 
-        // Create a process request
-        $processRequest = ProcessRequest::factory()->create();
-        $processRequest->process_id = $process->id;
-        $processRequest->save();
-        $processRequest->refresh();
+        // Create first process request for the case that should be deleted (20 months old)
+        $processRequestOld = ProcessRequest::factory()->create();
+        $processRequestOld->process_id = $process->id;
+        $processRequestOld->save();
+        $processRequestOld->refresh();
 
         // Create an old case (20 months ago, before retention_updated_at which is 6 months ago)
         // Old cases cutoff = 6 months ago - 1 year = 18 months ago
         // 20 months ago < 18 months ago (earlier date), so it SHOULD be deleted
         $oldCaseDate = Carbon::now()->subMonths(20);
         $oldCase = CaseNumber::factory()->create([
-            'process_request_id' => $processRequest->id,
+            'process_request_id' => $processRequestOld->id,
         ]);
         $oldCase->created_at = $oldCaseDate;
         $oldCase->save();
+        $processRequestOld->case_number = $oldCase->id;
+        $processRequestOld->save();
 
         // Create a case 7 months ago (before retention_updated_at) that should NOT be deleted
         // Old cases cutoff = 6 months ago - 1 year = 18 months ago
         // 7 months ago is NOT < 18 months ago (7 months ago is more recent), so it should NOT be deleted
+        $processRequestKept = ProcessRequest::factory()->create();
+        $processRequestKept->process_id = $process->id;
+        $processRequestKept->save();
+        $processRequestKept->refresh();
+
+        // Create a case 7 months ago that should NOT be deleted
         $oldCaseNotDeletedDate = Carbon::now()->subMonths(7);
         $oldCaseNotDeleted = CaseNumber::factory()->create([
-            'process_request_id' => $processRequest->id,
+            'process_request_id' => $processRequestKept->id,
         ]);
         $oldCaseNotDeleted->created_at = $oldCaseNotDeletedDate;
         $oldCaseNotDeleted->save();
+        $processRequestKept->case_number = $oldCaseNotDeleted->id;
+        $processRequestKept->save();
 
         // Dispatch the job
         EvaluateProcessRetentionJob::dispatchSync($process->id);
 
         // The 20-month-old case should be deleted (older than 18 months cutoff)
         // The 7-month-old case should NOT be deleted (newer than 18 months cutoff)
-        // Plus the auto-created case = 2 total
+        // Plus the auto-created case for processRequestKept = 2 total
         $this->assertNull(CaseNumber::find($oldCase->id), 'The 20-month-old case should be deleted');
         $this->assertNotNull(CaseNumber::find($oldCaseNotDeleted->id), 'The 7-month-old case should NOT be deleted');
         $this->assertDatabaseCount('case_numbers', 2);
@@ -293,37 +309,47 @@ class EvaluateProcessRetentionJobTest extends TestCase
         $process->save();
         $process->refresh();
 
-        // Create a process request
-        $processRequest = ProcessRequest::factory()->create();
-        $processRequest->process_id = $process->id;
-        $processRequest->save();
-        $processRequest->refresh();
+        // Create a process request for the case that should be deleted (13 months old)
+        $processRequestOld = ProcessRequest::factory()->create();
+        $processRequestOld->process_id = $process->id;
+        $processRequestOld->save();
+        $processRequestOld->refresh();
 
         // Create a case created 13 months ago (older than default 1 year retention)
         // Since retention_updated_at defaults to now, old cases cutoff = now - 1 year
         // 13 months ago < (now - 1 year), so it should be deleted
         $oldCaseDate = Carbon::now()->subMonths(13);
         $oldCase = CaseNumber::factory()->create([
-            'process_request_id' => $processRequest->id,
+            'process_request_id' => $processRequestOld->id,
         ]);
         $oldCase->created_at = $oldCaseDate;
         $oldCase->save();
+        $processRequestOld->case_number = $oldCase->id;
+        $processRequestOld->save();
+
+        // Create second process request for the case that should NOT be deleted (5 months old)
+        $processRequestNew = ProcessRequest::factory()->create();
+        $processRequestNew->process_id = $process->id;
+        $processRequestNew->save();
+        $processRequestNew->refresh();
 
         // Create a case created 5 months ago (within default 1 year retention)
         // 5 months ago is NOT < (now - 1 year), so it should NOT be deleted
         $newCaseDate = Carbon::now()->subMonths(5);
         $newCase = CaseNumber::factory()->create([
-            'process_request_id' => $processRequest->id,
+            'process_request_id' => $processRequestNew->id,
         ]);
         $newCase->created_at = $newCaseDate;
         $newCase->save();
+        $processRequestNew->case_number = $newCase->id;
+        $processRequestNew->save();
 
         // Dispatch the job
         EvaluateProcessRetentionJob::dispatchSync($process->id);
 
         // The 13-month-old case should be deleted (older than 1 year default)
         // The 5-month-old case should NOT be deleted (within 1 year default)
-        // Plus the auto-created case = 2 total
+        // Plus the auto-created case for processRequestNew = 2 total
         $this->assertNull(CaseNumber::find($oldCase->id), 'The 13-month-old case should be deleted with default 1 year retention');
         $this->assertNotNull(CaseNumber::find($newCase->id), 'The 5-month-old case should NOT be deleted with default 1 year retention');
         $this->assertDatabaseCount('case_numbers', 2);


### PR DESCRIPTION
# Issue
Ticket: [FOUR-29112](https://processmaker.atlassian.net/browse/FOUR-29112)

Cases deleted by the retention job (`EvaluateProcessRetentionJob`) were only removed from the `case_numbers` table. The job did not touch:
- `cases_started` (drives the "All Cases" list in the UI)
- `cases_participated`
- `process_requests` and related tables (tokens, comments, notifications, media, etc.)

As a result, retention-deleted cases still appeared in the Cases UI, search, APIs, and reports.

# Solution
Replicate the **full case deletion** performed by the `DeleteCase` action so that retention-deleted cases are removed from all user-visible surfaces and APIs. We could not call the `DeleteCase` action itself because it is designed for a single case and does not support bulk deletes. Instead we:

1. **Use the `DeletesCaseRecords` trait** in `EvaluateProcessRetentionJob` so the job reuses the same delete logic as manual case delete.
2. **Run the same sequence of deletes inside a `DB::transaction`** as in `DeleteCase::__invoke()`: for each chunk of cases, resolve process request IDs, then in one transaction delete (in order) inbox rule logs, inbox rules, locks, ABE tokens, scheduled tasks, Ellucian sync tasks (if present), task draft media, task drafts, comments, notifications, request media, case_numbers, cases_started, cases_participated, process_request_tokens, and process_requests.
3. **Keep the job bulk-oriented**: for each chunk, we gather all `requestIds` for those case numbers (root + subprocess requests), then run one transaction per chunk so many cases are fully deleted in a single transaction.

This ensures retention-deleted cases are removed from:
- **UI lists** (e.g. All Cases), because `cases_started` and `cases_participated` are deleted.
- **APIs** that read from `process_requests` or case-related tables.
- **Search/reports** that rely on the same data.

### Updated `tests/Jobs/EvaluateProcessRetentionJobTest.php`
- **Link process request to case number where the job must perform a delete:** The job resolves request IDs with `ProcessRequest::whereIn('case_number', $caseNumbers)`. Tests now set `$processRequest->case_number = $caseId` (for the CaseNumber under test) so the job finds the request and runs the full delete.
- **testItDeletesCasesThatExceedRetentionPeriod:** Set `process_request.case_number = $caseOld->id` after creating the old case so the job can resolve the request and fully delete.
- **testItHandlesMultipleCasesInBatches:** Set `process_request.case_number = $cases->first()->id` and assert `case_numbers` count 0 (full delete removes the single process request and all its case numbers, including the observer-created one).
- **testItDeletesOldCasesAfterRetentionPolicyUpdate:** Use two process requests (one for the case to be deleted, one for the case to be kept) and set each request’s `case_number` to the corresponding CaseNumber id so only the intended case is fully deleted.
- **testItDefaultsToOneYearForProcessesWithoutRetentionPeriod:** Same pattern: two process requests, each linked to its CaseNumber via `case_number`, so the old case is fully deleted and the new one remains.

# How To Test
1. Run `vendor/bin/phpunit tests/Jobs/EvaluateProcessRetentionJobTest.php`
		- All tests should pass.
2. Ensure `CASE_RETENTION_TIER=1` in your `.env` file.
3. Log in to ProcessMaker. Open a Process' Configurations.
  - Set a retention period of six months.
4. Run the process. Ensure the process appears in the Cases listing.
5. In your database, ensure that the retention settings updated under `process.properties`.
	- Ensure that there is a value for `retention_updated_at`.
6. In your database, or using tinker, create a case with a `created_at` date that is six months before the date of the `retention_updated_at` value.
7. Run the Evaluate Retention Job via `php artisan cases:retention:evaluate`.
8. Ensure the case is removed from the `case_numbers`, `cases_participated`, and `cases_started` tables.
      - Ensure the case no longer displays in the Cases listing (My Cases, All Cases, etc.)
      - Ensure that the case does not display when searching for Cases.

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-29112]: https://processmaker.atlassian.net/browse/FOUR-29112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bulk deletion logic across multiple related tables and relies on transactional ordering, so mistakes could cause unintended data loss or leave orphaned records despite added test coverage.
> 
> **Overview**
> Retention deletion is expanded from removing only `case_numbers` to performing a **full case teardown**: `EvaluateProcessRetentionJob` now reuses `DeletesCaseRecords` and, per chunk, deletes associated requests/tokens/drafts/comments/notifications/media plus `cases_started`/`cases_participated` inside a transaction; it also triggers a saved-search recount after completion.
> 
> Retention period property keys are standardized from `1_year`/`6_months`/etc. to `one_year`/`six_months`/etc. (including the default), and tests are updated/expanded to validate full removal (including an API-level check that a retained-deleted case no longer lists and DELETE returns 404).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9539d17dabdf4f69219d1f06f845d752725a922e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->