### PR TITLE
bugfix/FOUR-25422 [46410] Saved Search Does Not Return Completed Cases When Filtering by Case Number

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -451,7 +451,10 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
         $setting = Setting::byKey('indexed-search');
         if ($setting && $setting->config['enabled'] === true) {
             if (is_numeric($filter)) {
-                $query->whereIn('id', [$filter]);
+                $query->where(function ($query) use ($filter) {
+                    $query->whereIn('id', [$filter])
+                        ->orWhere('case_number', $filter);
+                });
             } else {
                 $matches = self::search($filter)->take(10000)->get()->pluck('id');
                 $query->whereIn('id', $matches);
@@ -465,7 +468,8 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
                     ->orWhere(DB::raw('LOWER(status)'), 'like', $filter)
                     ->orWhere('initiated_at', 'like', $filter)
                     ->orWhere('created_at', 'like', $filter)
-                    ->orWhere('updated_at', 'like', $filter);
+                    ->orWhere('updated_at', 'like', $filter)
+                    ->orWhere('case_number', 'like', $filter);
             });
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
[46410] Saved Search Does Not Return Completed Cases When Filtering by Case Number

## Solution
Added case_number to savedsearch search filter

## How to Test
Create a new process in ProcessMaker with:
A Start Event
Two sequential Tasks (e.g., Task A and Task B)
An End Event

Start two cases of this process:

Case 1 and leave it In Progress
Case 2and complete it (Status: Completed)

Go to Requests > All Requests

Apply a filter by the process name (e.g., 46410 Warba) and save it as a Saved Search
From that Saved Search view, attempt to search by Case Number:
Enter case id → Result appears

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-25422


ci:deploy