### PR TITLE
FOUR-29252: Long project names overflow Data Connector creation modal boundaries

### DIFF
--- a/resources/js/components/shared/ProjectSelect.vue
+++ b/resources/js/components/shared/ProjectSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="form-group">
+  <div class="form-group project-select">
     <label>{{ $t(label) }}</label>
     <multiselect
       v-model="content"
@@ -14,10 +14,26 @@
       :show-labels="false"
       :searchable="true"
       :internal-search="true"
+      class="project-select__multiselect"
       @open="load()"
       @search-change="load"
       @select="(selected) => lastSelectedId = selected.id"
     >
+      <template slot="tag" slot-scope="slotProps">
+        <span
+          class="project-select__tag multiselect__tag"
+          :title="slotProps.option.title"
+        >
+          <span class="project-select__tag-label">{{ slotProps.option.title }}</span>
+          <i
+            aria-hidden="true"
+            tabindex="1"
+            class="multiselect__tag-icon"
+            @mousedown.prevent
+            @click="slotProps.remove(slotProps.option)"
+          />
+        </span>
+      </template>
       <template slot="noResult">
         {{ $t('No elements found. Consider changing the search query.') }}
       </template>
@@ -147,3 +163,38 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.project-select {
+  min-width: 0;
+}
+
+.project-select__multiselect {
+  min-width: 0;
+}
+
+.project-select__tag {
+  align-items: center;
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.project-select__tag-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+::v-deep .multiselect__tags {
+  max-width: 100%;
+}
+
+::v-deep .multiselect__tags-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  max-width: 100%;
+}
+</style>


### PR DESCRIPTION
## Issue & Reproduction Steps
FOUR-29252: Long project names overflow Data Connector creation modal boundaries
Ticket: https://processmaker.atlassian.net/browse/FOUR-29252

Long project names in the Data Connector creation modal caused the selected project chip to overflow and break the modal layout.

1. Create a project with a long name such as "E2E QA Integration Testing Project for ProcessMaker".
2. Go to /designer/data-sources, open "+ Data Connector", select that project in the Project field, and observe the selected chip overflowing the modal boundaries.

## Solution
- Updated the shared Project selector to render selected project chips with constrained width, ellipsis truncation, wrapping-safe tag layout, and a hover tooltip showing the full project name.
- Added a shrink guard to the Data Connector basic-information two-column grid so the Project field can compress inside the modal without forcing horizontal overflow.

## How to Test
1. Open the Data Connector creation modal from /designer/data-sources and select a project with a very long name.
2. Verify the selected project chip stays inside the modal, shows truncated text with ellipsis, and the full name is available on hover.
3. Confirm the modal keeps its width, no horizontal overflow appears, and removing/reselecting the project still works normally.
4. Optionally open another modal that uses the shared Project selector, such as Add to Project, and verify long project names are also contained correctly there.

## Related Tickets & Packages
- FOUR-29252: https://processmaker.atlassian.net/browse/FOUR-29252
- [Package Data Source PR](https://github.com/ProcessMaker/package-data-sources/pull/483)

ci:deploy
ci:package-data-sources:task/FOUR-29252