### PR TITLE
Enforce Admin-Only Updates for Case Retention Policy via API

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -601,11 +601,9 @@ class ProcessController extends Controller
             }
         }
 
-        // Prevent non-administrators from updating the retention period
+        // Non-administrators cannot change retention metadata: persist pre-request values.
         if (!auth()->user()->is_administrator) {
-            unset($process->properties['retention_updated_by']);
-            unset($process->properties['retention_updated_at']);
-            unset($process->properties['retention_period']);
+            $this->restoreProcessRetentionPropertiesFromOriginal($process, $original);
         }
 
         // Catch errors to send more specific status
@@ -675,6 +673,40 @@ class ProcessController extends Controller
         }
 
         return $managerIds;
+    }
+
+    /**
+     * Re-apply retention-related keys on $process->properties from the model snapshot taken before fill().
+     * Non-admins cannot add these keys if absent originally, or change values if present.
+     *
+     * @param  array<string, mixed>  $original
+     */
+    private function restoreProcessRetentionPropertiesFromOriginal(Process $process, array $original): void
+    {
+        $originalProperties = $original['properties'] ?? null;
+        if (is_string($originalProperties)) {
+            $decoded = json_decode($originalProperties, true);
+            $originalProperties = is_array($decoded) ? $decoded : [];
+        }
+        if (!is_array($originalProperties)) {
+            $originalProperties = [];
+        }
+
+        $properties = $process->properties;
+        if (!is_array($properties)) {
+            $properties = [];
+        }
+
+        $keys = ['retention_updated_by', 'retention_updated_at', 'retention_period'];
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $originalProperties)) {
+                $properties[$key] = $originalProperties[$key];
+            } else {
+                unset($properties[$key]);
+            }
+        }
+
+        $process->properties = $properties;
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -601,6 +601,13 @@ class ProcessController extends Controller
             }
         }
 
+        // Prevent non-administrators from updating the retention period
+        if (!auth()->user()->is_administrator) {
+            unset($process->properties['retention_updated_by']);
+            unset($process->properties['retention_updated_at']);
+            unset($process->properties['retention_period']);
+        }
+
         // Catch errors to send more specific status
         try {
             $process->saveOrFail();
@@ -614,13 +621,6 @@ class ProcessController extends Controller
         }
         $changes = $process->getChanges();
         $changes['tmp_process_category_id'] = $request->input('process_category_id');
-
-        // Prevent non-administrators from updating the retention period
-        if (!auth()->user()->is_administrator) {
-            unset($changes['properties']['retention_updated_by']);
-            unset($changes['properties']['retention_updated_at']);
-            unset($changes['properties']['retention_period']);
-        }
 
         // Register the Event
         ProcessPublished::dispatch($process->refresh(), $changes, $original);

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -615,6 +615,13 @@ class ProcessController extends Controller
         $changes = $process->getChanges();
         $changes['tmp_process_category_id'] = $request->input('process_category_id');
 
+        // Prevent non-administrators from updating the retention period
+        if (!auth()->user()->is_administrator) {
+            unset($changes['properties']['retention_updated_by']);
+            unset($changes['properties']['retention_updated_at']);
+            unset($changes['properties']['retention_period']);
+        }
+
         // Register the Event
         ProcessPublished::dispatch($process->refresh(), $changes, $original);
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves an issue where non-admin users were able to modify Case Retention Policy configurations via the API. With this change, only admin users can update retention-related fields, ensuring proper authorization at the backend level.

## Solution
- Added a check to verify if the authenticated user is an admin before persisting retention-related configuration changes
- For non-admin users, retention-related fields are reverted to their original values prior to saving

## How to Test

1. Authenticate as a non-admin user
2. Send a PUT request to `/api/1.0/processes/{id}` with retention policy updates
3. Verify that retention-related changes are not persisted

## Related Tickets & Packages
- [FOUR-30278](https://processmaker.atlassian.net/browse/FOUR-30278)

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-30278]: https://processmaker.atlassian.net/browse/FOUR-30278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ