### PR TITLE
FOUR-30705 Fix DevLink

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/DevLinkController.php
+++ b/ProcessMaker/Http/Controllers/Admin/DevLinkController.php
@@ -36,20 +36,24 @@ class DevLinkController extends Controller
         $devLinkId = $request->input('devlink_id');
         $redirectUri = $request->input('redirect_uri');
 
-        $client = Client::where([
+        // We can't re-use a client because the secret is hashed.
+        Client::where([
             'name' => 'devlink',
             'redirect' => $redirectUri,
-        ])->first();
+        ])
+        ->get()
+        ->each(function ($c) {
+            $c->delete();
+        });
 
-        if (!$client) {
-            $clientRepository = app('Laravel\Passport\ClientRepository');
-            $client = $clientRepository->createAuthorizationCodeGrantClient('devlink', [$redirectUri]);
-        }
+        $clientRepository = app('Laravel\Passport\ClientRepository');
+        $client = $clientRepository->createAuthorizationCodeGrantClient('devlink', [$redirectUri]);
+        $plainSecret = $client->plainSecret;
 
         $query = http_build_query([
             'devlink_id' => $devLinkId,
             'client_id' => $client->id,
-            'client_secret' => $client->secret,
+            'client_secret' => $plainSecret,
         ]);
 
         return redirect($redirectUri . '?' . $query);

--- a/tests/Feature/Admin/DevLinkTest.php
+++ b/tests/Feature/Admin/DevLinkTest.php
@@ -83,12 +83,16 @@ class DevLinkTest extends TestCase
         $response = $this->webCall('GET', $url);
 
         $response->assertStatus(302);
+        $locationHeader = $response->headers->get('Location');
+        $queryString = parse_url($locationHeader, PHP_URL_QUERY);
+        parse_str($queryString, $queryParams);
+        $clientSecretQueryParam = $queryParams['client_secret'] ?? '';
 
         $lastCreatedClient = Client::orderBy('id', 'desc')->first();
         $expectedParams = [
             'devlink_id' => $devLink->id,
             'client_id' => $lastCreatedClient->id,
-            'client_secret' => $lastCreatedClient->secret,
+            'client_secret' => $clientSecretQueryParam,
         ];
         $response->assertRedirect(route('devlink.index', $expectedParams));
     }

--- a/upgrades/2026_04_22_200226_encrypt_client_secrets.php
+++ b/upgrades/2026_04_22_200226_encrypt_client_secrets.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class EncryptClientSecrets extends Upgrade
+{
+    /**
+     * Run any validations/pre-run checks to ensure the environment, settings,
+     * packages installed, etc. are right correct to run this upgrade.
+     *
+     * Throw a \RuntimeException if the conditions are *NOT* correct for this
+     * upgrade migration to run. If this is not a required upgrade, then it
+     * will be skipped. Otherwise the exception thrown will be caught, noted,
+     * and will prevent the remaining migrations from continuing to run.
+     *
+     * Returning void or null denotes the checks were successful.
+     *
+     * @return void
+     *
+     * @throws RuntimeException
+     */
+    public function preflightChecks()
+    {
+        //
+    }
+
+    /**
+     * Run the upgrade migration.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Artisan::call('passport:hash', ['--force' => true]);
+        $output = Artisan::output();
+        if (!str_contains($output, 'All client secrets were successfully hashed')) {
+            throw new RuntimeException('Failed to hash client secrets. Output: ' . $output);
+        }
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
See https://processmaker.atlassian.net/browse/FOUR-30705

Laravel 13 and Passport 13 now [require hashed secrets](https://github.com/laravel/passport/blob/13.x/UPGRADE.md#client-secrets-hashed-by-default) so we had to make this compatible with DevLink

Also, I added an upgrade script to convert existing secrets to hashes

.