### PR TITLE
Bugfix/FOUR-26369: Error object object, when wanting create a pmblock from recent asset

### DIFF
--- a/resources/js/processes/designer/RecentAssetsList.vue
+++ b/resources/js/processes/designer/RecentAssetsList.vue
@@ -4,7 +4,7 @@
       <img
         class="image"
         src="/img/recent_assets.svg"
-        alt="resent assets"
+        alt="Recent assets"
       >
       <div class="content-text">
         <span class="title">
@@ -15,8 +15,7 @@
     </div>
   </div>
   <div v-else class="data-table">
-    <div class="data-table">
-      <data-loading
+    <data-loading
         v-if="shouldShowLoader"
         :for="/projects\{project_id}?/"
         :empty="'No Data Available'"
@@ -92,7 +91,6 @@
           :assetName="assetName"
         />
       </div>
-    </div>
   </div>
 </template>
 
@@ -177,32 +175,31 @@ export default {
      * get data for Recent Assets
      */
     fetch(pmql = "") {
-      if (this.project) {
-        this.loading = true;
-        this.apiDataLoading = true;
-        let url = "projects/assets/recent?";
-        // Load from our api client
-        window.ProcessMaker.apiClient
-          .get(
-              url +
-              "asset_types=" +
-              this.types +
-              "&pmql=" +
-              encodeURIComponent(pmql) +
-              "&order_by=" +
-              this.orderBy +
-              "&order_direction=" +
-              this.orderDirection,
-            )
-          .then((response) => {
-            this.data = this.transform(response.data);
-            this.apiDataLoading = false;
-            this.loading = false;
-          }).catch((error) => {
-            ProcessMaker.alert(error.response?.data?.message, "danger");
-            this.data = [];
-          });
-      }
+      if (!this.project) return;
+
+      this.loading = true;
+      this.apiDataLoading = true;
+
+      const params = new URLSearchParams({
+        asset_types: this.types,
+        pmql,
+        order_by: this.orderBy,
+        order_direction: this.orderDirection,
+      });
+
+      window.ProcessMaker.apiClient
+        .get(`projects/assets/recent?${params}`)
+        .then((response) => {
+          this.data = this.transform(response.data);
+        })
+        .catch((error) => {
+          ProcessMaker.alert(error.response?.data?.message, "danger");
+          this.data = [];
+        })
+        .finally(() => {
+          this.apiDataLoading = false;
+          this.loading = false;
+        });
     },
     /**
      * reload page

--- a/resources/js/processes/designer/RecentAssetsList.vue
+++ b/resources/js/processes/designer/RecentAssetsList.vue
@@ -316,7 +316,7 @@ export default {
      * open modal to PM Block
      */
     showPmBlockModal(name, id) {
-      this.processId = id;
+      this.assetId = id;
       this.pmBlockName = name;
       this.$refs["create-pm-block-modal"].show();
     },


### PR DESCRIPTION
## Solution
- The fix was implemented to allow create a PM Block from Recent Assets section in designer page

## How to Test
1. Create a Project
2.Add some Process as Asset
3. Go to Recent Assets section and click on ellipsis menu from previous created project
4. Select Export as PM Block

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-26369

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized Vue UI bugfix and request param refactor; minimal impact outside the Recent Assets table and modal invocation paths.
> 
> **Overview**
> Fixes the Recent Assets designer list so the **“Export as PM Block”** action uses the correct asset id (sets `assetId` instead of `processId`), avoiding the `Object object`/failed modal flow.
> 
> Refactors recent-assets fetching to build query strings via `URLSearchParams`, adds a `finally` to always clear loading flags, and makes a small template cleanup (loader wrapper removal + alt text typo fix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18dbb8195a880b2491a67a335c7f521c723f7957. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->