### PR TITLE
Move package-accessibility to custom packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,10 +144,10 @@
                 "package-zj-birmingham": "dev-main",
                 "package-tce": "dev-master",
                 "package-case-overview": "dev-main",
-                "package-sis-integration": "dev-develop"
+                "package-sis-integration": "dev-develop",
+                "package-accessibility": "1.0.1"
             },
             "enterprise": {
-                "package-accessibility": "1.0.1",
                 "connector-docusign": "1.11.2",
                 "connector-idp": "1.14.2",
                 "connector-pdf-print": "1.23.3",


### PR DESCRIPTION
Turns out, accessibility should be a custom package. This move is back