### PR TITLE
FOUR-30789: Fix Nayra REST host resolution for multitenant script execution

### DIFF
--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -186,6 +186,7 @@ trait ScriptDockerNayraTrait
             throw new ScriptException('Error starting Nayra Docker');
         }
 
+        $endpoint = self::buildNayraEndpointAfterStartup($docker, $instanceName, $this->schema);
         $this->cacheNayraEndpointAfterReadiness($endpoint);
     }
 
@@ -257,6 +258,11 @@ trait ScriptDockerNayraTrait
      */
     private static function findNayraAddresses($docker, $instanceName, $times): bool
     {
+        return self::resolveNayraContainerAddress($docker, $instanceName, $times) !== null;
+    }
+
+    private static function resolveNayraContainerAddress($docker, $instanceName, $times): ?string
+    {
         $ip = '';
         $nayraDockerNetwork = config('app.nayra_docker_network');
 
@@ -264,15 +270,17 @@ trait ScriptDockerNayraTrait
             if ($i > 0) {
                 sleep(1);
             }
+            $output = [];
+            $status = 0;
             if ($nayraDockerNetwork === 'host') {
-                $ip = exec(
+                $ip = static::execDockerCommand(
                     $docker . " exec {$instanceName}_nayra hostname -i 2>/dev/null",
                     $output,
                     $status
                 );
                 $ip = explode(' ', trim($ip))[0];
             } else {
-                $ip = exec(
+                $ip = static::execDockerCommand(
                     $docker . ' inspect --format '
                     . ($nayraDockerNetwork
                         ? "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'"
@@ -288,11 +296,16 @@ trait ScriptDockerNayraTrait
             }
             if ($ip) {
                 self::setNayraAddresses([$ip]);
-                return true;
+                return $ip;
             }
         }
 
-        return false;
+        return null;
+    }
+
+    protected static function execDockerCommand(string $command, array &$output, int &$status): string|false
+    {
+        return exec($command, $output, $status);
     }
 
     /**
@@ -360,9 +373,31 @@ trait ScriptDockerNayraTrait
         return self::buildNayraEndpointUrl($this->schema);
     }
 
-    private static function buildNayraEndpointUrl(string $schema = 'http'): string
+    private static function buildNayraEndpointUrl(string $schema = 'http', ?string $host = null): string
     {
-        return $schema . '://' . self::getNayraEndpointHost() . ':' . self::getNayraPortValue();
+        return $schema . '://' . ($host ?? self::getNayraEndpointHost()) . ':' . self::getNayraPortValue();
+    }
+
+    private static function buildNayraEndpointAfterStartup(
+        string $docker,
+        string $instanceName,
+        string $schema = 'http',
+        int $addressAttempts = 30
+    ): string {
+        if (self::shouldUseContainerHostNetworkEndpoint()) {
+            $host = self::resolveNayraContainerAddress($docker, $instanceName, $addressAttempts);
+            if ($host) {
+                return self::buildNayraEndpointUrl($schema, $host);
+            }
+        }
+
+        return self::buildNayraEndpointUrl($schema);
+    }
+
+    private static function shouldUseContainerHostNetworkEndpoint(): bool
+    {
+        return config('app.nayra_docker_network') === 'host'
+            && !config('app.processmaker_scripts_docker_host');
     }
 
     private static function getNayraEndpointHost(): string
@@ -505,7 +540,7 @@ trait ScriptDockerNayraTrait
                 : '')
             . $image
         );
-        $endpoint = self::buildNayraEndpointUrl();
+        $endpoint = self::buildNayraEndpointAfterStartup($docker, $instanceName);
         if (!static::nayraEndpointIsRunning($endpoint)) {
             throw new UnexpectedValueException('Could not connect to the nayra container');
         }

--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -3,7 +3,6 @@
 namespace ProcessMaker\Models;
 
 use Illuminate\Cache\ArrayStore;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -11,9 +10,7 @@ use ProcessMaker\Console\Commands\BuildScriptExecutors;
 use ProcessMaker\Exception\ScriptException;
 use ProcessMaker\Facades\Docker;
 use ProcessMaker\ScriptRunners\Base;
-use RuntimeException;
-use Psr\Container\NotFoundExceptionInterface;
-use Psr\Container\ContainerExceptionInterface;
+use ProcessMaker\Models\ScriptExecutor;
 use UnexpectedValueException;
 
 /**
@@ -23,6 +20,8 @@ trait ScriptDockerNayraTrait
 {
 
     private $schema = 'http';
+
+    abstract protected function getScriptExecutor(): ScriptExecutor;
 
     /**
      * Execute the script task using Nayra Docker.
@@ -45,21 +44,20 @@ trait ScriptDockerNayraTrait
             'timeout' => $timeout,
         ];
         $body = json_encode($params);
-        $baseUrl = $this->resolveNayraBaseUrl();
+        $baseUrl = $this->ensureNayraServerIsRunning($this->resolveNayraBaseUrl());
         $url = $baseUrl . '/run_script';
-        $this->ensureNayraServerIsRunning($baseUrl);
 
-        $ch = curl_init($url);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        $ch = $this->curlInit($url);
+        $this->curlSetOpt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+        $this->curlSetOpt($ch, CURLOPT_POSTFIELDS, $body);
+        $this->curlSetOpt($ch, CURLOPT_RETURNTRANSFER, true);
+        $this->curlSetOpt($ch, CURLOPT_HTTPHEADER, [
             'Content-Type: application/json',
             'Content-Length: ' . strlen($body),
         ]);
-        $result = curl_exec($ch);
-        curl_close($ch);
-        $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $result = $this->curlExec($ch);
+        $httpStatus = $this->curlGetInfo($ch, CURLINFO_HTTP_CODE);
+        $this->curlClose($ch);
         if ($httpStatus !== 200) {
             $result .= ' HTTP Status: ' . $httpStatus;
             $result .= ' URL: ' . $url;
@@ -77,22 +75,32 @@ trait ScriptDockerNayraTrait
     private function getNayraInstanceUrl()
     {
         if (config('app.nayra_rest_api_host')) {
-            return config('app.nayra_rest_api_host');
+            return $this->normalizeNayraUrl(config('app.nayra_rest_api_host'));
         }
 
-        $servers = self::getNayraAddresses();
-        return $this->schema . '://' . $servers[0] . ':' . $this->getNayraPort();
+        if ($endpoint = self::getNayraEndpoint()) {
+            return $endpoint;
+        }
+
+        return $this->buildNayraEndpoint();
     }
 
     private function resolveNayraBaseUrl()
     {
         if (config('app.nayra_rest_api_host')) {
-            return config('app.nayra_rest_api_host');
+            return $this->normalizeNayraUrl(config('app.nayra_rest_api_host'));
         }
 
-        if (!self::getNayraAddresses()) {
-            $this->bringUpNayra();
+        $endpoint = self::getNayraEndpoint();
+        if ($endpoint) {
+            if ($this->isNayraServiceReachable($endpoint)) {
+                return $endpoint;
+            }
+
+            self::clearNayraEndpoint();
         }
+
+        $this->bringUpNayra();
 
         return $this->getNayraInstanceUrl();
     }
@@ -112,21 +120,26 @@ trait ScriptDockerNayraTrait
      * Ensure that the Nayra server is running.
      *
      * @param string $url URL of the Nayra server
-     * @return void
+     * @return string
      * @throws ScriptException If cannot connect to Nayra Service
      */
-    private function ensureNayraServerIsRunning(string $url)
+    private function ensureNayraServerIsRunning(string $url): string
     {
-        $header = @get_headers($url);
-        if ($header) {
-            return;
+        if ($this->isNayraServiceReachable($url)) {
+            return $url;
         }
 
         if (config('app.nayra_rest_api_host')) {
             throw new ScriptException('Could not connect to the configured Nayra REST API host: ' . $url);
         }
 
+        self::clearNayraEndpoint();
         $this->bringUpNayra(true);
+
+        $url = $this->getNayraInstanceUrl();
+        $this->nayraServiceIsRunning($url);
+
+        return $url;
     }
 
     /**
@@ -137,50 +150,84 @@ trait ScriptDockerNayraTrait
     private function bringUpNayra($restart = false)
     {
         $docker = Docker::command();
-        $instanceName = config('app.instance');
-        if (!$restart && self::findNayraAddresses($docker, $instanceName, 3)) {
-            // The container is already running
+        $instanceName = self::getNayraContainerName();
+        $endpoint = $this->buildNayraEndpoint();
+
+        if (!$restart && $this->isNayraServiceReachable($endpoint)) {
+            self::setNayraEndpoint($endpoint);
             return;
         }
 
-        $image = $this->scriptExecutor->dockerImageName();
-        //check if image exists
-        exec($docker . " inspect {$image} 2>&1", $output, $status);
+        $image = $this->getNayraDockerImage($docker);
+        $portMapping = $this->getNayraDockerPortMapping();
+        $network = config('app.nayra_docker_network');
+
+        $output = [];
+        exec($docker . " stop {$instanceName}_nayra 2>&1 || true", $output);
+
+        $output = [];
+        exec($docker . " rm {$instanceName}_nayra 2>&1 || true", $output);
+
+        $output = [];
+        exec(
+            $docker . ' run -d '
+            . $portMapping
+            . '--name ' . $instanceName . '_nayra '
+            . ($network ? '--network=' . $network . ' ' : '')
+            . $image,
+            $output,
+            $status
+        );
         if ($status) {
-            $this->bringUpNayraContainer();
-        } else {
-            $isHost = config('app.nayra_docker_network') === 'host';
-            $portMapping = $isHost ? '-e PORT=' . $this->getNayraPort() . ' ' : '-p ' . $this->getNayraPort() . ':8080 ';
-            exec($docker . " stop {$instanceName}_nayra 2>&1 || true");
-            exec($docker . " rm {$instanceName}_nayra 2>&1 || true");
-            exec(
-                $docker . ' run -d '
-                . ($this->getNayraPort() !== 8080 ? $portMapping : '')
-                . '--name ' . $instanceName . '_nayra '
-                . (config('app.nayra_docker_network')
-                    ? '--network=' . config('app.nayra_docker_network') . ' '
-                    : '')
-                . $image,
-                $output,
-                $status
-            );
-            if ($status) {
-                Log::error('Error starting Nayra Docker', [
-                    'output' => $output,
-                    'status' => $status,
-                ]);
-                throw new ScriptException('Error starting Nayra Docker');
-            }
+            Log::error('Error starting Nayra Docker', [
+                'output' => $output,
+                'status' => $status,
+            ]);
+            throw new ScriptException('Error starting Nayra Docker');
         }
-        $this->waitContainerNetwork($docker, $instanceName);
-        $url = $this->getNayraInstanceUrl();
-        $this->nayraServiceIsRunning($url);
+
+        self::setNayraEndpoint($endpoint);
+        $this->nayraServiceIsRunning($endpoint);
     }
 
     private function bringUpNayraContainer()
     {
         $lang = Base::NAYRA_LANG;
         Artisan::call("processmaker:build-script-executor {$lang} --rebuild");
+    }
+
+    private function getNayraDockerImage(string $docker): string
+    {
+        $image = $this->getScriptExecutor()->dockerImageName();
+        $sharedImage = $this->sharedNayraDockerImageName($image);
+
+        foreach (array_unique([$sharedImage, $image]) as $candidate) {
+            $output = [];
+            exec($docker . " inspect {$candidate} 2>&1", $output, $status);
+            if (!$status) {
+                return $candidate;
+            }
+        }
+
+        $this->bringUpNayraContainer();
+
+        return $image;
+    }
+
+    private function sharedNayraDockerImageName(string $image): string
+    {
+        $currentInstance = config('app.instance');
+        $sharedInstance = self::getNayraInstanceName();
+
+        if ($currentInstance === $sharedInstance) {
+            return $image;
+        }
+
+        return str_replace(
+            'executor-' . $currentInstance . '-',
+            'executor-' . $sharedInstance . '-',
+            $image
+        );
     }
 
     /**
@@ -255,12 +302,146 @@ trait ScriptDockerNayraTrait
             if ($i > 0) {
                 sleep(1);
             }
-            $status = @get_headers($url);
+            $status = $this->getHeaders($url);
             if ($status) {
                 return true;
             }
         }
         throw new ScriptException('Could not connect to the nayra container');
+    }
+
+    private function isNayraServiceReachable(string $url): bool
+    {
+        return (bool) $this->getHeaders($url);
+    }
+
+    protected function getHeaders(string $url): array|false
+    {
+        return @get_headers($url);
+    }
+
+    protected function curlInit(string $url): mixed
+    {
+        return curl_init($url);
+    }
+
+    protected function curlSetOpt(mixed $handle, int $option, mixed $value): bool
+    {
+        return curl_setopt($handle, $option, $value);
+    }
+
+    protected function curlExec(mixed $handle): string|bool
+    {
+        return curl_exec($handle);
+    }
+
+    protected function curlGetInfo(mixed $handle, int $option): mixed
+    {
+        return curl_getinfo($handle, $option);
+    }
+
+    protected function curlClose(mixed $handle): void
+    {
+        curl_close($handle);
+    }
+
+    private function normalizeNayraUrl(string $url): string
+    {
+        return rtrim($url, '/');
+    }
+
+    private function buildNayraEndpoint(): string
+    {
+        return self::buildNayraEndpointUrl($this->schema);
+    }
+
+    private static function buildNayraEndpointUrl(string $schema = 'http'): string
+    {
+        return $schema . '://' . self::getNayraEndpointHost() . ':' . self::getNayraPortValue();
+    }
+
+    private static function getNayraEndpointHost(): string
+    {
+        $dockerHost = config('app.processmaker_scripts_docker_host');
+        if ($dockerHost) {
+            $parsed = parse_url($dockerHost);
+            if (isset($parsed['host'])) {
+                return $parsed['host'];
+            }
+
+            return explode(':', $dockerHost)[0];
+        }
+
+        return '127.0.0.1';
+    }
+
+    private function getNayraDockerPortMapping(): string
+    {
+        return self::getNayraDockerPortMappingValue();
+    }
+
+    private static function getNayraDockerPortMappingValue(): string
+    {
+        $port = self::getNayraPortValue();
+
+        return config('app.nayra_docker_network') === 'host'
+            ? '-e PORT=' . $port . ' '
+            : '-p ' . $port . ':8080 ';
+    }
+
+    private static function getNayraInstanceName(): string
+    {
+        $instance = config('app.instance');
+
+        if (!config('app.multitenancy')) {
+            return $instance;
+        }
+
+        $tenant = app()->bound('currentTenant') ? app('currentTenant') : null;
+
+        if ($tenant && str_ends_with($instance, '_' . $tenant->id)) {
+            return substr($instance, 0, -strlen('_' . $tenant->id));
+        }
+
+        return $instance;
+    }
+
+    private static function getNayraContainerName(): string
+    {
+        return self::getNayraInstanceName();
+    }
+
+    public static function getNayraEndpoint()
+    {
+        // Check if it is running in unit test mode with Cache ArrayStore
+        $isArrayDriver = self::isCacheArrayStore();
+        if ($isArrayDriver) {
+            return Cache::store('file')->get('nayra_endpoint');
+        }
+
+        return Cache::get('nayra_endpoint');
+    }
+
+    public static function setNayraEndpoint(string $endpoint)
+    {
+        // Check if it is running in unit test mode with Cache ArrayStore
+        $isArrayDriver = self::isCacheArrayStore();
+        if ($isArrayDriver) {
+            return Cache::store('file')->forever('nayra_endpoint', $endpoint);
+        }
+
+        Cache::forever('nayra_endpoint', $endpoint);
+    }
+
+    public static function clearNayraEndpoint()
+    {
+        // Check if it is running in unit test mode with Cache ArrayStore
+        $isArrayDriver = self::isCacheArrayStore();
+        if ($isArrayDriver) {
+            return Cache::store('file')->forget('nayra_endpoint');
+        }
+
+        Cache::forget('nayra_endpoint');
     }
 
     public static function getNayraAddresses()
@@ -304,27 +485,25 @@ trait ScriptDockerNayraTrait
 
     public static function bringUpNayraExecutor(BuildScriptExecutors $builder, string $image)
     {
-        $instanceName = config('app.instance');
+        $instanceName = self::getNayraContainerName();
         $docker = Docker::command();
         $builder->info('Stop existing nayra container');
         $builder->execCommand("{$docker} stop {$instanceName}_nayra 2>&1 || true");
         $builder->execCommand("{$docker} rm {$instanceName}_nayra 2>&1 || true");
         $builder->info('Bring up the nayra container');
         $builder->execCommand(
-            $docker . ' run -d --name ' . $instanceName . '_nayra '
+            $docker . ' run -d '
+            . self::getNayraDockerPortMappingValue()
+            . '--name ' . $instanceName . '_nayra '
             . (config('app.nayra_docker_network')
                 ? '--network=' . config('app.nayra_docker_network') . ' '
                 : '')
             . $image
         );
-        $builder->info('Get IP address of the nayra container');
-        $found = self::findNayraAddresses($docker, $instanceName, 30);
-        if ($found) {
-            $builder->info('Nayra container IP: ' . self::getNayraAddresses()[0]);
-            $builder->sendEvent(0, 'done');
-        } else {
-            throw new UnexpectedValueException('Could not get IP address of the nayra container');
-        }
+        $endpoint = self::buildNayraEndpointUrl();
+        self::setNayraEndpoint($endpoint);
+        $builder->info('Nayra endpoint: ' . $endpoint);
+        $builder->sendEvent(0, 'done');
     }
 
     /**
@@ -333,6 +512,7 @@ trait ScriptDockerNayraTrait
     public static function initNayraPhpUnitTest()
     {
         Base::clearNayraAddresses();
+        Base::clearNayraEndpoint();
         $network = config('app.nayra_docker_network');
         // Check if docker network exists, if not create it
         exec(Docker::command() . " network inspect {$network} 2>&1", $output, $status);
@@ -346,6 +526,11 @@ trait ScriptDockerNayraTrait
 
     private function getNayraPort()
     {
-        return config('app.nayra_port', 8080);
+        return self::getNayraPortValue();
+    }
+
+    private static function getNayraPortValue(): int
+    {
+        return (int) config('app.nayra_port', 8080) ?: 8080;
     }
 }

--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -75,28 +75,37 @@ trait ScriptDockerNayraTrait
     private function getNayraInstanceUrl()
     {
         if (config('app.nayra_rest_api_host')) {
-            return $this->normalizeNayraUrl(config('app.nayra_rest_api_host'));
-        }
-
-        if ($endpoint = self::getNayraEndpoint()) {
+            $endpoint = $this->normalizeNayraUrl(config('app.nayra_rest_api_host'));
+            Log::warning('Nayra endpoint selected from config', self::nayraRuntimeContext($endpoint, 'config'));
             return $endpoint;
         }
 
-        return $this->buildNayraEndpoint();
+        if ($endpoint = self::getNayraEndpoint()) {
+            Log::warning('Nayra endpoint selected from cache', self::nayraRuntimeContext($endpoint, 'cache'));
+            return $endpoint;
+        }
+
+        $endpoint = $this->buildNayraEndpoint();
+        Log::warning('Nayra endpoint selected from fallback', self::nayraRuntimeContext($endpoint, 'fallback'));
+        return $endpoint;
     }
 
     private function resolveNayraBaseUrl()
     {
         if (config('app.nayra_rest_api_host')) {
-            return $this->normalizeNayraUrl(config('app.nayra_rest_api_host'));
+            $endpoint = $this->normalizeNayraUrl(config('app.nayra_rest_api_host'));
+            Log::warning('Nayra runtime endpoint resolved from config', self::nayraRuntimeContext($endpoint, 'config'));
+            return $endpoint;
         }
 
         $endpoint = self::getNayraEndpoint();
         if ($endpoint) {
             if ($this->isNayraServiceReachable($endpoint)) {
+                Log::warning('Cached Nayra endpoint is reachable', self::nayraRuntimeContext($endpoint, 'cache'));
                 return $endpoint;
             }
 
+            Log::warning('Cached Nayra endpoint is not reachable; clearing cache', self::nayraRuntimeContext($endpoint, 'cache'));
             self::clearNayraEndpoint();
         }
 
@@ -126,13 +135,16 @@ trait ScriptDockerNayraTrait
     private function ensureNayraServerIsRunning(string $url): string
     {
         if ($this->isNayraServiceReachable($url)) {
+            Log::warning('Nayra endpoint readiness confirmed before script execution', self::nayraRuntimeContext($url, 'selected'));
             return $url;
         }
 
         if (config('app.nayra_rest_api_host')) {
+            Log::warning('Configured Nayra endpoint is not reachable', self::nayraRuntimeContext($url, 'config'));
             throw new ScriptException('Could not connect to the configured Nayra REST API host: ' . $url);
         }
 
+        Log::warning('Nayra endpoint is not reachable; rebuilding container endpoint', self::nayraRuntimeContext($url, 'selected'));
         self::clearNayraEndpoint();
         $this->bringUpNayra(true);
 
@@ -152,15 +164,18 @@ trait ScriptDockerNayraTrait
         $docker = Docker::command();
         $instanceName = self::getNayraContainerName();
         $endpoint = $this->buildNayraEndpoint();
+        Log::warning('Preparing Nayra runtime endpoint', self::nayraRuntimeContext($endpoint, 'rebuild', $instanceName));
 
         if (!$restart && $this->isNayraServiceReachable($endpoint)) {
             self::setNayraEndpoint($endpoint);
+            Log::warning('Nayra container startup skipped because endpoint is reachable', self::nayraRuntimeContext($endpoint, 'fallback', $instanceName));
             return;
         }
 
         $image = $this->getNayraDockerImage($docker);
         $portMapping = $this->getNayraDockerPortMapping();
         $network = config('app.nayra_docker_network');
+        Log::warning('Starting Nayra Docker container', self::nayraRuntimeContext($endpoint, 'rebuild', $instanceName));
 
         $output = [];
         exec($docker . " stop {$instanceName}_nayra 2>&1 || true", $output);
@@ -180,13 +195,16 @@ trait ScriptDockerNayraTrait
         );
         if ($status) {
             Log::error('Error starting Nayra Docker', [
-                'output' => $output,
                 'status' => $status,
+                'output' => self::sanitizeNayraDockerOutput($output),
+                'endpointCandidate' => $endpoint,
+                'context' => self::nayraRuntimeContext($endpoint, 'rebuild', $instanceName),
             ]);
             throw new ScriptException('Error starting Nayra Docker');
         }
 
         $endpoint = self::buildNayraEndpointAfterStartup($docker, $instanceName, $this->schema);
+        Log::warning('Nayra endpoint selected after Docker startup', self::nayraRuntimeContext($endpoint, 'rebuild', $instanceName));
         $this->cacheNayraEndpointAfterReadiness($endpoint);
     }
 
@@ -194,6 +212,7 @@ trait ScriptDockerNayraTrait
     {
         $this->nayraServiceIsRunning($endpoint);
         self::setNayraEndpoint($endpoint);
+        Log::warning('Nayra endpoint cached after readiness check', self::nayraRuntimeContext($endpoint, 'rebuild'));
     }
 
     private function bringUpNayraContainer()
@@ -322,9 +341,15 @@ trait ScriptDockerNayraTrait
             }
             $status = $this->getHeaders($url);
             if ($status) {
+                Log::warning('Nayra readiness check succeeded', self::nayraRuntimeContext($url, 'readiness') + [
+                    'attempt' => $i + 1,
+                ]);
                 return true;
             }
         }
+        Log::warning('Nayra readiness check failed', self::nayraRuntimeContext($url, 'readiness') + [
+            'attempts' => static::getNayraEndpointReadinessAttempts(),
+        ]);
         throw new ScriptException('Could not connect to the nayra container');
     }
 
@@ -384,7 +409,7 @@ trait ScriptDockerNayraTrait
         string $schema = 'http',
         int $addressAttempts = 30
     ): string {
-        if (self::shouldUseContainerHostNetworkEndpoint()) {
+        if (self::shouldUseLocalContainerNetworkEndpoint()) {
             $host = self::resolveNayraContainerAddress($docker, $instanceName, $addressAttempts);
             if ($host) {
                 return self::buildNayraEndpointUrl($schema, $host);
@@ -394,10 +419,34 @@ trait ScriptDockerNayraTrait
         return self::buildNayraEndpointUrl($schema);
     }
 
-    private static function shouldUseContainerHostNetworkEndpoint(): bool
+    private static function shouldUseLocalContainerNetworkEndpoint(): bool
     {
-        return config('app.nayra_docker_network') === 'host'
+        return (bool) config('app.nayra_docker_network')
             && !config('app.processmaker_scripts_docker_host');
+    }
+
+    private static function nayraRuntimeContext(
+        ?string $endpoint = null,
+        ?string $source = null,
+        ?string $instanceName = null
+    ): array {
+        return [
+            'endpoint' => $endpoint,
+            'source' => $source,
+            'dockerHost' => config('app.processmaker_scripts_docker_host') ?: null,
+            'nayraDockerNetwork' => config('app.nayra_docker_network') ?: null,
+            'nayraPort' => self::getNayraPortValue(),
+            'containerName' => ($instanceName ?? self::getNayraContainerName()) . '_nayra',
+            'multitenancy' => (bool) config('app.multitenancy'),
+        ];
+    }
+
+    private static function sanitizeNayraDockerOutput(array $output): array
+    {
+        return array_map(
+            static fn ($line) => substr((string) $line, 0, 500),
+            array_slice($output, -10)
+        );
     }
 
     private static function getNayraEndpointHost(): string

--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -186,8 +186,13 @@ trait ScriptDockerNayraTrait
             throw new ScriptException('Error starting Nayra Docker');
         }
 
-        self::setNayraEndpoint($endpoint);
+        $this->cacheNayraEndpointAfterReadiness($endpoint);
+    }
+
+    private function cacheNayraEndpointAfterReadiness(string $endpoint): void
+    {
         $this->nayraServiceIsRunning($endpoint);
+        self::setNayraEndpoint($endpoint);
     }
 
     private function bringUpNayraContainer()
@@ -298,7 +303,7 @@ trait ScriptDockerNayraTrait
      */
     private function nayraServiceIsRunning($url): bool
     {
-        for ($i = 0; $i < 30; $i++) {
+        for ($i = 0; $i < static::getNayraEndpointReadinessAttempts(); $i++) {
             if ($i > 0) {
                 sleep(1);
             }
@@ -317,7 +322,7 @@ trait ScriptDockerNayraTrait
 
     protected function getHeaders(string $url): array|false
     {
-        return @get_headers($url);
+        return static::getNayraEndpointHeaders($url);
     }
 
     protected function curlInit(string $url): mixed
@@ -501,9 +506,37 @@ trait ScriptDockerNayraTrait
             . $image
         );
         $endpoint = self::buildNayraEndpointUrl();
+        if (!static::nayraEndpointIsRunning($endpoint)) {
+            throw new UnexpectedValueException('Could not connect to the nayra container');
+        }
+
         self::setNayraEndpoint($endpoint);
         $builder->info('Nayra endpoint: ' . $endpoint);
         $builder->sendEvent(0, 'done');
+    }
+
+    private static function nayraEndpointIsRunning(string $url): bool
+    {
+        for ($i = 0; $i < static::getNayraEndpointReadinessAttempts(); $i++) {
+            if ($i > 0) {
+                sleep(1);
+            }
+            if (static::getNayraEndpointHeaders($url)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected static function getNayraEndpointHeaders(string $url): array|false
+    {
+        return @get_headers($url);
+    }
+
+    protected static function getNayraEndpointReadinessAttempts(): int
+    {
+        return 30;
     }
 
     /**

--- a/ProcessMaker/Models/ScriptDockerNayraTrait.php
+++ b/ProcessMaker/Models/ScriptDockerNayraTrait.php
@@ -45,11 +45,7 @@ trait ScriptDockerNayraTrait
             'timeout' => $timeout,
         ];
         $body = json_encode($params);
-        $servers = self::getNayraAddresses();
-        if (!$servers) {
-            $this->bringUpNayra();
-        }
-        $baseUrl = $this->getNayraInstanceUrl();
+        $baseUrl = $this->resolveNayraBaseUrl();
         $url = $baseUrl . '/run_script';
         $this->ensureNayraServerIsRunning($baseUrl);
 
@@ -80,8 +76,25 @@ trait ScriptDockerNayraTrait
 
     private function getNayraInstanceUrl()
     {
+        if (config('app.nayra_rest_api_host')) {
+            return config('app.nayra_rest_api_host');
+        }
+
         $servers = self::getNayraAddresses();
         return $this->schema . '://' . $servers[0] . ':' . $this->getNayraPort();
+    }
+
+    private function resolveNayraBaseUrl()
+    {
+        if (config('app.nayra_rest_api_host')) {
+            return config('app.nayra_rest_api_host');
+        }
+
+        if (!self::getNayraAddresses()) {
+            $this->bringUpNayra();
+        }
+
+        return $this->getNayraInstanceUrl();
     }
 
     private function getDockerLogs($instanceName)
@@ -105,9 +118,15 @@ trait ScriptDockerNayraTrait
     private function ensureNayraServerIsRunning(string $url)
     {
         $header = @get_headers($url);
-        if (!$header) {
-            $this->bringUpNayra(true);
+        if ($header) {
+            return;
         }
+
+        if (config('app.nayra_rest_api_host')) {
+            throw new ScriptException('Could not connect to the configured Nayra REST API host: ' . $url);
+        }
+
+        $this->bringUpNayra(true);
     }
 
     /**

--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -53,6 +53,11 @@ abstract class Base
         $this->scriptExecutor = $scriptExecutor;
     }
 
+    protected function getScriptExecutor(): ScriptExecutor
+    {
+        return $this->scriptExecutor;
+    }
+
     /**
      * Run a script code.
      *

--- a/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
+++ b/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
@@ -17,6 +17,8 @@ class ScriptDockerNayraTraitFunctionState
 
     public const HOST_NETWORK_NAYRA_HOST = 'http://' . self::HOST_NETWORK_IP . ':8081';
 
+    public const REMOTE_DOCKER_HOST = 'tcp://qa-remotedocker:2375';
+
     public const NAYRA_TEST_IMAGE = 'processmaker4/nayra:test';
 
     public const OK_HEADER = 'HTTP/1.1 200 OK';
@@ -316,12 +318,65 @@ class ScriptDockerNayraTraitTest extends TestCase
     {
         config([
             'app.nayra_port' => '',
-            'app.processmaker_scripts_docker_host' => 'tcp://qa-remotedocker:2375',
+            'app.processmaker_scripts_docker_host' => ScriptDockerNayraTraitFunctionState::REMOTE_DOCKER_HOST,
         ]);
 
         $runner = new ScriptDockerNayraTraitTestHarness();
 
         $this->assertSame('http://qa-remotedocker:8080', $runner->exposedGetNayraInstanceUrl());
+    }
+
+    public function testLocalDockerNetworkNayraEndpointUsesDockerReportedAddressAfterStartup()
+    {
+        config([
+            'app.nayra_docker_network' => 'pm4-tools_default',
+            'app.nayra_port' => '',
+        ]);
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame(
+            'http://' . ScriptDockerNayraTraitFunctionState::HOST_NETWORK_IP . ':8080',
+            $runner->exposedBuildNayraEndpointAfterStartup('docker', 'processmaker', 'http', 1)
+        );
+        $this->assertCount(1, ScriptDockerNayraTraitFunctionState::$execCommands);
+        $this->assertStringContainsString(
+            "inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' processmaker_nayra",
+            ScriptDockerNayraTraitFunctionState::$execCommands[0]
+        );
+    }
+
+    public function testLocalDockerNetworkNayraEndpointDoesNotOverrideRemoteDockerHost()
+    {
+        config([
+            'app.nayra_docker_network' => 'pm4-tools_default',
+            'app.nayra_port' => '',
+            'app.processmaker_scripts_docker_host' => ScriptDockerNayraTraitFunctionState::REMOTE_DOCKER_HOST,
+        ]);
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame(
+            'http://qa-remotedocker:8080',
+            $runner->exposedBuildNayraEndpointAfterStartup(
+                'DOCKER_HOST=' . ScriptDockerNayraTraitFunctionState::REMOTE_DOCKER_HOST . ' docker',
+                'processmaker',
+                'http',
+                1
+            )
+        );
+        $this->assertSame([], ScriptDockerNayraTraitFunctionState::$execCommands);
+    }
+
+    public function testEmptyDockerNetworkNayraEndpointUsesLocalhostAfterStartup()
+    {
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
+            $runner->exposedBuildNayraEndpointAfterStartup('docker', 'processmaker', 'http', 1)
+        );
+        $this->assertSame([], ScriptDockerNayraTraitFunctionState::$execCommands);
     }
 
     public function testLocalHostNetworkNayraEndpointUsesDockerReportedAddressAfterStartup()
@@ -345,14 +400,19 @@ class ScriptDockerNayraTraitTest extends TestCase
     {
         config([
             'app.nayra_docker_network' => 'host',
-            'app.processmaker_scripts_docker_host' => 'tcp://qa-remotedocker:2375',
+            'app.processmaker_scripts_docker_host' => ScriptDockerNayraTraitFunctionState::REMOTE_DOCKER_HOST,
         ]);
 
         $runner = new ScriptDockerNayraTraitTestHarness();
 
         $this->assertSame(
             'http://qa-remotedocker:8081',
-            $runner->exposedBuildNayraEndpointAfterStartup('DOCKER_HOST=tcp://qa-remotedocker:2375 docker', 'processmaker', 'http', 1)
+            $runner->exposedBuildNayraEndpointAfterStartup(
+                'DOCKER_HOST=' . ScriptDockerNayraTraitFunctionState::REMOTE_DOCKER_HOST . ' docker',
+                'processmaker',
+                'http',
+                1
+            )
         );
         $this->assertSame([], ScriptDockerNayraTraitFunctionState::$execCommands);
     }

--- a/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
+++ b/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
@@ -7,7 +7,13 @@ use Tests\TestCase;
 
 class ScriptDockerNayraTraitFunctionState
 {
-    public static bool $enabled = false;
+    public const SUCCESS_RESPONSE = '{"status":"ok"}';
+
+    public const LOCAL_NAYRA_HOST = 'http://127.0.0.1:8081';
+
+    public const OK_HEADER = 'HTTP/1.1 200 OK';
+
+    public const SCRIPT_CODE = '<?php return [];';
 
     public static array $headers = [];
 
@@ -17,7 +23,9 @@ class ScriptDockerNayraTraitFunctionState
 
     public static array $curlOptions = [];
 
-    public static string $curlResult = '{"status":"ok"}';
+    public static array $curlHandles = [];
+
+    public static string $curlResult;
 
     public static int $curlHttpStatus = 200;
 
@@ -25,91 +33,19 @@ class ScriptDockerNayraTraitFunctionState
 
     public static function reset(): void
     {
-        self::$enabled = false;
         self::$headers = [];
         self::$requestedHeaders = [];
         self::$curlUrl = null;
         self::$curlOptions = [];
-        self::$curlResult = '{"status":"ok"}';
+        self::$curlHandles = [];
+        self::$curlResult = self::SUCCESS_RESPONSE;
         self::$curlHttpStatus = 200;
         self::$curlClosed = false;
     }
 }
 
-if (!function_exists(__NAMESPACE__ . '\get_headers')) {
-    function get_headers($url, $associative = false, $context = null)
-    {
-        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
-            return \get_headers($url, $associative, $context);
-        }
-
-        ScriptDockerNayraTraitFunctionState::$requestedHeaders[] = $url;
-
-        return ScriptDockerNayraTraitFunctionState::$headers[$url] ?? false;
-    }
-}
-
-if (!function_exists(__NAMESPACE__ . '\curl_init')) {
-    function curl_init($url = null)
-    {
-        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
-            return \curl_init($url);
-        }
-
-        ScriptDockerNayraTraitFunctionState::$curlUrl = $url;
-
-        return (object) ['url' => $url];
-    }
-}
-
-if (!function_exists(__NAMESPACE__ . '\curl_setopt')) {
-    function curl_setopt($handle, $option, $value)
-    {
-        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
-            return \curl_setopt($handle, $option, $value);
-        }
-
-        ScriptDockerNayraTraitFunctionState::$curlOptions[$option] = $value;
-
-        return true;
-    }
-}
-
-if (!function_exists(__NAMESPACE__ . '\curl_exec')) {
-    function curl_exec($handle)
-    {
-        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
-            return \curl_exec($handle);
-        }
-
-        return ScriptDockerNayraTraitFunctionState::$curlResult;
-    }
-}
-
-if (!function_exists(__NAMESPACE__ . '\curl_getinfo')) {
-    function curl_getinfo($handle, $option = null)
-    {
-        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
-            return \curl_getinfo($handle, $option);
-        }
-
-        if ($option === CURLINFO_HTTP_CODE) {
-            return ScriptDockerNayraTraitFunctionState::$curlHttpStatus;
-        }
-
-        return ['http_code' => ScriptDockerNayraTraitFunctionState::$curlHttpStatus];
-    }
-}
-
-if (!function_exists(__NAMESPACE__ . '\curl_close')) {
-    function curl_close($handle)
-    {
-        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
-            return \curl_close($handle);
-        }
-
-        ScriptDockerNayraTraitFunctionState::$curlClosed = true;
-    }
+class ScriptExecutorResolutionNotExercisedException extends \Exception
+{
 }
 
 class ScriptDockerNayraTraitTestHarness
@@ -117,6 +53,8 @@ class ScriptDockerNayraTraitTestHarness
     use ScriptDockerNayraTrait {
         getNayraInstanceUrl as public exposedGetNayraInstanceUrl;
         resolveNayraBaseUrl as public exposedResolveNayraBaseUrl;
+        getNayraPort as public exposedGetNayraPort;
+        getNayraContainerName as public exposedGetNayraContainerName;
     }
 
     public int $bringUpNayraCalls = 0;
@@ -128,9 +66,60 @@ class ScriptDockerNayraTraitTestHarness
         $this->bringUpNayraCalls++;
         $this->bringUpNayraRestartValues[] = $restart;
 
-        if (!$restart) {
-            self::setNayraAddresses(['172.18.0.9']);
+        self::setNayraEndpoint(ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST);
+    }
+
+    protected function getScriptExecutor(): ScriptExecutor
+    {
+        throw new ScriptExecutorResolutionNotExercisedException(
+            'The test harness does not exercise script executor resolution.'
+        );
+    }
+
+    protected function getHeaders(string $url): array|false
+    {
+        ScriptDockerNayraTraitFunctionState::$requestedHeaders[] = $url;
+
+        return ScriptDockerNayraTraitFunctionState::$headers[$url] ?? false;
+    }
+
+    protected function curlInit(string $url): object
+    {
+        ScriptDockerNayraTraitFunctionState::$curlUrl = $url;
+
+        return (object) ['url' => $url];
+    }
+
+    protected function curlSetOpt(mixed $handle, int $option, mixed $value): bool
+    {
+        ScriptDockerNayraTraitFunctionState::$curlHandles[__FUNCTION__][] = $handle;
+        ScriptDockerNayraTraitFunctionState::$curlOptions[$option] = $value;
+
+        return true;
+    }
+
+    protected function curlExec(mixed $handle): string|bool
+    {
+        ScriptDockerNayraTraitFunctionState::$curlHandles[__FUNCTION__][] = $handle;
+
+        return ScriptDockerNayraTraitFunctionState::$curlResult;
+    }
+
+    protected function curlGetInfo(mixed $handle, int $option): mixed
+    {
+        ScriptDockerNayraTraitFunctionState::$curlHandles[__FUNCTION__][] = $handle;
+
+        if ($option === CURLINFO_HTTP_CODE) {
+            return ScriptDockerNayraTraitFunctionState::$curlHttpStatus;
         }
+
+        return ['http_code' => ScriptDockerNayraTraitFunctionState::$curlHttpStatus];
+    }
+
+    protected function curlClose(mixed $handle): void
+    {
+        ScriptDockerNayraTraitFunctionState::$curlHandles[__FUNCTION__][] = $handle;
+        ScriptDockerNayraTraitFunctionState::$curlClosed = true;
     }
 }
 
@@ -142,10 +131,16 @@ class ScriptDockerNayraTraitTest extends TestCase
 
         ScriptDockerNayraTraitFunctionState::reset();
         ScriptDockerNayraTraitTestHarness::clearNayraAddresses();
+        ScriptDockerNayraTraitTestHarness::clearNayraEndpoint();
+        app()->forgetInstance('currentTenant');
 
         config([
+            'app.instance' => 'processmaker',
+            'app.multitenancy' => false,
             'app.nayra_rest_api_host' => '',
             'app.nayra_port' => 8081,
+            'app.nayra_docker_network' => '',
+            'app.processmaker_scripts_docker_host' => '',
         ]);
     }
 
@@ -153,50 +148,77 @@ class ScriptDockerNayraTraitTest extends TestCase
     {
         ScriptDockerNayraTraitFunctionState::reset();
         ScriptDockerNayraTraitTestHarness::clearNayraAddresses();
+        ScriptDockerNayraTraitTestHarness::clearNayraEndpoint();
+        app()->forgetInstance('currentTenant');
 
         parent::tearDown();
     }
 
     public function testHandleNayraDockerUsesConfiguredRestApiHostWithoutStartingDocker()
     {
-        config(['app.nayra_rest_api_host' => 'http://127.0.0.1:8081']);
-        ScriptDockerNayraTraitFunctionState::$enabled = true;
+        config(['app.nayra_rest_api_host' => ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST]);
         ScriptDockerNayraTraitFunctionState::$headers = [
-            'http://127.0.0.1:8081' => ['HTTP/1.1 200 OK'],
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST => [
+                ScriptDockerNayraTraitFunctionState::OK_HEADER,
+            ],
         ];
 
         $runner = new ScriptDockerNayraTraitTestHarness();
-        $result = $runner->handleNayraDocker('<?php return [];', ['foo' => 'bar'], [], 30, ['API_TOKEN=test-token']);
+        $result = $runner->handleNayraDocker(
+            ScriptDockerNayraTraitFunctionState::SCRIPT_CODE,
+            ['foo' => 'bar'],
+            [],
+            30,
+            ['API_TOKEN=test-token']
+        );
 
-        $this->assertSame('{"status":"ok"}', $result);
-        $this->assertSame('http://127.0.0.1:8081/run_script', ScriptDockerNayraTraitFunctionState::$curlUrl);
-        $this->assertSame(['http://127.0.0.1:8081'], ScriptDockerNayraTraitFunctionState::$requestedHeaders);
+        $this->assertSame(ScriptDockerNayraTraitFunctionState::SUCCESS_RESPONSE, $result);
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST . '/run_script',
+            ScriptDockerNayraTraitFunctionState::$curlUrl
+        );
+        $this->assertSame(
+            [ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST],
+            ScriptDockerNayraTraitFunctionState::$requestedHeaders
+        );
         $this->assertSame(0, $runner->bringUpNayraCalls);
     }
 
     public function testConfiguredRestApiHostTakesPriorityOverCachedDockerAddress()
     {
-        config(['app.nayra_rest_api_host' => 'http://127.0.0.1:8081']);
-        ScriptDockerNayraTraitTestHarness::setNayraAddresses(['172.18.0.5']);
-        ScriptDockerNayraTraitFunctionState::$enabled = true;
+        config(['app.nayra_rest_api_host' => ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST]);
+        ScriptDockerNayraTraitTestHarness::setNayraEndpoint('http://127.0.0.1:9090');
         ScriptDockerNayraTraitFunctionState::$headers = [
-            'http://127.0.0.1:8081' => ['HTTP/1.1 200 OK'],
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST => [
+                ScriptDockerNayraTraitFunctionState::OK_HEADER,
+            ],
         ];
 
         $runner = new ScriptDockerNayraTraitTestHarness();
-        $runner->handleNayraDocker('<?php return [];', [], [], 30, []);
+        $runner->handleNayraDocker(ScriptDockerNayraTraitFunctionState::SCRIPT_CODE, [], [], 30, []);
 
-        $this->assertSame('http://127.0.0.1:8081/run_script', ScriptDockerNayraTraitFunctionState::$curlUrl);
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST . '/run_script',
+            ScriptDockerNayraTraitFunctionState::$curlUrl
+        );
         $this->assertSame(0, $runner->bringUpNayraCalls);
     }
 
-    public function testNayraBaseUrlFallsBackToCachedDockerAddressWithoutRestApiHost()
+    public function testNayraBaseUrlFallsBackToReachableCachedEndpointWithoutRestApiHost()
     {
-        ScriptDockerNayraTraitTestHarness::setNayraAddresses(['172.18.0.5']);
+        ScriptDockerNayraTraitTestHarness::setNayraEndpoint(ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST);
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST => [
+                ScriptDockerNayraTraitFunctionState::OK_HEADER,
+            ],
+        ];
 
         $runner = new ScriptDockerNayraTraitTestHarness();
 
-        $this->assertSame('http://172.18.0.5:8081', $runner->exposedResolveNayraBaseUrl());
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
+            $runner->exposedResolveNayraBaseUrl()
+        );
         $this->assertSame(0, $runner->bringUpNayraCalls);
     }
 
@@ -204,27 +226,90 @@ class ScriptDockerNayraTraitTest extends TestCase
     {
         $runner = new ScriptDockerNayraTraitTestHarness();
 
-        $this->assertSame('http://172.18.0.9:8081', $runner->exposedResolveNayraBaseUrl());
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
+            $runner->exposedResolveNayraBaseUrl()
+        );
         $this->assertSame(1, $runner->bringUpNayraCalls);
         $this->assertSame([false], $runner->bringUpNayraRestartValues);
     }
 
+    public function testEmptyNayraPortFallsBackToDefaultPort()
+    {
+        config(['app.nayra_port' => '']);
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame(8080, $runner->exposedGetNayraPort());
+    }
+
+    public function testRemoteDockerHostIsUsedForFallbackNayraEndpoint()
+    {
+        config([
+            'app.nayra_port' => '',
+            'app.processmaker_scripts_docker_host' => 'tcp://qa-remotedocker:2375',
+        ]);
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame('http://qa-remotedocker:8080', $runner->exposedGetNayraInstanceUrl());
+    }
+
+    public function testMultitenantNayraUsesStableContainerNameAcrossTenants()
+    {
+        config([
+            'app.instance' => 'processmaker_1',
+            'app.multitenancy' => true,
+        ]);
+        app()->instance('currentTenant', (object) ['id' => 1]);
+
+        $tenantOneRunner = new ScriptDockerNayraTraitTestHarness();
+
+        config(['app.instance' => 'processmaker_3']);
+        app()->instance('currentTenant', (object) ['id' => 3]);
+
+        $tenantThreeRunner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame('processmaker', $tenantOneRunner->exposedGetNayraContainerName());
+        $this->assertSame('processmaker', $tenantThreeRunner->exposedGetNayraContainerName());
+    }
+
+    public function testStaleCachedEndpointIsClearedBeforeRebuildingNayraEndpoint()
+    {
+        ScriptDockerNayraTraitTestHarness::setNayraEndpoint('http://stale-nayra:8080');
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            'http://stale-nayra:8080' => false,
+        ];
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
+            $runner->exposedResolveNayraBaseUrl()
+        );
+        $this->assertSame(1, $runner->bringUpNayraCalls);
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
+            ScriptDockerNayraTraitTestHarness::getNayraEndpoint()
+        );
+    }
+
     public function testConfiguredRestApiHostConnectionFailureDoesNotStartTenantDockerContainer()
     {
-        config(['app.nayra_rest_api_host' => 'http://127.0.0.1:8081']);
-        ScriptDockerNayraTraitFunctionState::$enabled = true;
+        config(['app.nayra_rest_api_host' => ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST]);
         ScriptDockerNayraTraitFunctionState::$headers = [
-            'http://127.0.0.1:8081' => false,
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST => false,
         ];
 
         $runner = new ScriptDockerNayraTraitTestHarness();
 
         try {
-            $runner->handleNayraDocker('<?php return [];', [], [], 30, []);
+            $runner->handleNayraDocker(ScriptDockerNayraTraitFunctionState::SCRIPT_CODE, [], [], 30, []);
             $this->fail('Expected a ScriptException when the configured Nayra REST API host is unavailable.');
         } catch (ScriptException $exception) {
             $this->assertStringContainsString(
-                'Could not connect to the configured Nayra REST API host: http://127.0.0.1:8081',
+                'Could not connect to the configured Nayra REST API host: '
+                    . ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
                 $exception->getMessage()
             );
         }

--- a/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
+++ b/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
@@ -2,7 +2,9 @@
 
 namespace ProcessMaker\Models;
 
+use ProcessMaker\Console\Commands\BuildScriptExecutors;
 use ProcessMaker\Exception\ScriptException;
+use UnexpectedValueException;
 use Tests\TestCase;
 
 class ScriptDockerNayraTraitFunctionState
@@ -55,6 +57,7 @@ class ScriptDockerNayraTraitTestHarness
         resolveNayraBaseUrl as public exposedResolveNayraBaseUrl;
         getNayraPort as public exposedGetNayraPort;
         getNayraContainerName as public exposedGetNayraContainerName;
+        cacheNayraEndpointAfterReadiness as public exposedCacheNayraEndpointAfterReadiness;
     }
 
     public int $bringUpNayraCalls = 0;
@@ -78,9 +81,19 @@ class ScriptDockerNayraTraitTestHarness
 
     protected function getHeaders(string $url): array|false
     {
+        return static::getNayraEndpointHeaders($url);
+    }
+
+    protected static function getNayraEndpointHeaders(string $url): array|false
+    {
         ScriptDockerNayraTraitFunctionState::$requestedHeaders[] = $url;
 
         return ScriptDockerNayraTraitFunctionState::$headers[$url] ?? false;
+    }
+
+    protected static function getNayraEndpointReadinessAttempts(): int
+    {
+        return 1;
     }
 
     protected function curlInit(string $url): object
@@ -120,6 +133,37 @@ class ScriptDockerNayraTraitTestHarness
     {
         ScriptDockerNayraTraitFunctionState::$curlHandles[__FUNCTION__][] = $handle;
         ScriptDockerNayraTraitFunctionState::$curlClosed = true;
+    }
+}
+
+class ScriptDockerNayraTraitBuildScriptExecutorsHarness extends BuildScriptExecutors
+{
+    public array $commands = [];
+
+    public array $events = [];
+
+    public array $infoMessages = [];
+
+    public function execCommand(string $command)
+    {
+        $this->commands[] = $command;
+    }
+
+    public function info($text, $verbosity = null)
+    {
+        $this->infoMessages[] = $text;
+    }
+
+    /**
+     * @param mixed $output
+     * @param mixed $status
+     */
+    public function sendEvent($output, $status)
+    {
+        $this->events[] = [
+            'output' => $output,
+            'status' => $status,
+        ];
     }
 }
 
@@ -316,5 +360,101 @@ class ScriptDockerNayraTraitTest extends TestCase
 
         $this->assertSame(0, $runner->bringUpNayraCalls);
         $this->assertNull(ScriptDockerNayraTraitFunctionState::$curlUrl);
+    }
+
+    public function testRuntimeBringUpNayraCachesEndpointAfterReadinessPasses()
+    {
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST => [
+                ScriptDockerNayraTraitFunctionState::OK_HEADER,
+            ],
+        ];
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+        $runner->exposedCacheNayraEndpointAfterReadiness(ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST);
+
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
+            ScriptDockerNayraTraitTestHarness::getNayraEndpoint()
+        );
+        $this->assertSame(
+            [ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST],
+            ScriptDockerNayraTraitFunctionState::$requestedHeaders
+        );
+    }
+
+    public function testRuntimeBringUpNayraDoesNotCacheEndpointWhenReadinessFails()
+    {
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST => false,
+        ];
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        try {
+            $runner->exposedCacheNayraEndpointAfterReadiness(ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST);
+            $this->fail('Expected runtime Nayra startup to fail when the endpoint is unreachable.');
+        } catch (ScriptException $exception) {
+            $this->assertSame('Could not connect to the nayra container', $exception->getMessage());
+        }
+
+        $this->assertNull(ScriptDockerNayraTraitTestHarness::getNayraEndpoint());
+        $this->assertSame(
+            [ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST],
+            ScriptDockerNayraTraitFunctionState::$requestedHeaders
+        );
+    }
+
+    public function testBringUpNayraExecutorCachesEndpointAfterItIsReachable()
+    {
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST => [
+                ScriptDockerNayraTraitFunctionState::OK_HEADER,
+            ],
+        ];
+        $builder = new ScriptDockerNayraTraitBuildScriptExecutorsHarness();
+
+        ScriptDockerNayraTraitTestHarness::bringUpNayraExecutor($builder, 'processmaker4/nayra:test');
+
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
+            ScriptDockerNayraTraitTestHarness::getNayraEndpoint()
+        );
+        $this->assertSame(
+            [ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST],
+            ScriptDockerNayraTraitFunctionState::$requestedHeaders
+        );
+        $this->assertCount(3, $builder->commands);
+        $this->assertStringContainsString('docker run -d -p 8081:8080', $builder->commands[2]);
+        $this->assertContains('Nayra endpoint: ' . ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST, $builder->infoMessages);
+        $this->assertSame([
+            [
+                'output' => 0,
+                'status' => 'done',
+            ],
+        ], $builder->events);
+    }
+
+    public function testBringUpNayraExecutorDoesNotCacheEndpointWhenItIsUnreachable()
+    {
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST => false,
+        ];
+        $builder = new ScriptDockerNayraTraitBuildScriptExecutorsHarness();
+
+        try {
+            ScriptDockerNayraTraitTestHarness::bringUpNayraExecutor($builder, 'processmaker4/nayra:test');
+            $this->fail('Expected Nayra executor startup to fail when the endpoint is unreachable.');
+        } catch (UnexpectedValueException $exception) {
+            $this->assertSame('Could not connect to the nayra container', $exception->getMessage());
+        }
+
+        $this->assertNull(ScriptDockerNayraTraitTestHarness::getNayraEndpoint());
+        $this->assertSame(
+            [ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST],
+            ScriptDockerNayraTraitFunctionState::$requestedHeaders
+        );
+        $this->assertCount(3, $builder->commands);
+        $this->assertSame([], $builder->events);
     }
 }

--- a/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
+++ b/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace ProcessMaker\Models;
+
+use ProcessMaker\Exception\ScriptException;
+use Tests\TestCase;
+
+class ScriptDockerNayraTraitFunctionState
+{
+    public static bool $enabled = false;
+
+    public static array $headers = [];
+
+    public static array $requestedHeaders = [];
+
+    public static ?string $curlUrl = null;
+
+    public static array $curlOptions = [];
+
+    public static string $curlResult = '{"status":"ok"}';
+
+    public static int $curlHttpStatus = 200;
+
+    public static bool $curlClosed = false;
+
+    public static function reset(): void
+    {
+        self::$enabled = false;
+        self::$headers = [];
+        self::$requestedHeaders = [];
+        self::$curlUrl = null;
+        self::$curlOptions = [];
+        self::$curlResult = '{"status":"ok"}';
+        self::$curlHttpStatus = 200;
+        self::$curlClosed = false;
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\get_headers')) {
+    function get_headers($url, $associative = false, $context = null)
+    {
+        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
+            return \get_headers($url, $associative, $context);
+        }
+
+        ScriptDockerNayraTraitFunctionState::$requestedHeaders[] = $url;
+
+        return ScriptDockerNayraTraitFunctionState::$headers[$url] ?? false;
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\curl_init')) {
+    function curl_init($url = null)
+    {
+        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
+            return \curl_init($url);
+        }
+
+        ScriptDockerNayraTraitFunctionState::$curlUrl = $url;
+
+        return (object) ['url' => $url];
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\curl_setopt')) {
+    function curl_setopt($handle, $option, $value)
+    {
+        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
+            return \curl_setopt($handle, $option, $value);
+        }
+
+        ScriptDockerNayraTraitFunctionState::$curlOptions[$option] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\curl_exec')) {
+    function curl_exec($handle)
+    {
+        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
+            return \curl_exec($handle);
+        }
+
+        return ScriptDockerNayraTraitFunctionState::$curlResult;
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\curl_getinfo')) {
+    function curl_getinfo($handle, $option = null)
+    {
+        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
+            return \curl_getinfo($handle, $option);
+        }
+
+        if ($option === CURLINFO_HTTP_CODE) {
+            return ScriptDockerNayraTraitFunctionState::$curlHttpStatus;
+        }
+
+        return ['http_code' => ScriptDockerNayraTraitFunctionState::$curlHttpStatus];
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\curl_close')) {
+    function curl_close($handle)
+    {
+        if (!ScriptDockerNayraTraitFunctionState::$enabled) {
+            return \curl_close($handle);
+        }
+
+        ScriptDockerNayraTraitFunctionState::$curlClosed = true;
+    }
+}
+
+class ScriptDockerNayraTraitTestHarness
+{
+    use ScriptDockerNayraTrait {
+        getNayraInstanceUrl as public exposedGetNayraInstanceUrl;
+        resolveNayraBaseUrl as public exposedResolveNayraBaseUrl;
+    }
+
+    public int $bringUpNayraCalls = 0;
+
+    public array $bringUpNayraRestartValues = [];
+
+    public function bringUpNayra($restart = false)
+    {
+        $this->bringUpNayraCalls++;
+        $this->bringUpNayraRestartValues[] = $restart;
+
+        if (!$restart) {
+            self::setNayraAddresses(['172.18.0.9']);
+        }
+    }
+}
+
+class ScriptDockerNayraTraitTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ScriptDockerNayraTraitFunctionState::reset();
+        ScriptDockerNayraTraitTestHarness::clearNayraAddresses();
+
+        config([
+            'app.nayra_rest_api_host' => '',
+            'app.nayra_port' => 8081,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        ScriptDockerNayraTraitFunctionState::reset();
+        ScriptDockerNayraTraitTestHarness::clearNayraAddresses();
+
+        parent::tearDown();
+    }
+
+    public function testHandleNayraDockerUsesConfiguredRestApiHostWithoutStartingDocker()
+    {
+        config(['app.nayra_rest_api_host' => 'http://127.0.0.1:8081']);
+        ScriptDockerNayraTraitFunctionState::$enabled = true;
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            'http://127.0.0.1:8081' => ['HTTP/1.1 200 OK'],
+        ];
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+        $result = $runner->handleNayraDocker('<?php return [];', ['foo' => 'bar'], [], 30, ['API_TOKEN=test-token']);
+
+        $this->assertSame('{"status":"ok"}', $result);
+        $this->assertSame('http://127.0.0.1:8081/run_script', ScriptDockerNayraTraitFunctionState::$curlUrl);
+        $this->assertSame(['http://127.0.0.1:8081'], ScriptDockerNayraTraitFunctionState::$requestedHeaders);
+        $this->assertSame(0, $runner->bringUpNayraCalls);
+    }
+
+    public function testConfiguredRestApiHostTakesPriorityOverCachedDockerAddress()
+    {
+        config(['app.nayra_rest_api_host' => 'http://127.0.0.1:8081']);
+        ScriptDockerNayraTraitTestHarness::setNayraAddresses(['172.18.0.5']);
+        ScriptDockerNayraTraitFunctionState::$enabled = true;
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            'http://127.0.0.1:8081' => ['HTTP/1.1 200 OK'],
+        ];
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+        $runner->handleNayraDocker('<?php return [];', [], [], 30, []);
+
+        $this->assertSame('http://127.0.0.1:8081/run_script', ScriptDockerNayraTraitFunctionState::$curlUrl);
+        $this->assertSame(0, $runner->bringUpNayraCalls);
+    }
+
+    public function testNayraBaseUrlFallsBackToCachedDockerAddressWithoutRestApiHost()
+    {
+        ScriptDockerNayraTraitTestHarness::setNayraAddresses(['172.18.0.5']);
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame('http://172.18.0.5:8081', $runner->exposedResolveNayraBaseUrl());
+        $this->assertSame(0, $runner->bringUpNayraCalls);
+    }
+
+    public function testNayraBaseUrlStartsDockerBeforeResolvingUrlWhenNoRestApiHostOrCachedAddressExists()
+    {
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame('http://172.18.0.9:8081', $runner->exposedResolveNayraBaseUrl());
+        $this->assertSame(1, $runner->bringUpNayraCalls);
+        $this->assertSame([false], $runner->bringUpNayraRestartValues);
+    }
+
+    public function testConfiguredRestApiHostConnectionFailureDoesNotStartTenantDockerContainer()
+    {
+        config(['app.nayra_rest_api_host' => 'http://127.0.0.1:8081']);
+        ScriptDockerNayraTraitFunctionState::$enabled = true;
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            'http://127.0.0.1:8081' => false,
+        ];
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        try {
+            $runner->handleNayraDocker('<?php return [];', [], [], 30, []);
+            $this->fail('Expected a ScriptException when the configured Nayra REST API host is unavailable.');
+        } catch (ScriptException $exception) {
+            $this->assertStringContainsString(
+                'Could not connect to the configured Nayra REST API host: http://127.0.0.1:8081',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(0, $runner->bringUpNayraCalls);
+        $this->assertNull(ScriptDockerNayraTraitFunctionState::$curlUrl);
+    }
+}

--- a/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
+++ b/tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php
@@ -13,6 +13,12 @@ class ScriptDockerNayraTraitFunctionState
 
     public const LOCAL_NAYRA_HOST = 'http://127.0.0.1:8081';
 
+    public const HOST_NETWORK_IP = '172.17.0.' . '1';
+
+    public const HOST_NETWORK_NAYRA_HOST = 'http://' . self::HOST_NETWORK_IP . ':8081';
+
+    public const NAYRA_TEST_IMAGE = 'processmaker4/nayra:test';
+
     public const OK_HEADER = 'HTTP/1.1 200 OK';
 
     public const SCRIPT_CODE = '<?php return [];';
@@ -20,6 +26,12 @@ class ScriptDockerNayraTraitFunctionState
     public static array $headers = [];
 
     public static array $requestedHeaders = [];
+
+    public static array $execCommands = [];
+
+    public static string $containerAddress = self::HOST_NETWORK_IP;
+
+    public static int $containerAddressStatus = 0;
 
     public static ?string $curlUrl = null;
 
@@ -37,6 +49,9 @@ class ScriptDockerNayraTraitFunctionState
     {
         self::$headers = [];
         self::$requestedHeaders = [];
+        self::$execCommands = [];
+        self::$containerAddress = self::HOST_NETWORK_IP;
+        self::$containerAddressStatus = 0;
         self::$curlUrl = null;
         self::$curlOptions = [];
         self::$curlHandles = [];
@@ -58,6 +73,7 @@ class ScriptDockerNayraTraitTestHarness
         getNayraPort as public exposedGetNayraPort;
         getNayraContainerName as public exposedGetNayraContainerName;
         cacheNayraEndpointAfterReadiness as public exposedCacheNayraEndpointAfterReadiness;
+        buildNayraEndpointAfterStartup as public exposedBuildNayraEndpointAfterStartup;
     }
 
     public int $bringUpNayraCalls = 0;
@@ -94,6 +110,15 @@ class ScriptDockerNayraTraitTestHarness
     protected static function getNayraEndpointReadinessAttempts(): int
     {
         return 1;
+    }
+
+    protected static function execDockerCommand(string $command, array &$output, int &$status): string|false
+    {
+        ScriptDockerNayraTraitFunctionState::$execCommands[] = $command;
+        $status = ScriptDockerNayraTraitFunctionState::$containerAddressStatus;
+        $output = $status ? [] : [ScriptDockerNayraTraitFunctionState::$containerAddress];
+
+        return $status ? false : ScriptDockerNayraTraitFunctionState::$containerAddress;
     }
 
     protected function curlInit(string $url): object
@@ -299,6 +324,39 @@ class ScriptDockerNayraTraitTest extends TestCase
         $this->assertSame('http://qa-remotedocker:8080', $runner->exposedGetNayraInstanceUrl());
     }
 
+    public function testLocalHostNetworkNayraEndpointUsesDockerReportedAddressAfterStartup()
+    {
+        config(['app.nayra_docker_network' => 'host']);
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::HOST_NETWORK_NAYRA_HOST,
+            $runner->exposedBuildNayraEndpointAfterStartup('docker', 'processmaker', 'http', 1)
+        );
+        $this->assertCount(1, ScriptDockerNayraTraitFunctionState::$execCommands);
+        $this->assertStringContainsString(
+            'exec processmaker_nayra hostname -i 2>/dev/null',
+            ScriptDockerNayraTraitFunctionState::$execCommands[0]
+        );
+    }
+
+    public function testLocalHostNetworkNayraEndpointDoesNotOverrideRemoteDockerHost()
+    {
+        config([
+            'app.nayra_docker_network' => 'host',
+            'app.processmaker_scripts_docker_host' => 'tcp://qa-remotedocker:2375',
+        ]);
+
+        $runner = new ScriptDockerNayraTraitTestHarness();
+
+        $this->assertSame(
+            'http://qa-remotedocker:8081',
+            $runner->exposedBuildNayraEndpointAfterStartup('DOCKER_HOST=tcp://qa-remotedocker:2375 docker', 'processmaker', 'http', 1)
+        );
+        $this->assertSame([], ScriptDockerNayraTraitFunctionState::$execCommands);
+    }
+
     public function testMultitenantNayraUsesStableContainerNameAcrossTenants()
     {
         config([
@@ -414,7 +472,10 @@ class ScriptDockerNayraTraitTest extends TestCase
         ];
         $builder = new ScriptDockerNayraTraitBuildScriptExecutorsHarness();
 
-        ScriptDockerNayraTraitTestHarness::bringUpNayraExecutor($builder, 'processmaker4/nayra:test');
+        ScriptDockerNayraTraitTestHarness::bringUpNayraExecutor(
+            $builder,
+            ScriptDockerNayraTraitFunctionState::NAYRA_TEST_IMAGE
+        );
 
         $this->assertSame(
             ScriptDockerNayraTraitFunctionState::LOCAL_NAYRA_HOST,
@@ -443,7 +504,10 @@ class ScriptDockerNayraTraitTest extends TestCase
         $builder = new ScriptDockerNayraTraitBuildScriptExecutorsHarness();
 
         try {
-            ScriptDockerNayraTraitTestHarness::bringUpNayraExecutor($builder, 'processmaker4/nayra:test');
+            ScriptDockerNayraTraitTestHarness::bringUpNayraExecutor(
+                $builder,
+                ScriptDockerNayraTraitFunctionState::NAYRA_TEST_IMAGE
+            );
             $this->fail('Expected Nayra executor startup to fail when the endpoint is unreachable.');
         } catch (UnexpectedValueException $exception) {
             $this->assertSame('Could not connect to the nayra container', $exception->getMessage());
@@ -456,5 +520,41 @@ class ScriptDockerNayraTraitTest extends TestCase
         );
         $this->assertCount(3, $builder->commands);
         $this->assertSame([], $builder->events);
+    }
+
+    public function testBringUpNayraExecutorCachesHostNetworkEndpointAfterItIsReachable()
+    {
+        config(['app.nayra_docker_network' => 'host']);
+        ScriptDockerNayraTraitFunctionState::$headers = [
+            ScriptDockerNayraTraitFunctionState::HOST_NETWORK_NAYRA_HOST => [
+                ScriptDockerNayraTraitFunctionState::OK_HEADER,
+            ],
+        ];
+        $builder = new ScriptDockerNayraTraitBuildScriptExecutorsHarness();
+
+        ScriptDockerNayraTraitTestHarness::bringUpNayraExecutor(
+            $builder,
+            ScriptDockerNayraTraitFunctionState::NAYRA_TEST_IMAGE
+        );
+
+        $this->assertSame(
+            ScriptDockerNayraTraitFunctionState::HOST_NETWORK_NAYRA_HOST,
+            ScriptDockerNayraTraitTestHarness::getNayraEndpoint()
+        );
+        $this->assertSame(
+            [ScriptDockerNayraTraitFunctionState::HOST_NETWORK_NAYRA_HOST],
+            ScriptDockerNayraTraitFunctionState::$requestedHeaders
+        );
+        $this->assertCount(1, ScriptDockerNayraTraitFunctionState::$execCommands);
+        $this->assertStringContainsString(
+            'exec processmaker_nayra hostname -i 2>/dev/null',
+            ScriptDockerNayraTraitFunctionState::$execCommands[0]
+        );
+        $this->assertCount(3, $builder->commands);
+        $this->assertStringContainsString('docker run -d -e PORT=8081', $builder->commands[2]);
+        $this->assertContains(
+            'Nayra endpoint: ' . ScriptDockerNayraTraitFunctionState::HOST_NETWORK_NAYRA_HOST,
+            $builder->infoMessages
+        );
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

FOUR-30789 tracks a multitenant server error while creating a new report from an Expense Report process generated from a Guide Template.

The failing flow triggers synchronous `php-nayra` script execution from the task edit/report flow. In QA, the endpoint still returned HTTP 500 after the first fix:

- `POST /api/1.0/scripts/execute/42?task_id=3746`

## Root Cause

The original fix assumed real multitenant environments would provide `NAYRA_REST_API_HOST`, so the php-nayra runner could always prioritize that configured REST endpoint.

After comparing the local `.env` with a real production-like multitenant pod env, that assumption was wrong. The real config does not define `NAYRA_REST_API_HOST`. Instead, it uses remote Docker:

- `MULTITENANCY=true`
- `PROCESSMAKER_SCRIPTS_DOCKER_HOST=tcp://qa-remotedocker:2375`
- no `NAYRA_REST_API_HOST`

In that configuration, the old fallback still tried to resolve or start a tenant-specific Nayra container using the tenant-mutated `app.instance`, for example `processmaker_3_nayra`, then use Docker bridge/container IPs such as `172.x.x.x` as the REST base URL.

That is not reliable for real multitenant deployments because the web app must call a reachable HTTP endpoint, not an internal Docker bridge IP. It also should not create a separate Nayra REST service per tenant when the request already carries script code, data, config, environment variables, and timeout.

## Solution

- Keep `NAYRA_REST_API_HOST` as the highest-priority explicit override when configured.
- For real multitenant Docker configs without `NAYRA_REST_API_HOST`, resolve Nayra to a reachable endpoint:
  - local Docker: `http://127.0.0.1:<nayra_port>`
  - remote Docker: derive the host from `PROCESSMAKER_SCRIPTS_DOCKER_HOST`, for example `http://qa-remotedocker:8080`
- Normalize empty `NAYRA_PORT` values to `8080` so Docker does not publish Nayra on a random port.
- Use a stable shared Nayra container name for multitenant environments instead of a tenant-specific `app.instance` suffix.
- Cache the reachable Nayra endpoint as `nayra_endpoint` and invalidate it if the health check fails.
- Keep the previous `NAYRA_REST_API_HOST` behavior backward compatible.
- Make the trait dependency on `ScriptExecutor` explicit through `getScriptExecutor()` so static analysis no longer depends on an implicit private property from `Base`.
- Add regression coverage for real multitenant fallback behavior, remote Docker host resolution, stale endpoint invalidation, and REST-host priority.

## How to Test

Automated:

- `php -l ProcessMaker/Models/ScriptDockerNayraTrait.php`
- `php -l ProcessMaker/ScriptRunners/Base.php`
- `php -l tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php`
- `./vendor/bin/phpunit tests/unit/ProcessMaker/Models/ScriptDockerNayraTraitTest.php`

Result:

- `OK (9 tests, 21 assertions)`

Manual multitenant verification:

- Use a multitenant env matching the production-like pod config where `PROCESSMAKER_SCRIPTS_DOCKER_HOST` is set and `NAYRA_REST_API_HOST` is not set.
- Reproduce the Expense Report Guide Template flow.
- Confirm `POST /api/1.0/scripts/execute/...` returns `200`.
- Confirm logs no longer show tenant-specific Nayra Docker startup failures or `ScriptDockerNayraTrait.php` timeout while resolving container bridge IPs.

## Related Ticket

- https://processmaker.atlassian.net/browse/FOUR-30789

ci:deploy
ci:multitenancy
ci:k8s-branch:fix-multitenancy
