### PR TITLE
Add cases_retention_policy_logs Table and Logging for Case Deletions

### DIFF
--- a/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
+++ b/ProcessMaker/Jobs/EvaluateProcessRetentionJob.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 use ProcessMaker\Http\Controllers\Api\Actions\Cases\DeletesCaseRecords;
 use ProcessMaker\Models\CaseNumber;
 use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Models\CaseRetentionPolicyLog;
 use ProcessMaker\Models\CaseStarted;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
@@ -139,6 +140,8 @@ class EvaluateProcessRetentionJob implements ShouldQueue
         CaseNumber::whereIn('process_request_id', $processRequestSubquery)
             ->where($this->buildRetentionQuery($retentionUpdatedAt, $oldCasesCutoff, $newCasesCutoff))
             ->chunkById(100, function ($cases) use (&$processRequestIdsToDelete, &$totalDeleted, &$chunkCount) {
+                $chunkStartTime = microtime(true);
+
                 $caseIds = $cases->pluck('id')->all();
                 $processRequestIds = $cases->pluck('process_request_id')->unique()->all();
 
@@ -170,10 +173,21 @@ class EvaluateProcessRetentionJob implements ShouldQueue
                 $chunkSize = count($caseIds);
                 $totalDeleted += $chunkSize;
 
+                $chunkTimeMs = round((microtime(true) - $chunkStartTime) * 1000, 2);
+
                 Log::info('EvaluateProcessRetentionJob: Deleted chunk of cases', [
                     'process_id' => $this->processId,
                     'chunk_number' => $chunkCount,
                     'cases_deleted' => $chunkSize,
+                    'deletion_time_ms' => $chunkTimeMs,
+                ]);
+
+                CaseRetentionPolicyLog::create([
+                    'process_id' => $this->processId,
+                    'case_ids' => json_encode($caseIds),
+                    'deleted_count' => $chunkSize,
+                    'total_time_taken' => $chunkTimeMs,
+                    'deleted_at' => Carbon::now(),
                 ]);
             });
 

--- a/ProcessMaker/Models/CaseRetentionPolicyLog.php
+++ b/ProcessMaker/Models/CaseRetentionPolicyLog.php
@@ -5,7 +5,7 @@ namespace ProcessMaker\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use ProcessMaker\Models\ProcessMakerModel;
 
-class CaseRetentionPolicyLogs extends ProcessMakerModel
+class CaseRetentionPolicyLog extends ProcessMakerModel
 {
     use HasFactory;
 

--- a/ProcessMaker/Models/CaseRetentionPolicyLogs.php
+++ b/ProcessMaker/Models/CaseRetentionPolicyLogs.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use ProcessMaker\Models\ProcessMakerModel;
+
+class CaseRetentionPolicyLogs extends ProcessMakerModel
+{
+    use HasFactory;
+
+    protected $table = 'case_retention_policy_logs';
+
+    const UPDATED_AT = null;
+
+    protected $guarded = [
+        'id',
+        'created_at',
+    ];
+
+    protected $fillable = [
+        'process_id',
+        'case_ids',
+        'deleted_count',
+        'total_time_taken',
+        'deleted_at',
+    ];
+}

--- a/database/factories/ProcessMaker/Models/CaseRetentionPolicyLogFactory.php
+++ b/database/factories/ProcessMaker/Models/CaseRetentionPolicyLogFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories\ProcessMaker\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * Model factory for a settings.
+ */
+class CaseRetentionPolicyLogFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'process_id' => function () {
+                return Process::factory()->create()->id;
+            },
+            'case_ids' => json_encode(CaseNumber::factory()->count($this->faker->numberBetween(1, 1000))->create()->pluck('id')->toArray()),
+            'deleted_count' => $this->faker->numberBetween(1, 1000),
+            'total_time_taken' => $this->faker->numberBetween(1, 1000000),
+            'deleted_at' => $this->faker->dateTimeBetween('-1 year', 'now'),
+            'created_at' => $this->faker->dateTimeBetween('-1 year', 'now'),
+        ];
+    }
+}

--- a/database/factories/ProcessMaker/Models/CaseRetentionPolicyLogFactory.php
+++ b/database/factories/ProcessMaker/Models/CaseRetentionPolicyLogFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories\ProcessMaker\Models;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use ProcessMaker\Models\CaseNumber;
+use ProcessMaker\Models\Process;
 
 /**
  * Model factory for a settings.

--- a/database/migrations/2026_02_24_180143_case_retention_policy_logs.php
+++ b/database/migrations/2026_02_24_180143_case_retention_policy_logs.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('case_retention_policy_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('process_id');
+            $table->json('case_ids')->nullable();
+            $table->bigInteger('deleted_count')->default(0);
+
+            $table->bigInteger('total_time_taken')->nullable(); // in seconds
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('case_retention_policy_logs');
+    }
+};

--- a/tests/unit/ProcessMaker/Models/CaseRetentionPolicyLogTest.php
+++ b/tests/unit/ProcessMaker/Models/CaseRetentionPolicyLogTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Models;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use ProcessMaker\Jobs\EvaluateProcessRetentionJob;
+use ProcessMaker\Models\CaseNumber;
+use ProcessMaker\Models\CaseParticipated;
+use ProcessMaker\Models\CaseRetentionPolicyLog;
+use ProcessMaker\Models\CaseStarted;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use Tests\TestCase;
+
+class CaseRetentionPolicyLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testJobAddsLogRecordWhenCasesAreDeleted(): void
+    {
+        Config::set('app.case_retention_policy_enabled', true);
+
+        $process = Process::factory()->create([
+            'properties' => ['retention_period' => 'one_year'],
+        ]);
+        $process->save();
+        $process->refresh();
+
+        $processRequest = ProcessRequest::factory()->create();
+        $processRequest->process_id = $process->id;
+        $processRequest->save();
+        $processRequest->refresh();
+
+        CaseNumber::where('process_request_id', $processRequest->id)->delete();
+
+        $oldCaseCreatedAt = Carbon::now()->subMonths(13)->toIso8601String();
+        $caseOld = CaseNumber::factory()->create([
+            'created_at' => $oldCaseCreatedAt,
+            'process_request_id' => $processRequest->id,
+        ]);
+        CaseStarted::factory()->create(['case_number' => $caseOld->id]);
+        CaseParticipated::factory()->create(['case_number' => $caseOld->id]);
+
+        $this->assertDatabaseCount('case_retention_policy_logs', 0);
+
+        EvaluateProcessRetentionJob::dispatchSync($process->id);
+
+        $this->assertDatabaseCount('case_retention_policy_logs', 1);
+
+        $log = CaseRetentionPolicyLog::first();
+        $this->assertSame((int) $process->id, (int) $log->process_id);
+        $this->assertSame(1, $log->deleted_count);
+        $this->assertNotEmpty($log->total_time_taken);
+        $this->assertIsNumeric($log->total_time_taken);
+        $this->assertNotNull($log->deleted_at);
+
+        $loggedCaseIds = json_decode($log->case_ids, true);
+        $this->assertIsArray($loggedCaseIds);
+        $this->assertContains((int) $caseOld->id, array_map('intval', $loggedCaseIds));
+
+        Config::set('app.case_retention_policy_enabled', false);
+    }
+}


### PR DESCRIPTION
This PR introduces a new database table, `cases_retention_policy_logs`, and logs records whenever the `EvaluateRetentionPolicyJob` deletes cases. Each log entry includes:

- `process_id` – the ID of the process the job ran for
- `case_ids` – the IDs of deleted cases
- `delete_count` – the number of cases deleted
- `total_time_taken` – duration in milliseconds for the job to run
-` created_at` and `deleted_at` timestamps

## How to Test

1. Run unit tests:
```
phpunit tests/unit/ProcessMaker/models/CaseRetentionPolicyLogTest.php
```
Ensure all tests pass.
2. Create a process and update its retention policy.
3. Modify the retention policy in the database to allow deletion of new cases.
4. Run the process to generate cases.
5. Execute the retention job:
```
php artisan cases:retention:evaluate
```
6. Verify that the `cases_retention_policy_logs` table contains proper log entries with the expected fields populated.


## Related Tickets & Packages
- [FOUR-29115](https://processmaker.atlassian.net/browse/FOUR-29115)

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-29115]: https://processmaker.atlassian.net/browse/FOUR-29115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ