### PR TITLE
FOUR-26677: Fix inbox dashboard scroll clipping

### DIFF
--- a/resources/js/tasks/components/ParticipantHomeScreen.vue
+++ b/resources/js/tasks/components/ParticipantHomeScreen.vue
@@ -31,7 +31,13 @@
 
     <div
       ref="processInfo"
-      class="tw-overflow-hidden tw-flex-1 tw-pb-4">
+      class="tw-flex-1 tw-pb-4"
+      :class="
+        selectedProcess === 'inbox'
+          ? 'tw-overflow-hidden'
+          : 'tw-overflow-auto'
+      "
+    >
       <div v-if="selectedProcess === 'inbox'">
         <div class="px-3 page-content mb-0">
           <div class="row">


### PR DESCRIPTION
## Issue & Reproduction Steps
FOUR-26677 reports that dashboards opened from the Inbox sidebar can be clipped because the main Inbox content pane does not expose a vertical scrollbar.

Reproduction:
1. Log in as a user assigned to a custom dashboard.
2. Open `/inbox`.
3. Select the assigned dashboard from the Dashboards section in the Inbox sidebar.
4. Observe that `/inbox/dashboard/:id` renders content below the visible area, but the page cannot scroll to it.

## Solution
- Changed the main Inbox content wrapper to keep `overflow: hidden` only for the standard Inbox task list.
- Changed dashboard/process views to use `overflow: auto`, allowing dashboard content taller than the viewport to scroll.

## How to Test
1. Login.
2. Open `https://processmaker.test/inbox`.
3. Click the `test` dashboard in the Inbox sidebar.
4. Confirm `/inbox/dashboard/2` shows a vertical scrollbar and all dashboard content can be reached.
5. Return to `/inbox` and confirm the task list still renders normally.
6. Optionally open a process from the sidebar and confirm it is not clipped.

Note: `npx eslint resources/js/tasks/components/ParticipantHomeScreen.vue` still reports pre-existing lint issues in this file unrelated to this change.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26677

ci:deploy