### PR TITLE
FOUR-26194 Implement a Schedulable Job to create the table in DB - Part 1

### DIFF
--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -202,10 +202,11 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
     {
         try {
             $config = json_decode($task->configuration);
-            $lastExecution = new DateTime($task->last_execution, new DateTimeZone('UTC'));
 
-            if ($lastExecution === null) {
-                return;
+            // SCHEDULED_JOB rows use last_execution = null until first run; BPMN timers always set last_execution.
+            $lastExecution = null;
+            if ($task->last_execution !== null && $task->last_execution !== '') {
+                $lastExecution = new DateTime($task->last_execution, new DateTimeZone('UTC'));
             }
 
             $owner = $task->processRequestToken ?: $task->processRequest ?: $task->process;
@@ -721,11 +722,14 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
         if (!isset($config['job'])) {
             throw new InvalidArgumentException('$config["job"] is required');
         }
+
+        // Must use "interval" so nextDate(TimeDate) picks up the target datetime (same shape as BPMN timer tasks).
         $configuration = [
             'type' => 'TimeDate',
-            'date' => $datetime,
             ...$config,
+            'interval' => $datetime,
         ];
+
         $scheduledTask = new ScheduledTask();
         $scheduledTask->configuration = json_encode($configuration);
         $scheduledTask->type = 'SCHEDULED_JOB';


### PR DESCRIPTION
## Issue & Reproduction Steps

### Implement a Schedulable Job to create the table in DB - Part 1

## Solution

## Related Tickets & Packages
[FOUR-26194](https://processmaker.atlassian.net/browse/FOUR-26194)
https://github.com/ProcessMaker/package-savedsearch/pull/589

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-savedsearch:FOUR-26194


[FOUR-26194]: https://processmaker.atlassian.net/browse/FOUR-26194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ