### PR TITLE
FOUR-30726 REGRESSION >> Public files are not displayed on screens

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -216,7 +216,7 @@ class ProcessRequestFileController extends Controller
         // we are in chunk mode, lets send the current progress
         /** @var AbstractHandler $handler */
         $handler = $save->handler();
-
+        \Illuminate\Support\Facades\Log::info("b2");
         return response()->json([
             'done' => $handler->getPercentageDone(),
         ]);
@@ -356,7 +356,7 @@ class ProcessRequestFileController extends Controller
         $media = $model
             ->addMedia($file)
             ->withCustomProperties([
-                'data_name' => $data_name,
+                'data_name' => $file->getClientOriginalName(),
                 'parent' => $parent != 0 ? $parent : null,
                 'row_id' => $rowId,
                 'createdBy' => $originalCreatedBy,

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -327,17 +327,7 @@ class ProcessRequestFileController extends Controller
         $user = pmUser();
         $originalCreatedBy = $user ? $user->id : null;
 
-        $parentRequest->loadMissing('process');
-        $isPublicFilesProcess = optional($parentRequest->process)->package_key === 'package-files/public-files';
-
-        $fileName = $file->getClientOriginalName();
-        $data_name = $laravelRequest->input('data_name', $fileName);
-        if ($isPublicFilesProcess) {
-            // File manager builds URLs as #/public/{data_name} (see Media::getManagerUrlAttribute).
-            // Key media by the real client file name so multi-file uploads and /public-files/{name}
-            // stay correct even when the client sends a shared or wrong data_name per file.
-            $data_name = $fileName;
-        }
+        $data_name = $laravelRequest->input('data_name', $file->getClientOriginalName());
         $rowId = $laravelRequest->input('row_id', null);
         $parent = (int) $laravelRequest->input('parent', null);
         $multiple = $laravelRequest->input('multiple', null);

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -327,7 +327,17 @@ class ProcessRequestFileController extends Controller
         $user = pmUser();
         $originalCreatedBy = $user ? $user->id : null;
 
-        $data_name = $laravelRequest->input('data_name', $file->getClientOriginalName());
+        $parentRequest->loadMissing('process');
+        $isPublicFilesProcess = optional($parentRequest->process)->package_key === 'package-files/public-files';
+
+        $fileName = $file->getClientOriginalName();
+        $data_name = $laravelRequest->input('data_name', $fileName);
+        if ($isPublicFilesProcess) {
+            // File manager builds URLs as #/public/{data_name} (see Media::getManagerUrlAttribute).
+            // Key media by the real client file name so multi-file uploads and /public-files/{name}
+            // stay correct even when the client sends a shared or wrong data_name per file.
+            $data_name = $fileName;
+        }
         $rowId = $laravelRequest->input('row_id', null);
         $parent = (int) $laravelRequest->input('parent', null);
         $multiple = $laravelRequest->input('multiple', null);
@@ -356,7 +366,7 @@ class ProcessRequestFileController extends Controller
         $media = $model
             ->addMedia($file)
             ->withCustomProperties([
-                'data_name' => $file->getClientOriginalName(),
+                'data_name' => $data_name,
                 'parent' => $parent != 0 ? $parent : null,
                 'row_id' => $rowId,
                 'createdBy' => $originalCreatedBy,

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -279,7 +279,7 @@ class ProcessRequestFileController extends Controller
     {
         //delete it and upload the new one
         if ($laravel_request->input('chunk')) {
-            // Perform a chunk uploadProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+            // Perform a chunk upload
             return $this->chunk($receiver, $request, $laravel_request);
         } else {
             try {

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -216,7 +216,7 @@ class ProcessRequestFileController extends Controller
         // we are in chunk mode, lets send the current progress
         /** @var AbstractHandler $handler */
         $handler = $save->handler();
-        \Illuminate\Support\Facades\Log::info("b2");
+
         return response()->json([
             'done' => $handler->getPercentageDone(),
         ]);
@@ -279,7 +279,7 @@ class ProcessRequestFileController extends Controller
     {
         //delete it and upload the new one
         if ($laravel_request->input('chunk')) {
-            // Perform a chunk upload
+            // Perform a chunk uploadProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
             return $this->chunk($receiver, $request, $laravel_request);
         } else {
             try {

--- a/ProcessMaker/Http/Middleware/FileSizeCheck.php
+++ b/ProcessMaker/Http/Middleware/FileSizeCheck.php
@@ -135,7 +135,7 @@ class FileSizeCheck
     {
         $files = $request->allFiles();
         $totalSize = (int) $request->get('totalSize', 0);
-        $maxSize = config('app.settings.max_filesize_limit');
+        $maxSize = $this->getMaxFileSize('application/octet-stream');
         $maxSizeInBytes = $this->convertToBytes($maxSize);
 
         // Check total size first if it exists (using a general max_filesize_limit from env)

--- a/tests/Feature/RequestControllerShowTest.php
+++ b/tests/Feature/RequestControllerShowTest.php
@@ -19,7 +19,7 @@ class RequestControllerShowTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         $this->user = User::factory()->create([
             'is_administrator' => true,
         ]);
@@ -88,10 +88,10 @@ class RequestControllerShowTest extends TestCase
 
         // Get the filtered scripts (should exclude the disabled ones)
         $managerModelerScripts = $response->viewData('managerModelerScripts');
-        
+
         // Assert that the filtered scripts contain only the allowed scripts
         $this->assertCount(2, $managerModelerScripts);
-        
+
         // Check that the disabled scripts are filtered out
         $scriptSources = array_column($managerModelerScripts, 'src');
         $this->assertContains('/js/test-script-1.js', $scriptSources);
@@ -105,7 +105,7 @@ class RequestControllerShowTest extends TestCase
         $response->assertSee('type="module"', false);
         $response->assertSee('async');
         $response->assertSee('defer');
-        
+
         // Assert that disabled scripts are not rendered
         $response->assertDontSee('/js/package-slideshow.js');
         $response->assertDontSee('/js/package-process-optimization.js');

--- a/tests/Feature/RequestControllerShowTest.php
+++ b/tests/Feature/RequestControllerShowTest.php
@@ -54,7 +54,8 @@ class RequestControllerShowTest extends TestCase
 
         // Mock the ModelerManager to return test scripts
         $mockManager = $this->createMock(ModelerManager::class);
-        $mockManager->method('getScriptWithParams')
+        $mockManager->expects($this->atLeastOnce())
+            ->method('getScriptWithParams')
             ->willReturn([
                 [
                     'src' => '/js/test-script-1.js',

--- a/tests/Model/ProcessRequestTokenTest.php
+++ b/tests/Model/ProcessRequestTokenTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Model;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Process;
@@ -11,6 +12,7 @@ use ProcessMaker\Models\User;
 use stdClass;
 use Tests\TestCase;
 
+#[AllowMockObjectsWithoutExpectations]
 class ProcessRequestTokenTest extends TestCase
 {
     public function testSetStagePropertiesInRecord()

--- a/tests/unit/FileSizeCheckTest.php
+++ b/tests/unit/FileSizeCheckTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\Middleware;
 
 use Illuminate\Http\UploadedFile;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use ProcessMaker\Http\Middleware\FileSizeCheck;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\User;

--- a/tests/unit/FileSizeCheckTest.php
+++ b/tests/unit/FileSizeCheckTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Middleware;
 
 use Illuminate\Http\UploadedFile;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Illuminate\Support\Facades\Route;
 use ProcessMaker\Http\Middleware\FileSizeCheck;
 use ProcessMaker\Models\ProcessRequest;
@@ -10,6 +11,7 @@ use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
+#[AllowMockObjectsWithoutExpectations]
 class FileSizeCheckTest extends TestCase
 {
     use RequestHelper;

--- a/tests/unit/ProcessMaker/Cache/Screens/ScreenCacheFactoryTest.php
+++ b/tests/unit/ProcessMaker/Cache/Screens/ScreenCacheFactoryTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\ProcessMaker\Cache\Screens;
 
 use Illuminate\Cache\CacheManager;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use ProcessMaker\Cache\CacheInterface;
 use ProcessMaker\Cache\Monitoring\CacheMetricsDecorator;
 use ProcessMaker\Cache\Monitoring\RedisMetricsManager;

--- a/tests/unit/ProcessMaker/Cache/Screens/ScreenCacheFactoryTest.php
+++ b/tests/unit/ProcessMaker/Cache/Screens/ScreenCacheFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\ProcessMaker\Cache\Screens;
 
 use Illuminate\Cache\CacheManager;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Illuminate\Support\Facades\Config;
 use ProcessMaker\Cache\CacheInterface;
 use ProcessMaker\Cache\Monitoring\CacheMetricsDecorator;
@@ -13,6 +14,7 @@ use ProcessMaker\Cache\Screens\ScreenCacheManager;
 use ProcessMaker\Managers\ScreenCompiledManager;
 use Tests\TestCase;
 
+#[AllowMockObjectsWithoutExpectations]
 class ScreenCacheFactoryTest extends TestCase
 {
     protected function setUp(): void


### PR DESCRIPTION
Description:
Issue: multiple uploads were sending the same `data_name`, causing incorrect values in media custom properties. Fix: use `$file->getClientOriginalName()` directly to ensure each file keeps its correct name in media custom properties.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-30726

ci:deploy
ci:screen-builder:bugfix/FOUR-30726