### PR TITLE
Security/FOUR-30042: Duplicate Email Allowed Across Multiple Accounts

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
@@ -4,6 +4,8 @@ namespace ProcessMaker\Http\Controllers\Auth;
 
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Models\User;
 
@@ -76,7 +78,9 @@ class ResetPasswordController extends Controller
      */
     public function reset(Request $request)
     {
-        $user = User::where('email', $request->input('email'))->first();
+        $user = User::where('email', $request->input('email'))
+            ->where('username', $request->input('username'))
+            ->first();
 
         if ($user && $user->status === 'BLOCKED') {
             return $this->sendResetFailedResponse($request, 'passwords.blocked');
@@ -86,6 +90,56 @@ class ResetPasswordController extends Controller
             return $this->sendResetFailedResponse($request, 'passwords.inactive');
         }
 
+        if (!$user) {
+            return redirect()->back()
+                ->withInput($request->only('email', 'username'))
+                ->withErrors(['email' => __('passwords.account_not_found')]);
+        }
+
         return $this->performPasswordReset($request);
+    }
+
+    /**
+     * Get the password reset validation rules.
+     */
+    protected function rules(): array
+    {
+        return [
+            'token' => 'required',
+            'email' => 'required|email',
+            'username' => 'required|string',
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ];
+    }
+
+    /**
+     * Get the password reset credentials from the request.
+     * Include username so the broker resolves the same user as email+username (not email alone).
+     */
+    protected function credentials(Request $request): array
+    {
+        return $request->only(
+            'email',
+            'username',
+            'password',
+            'password_confirmation',
+            'token'
+        );
+    }
+
+    /**
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    protected function sendResetFailedResponse(Request $request, $response)
+    {
+        if ($request->wantsJson()) {
+            throw ValidationException::withMessages([
+                'email' => [trans($response)],
+            ]);
+        }
+
+        return redirect()->back()
+            ->withInput($request->only('email', 'username'))
+            ->withErrors(['email' => trans($response)]);
     }
 }

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -20,5 +20,6 @@ return [
     'user' => "We can't find a user with that email address.",
     'blocked' => 'Your account has been blocked. Please contact your administrator.',
     'inactive' => 'Your account is inactive. Please contact your administrator.',
+    'account_not_found' => 'We could not find an account with the data provided.',
 
 ];

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -25,6 +25,10 @@
 
       </div>
       <div class="form-group">
+        <label for="username">{{__('Username')}}</label>
+        <input id="username" type="text" class="form-control" name="username" value="{{ old('username') }}" autocomplete="username" autocapitalize="none" spellcheck="false">
+      </div>
+      <div class="form-group">
         <label for="password">{{__('New Password')}}</label>
         <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password">
         @if ($errors->has('password'))

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -123,6 +123,7 @@ class PasswordResetTest extends TestCase
         $response = $this->from(route('password.request'))->post('/password/reset', [
             'token' => 'will-not-be-used',
             'email' => $user->email,
+            'username' => $user->username,
             'password' => 'NewPassword123!',
             'password_confirmation' => 'NewPassword123!',
         ]);
@@ -142,6 +143,7 @@ class PasswordResetTest extends TestCase
         $response = $this->from(route('password.request'))->post('/password/reset', [
             'token' => 'will-not-be-used',
             'email' => $user->email,
+            'username' => $user->username,
             'password' => 'NewPassword123!',
             'password_confirmation' => 'NewPassword123!',
         ]);
@@ -149,6 +151,35 @@ class PasswordResetTest extends TestCase
         $response->assertSessionHasErrors([
             'email' => __('passwords.inactive'),
         ]);
+    }
+
+    public function testResetPasswordRejectsWrongUsername(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'wrong-username-reset@example.com',
+            'username' => 'correct_username',
+            'status' => 'ACTIVE',
+        ]);
+
+        /** @var ConcretePasswordBroker $broker */
+        $broker = Password::broker();
+        $token = $broker->createToken($user);
+
+        $response = $this->from(route('password.reset', ['token' => $token]))->post('/password/reset', [
+            'token' => $token,
+            'email' => $user->email,
+            'username' => 'some_other_username',
+            'password' => 'NewSecurePass123!',
+            'password_confirmation' => 'NewSecurePass123!',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => __('passwords.account_not_found'),
+        ]);
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('oneOnlyPassword', $user->password));
     }
 
     public function testResetPasswordUpdatesPasswordForActiveUser(): void
@@ -167,6 +198,7 @@ class PasswordResetTest extends TestCase
         $response = $this->post('/password/reset', [
             'token' => $token,
             'email' => $user->email,
+            'username' => $user->username,
             'password' => $plaintextSecret,
             'password_confirmation' => $plaintextSecret,
         ]);


### PR DESCRIPTION
# Description
- Include username in combination with email to validate when using the reset password.


https://github.com/user-attachments/assets/60a33be5-322f-4014-8459-ab92b92d6a1f

ci:deploy 

...

# Related Tickets and PRs
https://processmaker.atlassian.net/browse/FOUR-30042