### PR TITLE
FOUR-29961: APPLICANT >> Improve Draft behavior

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -246,6 +246,7 @@ return [
         'cache_enabled' => env('SCREEN_CACHE_ENABLED', false),
         'cache_timeout' => env('SCREEN_CACHE_TIMEOUT', 5000), // timeout in milliseconds
         'show_secure_handler_toggle' => filter_var(env('SCREEN_SECURE_HANDLER_TOGGLE_VISIBLE', false), FILTER_VALIDATE_BOOLEAN),
+        'merge_draft_on_restore' => filter_var(env('SCREEN_MERGE_DRAFT_ON_RESTORE', true), FILTER_VALIDATE_BOOLEAN),
     ],
 
     'queue_imports' => env('QUEUE_IMPORTS', true),

--- a/resources/js/next/screenBuilder.js
+++ b/resources/js/next/screenBuilder.js
@@ -32,10 +32,12 @@ export default () => {
         const screenCacheEnabled = document.head.querySelector("meta[name=\"screen-cache-enabled\"]")?.content ?? "false";
         const screenCacheTimeout = document.head.querySelector("meta[name=\"screen-cache-timeout\"]")?.content ?? "5000";
         const screenSecureHandlerToggleVisible = document.head.querySelector("meta[name='screen-secure-handler-toggle-visible']");
+        const screenMergeDraftOnRestore = document.head.querySelector("meta[name='screen-merge-draft-on-restore']")?.content ?? "true";
         const screen = {
           cacheEnabled: screenCacheEnabled === "true",
           cacheTimeout: Number(screenCacheTimeout),
           secureHandlerToggleVisible: !!Number(screenSecureHandlerToggleVisible?.content),
+          mergeDraftOnRestore: screenMergeDraftOnRestore === "true",
         };
 
         setGlobalVariable("ScreenBuilder", ScreenBuilder);

--- a/resources/views/layouts/layoutnext.blade.php
+++ b/resources/views/layouts/layoutnext.blade.php
@@ -16,6 +16,7 @@
     <meta name="screen-cache-enabled" content="{{ config('app.screen.cache_enabled') ? 'true' : 'false' }}">
     <meta name="screen-cache-timeout" content="{{ config('app.screen.cache_timeout') }}">
     <meta name="screen-secure-handler-toggle-visible" content="{{ config('app.screen.show_secure_handler_toggle') }}">
+    <meta name="screen-merge-draft-on-restore" content="{{ config('app.screen.merge_draft_on_restore') ? 'true' : 'false' }}">
     <meta name="settings-translations-enabled" content="{{ config('translations.enabled') ? 'true' : 'false' }}">
     @include('layouts.common-meta')
     @if(Auth::user())


### PR DESCRIPTION
## Issue & Reproduction Steps

Currently the draft are restored using a merge aproach, this cause problems when the user remove elements from arrays like RecordLists.

As a developer I want to have an env property to replace the saved data instead of merging it. 
For backward compatibility keep the merge behavior.
SCREEN_MERGE_DRAFT_ON_RESTORE=true

In the screen builder/renderer side:
ProcessMaker.screen.mergeDraftOnRestore


## Solution
- Create mergeDraftOnRestore envirenment variable to manage the screen draft merge
<img width="1728" height="966" alt="image" src="https://github.com/user-attachments/assets/8c2eda1f-3b35-4a8c-bb18-f0d21595c5d7" />

## How to Test
set SCREEN_MERGE_DRAFT_ON_RESTORE=true or false
in developer tools see teh variable as the previous picture


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-29961

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:screen-builder:feature/FOUR-29961
