### PR TITLE
FOUR-30789: MULTITENANT Server Error creating a new report from an Expense Report process created from Guide Template

### DIFF
--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -11,9 +11,9 @@ use ProcessMaker\Console\Commands\BuildScriptExecutors;
 use ProcessMaker\Exception\ScriptException;
 use ProcessMaker\Facades\Docker;
 use ProcessMaker\ScriptRunners\Base;
-use RuntimeException;
-use Psr\Container\NotFoundExceptionInterface;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use RuntimeException;
 use UnexpectedValueException;
 
 /**
@@ -21,7 +21,6 @@ use UnexpectedValueException;
  */
 trait ScriptDockerNayraTrait
 {
-
     private $schema = 'http';
 
     /**
@@ -45,13 +44,16 @@ trait ScriptDockerNayraTrait
             'timeout' => $timeout,
         ];
         $body = json_encode($params);
-        $servers = self::getNayraAddresses();
-        if (!$servers) {
+
+        if (!$this->hasConfiguredNayraRestApiHost() && !self::getNayraAddresses()) {
             $this->bringUpNayra();
         }
+
         $baseUrl = $this->getNayraInstanceUrl();
         $url = $baseUrl . '/run_script';
-        $this->ensureNayraServerIsRunning($baseUrl);
+        if (!$this->hasConfiguredNayraRestApiHost()) {
+            $this->ensureNayraServerIsRunning($baseUrl);
+        }
 
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
@@ -62,8 +64,8 @@ trait ScriptDockerNayraTrait
             'Content-Length: ' . strlen($body),
         ]);
         $result = curl_exec($ch);
-        curl_close($ch);
         $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
         if ($httpStatus !== 200) {
             $result .= ' HTTP Status: ' . $httpStatus;
             $result .= ' URL: ' . $url;
@@ -75,13 +77,29 @@ trait ScriptDockerNayraTrait
             ]);
             throw new ScriptException($result);
         }
+
         return $result;
     }
 
     private function getNayraInstanceUrl()
     {
+        if ($this->hasConfiguredNayraRestApiHost()) {
+            return $this->getConfiguredNayraRestApiHost();
+        }
+
         $servers = self::getNayraAddresses();
+
         return $this->schema . '://' . $servers[0] . ':' . $this->getNayraPort();
+    }
+
+    private function hasConfiguredNayraRestApiHost(): bool
+    {
+        return $this->getConfiguredNayraRestApiHost() !== '';
+    }
+
+    private function getConfiguredNayraRestApiHost(): string
+    {
+        return rtrim((string) config('app.nayra_rest_api_host'), '/');
     }
 
     private function getDockerLogs($instanceName)
@@ -92,6 +110,7 @@ trait ScriptDockerNayraTrait
         if ($status) {
             return 'Error getting logs from Nayra Docker: ' . implode("\n", $logs);
         }
+
         return implode("\n", $logs);
     }
 
@@ -106,6 +125,10 @@ trait ScriptDockerNayraTrait
     {
         $header = @get_headers($url);
         if (!$header) {
+            if ($this->hasConfiguredNayraRestApiHost()) {
+                throw new ScriptException('Could not connect to configured Nayra REST API host');
+            }
+
             $this->bringUpNayra(true);
         }
     }
@@ -206,7 +229,7 @@ trait ScriptDockerNayraTrait
                     . ($nayraDockerNetwork
                         ? "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'"
                         : "'{{ .NetworkSettings.IPAddress }}'"
-                        )
+                    )
                     . " {$instanceName}_nayra 2>/dev/null",
                     $output,
                     $status
@@ -217,6 +240,7 @@ trait ScriptDockerNayraTrait
             }
             if ($ip) {
                 self::setNayraAddresses([$ip]);
+
                 return true;
             }
         }
@@ -280,6 +304,7 @@ trait ScriptDockerNayraTrait
     private static function isCacheArrayStore(): bool
     {
         $cacheDriver = Cache::getFacadeRoot()->getStore();
+
         return $cacheDriver instanceof ArrayStore;
     }
 

--- a/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
+++ b/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Models;
+
+use Illuminate\Cache\FileStore;
+use Illuminate\Cache\Repository as CacheRepository;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\TestCase;
+use ProcessMaker\Models\ScriptDockerNayraTrait;
+use ReflectionClass;
+
+class ScriptDockerNayraTraitTest extends TestCase
+{
+    private string $cachePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $app = new Container();
+        Container::setInstance($app);
+        Facade::setFacadeApplication($app);
+
+        $app->instance('config', new ConfigRepository([
+            'app' => [
+                'nayra_rest_api_host' => '',
+                'nayra_port' => 8080,
+            ],
+        ]));
+
+        $this->cachePath = sys_get_temp_dir() . '/processmaker-nayra-test-cache-' . uniqid('', true);
+        Cache::swap(new CacheRepository(new FileStore(new Filesystem(), $this->cachePath)));
+    }
+
+    protected function tearDown(): void
+    {
+        TestNayraScriptRunner::clearNayraAddresses();
+        (new Filesystem())->deleteDirectory($this->cachePath);
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
+    public function testConfiguredNayraRestApiHostIsUsedInsteadOfCachedDockerAddress(): void
+    {
+        config([
+            'app.nayra_rest_api_host' => 'http://nayra-service:8080/',
+            'app.nayra_port' => 8080,
+        ]);
+        TestNayraScriptRunner::setNayraAddresses(['172.18.0.5']);
+
+        $this->assertSame(
+            'http://nayra-service:8080',
+            $this->getNayraInstanceUrl()
+        );
+    }
+
+    public function testDockerAddressIsUsedWhenNayraRestApiHostIsNotConfigured(): void
+    {
+        config([
+            'app.nayra_rest_api_host' => '',
+            'app.nayra_port' => 8081,
+        ]);
+        TestNayraScriptRunner::setNayraAddresses(['172.18.0.5']);
+
+        $this->assertSame(
+            'http://172.18.0.5:8081',
+            $this->getNayraInstanceUrl()
+        );
+    }
+
+    private function getNayraInstanceUrl(): string
+    {
+        $runner = new TestNayraScriptRunner();
+        $reflection = new ReflectionClass($runner);
+        $method = $reflection->getMethod('getNayraInstanceUrl');
+
+        return $method->invoke($runner);
+    }
+}
+
+class TestNayraScriptRunner
+{
+    use ScriptDockerNayraTrait;
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
FOUR-30789: MULTITENANT Server Error creating a new report from an Expense Report process created from Guide Template
Ticket: https://processmaker.atlassian.net/browse/FOUR-30789

Creating a report from an Expense Report process generated from a Guide Template can trigger php-nayra script execution in multitenant mode, where Nayra resolves a tenant-specific Docker container instead of the configured REST service.

1. Create or select a guide template that includes an Expense Report process.
2. Generate a new Expense Report process from the template.
3. Attempt to create a new report associated with that generated process.
4. Fill required fields and save or create the report.
5. Observe the server error during report creation when php-nayra execution resolves the wrong Nayra endpoint in multitenant mode.

## Solution
- Updated php-nayra execution to use app.nayra_rest_api_host directly when configured.
- Skipped Docker Nayra address discovery, health fallback, and container startup when a configured Nayra REST API host is present.
- Normalized configured Nayra REST API hosts by trimming trailing slashes before appending /run_script.
- Moved curl HTTP status inspection before closing the curl handle.
- Added focused unit coverage for configured REST host precedence and the existing Docker-address fallback.

## How to Test
1. Run vendor/bin/phpunit tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php.
2. In a multitenant environment with NAYRA_REST_API_HOST configured, generate an Expense Report process from a guide template and create a new report.
3. Verify the report is created without a server error and php-nayra posts to the configured Nayra REST endpoint instead of attempting tenant-specific Docker container discovery.

## Related Tickets & Packages
- FOUR-30789: https://processmaker.atlassian.net/browse/FOUR-30789