### PR TITLE
Upgrade for axios 1.15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "@processmaker/vue-form-elements": "0.65.6",
         "@processmaker/vue-multiselect": "2.3.0",
         "@tinymce/tinymce-vue": "2.0.0",
-        "axios": "^0.27.2",
+        "axios": "^1.15.2",
         "bootstrap": "^4.5.3",
         "bootstrap-vue": "^2.18.1",
         "bpmn-font": "^0.10.0",

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -4,7 +4,8 @@ import * as bootstrap from "bootstrap";
 import TenantAwareEcho from "./common/TenantAwareEcho";
 import { initSessionSync } from "./common/sessionSync";
 import Router from "vue-router";
-import ScreenBuilder, { initializeScreenCache } from "@processmaker/screen-builder";
+import ScreenBuilder from "@processmaker/screen-builder";
+import attachScreenCacheAdapter from "./common/attachScreenCacheAdapter";
 import * as VueDeepSet from "vue-deepset";
 
 /**
@@ -393,8 +394,9 @@ window.ProcessMaker.screen = {
   cacheTimeout: Number(screenCacheTimeout),
   secureHandlerToggleVisible: !!Number(screenSecureHandlerToggleVisible?.content),
 };
-// Initialize screen-builder cache
-initializeScreenCache(window.ProcessMaker.apiClient, window.ProcessMaker.screen);
+// Axios 1.x uses adapter name list on defaults.adapter, not a function. screen-builder's
+// initializeScreenCache passes that through to cacheAdapterEnhancer and breaks dispatch.
+attachScreenCacheAdapter(window.ProcessMaker.apiClient, window.ProcessMaker.screen);
 
 const clickTab = () => {
   const { hash } = window.location;

--- a/resources/js/common/attachScreenCacheAdapter.js
+++ b/resources/js/common/attachScreenCacheAdapter.js
@@ -1,0 +1,30 @@
+import { cacheAdapterEnhancer } from "axios-extensions";
+import * as LRUCacheModule from "lru-cache";
+
+// Root install may hoist lru-cache@5 (default export only) or v10 (named LRUCache); screen-builder uses v10 API.
+const LRUCache = LRUCacheModule.LRUCache ?? LRUCacheModule.default;
+
+/**
+ * Wraps the axios HTTP adapter with screen-builder GET caching (axios-extensions).
+ * Axios 1.x sets defaults.adapter to adapter names (e.g. ['xhr','http','fetch']), not a
+ * function; cacheAdapterEnhancer must receive the resolved adapter from getAdapter().
+ *
+ * @param {import("axios").AxiosInstance} apiClient
+ * @param {{ cacheEnabled: boolean, cacheTimeout: number }} screen
+ */
+export default function attachScreenCacheAdapter(apiClient, screen) {
+  const raw = apiClient.defaults.adapter;
+  const baseAdapter = typeof raw === "function"
+    ? raw
+    : apiClient.getAdapter(raw);
+
+  apiClient.defaults.adapter = cacheAdapterEnhancer(baseAdapter, {
+    enabledByDefault: screen.cacheEnabled,
+    cacheFlag: "useCache",
+    defaultCache: new LRUCache({
+      max: 100,
+      ttl: screen.cacheTimeout,
+      maxAge: screen.cacheTimeout,
+    }),
+  });
+}

--- a/resources/js/next/screenBuilder.js
+++ b/resources/js/next/screenBuilder.js
@@ -1,6 +1,7 @@
 import {
   getGlobalVariable, setGlobalVariable, getGlobalPMVariable, setGlobalPMVariable,
 } from "./globalVariables";
+import attachScreenCacheAdapter from "../common/attachScreenCacheAdapter";
 
 const addScriptsToDOM = async function (scripts) {
   for (const script of scripts) {
@@ -26,7 +27,6 @@ export default () => {
       import("@processmaker/screen-builder").then((ScreenBuilder) => {
         const apiClient = getGlobalPMVariable("apiClient");
 
-        const { initializeScreenCache } = ScreenBuilder;
         // Configuration Global object used by ScreenBuilder
         // @link https://processmaker.atlassian.net/browse/FOUR-6833 Cache configuration
         const screenCacheEnabled = document.head.querySelector("meta[name=\"screen-cache-enabled\"]")?.content ?? "false";
@@ -42,8 +42,7 @@ export default () => {
 
         setGlobalVariable("ScreenBuilder", ScreenBuilder);
         setGlobalPMVariable("screen", screen);
-        // Initialize screen-builder cache
-        initializeScreenCache(apiClient, screen);// TODO: Its a bad practice to use the apiClient here
+        attachScreenCacheAdapter(apiClient, screen);
         if (screenBuilderScripts) {
           addScriptsToDOM(screenBuilderScripts).then(() => {
             // The order of the scripts is important, the screenBuilderScripts must be loaded before the ScreenBuilder.default

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -28,7 +28,18 @@ mix.webpackConfig({
     alias: {
       "vue-monaco": path.resolve(__dirname, "resources/js/vue-monaco-amd.js"),
       styles: path.resolve(__dirname, "resources/sass"),
+      // axios-extensions still imports axios 0.x deep paths; axios 1 only exposes them via "unsafe" (or alias here).
+      "axios/lib/helpers/buildURL": path.resolve(
+        __dirname,
+        "node_modules/axios/lib/helpers/buildURL.js",
+      ),
     },
+  },
+  // Disable webpack minification (Terser). Pre-built vendor UMD chunks (e.g. screen-builder)
+  // stay minified in the bundle; use source maps to map stacks back to originals.
+  optimization: {
+    minimize: false,
+    minimizer: [],
   },
 });
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -35,12 +35,6 @@ mix.webpackConfig({
       ),
     },
   },
-  // Disable webpack minification (Terser). Pre-built vendor UMD chunks (e.g. screen-builder)
-  // stay minified in the bundle; use source maps to map stacks back to originals.
-  optimization: {
-    minimize: false,
-    minimizer: [],
-  },
 });
 
 mix.options({


### PR DESCRIPTION
## Issue & Reproduction Steps
* After upgrading to Axios 1.x, the screen-builder HTTP cache integration broke: the browser threw Uncaught (in promise) TypeError: t is not a function inside the axios dispatch path (stack pointed at bundled `cacheAdapterEnhancer` / `app.js`).
* **Root cause:** `@processmaker/screen-builder’s initializeScreenCache()` wraps `apiClient.defaults.adapter` with `axios-extensions’ cacheAdapterEnhancer`. In Axios 1.x, defaults.adapter is often a list of adapter names (e.g. ['xhr','http','fetch']), not a callable adapter. The enhancer must receive the resolved adapter from `apiClient.getAdapter(...)`.
* **Build:** Importing `axios-extensions` triggered `Module not found`: Package path `./lib/helpers/buildURL` is not exported because Axios 1 no longer exports the old deep path `axios/lib/helpers/buildURL`.
* **Runtime (after build fix):** `LRUCache` is not a constructor because the app resolved hoisted `lru-cache@5` (default export only) while the code used a named `{ LRUCache }` import (v10 style).

## Solution
* Added `resources/js/common/attachScreenCacheAdapter.js`: resolves the real HTTP adapter with `apiClient.getAdapter(apiClient.defaults.adapter)` when `defaults.adapter` is not a function, then applies `cacheAdapterEnhancer` with the same options as screen-builder (cache flag, LRU defaults, screen config).
* `resources/js/bootstrap.js`: stopped calling `initializeScreenCache` from screen-builder; calls `attachScreenCacheAdapter(apiClient, window.ProcessMaker.screen)` after `ProcessMaker.screen` is defined.
* `resources/js/next/screenBuilder.js`: same behavior for the dynamic screen-builder path, passing the local screen object.
* `webpack.mix.js`: Resolve.alias for `axios/lib/helpers/buildURL` → `node_modules/axios/lib/helpers/buildURL.js` so axios-extensions builds against Axios 1 exports.

## How to Test
1. `npm ci` (or `npm install`), then `npm run development` — confirm webpack completes with no `axios/lib/helpers/buildURL` error.
2. Load the main app (layout using `bootstrap.js`): confirm no t is not a function and no `LRUCache` is not a constructor in the console on load and on normal navigation/API use.
3. Toggle screen-cache-enabled (and timeout) via admin/meta as you normally do: confirm GETs still behave correctly with cache on/off (no adapter errors).
4. If you use the next screen-builder loader path, hit a page that runs `resources/js/next/screenBuilder.js` and repeat smoke checks.

## Related Tickets & Packages
- Packages: `@processmaker/screen-builder` (upstream still exports `initializeScreenCache` with Axios 0.x assumptions), axios, axios-extensions, lru-cache.
- Tickets: Link your FOUR-28803 ticket here (e.g. “Axios 1.x: screen cache adapter / frontend build”).

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
