### PR TITLE
Account Lock Bypass via Password Reset Flow

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ForgotPasswordController.php
@@ -35,7 +35,7 @@ class ForgotPasswordController extends Controller
 
     /**
      * Send a reset link to the given user.
-     * Blocked users will not receive the reset email for security reasons.
+     * Blocked or inactive users will not receive the reset email for security reasons.
      *
      * @param  Request  $request
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
@@ -46,7 +46,7 @@ class ForgotPasswordController extends Controller
 
         $user = User::where('email', $request->input('email'))->first();
 
-        if ($user && $user->status === 'BLOCKED') {
+        if ($user && ($user->status === 'BLOCKED' || $user->status === 'INACTIVE')) {
             return $this->sendResetLinkResponse($request, Password::RESET_LINK_SENT);
         }
 

--- a/ProcessMaker/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ForgotPasswordController.php
@@ -3,7 +3,10 @@
 namespace ProcessMaker\Http\Controllers\Auth;
 
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
 use ProcessMaker\Http\Controllers\Controller;
+use ProcessMaker\Models\User;
 
 class ForgotPasswordController extends Controller
 {
@@ -28,5 +31,31 @@ class ForgotPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+    }
+
+    /**
+     * Send a reset link to the given user.
+     * Blocked users will not receive the reset email for security reasons.
+     *
+     * @param  Request  $request
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    public function sendResetLinkEmail(Request $request)
+    {
+        $this->validateEmail($request);
+
+        $user = User::where('email', $request->input('email'))->first();
+
+        if ($user && $user->status === 'BLOCKED') {
+            return $this->sendResetLinkResponse($request, Password::RESET_LINK_SENT);
+        }
+
+        $response = $this->broker()->sendResetLink(
+            $this->credentials($request)
+        );
+
+        return $response == Password::RESET_LINK_SENT
+            ? $this->sendResetLinkResponse($request, $response)
+            : $this->sendResetLinkFailedResponse($request, $response);
     }
 }

--- a/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
@@ -20,7 +20,9 @@ class ResetPasswordController extends Controller
     |
     */
 
-    use ResetsPasswords;
+    use ResetsPasswords {
+        reset as protected performPasswordReset;
+    }
 
     /**
      * Where to redirect users after resetting their password.
@@ -46,8 +48,35 @@ class ResetPasswordController extends Controller
      */
     public function showResetForm(Request $request, $token)
     {
-        $username = User::where('email', $request->input('email'))->firstOrFail()->username;
+        $user = User::where('email', $request->input('email'))->firstOrFail();
 
-        return view('auth.passwords.reset', compact('username', 'token'));
+        if ($user->status === 'BLOCKED') {
+            return redirect()->route('password.request')
+                ->withErrors(['email' => __('passwords.blocked')]);
+        }
+
+        return view('auth.passwords.reset', [
+            'username' => $user->username,
+            'token' => $token,
+            'email' => $request->input('email'),
+        ]);
+    }
+
+    /**
+     * Reset the given user's password.
+     * Blocked users cannot reset their password.
+     *
+     * @param  Request  $request
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    public function reset(Request $request)
+    {
+        $user = User::where('email', $request->input('email'))->first();
+
+        if ($user && $user->status === 'BLOCKED') {
+            return $this->sendResetFailedResponse($request, 'passwords.blocked');
+        }
+
+        return $this->performPasswordReset($request);
     }
 }

--- a/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
@@ -55,6 +55,11 @@ class ResetPasswordController extends Controller
                 ->withErrors(['email' => __('passwords.blocked')]);
         }
 
+        if ($user->status === 'INACTIVE') {
+            return redirect()->route('password.request')
+                ->withErrors(['email' => __('passwords.inactive')]);
+        }
+
         return view('auth.passwords.reset', [
             'username' => $user->username,
             'token' => $token,
@@ -64,7 +69,7 @@ class ResetPasswordController extends Controller
 
     /**
      * Reset the given user's password.
-     * Blocked users cannot reset their password.
+     * Blocked or inactive users cannot reset their password.
      *
      * @param  Request  $request
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
@@ -75,6 +80,10 @@ class ResetPasswordController extends Controller
 
         if ($user && $user->status === 'BLOCKED') {
             return $this->sendResetFailedResponse($request, 'passwords.blocked');
+        }
+
+        if ($user && $user->status === 'INACTIVE') {
+            return $this->sendResetFailedResponse($request, 'passwords.inactive');
         }
 
         return $this->performPasswordReset($request);

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1547,6 +1547,7 @@
   "passwords.token": "This password reset token is invalid.",
   "passwords.user": "We can't find a user with that e-mail address.",
   "passwords.blocked": "Your account has been blocked. Please contact your administrator.",
+  "passwords.inactive": "Your account is inactive. Please contact your administrator.",
   "Pause Start Timer Events": "Pause Start Timer Events",
   "Pause Timer Start Events": "Pause Timer Start Events",
   "per page": "per page",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1546,6 +1546,7 @@
   "passwords.sent": "We have e-mailed your password reset link!",
   "passwords.token": "This password reset token is invalid.",
   "passwords.user": "We can't find a user with that e-mail address.",
+  "passwords.blocked": "Your account has been blocked. Please contact your administrator.",
   "Pause Start Timer Events": "Pause Start Timer Events",
   "Pause Timer Start Events": "Pause Timer Start Events",
   "per page": "per page",

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -19,5 +19,6 @@ return [
     'token' => 'This password reset token is invalid.',
     'user' => "We can't find a user with that email address.",
     'blocked' => 'Your account has been blocked. Please contact your administrator.',
+    'inactive' => 'Your account is inactive. Please contact your administrator.',
 
 ];

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -18,5 +18,6 @@ return [
     'throttled' => 'Please wait before retrying.',
     'token' => 'This password reset token is invalid.',
     'user' => "We can't find a user with that email address.",
+    'blocked' => 'Your account has been blocked. Please contact your administrator.',
 
 ];

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -15,7 +15,7 @@
       <input type="hidden" name="token" value="{{ $token }}">
       <div class="form-group">
         <label for="email">{{__('Email Address')}}</label>
-        <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email">
+        <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email ?? old('email') }}">
         @if ($errors->has('email'))
         <span class="
         invalid-feedback" role="alert">

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -29,6 +29,23 @@ class PasswordResetTest extends TestCase
         Notification::assertNothingSent();
     }
 
+    public function testForgotPasswordDoesNotNotifyInactiveUser(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'inactive-forgot@example.com',
+            'status' => 'INACTIVE',
+        ]);
+
+        $response = $this->post(route('password.email'), [
+            'email' => $user->email,
+        ]);
+
+        $response->assertSessionHas('status');
+        Notification::assertNothingSent();
+    }
+
     public function testForgotPasswordSendsNotificationToActiveUser(): void
     {
         Notification::fake();
@@ -57,7 +74,25 @@ class PasswordResetTest extends TestCase
         $response = $this->get($url . '?email=' . urlencode($user->email));
 
         $response->assertRedirect(route('password.request'));
-        $response->assertSessionHasErrors('email');
+        $response->assertSessionHasErrors([
+            'email' => __('passwords.blocked'),
+        ]);
+    }
+
+    public function testShowResetFormRedirectsInactiveUserToRequestForm(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'inactive-reset-form@example.com',
+            'status' => 'INACTIVE',
+        ]);
+
+        $url = route('password.reset', ['token' => 'unused-token']);
+        $response = $this->get($url . '?email=' . urlencode($user->email));
+
+        $response->assertRedirect(route('password.request'));
+        $response->assertSessionHasErrors([
+            'email' => __('passwords.inactive'),
+        ]);
     }
 
     public function testShowResetFormDisplaysForActiveUser(): void
@@ -94,6 +129,25 @@ class PasswordResetTest extends TestCase
 
         $response->assertSessionHasErrors([
             'email' => __('passwords.blocked'),
+        ]);
+    }
+
+    public function testResetPasswordRejectsInactiveUser(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'inactive-reset-post@example.com',
+            'status' => 'INACTIVE',
+        ]);
+
+        $response = $this->from(route('password.request'))->post('/password/reset', [
+            'token' => 'will-not-be-used',
+            'email' => $user->email,
+            'password' => 'NewPassword123!',
+            'password_confirmation' => 'NewPassword123!',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => __('passwords.inactive'),
         ]);
     }
 

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use Illuminate\Auth\Passwords\PasswordBroker as ConcretePasswordBroker;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use ProcessMaker\Models\User;
+use ProcessMaker\Notifications\ResetPassword as ResetPasswordNotification;
+use Tests\TestCase;
+
+class PasswordResetTest extends TestCase
+{
+    public function testForgotPasswordDoesNotNotifyBlockedUser(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'blocked-forgot@example.com',
+            'status' => 'BLOCKED',
+        ]);
+
+        $response = $this->post(route('password.email'), [
+            'email' => $user->email,
+        ]);
+
+        $response->assertSessionHas('status');
+        Notification::assertNothingSent();
+    }
+
+    public function testForgotPasswordSendsNotificationToActiveUser(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'active-forgot@example.com',
+            'status' => 'ACTIVE',
+        ]);
+
+        $response = $this->post(route('password.email'), [
+            'email' => $user->email,
+        ]);
+
+        $response->assertSessionHas('status');
+        Notification::assertSentTo($user, ResetPasswordNotification::class);
+    }
+
+    public function testShowResetFormRedirectsBlockedUserToRequestForm(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'blocked-reset-form@example.com',
+            'status' => 'BLOCKED',
+        ]);
+
+        $url = route('password.reset', ['token' => 'unused-token']);
+        $response = $this->get($url . '?email=' . urlencode($user->email));
+
+        $response->assertRedirect(route('password.request'));
+        $response->assertSessionHasErrors('email');
+    }
+
+    public function testShowResetFormDisplaysForActiveUser(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'active-reset-form@example.com',
+            'status' => 'ACTIVE',
+            'username' => 'active_reset_user',
+        ]);
+
+        $url = route('password.reset', ['token' => 'some-token']);
+        $response = $this->get($url . '?email=' . urlencode($user->email));
+
+        $response->assertOk();
+        $response->assertViewIs('auth.passwords.reset');
+        $response->assertViewHas('email', $user->email);
+        $response->assertViewHas('username', $user->username);
+        $response->assertViewHas('token', 'some-token');
+    }
+
+    public function testResetPasswordRejectsBlockedUser(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'blocked-reset-post@example.com',
+            'status' => 'BLOCKED',
+        ]);
+
+        $response = $this->from(route('password.request'))->post('/password/reset', [
+            'token' => 'will-not-be-used',
+            'email' => $user->email,
+            'password' => 'NewPassword123!',
+            'password_confirmation' => 'NewPassword123!',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => __('passwords.blocked'),
+        ]);
+    }
+
+    public function testResetPasswordUpdatesPasswordForActiveUser(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'active-reset-post@example.com',
+            'status' => 'ACTIVE',
+        ]);
+
+        /** @var ConcretePasswordBroker $broker */
+        $broker = Password::broker();
+        $token = $broker->createToken($user);
+        $plaintextSecret = 'NewSecurePass123!';
+
+        $response = $this->post('/password/reset', [
+            'token' => $token,
+            'email' => $user->email,
+            'password' => $plaintextSecret,
+            'password_confirmation' => $plaintextSecret,
+        ]);
+
+        $response->assertRedirect('/password/success');
+        $response->assertSessionHas('status');
+
+        $user->refresh();
+        $this->assertTrue(Hash::check($plaintextSecret, $user->password));
+        $this->assertAuthenticatedAs($user, 'web');
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
During the process of resetting a password in the Forgot Password section, it was possible to access the user's session even if the user was locked out.

## Solution
- Now, if a user is locked out and accesses the Forgot Password section, they are no longer sent the password reset email.

## How to Test
This should be tested with both active and locked users in the Forgot Password section.

## Related Tickets & Packages
- [FOUR-30040](https://processmaker.atlassian.net/browse/FOUR-30040)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-30040]: https://processmaker.atlassian.net/browse/FOUR-30040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ