### PR TITLE
FOUR-29531 The screen does not open when a user belongs to a self-service group

### DIFF
--- a/ProcessMaker/Events/ActivityAssigned.php
+++ b/ProcessMaker/Events/ActivityAssigned.php
@@ -54,6 +54,16 @@ class ActivityAssigned implements ShouldBroadcastNow
     /**
      * Return the process request.
      *
+     * @return \ProcessMaker\Models\ProcessRequest
+     */
+    public function getProcessRequest()
+    {
+        return $this->processRequest;
+    }
+
+    /**
+     * Return the process request token.
+     *
      * @return \ProcessMaker\Models\ProcessRequestToken
      */
     public function getProcessRequestToken()

--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -26,6 +26,9 @@ class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
                     ->getAttribute('process_request_id'),
             ]);
         }
+
+        $user = Auth::user();
+
         $this->setRedirectTo($request,
             'redirectToTask',
             [
@@ -34,7 +37,7 @@ class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
                 'nodeId' => $event->getProcessRequestToken()->element_id,
                 'userId' => $event->getProcessRequestToken()->user_id,
                 'allowInterstitial' => $event->getProcessRequestToken()->getInterstitial()['allow_interstitial'],
-                'userCanClaim' => $event->getProcessRequest()->canUserClaimASelfServiceTask(Auth::user()),
+                'userCanClaim' => !is_null($user) ? $event->getProcessRequest()->canUserClaimASelfServiceTask($user) : false,
             ]
         );
     }

--- a/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
+++ b/ProcessMaker/Listeners/HandleActivityAssignedInterstitialRedirect.php
@@ -2,6 +2,7 @@
 
 namespace ProcessMaker\Listeners;
 
+use Auth;
 use ProcessMaker\Events\ActivityAssigned;
 
 class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
@@ -33,6 +34,7 @@ class HandleActivityAssignedInterstitialRedirect extends HandleRedirectListener
                 'nodeId' => $event->getProcessRequestToken()->element_id,
                 'userId' => $event->getProcessRequestToken()->user_id,
                 'allowInterstitial' => $event->getProcessRequestToken()->getInterstitial()['allow_interstitial'],
+                'userCanClaim' => $event->getProcessRequest()->canUserClaimASelfServiceTask(Auth::user()),
             ]
         );
     }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
If the user can claim the case should be redirected to the next assigned task

Actual behavior: 
The user is not redirected to the next assigned task

## Solution
Use the new attribute "userCanClaim" to determine if the current user can claim the current request

## How to Test

1. Go to server https://develop-qa.processmaker.net/
2. Create a process (start event - task (assign user) - task (self-service group) - task (Previous task assigned) - end event)  
3. Create a normal user
4. Create a Group
5. Assign the user to Group
6. Login with the user
7. Start the request
8. Fill data in the first task
9. Press Submit button
10. The interstitial screen is displayed 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-29531

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.



ci:screen-builder:bugfix/FOUR-29531
ci:deploy