### PR TITLE
bugfix/FOUR-26367: Cannot copy a script from the recent asset frame

### DIFF
--- a/resources/js/components/shared/scriptNavigation.js
+++ b/resources/js/components/shared/scriptNavigation.js
@@ -21,7 +21,7 @@ export default {
         onScriptNavigate(action, data) {
             switch (action.value) {
               case "duplicate-item":
-                this.dupScript.title = data.title + " Copy";
+                this.dupScript.title = (data.title || data.name || "") + " Copy";
                 this.dupScript.language = data.language;
                 this.dupScript.code = data.code;
                 this.dupScript.description = data.description;
@@ -36,7 +36,7 @@ export default {
                 ProcessMaker.confirmModal(
                   this.$t("Caution!"),
                    this.$t("Are you sure you want to delete the script {{item}}? Deleting this asset will break any active tasks that are assigned.", {
-                      item: data.title,
+                      item: data.title || data.name,
                     }),
                     "",
                   function() {
@@ -53,7 +53,7 @@ export default {
                 );
                 break;
               case 'add-to-project':
-                this.showAddToProjectModal(data.title, data.id);
+                this.showAddToProjectModal(data.title || data.name, data.id);
                 break;
             }
         },

--- a/resources/js/processes/designer/RecentAssetsList.vue
+++ b/resources/js/processes/designer/RecentAssetsList.vue
@@ -91,6 +91,38 @@
           :assetId="assetId"
           :assetName="assetName"
         />
+        <b-modal ref="duplicateScriptModalRef" :title="$t('Copy Script')" centered header-close-content="&times;">
+          <form>
+            <div class="form-group">
+              <label for="dup-script-title">{{ $t('Name') }}<small class="ml-1">*</small></label>
+              <input
+                id="dup-script-title"
+                type="text"
+                class="form-control"
+                v-model="dupScript.title"
+                v-bind:class="{ 'is-invalid': errors.title }"
+              />
+              <div class="invalid-feedback" role="alert" v-if="errors.title">{{ errors.title[0] }}</div>
+            </div>
+            <div class="form-group">
+              <category-select
+                :label="$t('Category')"
+                api-get="script_categories"
+                api-list="script_categories"
+                v-model="dupScript.script_category_id"
+                :errors="errors.script_category_id"
+              />
+            </div>
+            <div class="form-group">
+              <label for="dup-script-description">{{ $t('Description') }}</label>
+              <textarea id="dup-script-description" class="form-control" rows="3" v-model="dupScript.description" />
+            </div>
+          </form>
+          <div slot="modal-footer" class="w-100 text-right">
+            <button type="button" class="btn btn-outline-secondary" @click="hideDuplicateScriptModal">{{ $t('Cancel') }}</button>
+            <button type="button" @click="onSubmitDuplicateScript" class="btn btn-secondary ml-2">{{ $t('Save') }}</button>
+          </div>
+        </b-modal>
       </div>
     </div>
   </div>
@@ -112,6 +144,7 @@ import AddToProjectModal from "../../components/shared/AddToProjectModal.vue";
 import CreateTemplateModal from "../../components/templates/CreateTemplateModal.vue";
 import CreatePmBlockModal from "../../components/pm-blocks/CreatePmBlockModal.vue";
 import EllipsisMenu from "../../components/shared/EllipsisMenu.vue";
+import CategorySelect from "../categories/components/CategorySelect.vue";
 
 const uniqIdsMixin = createUniqIdsMixin();
 
@@ -121,6 +154,7 @@ export default {
     CreateTemplateModal,
     CreatePmBlockModal,
     EllipsisMenu,
+    CategorySelect,
   },
   mixins: [
     datatableMixin,
@@ -319,6 +353,29 @@ export default {
       this.processId = id;
       this.pmBlockName = name;
       this.$refs["create-pm-block-modal"].show();
+    },
+    /**
+     * Open the duplicate script modal (required by scriptNavigation mixin for "Copy").
+     */
+    showModal() {
+      this.$refs.duplicateScriptModalRef.show();
+    },
+    hideDuplicateScriptModal() {
+      this.$refs.duplicateScriptModalRef.hide();
+    },
+    onSubmitDuplicateScript() {
+      window.ProcessMaker.apiClient
+        .put("scripts/" + this.dupScript.id + "/duplicate", this.dupScript)
+        .then(() => {
+          ProcessMaker.alert(this.$t("The script was duplicated."), "success");
+          this.hideDuplicateScriptModal();
+          this.fetch();
+        })
+        .catch((error) => {
+          if (error.response?.status === 422 && error.response?.data?.errors) {
+            this.errors = error.response.data.errors;
+          }
+        });
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
Issue: We get an error when trying to copy a script from the recenter. Assets

## Solution
- Fix was applied for "Copy" option in ellipsis menu in Recent Assets with Scripts

## How to Test

1. Log in 
2. Go to Designer
3. We see the recent assets frame.
4. Click on the ellipsis menu of a script.
5. Click on copy

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-26367

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
