### PR TITLE
Add support for SMART_EXTRACT env variables in ScriptMicroserviceRunner

### DIFF
--- a/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
@@ -136,6 +136,8 @@ class ScriptMicroserviceRunner
             $variablesParameter['API_HOST'] = config('app.docker_host_url') . '/api/1.0';
             $variablesParameter['APP_URL'] = config('app.docker_host_url');
             $variablesParameter['API_SSL_VERIFY'] = (config('app.api_ssl_verify') ? '1' : '0');
+            $variablesParameter['SMART_EXTRACT_API_HOST'] = config('smart-extract.api_host');
+            $variablesParameter['SMART_EXTRACT_REQUEST_TIMEOUT'] = config('smart-extract.request_timeout');
         }
 
         return $variablesParameter;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR updates `ScriptMicroserviceRunner.php` to include the `SMART_EXTRACT_API_HOST` and `SMART_EXTRACT_REQUEST_TIMEOUT` environment variable in the list of accessible variables for the Scripts microservice.

Previously, only a limited set of environment variables were available by default, which caused `getenv('SMART_EXTRACT_API_HOST')` to return null. With this change, the Smart Extract package can now correctly retrieve the host value using `getenv()`.


## Related Tickets & Packages
- [FOUR-30560](https://processmaker.atlassian.net/browse/FOUR-30560)

ci:deploy


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-30560]: https://processmaker.atlassian.net/browse/FOUR-30560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ