### PR TITLE
task/FOUR-30041: Account Lock Fails to Invalidate Active Login Session

### DIFF
--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -42,6 +42,7 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             Middleware\SessionStarted::class,
             Middleware\AuthenticateSession::class,
+            Middleware\EnsureAccountAllowsAccess::class,
             Middleware\SessionControlKill::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             //\ProcessMaker\Http\Middleware\VerifyCsrfToken::class,

--- a/ProcessMaker/Http/Middleware/EnsureAccountAllowsAccess.php
+++ b/ProcessMaker/Http/Middleware/EnsureAccountAllowsAccess.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Models\User;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureAccountAllowsAccess
+{
+    /**
+     * Status values that cannot use the application while authenticated (aligned with LoginController).
+     */
+    private const DENIED_STATUSES = ['BLOCKED', 'INACTIVE'];
+
+    /**
+     * If any active guard has a blocked/inactive user, log out and return the appropriate response.
+     * Used by the web middleware group and by ProcessMakerAuthenticate (covers all auth:api routes, including packages).
+     */
+    public static function blockingResponseForRequest(Request $request): ?Response
+    {
+        foreach (['web', 'api'] as $guard) {
+            if (!Auth::guard($guard)->check()) {
+                continue;
+            }
+
+            /** @var User $user */
+            $user = Auth::guard($guard)->user();
+            if (!$user instanceof User || !in_array($user->status, self::DENIED_STATUSES, true)) {
+                continue;
+            }
+
+            return self::denyAccess($request, $guard, $user);
+        }
+
+        return null;
+    }
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $blocked = self::blockingResponseForRequest($request);
+        if ($blocked !== null) {
+            return $blocked;
+        }
+
+        return $next($request);
+    }
+
+    public static function denyAccess(Request $request, string $guard, User $user): Response
+    {
+        Auth::guard($guard)->logout();
+
+        if ($request->hasSession()) {
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+        }
+
+        if ($guard === 'api' || $request->expectsJson()) {
+            $message = $user->status === 'BLOCKED'
+                ? __('Account locked after too many failed attempts. Contact administrator.')
+                : __('Unauthorized');
+
+            return response()->json(['message' => $message], 401);
+        }
+
+        return redirect()
+            ->guest(route('login'))
+            ->withErrors([
+                'username' => $user->status === 'BLOCKED'
+                    ? __('Account locked after too many failed attempts. Contact administrator.')
+                    : __('These credentials do not match our records.'),
+            ]);
+    }
+}

--- a/ProcessMaker/Http/Middleware/ProcessMakerAuthenticate.php
+++ b/ProcessMaker/Http/Middleware/ProcessMakerAuthenticate.php
@@ -2,11 +2,29 @@
 
 namespace ProcessMaker\Http\Middleware;
 
+use Closure;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Support\Str;
 
 class ProcessMakerAuthenticate extends Authenticate
 {
+    /**
+     * {@inheritdoc}
+     *
+     * After a successful authenticate(), reject BLOCKED/INACTIVE users so every auth:api route
+     * (core and packages) is covered without listing middleware per route file.
+     */
+    public function handle($request, Closure $next, ...$guards)
+    {
+        $this->authenticate($request, $guards);
+
+        if ($blocked = EnsureAccountAllowsAccess::blockingResponseForRequest($request)) {
+            return $blocked;
+        }
+
+        return $next($request);
+    }
+
     protected function authenticate($request, array $guards)
     {
         $this->addAcceptJsonHeaderIfApiCall($request, $guards);


### PR DESCRIPTION
ci:performance-tests
.

# Description
During the web application penetration test, it was identified that when an administrator locks or disables a user account, any already established active sessions for that user remain valid and functional.

Although the application correctly prevents new login attempts for the locked account, previously issued session tokens are not invalidated or terminated. As a result, a user who was locked out by an administrator can continue accessing the application using their existing authenticated session.


# Solution
- Add middleware to block authenticated users whose status is BLOCKED or INACTIVE. 
- Introduces EnsureAccountAllowsAccess middleware (with blockingResponseForRequest and denyAccess helpers) that logs out the user, invalidates the session, and returns a JSON 401 for API requests or redirects to login with appropriate error messages for web requests. 
- Wire the middleware into the HTTP kernel and update ProcessMakerAuthenticate to invoke the same blocking check after successful authentication so auth:api routes (core and packages) are also enforced.


https://github.com/user-attachments/assets/697a7cec-4383-46a7-a14a-d5ed16a0b93d


https://github.com/user-attachments/assets/feed9f21-468d-4c3d-b32a-923b57191c5f



# Related Tickets and PRs
https://processmaker.atlassian.net/browse/FOUR-30041