### PR TITLE
MSC - 401 errors after losing session when no action is selected in the warning message

### DIFF
--- a/resources/js/common/sessionSync.js
+++ b/resources/js/common/sessionSync.js
@@ -260,10 +260,16 @@ export const initSessionSync = ({
   const markActivity = (source) => {
     setSessionState(accountTimeoutLength);
     clearWarningState();
+    setSuppressWarning(2000);
     broadcastSessionEvent("activity", { timeout: accountTimeoutLength, source });
     sessionDebugLog("activity", { source, timeout: accountTimeoutLength });
+    const closeSessionModal = resolveCloseSessionModal();
+    if (closeSessionModal) {
+      closeSessionModal();
+    }
     if (isLeader()) {
       ensureWorkerRunning(`activity:${source}`);
+      startTimeoutWorker(sessionState.timeout);
     }
   };
 
@@ -497,20 +503,6 @@ export const initSessionSync = ({
     }
     clearWarningState();
     broadcastSessionEvent("logout");
-  });
-
-  // Restart the timeout worker (when the user interacts with the page)
-  const eventsTimeoutWorker = ["click", "keypress"];
-  eventsTimeoutWorker.forEach((event) => {
-    document.addEventListener(event, () => {
-      if (!isLeader()) {
-        sessionDebugLog("worker:restart:skip", { event });
-        return;
-      }
-      markActivity(event);
-      sessionDebugLog("worker:restart", { event });
-      AccountTimeoutWorker.postMessage({ method: "restart" });
-    });
   });
 
   const isSameDevice = (e) => {


### PR DESCRIPTION
## Issue & Reproduction Steps
Clicking inside or outside the window reset the counter, therefore the window became unstable.

## Solution
- Remove redundant event listeners for timeout worker restart.

## How to Test
Review the session flow.
Click inside or outside the warning window to verify that the counter does not reset.

## Related Tickets & Packages
- [FOUR-29632](https://processmaker.atlassian.net/browse/FOUR-29632)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-29632]: https://processmaker.atlassian.net/browse/FOUR-29632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ