### PR TITLE
FOUR-30819 Sanitize screen template config

### DIFF
--- a/ProcessMaker/Helpers/ScreenTemplateHelper.php
+++ b/ProcessMaker/Helpers/ScreenTemplateHelper.php
@@ -4,6 +4,32 @@ namespace ProcessMaker\Helpers;
 
 class ScreenTemplateHelper
 {
+    private const RENDERABLE_STRING_FIELDS = [
+        'ariaLabel',
+        'content',
+        'fieldValue',
+        'helper',
+        'label',
+        'loadingLabel',
+        'placeholder',
+    ];
+
+    /**
+     * Remove serialized Vue component definitions from screen config.
+     *
+     * Screen templates can contain old inspector metadata where inspector.type
+     * is a serialized Vue component object. That data is not needed at runtime
+     * and can reach renderer paths that expect Mustache templates to be strings.
+     */
+    public static function sanitizeScreenConfig($config): array
+    {
+        if (!is_array($config)) {
+            return [];
+        }
+
+        return self::sanitizeConfigValue($config);
+    }
+
     /**
      * Remove screen components from the configuration based on the provided components.
      *
@@ -401,5 +427,66 @@ class ScreenTemplateHelper
         }
 
         return $cssString;
+    }
+
+    private static function sanitizeConfigValue($value, ?string $key = null)
+    {
+        if ($key === 'validation' && is_array($value) && $value === []) {
+            return null;
+        }
+
+        if (in_array($key, self::RENDERABLE_STRING_FIELDS, true)) {
+            return self::sanitizeRenderableString($value);
+        }
+
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            return array_map(fn ($item) => self::sanitizeConfigValue($item), $value);
+        }
+
+        $sanitized = [];
+        foreach ($value as $childKey => $childValue) {
+            if ($childKey === 'inspector' && is_array($childValue)) {
+                $sanitized[$childKey] = array_map(
+                    fn ($item) => self::sanitizeInspectorItem($item),
+                    $childValue
+                );
+                continue;
+            }
+
+            $sanitized[$childKey] = self::sanitizeConfigValue($childValue, (string) $childKey);
+        }
+
+        return $sanitized;
+    }
+
+    private static function sanitizeInspectorItem($item)
+    {
+        if (!is_array($item)) {
+            return $item;
+        }
+
+        $sanitized = [];
+        foreach ($item as $key => $value) {
+            if ($key === 'type' && is_array($value)) {
+                continue;
+            }
+
+            $sanitized[$key] = self::sanitizeConfigValue($value, (string) $key);
+        }
+
+        return $sanitized;
+    }
+
+    private static function sanitizeRenderableString($value): ?string
+    {
+        if ($value === null || is_array($value)) {
+            return null;
+        }
+
+        return is_string($value) ? $value : (string) $value;
     }
 }

--- a/ProcessMaker/Helpers/ScreenTemplateHelper.php
+++ b/ProcessMaker/Helpers/ScreenTemplateHelper.php
@@ -21,7 +21,7 @@ class ScreenTemplateHelper
      * is a serialized Vue component object. That data is not needed at runtime
      * and can reach renderer paths that expect Mustache templates to be strings.
      */
-    public static function sanitizeScreenConfig($config): array
+    public static function sanitizeScreenConfig(mixed $config): array
     {
         if (!is_array($config)) {
             return [];
@@ -429,41 +429,35 @@ class ScreenTemplateHelper
         return $cssString;
     }
 
-    private static function sanitizeConfigValue($value, ?string $key = null)
+    private static function sanitizeConfigValue(mixed $value, ?string $key = null): mixed
     {
         if ($key === 'validation' && is_array($value) && $value === []) {
-            return null;
-        }
+            $sanitized = null;
+        } elseif (in_array($key, self::RENDERABLE_STRING_FIELDS, true)) {
+            $sanitized = self::sanitizeRenderableString($value);
+        } elseif (!is_array($value)) {
+            $sanitized = $value;
+        } elseif (array_is_list($value)) {
+            $sanitized = array_map(fn ($item) => self::sanitizeConfigValue($item), $value);
+        } else {
+            $sanitized = [];
+            foreach ($value as $childKey => $childValue) {
+                if ($childKey === 'inspector' && is_array($childValue)) {
+                    $sanitized[$childKey] = array_map(
+                        fn ($item) => self::sanitizeInspectorItem($item),
+                        $childValue
+                    );
+                    continue;
+                }
 
-        if (in_array($key, self::RENDERABLE_STRING_FIELDS, true)) {
-            return self::sanitizeRenderableString($value);
-        }
-
-        if (!is_array($value)) {
-            return $value;
-        }
-
-        if (array_is_list($value)) {
-            return array_map(fn ($item) => self::sanitizeConfigValue($item), $value);
-        }
-
-        $sanitized = [];
-        foreach ($value as $childKey => $childValue) {
-            if ($childKey === 'inspector' && is_array($childValue)) {
-                $sanitized[$childKey] = array_map(
-                    fn ($item) => self::sanitizeInspectorItem($item),
-                    $childValue
-                );
-                continue;
+                $sanitized[$childKey] = self::sanitizeConfigValue($childValue, (string) $childKey);
             }
-
-            $sanitized[$childKey] = self::sanitizeConfigValue($childValue, (string) $childKey);
         }
 
         return $sanitized;
     }
 
-    private static function sanitizeInspectorItem($item)
+    private static function sanitizeInspectorItem(mixed $item): mixed
     {
         if (!is_array($item)) {
             return $item;
@@ -481,10 +475,10 @@ class ScreenTemplateHelper
         return $sanitized;
     }
 
-    private static function sanitizeRenderableString($value): ?string
+    private static function sanitizeRenderableString(mixed $value): string
     {
         if ($value === null || is_array($value)) {
-            return null;
+            return '';
         }
 
         return is_string($value) ? $value : (string) $value;

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -725,6 +725,8 @@ class ScreenTemplate implements TemplateInterface
                         $newTemplateScreen, $currentScreen, $templateOptions, $currentScreenPage);
                 }
 
+                $currentScreen->config = ScreenTemplateHelper::sanitizeScreenConfig($currentScreen->config);
+
                 // Copy the updated config from screenVersion to screen
                 // This is needed to save the changes to the current screen when applying a template to the screen version
                 if ($hasVersionsPackage) {
@@ -854,8 +856,10 @@ class ScreenTemplate implements TemplateInterface
                 throw new MissingScreenPageException();
             }
 
-            $templateComponents = ScreenTemplateHelper::getScreenComponents($newTemplateScreen->config,
-                $supportedComponents, false)[0]['items'];
+            $templateComponents = ScreenTemplateHelper::sanitizeScreenConfig(
+                ScreenTemplateHelper::getScreenComponents($newTemplateScreen->config,
+                    $supportedComponents, false)[0]['items'] ?? []
+            );
 
             $screenConfig[$currentScreenPage]['items'] =
                 array_merge($screenConfig[$currentScreenPage]['items'], $templateComponents);
@@ -866,11 +870,13 @@ class ScreenTemplate implements TemplateInterface
 
     private function getTemplateComponents($newTemplateScreen, $templateOptions, $supportedComponents)
     {
-        return !in_array('Fields', $templateOptions)
+        $templateComponents = !in_array('Fields', $templateOptions)
             ? ScreenTemplateHelper::getScreenComponents($newTemplateScreen->config,
                 $supportedComponents, false)[0]['items']
             ?? []
                 : $newTemplateScreen->config[0]['items'] ?? [];
+
+        return ScreenTemplateHelper::sanitizeScreenConfig($templateComponents);
     }
 
     private function setScreenConfig($screen)

--- a/ProcessMaker/Templates/ScreenTemplate.php
+++ b/ProcessMaker/Templates/ScreenTemplate.php
@@ -725,8 +725,6 @@ class ScreenTemplate implements TemplateInterface
                         $newTemplateScreen, $currentScreen, $templateOptions, $currentScreenPage);
                 }
 
-                $currentScreen->config = ScreenTemplateHelper::sanitizeScreenConfig($currentScreen->config);
-
                 // Copy the updated config from screenVersion to screen
                 // This is needed to save the changes to the current screen when applying a template to the screen version
                 if ($hasVersionsPackage) {
@@ -856,6 +854,7 @@ class ScreenTemplate implements TemplateInterface
                 throw new MissingScreenPageException();
             }
 
+            // Sanitize only imported template components so existing screen config is not altered.
             $templateComponents = ScreenTemplateHelper::sanitizeScreenConfig(
                 ScreenTemplateHelper::getScreenComponents($newTemplateScreen->config,
                     $supportedComponents, false)[0]['items'] ?? []
@@ -876,6 +875,7 @@ class ScreenTemplate implements TemplateInterface
             ?? []
                 : $newTemplateScreen->config[0]['items'] ?? [];
 
+        // Sanitize only imported template components so existing screen config is not altered.
         return ScreenTemplateHelper::sanitizeScreenConfig($templateComponents);
     }
 

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -27,6 +27,16 @@ class ScreenTemplateTest extends TestCase
 
     private const SCREEN_PATH = 'tests/Feature/Templates/fixtures/screen-config-with-two-pages.json';
 
+    private const RENDERABLE_STRING_FIELDS = [
+        'ariaLabel',
+        'content',
+        'fieldValue',
+        'helper',
+        'label',
+        'loadingLabel',
+        'placeholder',
+    ];
+
     public function testCreateScreenTemplate()
     {
         $screenCategoryId = ScreenCategory::factory()->create()->id;
@@ -513,6 +523,54 @@ class ScreenTemplateTest extends TestCase
         $this->assertScreenConfigSanitized($updatedScreen->config);
     }
 
+    public function testApplyTemplateSanitizesDatePickerRenderableStrings()
+    {
+        $templatePath = base_path(self::SCREEN_TEMPLATE_PATH);
+        $screenTemplateData = $this->addDatePickerWithInvalidRenderableFields(File::get($templatePath));
+
+        $screenTemplate = $this->createScreenTemplateFromManifest($screenTemplateData);
+
+        $screenPath = base_path(self::SCREEN_PATH);
+        $screenData = json_decode(File::get($screenPath), true);
+
+        $newScreen = Screen::factory()->create([
+            'config' => $screenData,
+        ]);
+
+        $route = route('api.template.applyTemplate', [
+            'type' => 'screen',
+            'id' => $screenTemplate->id,
+        ]);
+
+        $response = $this->apiCall('POST', $route, [
+            'screenId' => $newScreen->id,
+            'templateOptions' => ['Fields'],
+            'currentScreenPage' => 1,
+        ]);
+
+        $response->assertStatus(200);
+
+        if (class_exists(VersionHistory::class)) {
+            $updatedScreen = \ProcessMaker\Models\ScreenVersion::select('config')->where('screen_id', $newScreen->id)->latest()->firstOrFail();
+        } else {
+            $updatedScreen = Screen::select('config')->where('id', $newScreen->id)->firstOrFail();
+        }
+
+        $datePicker = $this->findScreenConfigItem(
+            $updatedScreen->config[1]['items'],
+            'FormDatePicker',
+            'date'
+        );
+
+        $this->assertNotNull($datePicker);
+        $this->assertSame('', $datePicker['config']['label']);
+        $this->assertSame('', $datePicker['config']['placeholder']);
+        $this->assertSame('', $datePicker['config']['helper']);
+        $this->assertSame('', $datePicker['config']['ariaLabel']);
+        $this->assertNull($datePicker['config']['validation']);
+        $this->assertScreenConfigSanitized($updatedScreen->config);
+    }
+
     public function testApplyLayoutToExistingScreen()
     {
         // Create screen from template-manifest-with-css-fields-layout.json
@@ -642,12 +700,109 @@ class ScreenTemplateTest extends TestCase
         return $screenTemplate;
     }
 
-    private function assertScreenConfigValueSanitized($value): void
+    private function addDatePickerWithInvalidRenderableFields(string $manifest): string
+    {
+        $payload = json_decode($manifest, true);
+        $root = $payload['root'];
+        $config = json_decode($payload['export'][$root]['attributes']['config'], true);
+
+        $config[0]['items'][] = [
+            'label' => 'Date Picker',
+            'config' => [
+                'icon' => 'far fa-calendar-alt',
+                'name' => 'date',
+                'type' => 'datetime',
+                'label' => null,
+                'helper' => null,
+                'placeholder' => null,
+                'ariaLabel' => null,
+                'minDate' => null,
+                'maxDate' => null,
+                'dataFormat' => 'date',
+                'validation' => [],
+            ],
+            'component' => 'FormDatePicker',
+            'inspector' => [
+                [
+                    'type' => 'FormInput',
+                    'field' => 'label',
+                    'config' => [
+                        'label' => 'Label',
+                        'helper' => 'The label describes the field\'s name',
+                    ],
+                ],
+                [
+                    'type' => 'ValidationSelect',
+                    'field' => 'validation',
+                    'config' => [
+                        'label' => 'Validation Rules',
+                        'helper' => 'The validation rules needed for this field',
+                    ],
+                ],
+            ],
+            'editor-control' => 'FormDatePicker',
+            'editor-component' => 'FormDatePicker',
+        ];
+
+        $payload['export'][$root]['attributes']['config'] = json_encode($config);
+
+        return json_encode($payload);
+    }
+
+    private function findScreenConfigItem(array $items, string $component, string $name): ?array
+    {
+        $matchingItem = null;
+
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            if (($item['component'] ?? null) === $component && ($item['config']['name'] ?? null) === $name) {
+                $matchingItem = $item;
+                break;
+            }
+
+            $nestedItem = $this->findScreenConfigItemInChildren($item, $component, $name);
+            if ($nestedItem !== null) {
+                $matchingItem = $nestedItem;
+                break;
+            }
+        }
+
+        return $matchingItem;
+    }
+
+    private function findScreenConfigItemInChildren(array $item, string $component, string $name): ?array
+    {
+        foreach ($this->screenConfigChildCollections($item) as $childItems) {
+            $nestedItem = $this->findScreenConfigItem($childItems, $component, $name);
+            if ($nestedItem !== null) {
+                return $nestedItem;
+            }
+        }
+
+        return null;
+    }
+
+    private function assertScreenConfigValueSanitized(mixed $value): void
     {
         if (!is_array($value)) {
             return;
         }
 
+        $this->assertInspectorItemsSanitized($value);
+        $this->assertRenderableFieldsSanitized($value);
+        $this->assertTooltipSanitized($value);
+        $this->assertValidationSanitized($value);
+
+        foreach ($value as $childValue) {
+            $this->assertScreenConfigValueSanitized($childValue);
+        }
+    }
+
+    private function assertInspectorItemsSanitized(array $value): void
+    {
         if (array_key_exists('inspector', $value) && is_array($value['inspector'])) {
             foreach ($value['inspector'] as $inspector) {
                 if (is_array($inspector) && array_key_exists('type', $inspector)) {
@@ -655,29 +810,46 @@ class ScreenTemplateTest extends TestCase
                 }
             }
         }
+    }
 
-        foreach (['content', 'label'] as $field) {
+    private function assertRenderableFieldsSanitized(array $value): void
+    {
+        foreach (self::RENDERABLE_STRING_FIELDS as $field) {
             if (!array_key_exists($field, $value)) {
                 continue;
             }
 
-            $this->assertFalse(is_array($value[$field]));
+            $this->assertIsString($value[$field]);
         }
+    }
 
-        if (
-            array_key_exists('tooltip', $value)
-            && is_array($value['tooltip'])
-            && array_key_exists('content', $value['tooltip'])
-        ) {
-            $this->assertFalse(is_array($value['tooltip']['content']));
+    private function assertTooltipSanitized(array $value): void
+    {
+        $tooltip = $value['tooltip'] ?? null;
+        if (is_array($tooltip) && array_key_exists('content', $tooltip)) {
+            $this->assertIsString($value['tooltip']['content']);
         }
+    }
 
+    private function assertValidationSanitized(array $value): void
+    {
         if (array_key_exists('validation', $value) && is_array($value['validation'])) {
             $this->assertNotEmpty($value['validation']);
         }
+    }
 
-        foreach ($value as $childValue) {
-            $this->assertScreenConfigValueSanitized($childValue);
+    private function screenConfigChildCollections(array $item): array
+    {
+        $collections = [];
+
+        if (array_key_exists('items', $item) && is_array($item['items'])) {
+            $collections[] = $item['items'];
         }
+
+        if (array_is_list($item)) {
+            $collections[] = $item;
+        }
+
+        return $collections;
     }
 }

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -477,6 +477,42 @@ class ScreenTemplateTest extends TestCase
         $this->assertNotEmpty($updatedScreen->config[1]['items']);
     }
 
+    public function testApplyTemplateSanitizesSerializedInspectorComponents()
+    {
+        $templatePath = base_path(self::SCREEN_TEMPLATE_PATH);
+        $screenTemplateData = File::get($templatePath);
+
+        $screenTemplate = $this->createScreenTemplateFromManifest($screenTemplateData);
+
+        $screenPath = base_path(self::SCREEN_PATH);
+        $screenData = json_decode(File::get($screenPath), true);
+
+        $newScreen = Screen::factory()->create([
+            'config' => $screenData,
+        ]);
+
+        $route = route('api.template.applyTemplate', [
+            'type' => 'screen',
+            'id' => $screenTemplate->id,
+        ]);
+
+        $response = $this->apiCall('POST', $route, [
+            'screenId' => $newScreen->id,
+            'templateOptions' => ['Fields', 'Layout'],
+            'currentScreenPage' => 1,
+        ]);
+
+        $response->assertStatus(200);
+
+        if (class_exists(VersionHistory::class)) {
+            $updatedScreen = \ProcessMaker\Models\ScreenVersion::select('config')->where('screen_id', $newScreen->id)->latest()->firstOrFail();
+        } else {
+            $updatedScreen = Screen::select('config')->where('id', $newScreen->id)->firstOrFail();
+        }
+
+        $this->assertScreenConfigSanitized($updatedScreen->config);
+    }
+
     public function testApplyLayoutToExistingScreen()
     {
         // Create screen from template-manifest-with-css-fields-layout.json
@@ -573,5 +609,75 @@ class ScreenTemplateTest extends TestCase
 
         // Check that the screen has the custom_css
         $this->assertNotNull($updatedScreen->custom_css);
+    }
+
+    private function assertScreenConfigSanitized(array $config): void
+    {
+        foreach ($config as $page) {
+            $this->assertScreenConfigValueSanitized($page);
+        }
+    }
+
+    private function createScreenTemplateFromManifest(string $manifest): ScreenTemplates
+    {
+        $screenTemplate = ScreenTemplates::make([
+            'unique_template_id' => 'serialized-inspector-regression',
+            'name' => 'Serialized Inspector Regression',
+            'description' => 'Template with serialized Vue component inspector metadata.',
+            'version' => '1.0.0',
+            'user_id' => null,
+            'editing_screen_uuid' => null,
+            'screen_category_id' => ScreenCategory::factory()->create()->getKey(),
+            'screen_type' => 'FORM',
+            'media_collection' => 'serialized-inspector-regression-media',
+            'manifest' => $manifest,
+            'screen_custom_css' => null,
+            'is_public' => true,
+            'is_default_template' => false,
+            'is_system' => false,
+            'asset_type' => null,
+        ]);
+        $screenTemplate->saveOrFail();
+
+        return $screenTemplate;
+    }
+
+    private function assertScreenConfigValueSanitized($value): void
+    {
+        if (!is_array($value)) {
+            return;
+        }
+
+        if (array_key_exists('inspector', $value) && is_array($value['inspector'])) {
+            foreach ($value['inspector'] as $inspector) {
+                if (is_array($inspector) && array_key_exists('type', $inspector)) {
+                    $this->assertFalse(is_array($inspector['type']));
+                }
+            }
+        }
+
+        foreach (['content', 'label'] as $field) {
+            if (!array_key_exists($field, $value)) {
+                continue;
+            }
+
+            $this->assertFalse(is_array($value[$field]));
+        }
+
+        if (
+            array_key_exists('tooltip', $value)
+            && is_array($value['tooltip'])
+            && array_key_exists('content', $value['tooltip'])
+        ) {
+            $this->assertFalse(is_array($value['tooltip']['content']));
+        }
+
+        if (array_key_exists('validation', $value) && is_array($value['validation'])) {
+            $this->assertNotEmpty($value['validation']);
+        }
+
+        foreach ($value as $childValue) {
+            $this->assertScreenConfigValueSanitized($childValue);
+        }
     }
 }

--- a/tests/Feature/Templates/Api/ScreenTemplateTest.php
+++ b/tests/Feature/Templates/Api/ScreenTemplateTest.php
@@ -392,13 +392,11 @@ class ScreenTemplateTest extends TestCase
 
     public function testApplyCssToExistingScreen()
     {
-        // Create a new screen with two pages and no custom_css
-        $screenPath = base_path(self::SCREEN_PATH);
-        $screenData = json_decode(File::get($screenPath), true);
-
+        // Create a new screen with no config and no custom_css
         $screen = Screen::factory()->create([
-            'config' => $screenData,
+            'config' => null,
         ]);
+        $this->assertNull($screen->config);
         $this->assertNull($screen->custom_css);
 
         // Create a screen template with custom_css
@@ -420,13 +418,14 @@ class ScreenTemplateTest extends TestCase
         $response->assertStatus(200);
 
         if (class_exists(VersionHistory::class)) {
-            $updatedScreen = \ProcessMaker\Models\ScreenVersion::select('custom_css')->where('screen_id', $screen->id)->latest()->firstOrFail();
+            $updatedScreen = \ProcessMaker\Models\ScreenVersion::select('config', 'custom_css')->where('screen_id', $screen->id)->latest()->firstOrFail();
         } else {
-            $updatedScreen = Screen::select('custom_css')->where('id', $screen->id)->firstOrFail();
+            $updatedScreen = Screen::select('config', 'custom_css')->where('id', $screen->id)->firstOrFail();
         }
 
         // Check that the screen has the custom_css
         $this->assertNotNull($updatedScreen->custom_css);
+        $this->assertNull($updatedScreen->config);
     }
 
     public function testApplyFieldsToExistingScreen()
@@ -475,6 +474,7 @@ class ScreenTemplateTest extends TestCase
 
         // Check that the screen config is not empty
         $this->assertNotEmpty($updatedScreen->config[1]['items']);
+        $this->assertScreenConfigSanitized($updatedScreen->config);
     }
 
     public function testApplyTemplateSanitizesSerializedInspectorComponents()


### PR DESCRIPTION
## Issue & Reproduction Steps
The default screen template "Single Form - Multi-Step Process" can persist serialized builder metadata in the target screen config. When the screen builder or preview renders that config, `mustache.render` can receive an object instead of a template string, causing a browser console error and preventing the screen from rendering correctly.

Reproduction:
1. Log in and go to Designer > Screens.
2. Create or open a screen.
3. Apply the default "Single Form - Multi-Step Process" screen template.
4. Save or reload the screen builder, then open preview/request mode.
5. Before this fix, the browser console reports `Invalid template! Template should be a "string" but "object" was given as the first argument for mustache#render`.

The regression test uses the existing `template-manifest-with-css-fields-layout.json` fixture, which contains serialized inspector metadata matching the failure mode.

## Solution
- Added backend sanitization for screen template config before applied templates are persisted.
- Removed serialized Vue component objects from `inspector[*].type` recursively.
- Normalized renderable string fields when template payloads provide non-renderable array/object values.
- Normalized empty `validation: []` values to `null` so form elements do not enter validation rendering paths with invalid template data.
- Kept the change backend-only; no public API, route, or frontend package changes were made.
- Added a regression test covering `POST /template/screen/{id}/apply` and nested sanitized config output.

## How to Test
Automated:
```bash
php ./vendor/bin/phpunit --filter testApplyTemplateSanitizesSerializedInspectorComponents tests/Feature/Templates/Api/ScreenTemplateTest.php
```

Manual:
1. Run `php artisan processmaker:sync-screen-templates` if the default screen templates need to be refreshed locally.
2. Create or open a screen in Designer.
3. Apply the default "Single Form - Multi-Step Process" screen template.
4. Save/reload the screen builder and open preview/request mode.
5. Confirm the browser console no longer shows the `mustache#render` invalid template error.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-30819

ci:deploy
