### PR TITLE
Add New Case Retention Policy Logs Icon to Admin Sidebar

### DIFF
--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -126,7 +126,7 @@ class GenerateMenus
                 if (config('app.case_retention_policy_enabled')) {
                     $submenu->add(__('Cases Retention Logs'), [
                         'route' => 'cases-retention.index',
-                        'icon' => 'fa-clock',
+                        'icon' => 'fa-sync-alt',
                     ]);
                 }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR introduces a new Case Retention Policy Logs icon within the Admin section sidebar navigation. This provides administrators with direct access to the Case Retention Policy Logs screen.

## Solution
- Added new sidebar icon entry under Admin > Case Retention Policy Logs


## How to Test

1. Log in
2. Navigate to the Admin section
3. Verify that the Case Retention Policy Logs icon is visible in the sidebar menu
4. Confirm the icon properly routes to the Case Retention Policy Logs screen

## Related Tickets & Packages
- [FOUR-29760](https://processmaker.atlassian.net/browse/FOUR-29760)

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-29760]: https://processmaker.atlassian.net/browse/FOUR-29760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ