### PR TITLE
Task/FOUR-28351: [48621] AUDIT EXCEPTIONS ON PROCESS MAKER for SameSite

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -91,7 +91,7 @@ class LoginController extends Controller
                     true,
                     true,
                     false,
-                    'none'
+                    $this->sessionSameSite()
                 );
 
                 // Redirect to SSO and attach the cookie
@@ -111,7 +111,7 @@ class LoginController extends Controller
             true,
             true,
             false,
-            'none'
+            $this->sessionSameSite()
         );
         $loginView = empty(config('app.login_view')) ? 'auth.login' : config('app.login_view');
         $response = response(view($loginView, compact('addons', 'block')));
@@ -358,7 +358,7 @@ class LoginController extends Controller
                     true,
                     true,
                     false,
-                    'none',
+                    $this->sessionSameSite(),
                 );
 
                 return redirect()->route('password.change');
@@ -405,5 +405,10 @@ class LoginController extends Controller
             $user->language = json_decode($language)->code;
             $user->save();
         }
+    }
+
+    private function sessionSameSite(): string
+    {
+        return config('session.same_site') ?: 'lax';
     }
 }

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -264,7 +264,17 @@ class TaskController extends Controller
             // Review if the autentication is required
             if ($abe->require_login && Auth::user()->username === AnonymousUser::ANONYMOUS_USERNAME) {
                 $request->session()->put('url.intended', url()->full());
-                $cookie = cookie('processmaker_intended', url()->full(), 10, '/');
+                $cookie = cookie(
+                    'processmaker_intended',
+                    url()->full(),
+                    10,
+                    '/',
+                    null,
+                    true,
+                    true,
+                    false,
+                    config('session.same_site') ?: 'lax'
+                );
 
                 return redirect('login')->withCookie($cookie);
             }


### PR DESCRIPTION
# Description
- Add `sessionSame` header to `processmaker_intended` cookie. By default uses `lax` but it can be configured in the .env file using `SESSION_SAME_SITE=strict`, `SESSION_SAME_SITE=none`, `SESSION_SAME_SITE=lax`


https://github.com/user-attachments/assets/96804749-a1a2-4535-817a-388486a41ded


# Related tickets and PRs
https://processmaker.atlassian.net/browse/FOUR-28351
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/8761)
- [Package webentry PR](https://github.com/ProcessMaker/package-webentry/pull/293)


ci:package-webentry:task/FOUR-28351
ci:deploy
