### PR TITLE
Change the Processes I Manage saved search from IN PROGRESS to IN PROGRESS AND COMPLETED

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -156,7 +156,7 @@ class TaskController extends Controller
 
         // Apply process manager filter BEFORE PMQL to avoid conflicts with is_self_service filtering
         if ($request->input('processesIManage') === 'true') {
-            $this->applyProcessManager($query, $user);
+            $this->applyProcessManager($query, $user, $request);
         } else {
             $this->applyForCurrentUser($query, $user);
         }

--- a/ProcessMaker/Traits/TaskControllerIndexMethods.php
+++ b/ProcessMaker/Traits/TaskControllerIndexMethods.php
@@ -19,6 +19,8 @@ use ProcessMaker\Query\SyntaxError;
 
 trait TaskControllerIndexMethods
 {
+    private const SELF_SERVICE_STATUS = 'self service';
+
     private function indexBaseQuery($request)
     {
         // Parse the includes parameter
@@ -291,6 +293,19 @@ trait TaskControllerIndexMethods
         }
     }
 
+    private function requestHasStatusFilter($request): bool
+    {
+        if ($request->filled('status') || $request->filled('statusfilter')) {
+            return true;
+        }
+
+        if ($this->advancedFilterHasStatus($request)) {
+            return true;
+        }
+
+        return preg_match('/(?:^|[\s(])status\s*(?:=|!=|<>)/i', $request->input('pmql', '')) === 1;
+    }
+
     private function applyPmql($query, $request, $user)
     {
         $pmql = $request->input('pmql', '');
@@ -327,7 +342,7 @@ trait TaskControllerIndexMethods
         foreach ($this->getAdvancedFilterArray($request) as $filter) {
             $values = (array) ($filter['value'] ?? []);
             foreach ($values as $v) {
-                if (mb_strtolower($v) === 'self service') {
+                if (mb_strtolower($v) === self::SELF_SERVICE_STATUS) {
                     return true;
                 }
             }
@@ -384,34 +399,62 @@ trait TaskControllerIndexMethods
             // If processesIManage is active, handle "Self Service" status filter specially
             if ($isProcessManager && is_array($filterArray)) {
                 $hasSelfServiceFilter = false;
-                $filteredArray = [];
+                $nonStatusFilters = [];
+                $statusFilters = [];
 
                 foreach ($filterArray as $filter) {
-                    // Check if this is a "Self Service" status filter
-                    if (isset($filter['subject']['type']) &&
-                        $filter['subject']['type'] === 'Status' &&
-                        isset($filter['value']) &&
-                        mb_strtolower($filter['value']) === 'self service') {
-                        $hasSelfServiceFilter = true;
-                        // Don't add this filter to the array - we'll handle it manually
+                    $isStatusFilter = isset($filter['subject']['type']) && $filter['subject']['type'] === 'Status';
+                    if (!$isStatusFilter) {
+                        $nonStatusFilters[] = $filter;
                         continue;
                     }
-                    $filteredArray[] = $filter;
+
+                    $values = is_array($filter['value']) ? $filter['value'] : [$filter['value']];
+                    $hasSelfServiceValue = in_array(
+                        self::SELF_SERVICE_STATUS,
+                        array_map(fn ($value) => is_string($value) ? mb_strtolower($value) : $value, $values),
+                        true
+                    );
+
+                    if ($hasSelfServiceValue) {
+                        $hasSelfServiceFilter = true;
+                        $values = array_values(array_filter($values, function ($value) {
+                            return !is_string($value) || mb_strtolower($value) !== self::SELF_SERVICE_STATUS;
+                        }));
+
+                        if (empty($values)) {
+                            continue;
+                        }
+
+                        $filter['value'] = is_array($filter['value']) ? $values : $values[0];
+                    }
+
+                    $statusFilters[] = $filter;
                 }
 
-                // Apply the filtered advanced_filter (without Self Service)
-                if (!empty($filteredArray)) {
-                    Filter::filter($query, $filteredArray);
+                if (!$hasSelfServiceFilter) {
+                    Filter::filter($query, $filterArray);
+
+                    return;
+                }
+
+                if (!empty($nonStatusFilters)) {
+                    Filter::filter($query, $nonStatusFilters);
                 }
 
                 // Manually apply the Self Service filter for process managers
-                if ($hasSelfServiceFilter) {
-                    $selfServiceTaskIds = ProcessRequestToken::select(['id'])
-                        ->whereIn('process_id', $processManagerIds)
-                        ->where('is_self_service', 1)
-                        ->whereNull('user_id')
-                        ->where('status', 'ACTIVE');
+                $selfServiceTaskIds = ProcessRequestToken::select(['id'])
+                    ->whereIn('process_id', $processManagerIds)
+                    ->where('is_self_service', 1)
+                    ->whereNull('user_id')
+                    ->where('status', 'ACTIVE');
 
+                if (!empty($statusFilters)) {
+                    $query->where(function ($query) use ($statusFilters, $selfServiceTaskIds) {
+                        Filter::filter($query, $statusFilters);
+                        $query->orWhereIn('process_request_tokens.id', $selfServiceTaskIds);
+                    });
+                } else {
                     $query->whereIn('process_request_tokens.id', $selfServiceTaskIds);
                 }
             } else {
@@ -453,7 +496,7 @@ trait TaskControllerIndexMethods
         });
     }
 
-    public function applyProcessManager($query, $user)
+    public function applyProcessManager($query, $user, $request)
     {
         $ids = Process::select(['id'])
             ->where(function ($subQuery) use ($user) {
@@ -472,7 +515,8 @@ trait TaskControllerIndexMethods
             return;
         }
 
-        // Show tasks from processes the user manages that are ACTIVE
+        // Show tasks from processes the user manages. Default to ACTIVE unless the request
+        // already has an explicit status filter that will be applied later.
         // OR show self-service tasks from those processes
         // Store the process IDs in the query so we can use them later to add self-service tasks
         // We'll add self-service tasks after PMQL is applied to avoid the is_self_service = 0 filter
@@ -480,9 +524,12 @@ trait TaskControllerIndexMethods
 
         // Apply condition for regular tasks from managed processes
         // Self-service tasks will be added after PMQL to avoid conflicts
-        $query->where(function ($query) use ($ids) {
-            $query->whereIn('process_request_tokens.process_id', $ids)
-                ->where('process_request_tokens.status', 'ACTIVE');
+        $query->where(function ($query) use ($ids, $request) {
+            $query->whereIn('process_request_tokens.process_id', $ids);
+
+            if (!$this->requestHasStatusFilter($request)) {
+                $query->where('process_request_tokens.status', 'ACTIVE');
+            }
         });
     }
 

--- a/tests/Feature/Api/TasksTest.php
+++ b/tests/Feature/Api/TasksTest.php
@@ -870,6 +870,109 @@ class TasksTest extends TestCase
         $this->assertNotContains($activeTask->id, $returnedIds);
     }
 
+    public function testProcessManagerAdvancedStatusFilterCanReturnCompletedTasks()
+    {
+        $manager = User::factory()->create();
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id],
+        ]);
+        $unmanagedProcess = Process::factory()->create();
+        $request = ProcessRequest::factory()->create(['process_id' => $process->id]);
+
+        $activeTask = ProcessRequestToken::factory()->create([
+            'status' => 'ACTIVE',
+            'element_type' => 'task',
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'is_self_service' => 0,
+        ]);
+
+        $completedTask = ProcessRequestToken::factory()->create([
+            'status' => 'CLOSED',
+            'element_type' => 'task',
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'is_self_service' => 0,
+        ]);
+
+        $unmanagedCompletedTask = ProcessRequestToken::factory()->create([
+            'status' => 'CLOSED',
+            'element_type' => 'task',
+            'process_id' => $unmanagedProcess->id,
+            'is_self_service' => 0,
+        ]);
+
+        $statusFilter = json_encode([
+            [
+                'subject' => ['type' => 'Status'],
+                'operator' => '=',
+                'value' => 'Completed',
+            ],
+        ]);
+
+        $response = $this->actingAs($manager, 'api')->get(route('api.tasks.index', [
+            'processesIManage' => 'true',
+            'advanced_filter' => $statusFilter,
+        ]));
+
+        $response->assertStatus(200);
+        $returnedIds = collect($response->json('data'))->pluck('id')->toArray();
+
+        $this->assertContains($completedTask->id, $returnedIds);
+        $this->assertNotContains($activeTask->id, $returnedIds);
+        $this->assertNotContains($unmanagedCompletedTask->id, $returnedIds);
+    }
+
+    public function testProcessManagerAdvancedStatusFilterCanReturnInProgressCompletedAndSelfServiceTasks()
+    {
+        $manager = User::factory()->create();
+        $process = Process::factory()->create([
+            'properties' => ['manager_id' => $manager->id],
+        ]);
+
+        $activeTask = ProcessRequestToken::factory()->create([
+            'status' => 'ACTIVE',
+            'element_type' => 'task',
+            'process_id' => $process->id,
+            'is_self_service' => 0,
+        ]);
+
+        $completedTask = ProcessRequestToken::factory()->create([
+            'status' => 'CLOSED',
+            'element_type' => 'task',
+            'process_id' => $process->id,
+            'is_self_service' => 0,
+        ]);
+
+        $selfServiceTask = ProcessRequestToken::factory()->create([
+            'status' => 'ACTIVE',
+            'element_type' => 'task',
+            'process_id' => $process->id,
+            'user_id' => null,
+            'is_self_service' => 1,
+        ]);
+
+        $statusFilter = json_encode([
+            [
+                'subject' => ['type' => 'Status'],
+                'operator' => '=',
+                'value' => ['In Progress', 'Completed', 'Self Service'],
+            ],
+        ]);
+
+        $response = $this->actingAs($manager, 'api')->get(route('api.tasks.index', [
+            'processesIManage' => 'true',
+            'advanced_filter' => $statusFilter,
+        ]));
+
+        $response->assertStatus(200);
+        $returnedIds = collect($response->json('data'))->pluck('id')->toArray();
+
+        $this->assertContains($activeTask->id, $returnedIds);
+        $this->assertContains($completedTask->id, $returnedIds);
+        $this->assertContains($selfServiceTask->id, $returnedIds);
+    }
+
     public function testPmqlStatusPreservedWhenNoAdvancedStatusFilter()
     {
         $user = User::factory()->create(['is_administrator' => true]);


### PR DESCRIPTION
## Issue & Reproduction Steps
The option to list multiple states ("In Progress", "Self Service", "Completed") needs to be added to the "Processes I Manage" list so that the user (Manager) can monitor these tasks.

## Solution
- The way filters are executed was modified to allow this search to be performed in the general query of the listings.

## How to Test
- Verify that the "Processes I Manage" configuration in the PMQL has the following query: "(status = "Self Service" or status = "In Progress" or status = "Completed")"
- For the test, the "Processes I Manage" listing needs to be verified to ensure it displays the correct listing according to the proposed filtering (STATUS).
- Since a part used in the listings has been modified, all listings for tasks need to be tested.

## Related Tickets & Packages
- [FOUR-31219](https://processmaker.atlassian.net/browse/FOUR-31219)


<img width="3430" height="1710" alt="image" src="https://github.com/user-attachments/assets/5c068016-5940-4e5a-9d32-92add201965f" />

Preview Task Completed
<img width="3434" height="1736" alt="image" src="https://github.com/user-attachments/assets/082d552b-5a52-47e3-ae62-418d304c7297" />


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-savedsearch:task/FOUR-31219
ci:deploy

[FOUR-31219]: https://processmaker.atlassian.net/browse/FOUR-31219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ