### PR TITLE
FOUR-31092 Military >> Unauthorized error with user TCO in tasks init…

### DIFF
--- a/routes/channels.php
+++ b/routes/channels.php
@@ -28,10 +28,14 @@ Broadcast::channel('ProcessMaker.Models.ProcessRequest.{id}', function ($user, $
     }
 
     $request = ProcessRequest::find($id);
+    if (!$request) {
+        return false;
+    }
 
     return $request->user_id === $user->id
         || !empty($request->participants()->where('users.id', $user->getKey())->first())
-        || in_array($user->id, $request->process?->manager_id ?? []);
+        || in_array($user->id, $request->process?->manager_id ?? [])
+        || $request->canUserClaimASelfServiceTask($user);
 });
 
 Broadcast::channel('ProcessMaker.Models.ProcessRequestToken.{id}', function ($user, $id) {


### PR DESCRIPTION
…iated by SFTP

Description:
When a user can claim an active self-service task, they can still see the task but receive 403 from /broadcasting/auth when subscribing to private-ProcessMaker.Models.ProcessRequest.{id>. The previous channel authorization only allowed request owner, participants, and process managers, so valid self-service users were excluded from request-level permission checks.

Changes Updated routes/channels.phpto add a null-safe guard for missing requests and to include self-service task access in the ProcessRequest channel authorization check by usingcanUserClaimASelfServiceTask($user).

Details This aligns broadcast authorization with existing task-level authorization behavior and prevents false-negative access denials for valid self-service flows while keeping admin/owner/participant logic intact.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-31092

ci:deploy
