### PR TITLE
New users should have these values ​​set to true by default.

### DIFF
--- a/ProcessMaker/Observers/UserObserver.php
+++ b/ProcessMaker/Observers/UserObserver.php
@@ -38,6 +38,11 @@ class UserObserver
         $perList = [
             'view-process-catalog',
             'view-my_requests',
+            'overview-tab-task',
+            'summary-tab-task',
+            'completed-tab-task',
+            'form-tab-task',
+            'files-tab-task',
         ];
         $permissionIds = Permission::whereIn('name', $perList)->pluck('id')->toArray();
         $user->permissions()->attach($permissionIds);


### PR DESCRIPTION
Ticket [FOUR-31100](https://processmaker.atlassian.net/browse/FOUR-31100)

Add additional permissions to UserObserver for task tabs
Updated UserObserver to include new permissions: overview-tab-task, summary-tab-task, completed-tab-task, form-tab-task, and files-tab-task.



[FOUR-31100]: https://processmaker.atlassian.net/browse/FOUR-31100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ