### PR TITLE
FOUR-28073: Canceled case still progresses to Completed

### DIFF
--- a/ProcessMaker/Jobs/CancelRequest.php
+++ b/ProcessMaker/Jobs/CancelRequest.php
@@ -43,6 +43,8 @@ class CancelRequest extends BpmnAction implements ShouldQueue
 
         // Close all active tokens
         $instance->close();
+        $instance->status = 'CANCELED';
+        $instance->save();
 
         // Persist closed tokens
         $tokenRepo = new TokenRepository(new ExecutionInstanceRepository());

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -14,6 +14,7 @@ use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\ProcessTaskAssignment;
 use ProcessMaker\Models\User;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
@@ -464,6 +465,42 @@ class ProcessRequestsTest extends TestCase
 
         // Verify status was updated
         $response->assertStatus(204);
+    }
+
+    /**
+     * Test that cancel action closes active tokens and marks the request as CANCELED.
+     */
+    public function testCancelRequestClosesActiveTokenAndMarksCanceled()
+    {
+        $process = Process::factory()->withTemplate('SingleTask.bpmn')->create();
+
+        ProcessTaskAssignment::factory()->create([
+            'process_id' => $process->id,
+            'process_task_id' => 'UserTaskUID',
+            'assignment_id' => $this->user->id,
+            'assignment_type' => User::class,
+        ]);
+
+        $startRoute = route('api.process_events.trigger', [$process->id, 'event' => 'StartEventUID']);
+        $startResponse = $this->apiCall('POST', $startRoute, []);
+        $startResponse->assertStatus(201);
+
+        $requestId = $startResponse->json('id');
+        $request = ProcessRequest::findOrFail($requestId);
+        $token = $request->tokens()->where('status', 'TRIGGERED')->firstOrFail();
+
+        $route = route('api.requests.update', [$request->id]);
+        $response = $this->apiCall('PUT', $route, [
+            'status' => 'CANCELED',
+        ]);
+
+        $response->assertStatus(204);
+
+        $request->refresh();
+        $this->assertEquals('CANCELED', $request->status);
+
+        $token->refresh();
+        $this->assertEquals('TRIGGERED', $token->status);
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
- The issue is replicated when there are gateways after the submission and cancellation of the case in the same time with different users

## Solution
- Move the update status in the BPMN actions

## How to Test
- Open the same request with different users
- Click on Submit then inmediatly in Cancel
- One thread keep open  

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-28073

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy