### PR TITLE
SSO>> Unable to log in using SAML OneLogin account

### DIFF
--- a/resources/views/errors/login-failed.blade.php
+++ b/resources/views/errors/login-failed.blade.php
@@ -11,6 +11,11 @@
     </div>
     <div class="error-content">
       <h1>{{__('No permissions to access this content')}}</h1>
+      @isset($message)
+        @if ($message !== '')
+          <p>{{ $message }}</p>
+        @endif
+      @endisset
       <p>{{__(
         'If you believe this is an error, please contact the system administrator or support team for assistance.'
       )}}</p>


### PR DESCRIPTION
## Issue & Reproduction Steps
When the user has more than one match, an error screen is displayed. More information was added so that the user knows they have duplicate emails and for that reason cannot log in to ProcessMaker.

## Solution
- Add conditional message display in login failed error view

## How to Test
add configuration SAML and login with user.

## Related Tickets & Packages
- [FOUR-30788](https://processmaker.atlassian.net/browse/FOUR-30788)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:package-auth:bugfix/FOUR-30788

[FOUR-30788]: https://processmaker.atlassian.net/browse/FOUR-30788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ