### PR TITLE
Restrict Case Retention Policy Configuration to Admin Users

### DIFF
--- a/resources/views/processes/edit.blade.php
+++ b/resources/views/processes/edit.blade.php
@@ -347,7 +347,7 @@
                                 </div>
                             </div>
 
-                            @if(config('app.case_retention_policy_enabled'))
+                            @if(config('app.case_retention_policy_enabled') && auth()->user()->is_administrator)
                             <div class="card card-custom-info">
                               <div class="card-header"
                                    id="headingCasesRetention">


### PR DESCRIPTION
This PR restricts visibility of the Case Retention Policy configuration within Process Configuration to admin users only.

## Solution
- Added a conditional check to verify the authenticated user has admin permissions before displaying the Case Retention Policy section

## How to Test

1. Log in as a non-admin user
2. Navigate to the Process Configuration screen
3. Ensure the Case Retention Policy section is not visible

## Related Tickets & Packages
- [FOUR-30263](https://processmaker.atlassian.net/browse/FOUR-30263)

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-30263]: https://processmaker.atlassian.net/browse/FOUR-30263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ