### PR TITLE
FOUR-30703 | Save Search Shows “Error Loading Items” in Available Columns

### DIFF
--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -651,10 +651,10 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
                 $query->where(DB::raw('LOWER(element_name)'), 'like', $filter)
                     ->orWhere(DB::raw('LOWER(data)'), 'like', $filter)
                     ->orWhere(DB::raw('LOWER(status)'), 'like', $filter)
-                    ->orWhere('id', 'like', $filter)
-                    ->orWhere('created_at', 'like', $filter)
-                    ->orWhere('due_at', 'like', $filter)
-                    ->orWhere('updated_at', 'like', $filter)
+                    ->orWhere('process_request_tokens.id', 'like', $filter)
+                    ->orWhere('process_request_tokens.created_at', 'like', $filter)
+                    ->orWhere('process_request_tokens.due_at', 'like', $filter)
+                    ->orWhere('process_request_tokens.updated_at', 'like', $filter)
                     ->orWhereHas('processRequest', function ($query) use ($filter) {
                         $query->where(DB::raw('LOWER(name)'), 'like', $filter);
                     })

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -640,10 +640,10 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
         $setting = Setting::byKey('indexed-search');
         if ($setting && $setting->config['enabled'] === true) {
             if (is_numeric($filter)) {
-                $query->whereIn('id', [$filter]);
+                $query->whereIn('process_request_tokens.id', [$filter]);
             } else {
                 $matches = self::search($filter)->take(10000)->get()->pluck('id');
-                $query->whereIn('id', $matches);
+                $query->whereIn('process_request_tokens.id', $matches);
             }
         } else {
             $filter = '%' . mb_strtolower($filter) . '%';

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -20,6 +20,7 @@ use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\ProcessTaskAssignment;
 use ProcessMaker\Models\Screen;
 use ProcessMaker\Models\ScreenVersion;
+use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
 use ProcessMaker\Notifications\ActivityActivatedNotification;
 use ProcessMaker\Providers\AuthServiceProvider;
@@ -947,11 +948,36 @@ class TasksTest extends TestCase
             collect($data)->contains('id', $matchingTask->id),
             'Expected matching task to appear in filtered results'
         );
+        $this->assertFalse(
+            collect($data)->contains('element_name', 'OtherTask'),
+            'Expected non-matching task to be excluded from filtered results'
+        );
     }
 
     /**
-     * Test that scopeFilter uses qualified column names so it works
-     * when the query has a join that introduces duplicate column names.
+     * Build a query that joins process_request_tokens to itself via a
+     * subquery aliased `cte`, matching the pattern used by the Saved Search
+     * package. Any WHERE clauses added afterwards must use qualified column
+     * names or they will hit an "ambiguous column" error.
+     */
+    private function buildJoinedSubquery()
+    {
+        $query = ProcessRequestToken::query()->where('element_type', 'task');
+
+        $subQuery = clone $query;
+        $subQuery->select('id', 'updated_at')->latest('updated_at')->take(25);
+
+        $query->select('process_request_tokens.*')
+            ->joinSub($subQuery, 'cte', function ($join) {
+                $join->on('process_request_tokens.id', '=', 'cte.id');
+            });
+
+        return $query;
+    }
+
+    /**
+     * Test that scopeFilter's non-indexed branch works when the query has
+     * a join that introduces duplicate column names (Saved Search pattern).
      */
     public function testScopeFilterWorksWithJoinedSubquery()
     {
@@ -964,24 +990,39 @@ class TasksTest extends TestCase
             'process_request_id' => $request->id,
         ]);
 
-        $query = ProcessRequestToken::query()
-            ->where('element_type', 'task');
-
-        $subQuery = clone $query;
-        $subQuery->select('id', 'updated_at')->latest('updated_at')->take(25);
-
-        $query->select('process_request_tokens.*')
-            ->joinSub($subQuery, 'cte', function ($join) {
-                $join->on('process_request_tokens.id', '=', 'cte.id');
-            });
-
+        $query = $this->buildJoinedSubquery();
         $query->filter('JoinTestTask');
 
         $results = $query->get();
 
         $this->assertNotEmpty($results);
-        $this->assertTrue(
-            $results->contains('element_name', 'JoinTestTask')
+        $this->assertTrue($results->contains('element_name', 'JoinTestTask'));
+    }
+
+    /**
+     * Test that scopeFilter's indexed-search branch (numeric filter path)
+     * uses a qualified `id` column so it works with the Saved Search join.
+     */
+    public function testScopeFilterIndexedSearchNumericWorksWithJoinedSubquery()
+    {
+        Setting::updateOrCreate(
+            ['key' => 'indexed-search'],
+            ['config' => ['enabled' => true]]
         );
+
+        $request = ProcessRequest::factory()->create();
+
+        $task = ProcessRequestToken::factory()->create([
+            'element_type' => 'task',
+            'status' => 'ACTIVE',
+            'process_request_id' => $request->id,
+        ]);
+
+        $query = $this->buildJoinedSubquery();
+        $query->filter((string) $task->id);
+
+        $results = $query->get();
+
+        $this->assertTrue($results->contains('id', $task->id));
     }
 }

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -913,4 +913,75 @@ class TasksTest extends TestCase
         $this->assertEquals($scriptTask->id, $response['data'][1]['id']);
         $this->assertEquals($gatewayTask->id, $response['data'][2]['id']);
     }
+
+    /**
+     * Test that the free-text filter parameter works on the tasks endpoint.
+     */
+    public function testFilterByFreeTextSearch()
+    {
+        $request = ProcessRequest::factory()->create();
+
+        $matchingTask = ProcessRequestToken::factory()->create([
+            'element_type' => 'task',
+            'element_name' => 'UniqueSearchableTaskName',
+            'status' => 'ACTIVE',
+            'process_request_id' => $request->id,
+        ]);
+
+        ProcessRequestToken::factory()->create([
+            'element_type' => 'task',
+            'element_name' => 'OtherTask',
+            'status' => 'ACTIVE',
+            'process_request_id' => $request->id,
+        ]);
+
+        $response = $this->apiCall('GET', route('api.' . $this->resource . '.index', [
+            'filter' => 'UniqueSearchableTaskName',
+            'per_page' => 50,
+        ]));
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertNotEmpty($data);
+        $this->assertTrue(
+            collect($data)->contains('id', $matchingTask->id),
+            'Expected matching task to appear in filtered results'
+        );
+    }
+
+    /**
+     * Test that scopeFilter uses qualified column names so it works
+     * when the query has a join that introduces duplicate column names.
+     */
+    public function testScopeFilterWorksWithJoinedSubquery()
+    {
+        $request = ProcessRequest::factory()->create();
+
+        ProcessRequestToken::factory()->create([
+            'element_type' => 'task',
+            'element_name' => 'JoinTestTask',
+            'status' => 'ACTIVE',
+            'process_request_id' => $request->id,
+        ]);
+
+        $query = ProcessRequestToken::query()
+            ->where('element_type', 'task');
+
+        $subQuery = clone $query;
+        $subQuery->select('id', 'updated_at')->latest('updated_at')->take(25);
+
+        $query->select('process_request_tokens.*')
+            ->joinSub($subQuery, 'cte', function ($join) {
+                $join->on('process_request_tokens.id', '=', 'cte.id');
+            });
+
+        $query->filter('JoinTestTask');
+
+        $results = $query->get();
+
+        $this->assertNotEmpty($results);
+        $this->assertTrue(
+            $results->contains('element_name', 'JoinTestTask')
+        );
+    }
 }


### PR DESCRIPTION
# Issue
Ticket: [FOUR-30703](https://processmaker.atlassian.net/browse/FOUR-30703)

When hitting `/api/1.0/saved-searches/{id}/columns?include=available,data,default`, the app returned an error:

> Column 'id' in EXISTS subquery is ambiguous

This only happened when a text search filter (e.g. "smart extract") was applied to a task-based Saved Search.

# Root Cause
The Saved Search package recently changed how it fetches task data (commit `9ee8acc`, ticket [FOUR-28867](https://processmaker.atlassian.net/browse/FOUR-28867)). To fix a CPU usage problem, it switched from a simple query to one that looks at the `process_request_tokens` table twice and stitches the results together side by side.

The issue is that both copies of the table have columns named `id` and `updated_at`. When the core `scopeFilter` method in `ProcessRequestToken` said "filter where `id` matches the search term," the database couldn't tell which `id` was meant — the one from the original table or the one from the copy.

# Solution
In `ProcessMaker/Models/ProcessRequestToken.php`, the `scopeFilter` method now uses fully qualified column names so the database always knows which table is being referenced:
| Before | After |
|---|---|
| `'id'` | `'process_request_tokens.id'` |
| `'created_at'` | `'process_request_tokens.created_at'` |
| `'due_at'` | `'process_request_tokens.due_at'` |
| `'updated_at'` | `'process_request_tokens.updated_at'` |

Added two tests in `tests/Feature/Api/TasksTest.php`:
- **`testScopeFilterWorksWithJoinedSubquery`** — Reproduces the exact bug scenario by building a query with a joined subquery (mimicking the Saved Search CTE pattern), then applying a text filter. Before the fix, this threw the ambiguous column error. Now it passes.
- **`testFilterByFreeTextSearch`** — Exercises the free-text `filter` parameter through the tasks API endpoint to confirm end-to-end filtering works.

# How To Test
1. Run `phpunit tests/Feature/Api/TasksTest.php`
    - Verify `testScopeFilterWorksWithJoinedSubquery` passes
    - Verify `testFilterByFreeTextSearch` passes
2. Log in to ProcessMaker. Start a couple of Cases.
3. Go to Tasks and filter by the Process name via the search bar.
4. Create a Saved Search based on the search results.
5. Go to Configure → Columns.
6. Available columns should be listed; the "Error loading items" error should not display.

ci:deploy

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-30703]: https://processmaker.atlassian.net/browse/FOUR-30703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-28867]: https://processmaker.atlassian.net/browse/FOUR-28867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ