### PR TITLE
FOUR-27623 | Users Can View All Cases Without “View All Cases” Permission

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/CaseController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/CaseController.php
@@ -43,6 +43,17 @@ class CaseController extends Controller
      */
     public function getAllCases(CaseListRequest $request): JsonResponse
     {
+        // Users are always allowed to view cases scoped to themselves
+        // Any broader query requires the `view-all_cases` permission.
+        // Admins pass through via Gate::before in AuthServiceProvider.
+        $authUser = Auth::user();
+        $requestedUserId = $request->filled('userId') ? (int) $request->input('userId') : null;
+        $isViewingOwnCases = $requestedUserId !== null && $requestedUserId === $authUser->id;
+
+        if (!$isViewingOwnCases && !$authUser->can('view-all_cases')) {
+            abort(403);
+        }
+
         $query = $this->caseRepository->getAllCases($request);
 
         return $this->paginateResponse($query);

--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -22,10 +22,19 @@ class CasesController extends Controller
     /**
      * Get the list of requests.
      *
+     * @param string|null $type One of `all|in_progress|completed` (constrained by the route).
+     *
      * @return \Illuminate\View\View|\Illuminate\Contracts\View
      */
-    public function index()
+    public function index($type = null)
     {
+        // The "All cases" tab exposes cases the user didn't participate in,
+        // so it must be gated by the same permission as the underlying API
+        // (`view-all_cases`). Admins are allowed through Gate::before.
+        if ($type === 'all' && !Auth::user()->can('view-all_cases')) {
+            abort(403);
+        }
+
         $manager = app(ScreenBuilderManager::class);
         event(new ScreenBuilderStarting($manager, 'FORM'));
         $currentUser = Auth::user()->only(['id', 'username', 'fullname', 'firstname', 'lastname', 'avatar']);

--- a/ProcessMaker/Http/Controllers/CasesController.php
+++ b/ProcessMaker/Http/Controllers/CasesController.php
@@ -28,9 +28,11 @@ class CasesController extends Controller
      */
     public function index($type = null)
     {
-        // The "All cases" tab exposes cases the user didn't participate in,
-        // so it must be gated by the same permission as the underlying API
-        // (`view-all_cases`). Admins are allowed through Gate::before.
+        // The "All cases" tab exposes every case in the platform regardless
+        // of the user's relationship to it, so it is gated by the
+        // `view-all_cases` permission. The other tabs (My cases, In progress,
+        // Completed) are scoped to the user and need no gate.
+        // Admins bypass this check via Gate::before in AuthServiceProvider.
         if ($type === 'all' && !Auth::user()->can('view-all_cases')) {
             abort(403);
         }

--- a/routes/v1_1/api.php
+++ b/routes/v1_1/api.php
@@ -35,8 +35,7 @@ Route::prefix('api/1.1')
         Route::name('cases.')->prefix('cases')->group(function () {
             // Route to list all cases
             Route::get('get_all_cases', [CaseController::class, 'getAllCases'])
-                ->name('all_cases')
-                ->middleware('can:view-all_cases');
+                ->name('all_cases');
 
             // Route to list all in-progress cases
             Route::get('get_in_progress', [CaseController::class, 'getInProgress'])

--- a/routes/v1_1/api.php
+++ b/routes/v1_1/api.php
@@ -35,7 +35,8 @@ Route::prefix('api/1.1')
         Route::name('cases.')->prefix('cases')->group(function () {
             // Route to list all cases
             Route::get('get_all_cases', [CaseController::class, 'getAllCases'])
-                ->name('all_cases');
+                ->name('all_cases')
+                ->middleware('can:view-all_cases');
 
             // Route to list all in-progress cases
             Route::get('get_in_progress', [CaseController::class, 'getInProgress'])

--- a/tests/Feature/Api/V1_1/CaseControllerSearchTest.php
+++ b/tests/Feature/Api/V1_1/CaseControllerSearchTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Api\V1_1;
 
+use Illuminate\Support\Facades\Gate;
+use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\User;
 use ProcessMaker\Repositories\CaseUtils;
 use Tests\Feature\Shared\RequestHelper;
@@ -16,6 +18,17 @@ class CaseControllerSearchTest extends TestCase
         parent::setUp();
 
         $this->user = CaseControllerTest::createUser('user_a');
+
+        // These tests intentionally exercise the unscoped `get_all_cases`
+        // endpoint, which now requires `view-all_cases`. Grant the
+        // non-admin test user the permission so each `apiCall` reaches
+        // the search logic rather than being short-circuited with a 403.
+        Permission::firstOrCreate(
+            ['name' => 'view-all_cases'],
+            ['title' => 'View All Cases'],
+        );
+        Gate::define('view-all_cases', fn ($user) => $user->hasPermission('view-all_cases'));
+        $this->user->giveDirectPermission('view-all_cases');
     }
 
     public function tearDown(): void

--- a/tests/Feature/Api/V1_1/CaseControllerTest.php
+++ b/tests/Feature/Api/V1_1/CaseControllerTest.php
@@ -479,29 +479,83 @@ class CaseControllerTest extends TestCase
 
     public function test_get_all_cases_forbidden_without_view_all_cases_permission(): void
     {
-        // Seed permissions and register gates so the `can:view-all_cases`
-        // middleware on api.1.1.cases.all_cases is enforceable in tests.
-        $this->initializePermissions();
+        // Ensure the permission row exists and register it as a Laravel Gate
+        // so $user->can('view-all_cases') is enforceable in tests.
+        Permission::firstOrCreate(
+            ['name' => 'view-all_cases'],
+            ['title' => 'View All Cases'],
+        );
+        Gate::define('view-all_cases', fn ($user) => $user->hasPermission('view-all_cases'));
 
         $nonAdmin = User::factory()->create([
             'is_administrator' => false,
         ]);
 
-        // Create some cases so a permitted user would get a non-empty payload.
         self::createCasesStartedForUser($nonAdmin->id, 3);
 
-        // Without the permission, access is denied.
+        // Unscoped request (the "All cases" tab) — denied without the permission.
         $response = $this->actingAs($nonAdmin, 'api')
             ->json('GET', route('api.1.1.cases.all_cases'));
         $response->assertStatus(403);
 
-        // Granting the permission restores access.
+        // Granting the permission restores access to the unscoped query.
         $nonAdmin->giveDirectPermission('view-all_cases');
 
         $response = $this->actingAs($nonAdmin, 'api')
             ->json('GET', route('api.1.1.cases.all_cases'));
         $response->assertStatus(200);
         $response->assertJsonCount(3, 'data');
+    }
+
+    public function test_get_all_cases_allows_user_to_view_their_own_cases_without_permission(): void
+    {
+        // The endpoint is shared by the "My cases" tab, which scopes the
+        // query to the authenticated user. That self-scoped path must work
+        // even when the user lacks `view-all_cases`.
+        $nonAdmin = User::factory()->create([
+            'is_administrator' => false,
+        ]);
+
+        $ownCases = self::createCasesStartedForUser($nonAdmin->id, 4);
+        $otherUser = self::createUser('other_user');
+        self::createCasesStartedForUser($otherUser->id, 6);
+
+        $response = $this->actingAs($nonAdmin, 'api')
+            ->json('GET', route('api.1.1.cases.all_cases', ['userId' => $nonAdmin->id]));
+
+        $response->assertStatus(200);
+        $response->assertJsonCount($ownCases->count(), 'data');
+        $response->assertJsonMissing(['user_id' => $otherUser->id]);
+    }
+
+    public function test_get_all_cases_forbids_user_from_viewing_another_users_cases_without_permission(): void
+    {
+        Permission::firstOrCreate(
+            ['name' => 'view-all_cases'],
+            ['title' => 'View All Cases'],
+        );
+        Gate::define('view-all_cases', fn ($user) => $user->hasPermission('view-all_cases'));
+
+        $nonAdmin = User::factory()->create([
+            'is_administrator' => false,
+        ]);
+        $otherUser = self::createUser('other_user');
+        self::createCasesStartedForUser($otherUser->id, 2);
+
+        // Passing another user's id must require `view-all_cases`; otherwise
+        // any authenticated user could iterate userIds to enumerate the
+        // entire platform.
+        $response = $this->actingAs($nonAdmin, 'api')
+            ->json('GET', route('api.1.1.cases.all_cases', ['userId' => $otherUser->id]));
+        $response->assertStatus(403);
+
+        // With the permission, the same request succeeds.
+        $nonAdmin->giveDirectPermission('view-all_cases');
+
+        $response = $this->actingAs($nonAdmin, 'api')
+            ->json('GET', route('api.1.1.cases.all_cases', ['userId' => $otherUser->id]));
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
     }
 
     public function test_get_all_cases_participants(): void

--- a/tests/Feature/Api/V1_1/CaseControllerTest.php
+++ b/tests/Feature/Api/V1_1/CaseControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\V1_1;
 
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Constants\CaseStatusConstants;
 use ProcessMaker\Models\CaseParticipated;
@@ -474,6 +475,33 @@ class CaseControllerTest extends TestCase
         $response->assertJsonFragment(['totalInProgress' => 5]);
         $response->assertJsonFragment(['totalCompleted' => 5]);
         $response->assertJsonFragment(['totalMyRequest' => 5]);
+    }
+
+    public function test_get_all_cases_forbidden_without_view_all_cases_permission(): void
+    {
+        // Seed permissions and register gates so the `can:view-all_cases`
+        // middleware on api.1.1.cases.all_cases is enforceable in tests.
+        $this->initializePermissions();
+
+        $nonAdmin = User::factory()->create([
+            'is_administrator' => false,
+        ]);
+
+        // Create some cases so a permitted user would get a non-empty payload.
+        self::createCasesStartedForUser($nonAdmin->id, 3);
+
+        // Without the permission, access is denied.
+        $response = $this->actingAs($nonAdmin, 'api')
+            ->json('GET', route('api.1.1.cases.all_cases'));
+        $response->assertStatus(403);
+
+        // Granting the permission restores access.
+        $nonAdmin->giveDirectPermission('view-all_cases');
+
+        $response = $this->actingAs($nonAdmin, 'api')
+            ->json('GET', route('api.1.1.cases.all_cases'));
+        $response->assertStatus(200);
+        $response->assertJsonCount(3, 'data');
     }
 
     public function test_get_all_cases_participants(): void

--- a/tests/Feature/CasesControllerTest.php
+++ b/tests/Feature/CasesControllerTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Gate;
 use ProcessMaker\Http\Controllers\CasesController;
+use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
@@ -58,6 +60,60 @@ class CasesControllerTest extends TestCase
 
         // Check the status
         $response->assertStatus(403);
+    }
+
+    public function testCasesAllPageReturns403WithoutViewAllCasesPermission()
+    {
+        Permission::firstOrCreate(
+            ['name' => 'view-all_cases'],
+            ['title' => 'View All Cases'],
+        );
+        Gate::define('view-all_cases', fn ($user) => $user->hasPermission('view-all_cases'));
+
+        $user = User::factory()->create(['is_administrator' => false]);
+        $this->actingAs($user);
+
+        $response = $this->get(route('cases-main.index', ['type' => 'all']));
+
+        $response->assertStatus(403);
+        // Confirms the standard ProcessMaker "Not Authorized" page renders
+        // rather than the cases shell with an empty list.
+        $response->assertSee('Not Authorized');
+    }
+
+    public function testCasesAllPageReturns200WithViewAllCasesPermission()
+    {
+        Permission::firstOrCreate(
+            ['name' => 'view-all_cases'],
+            ['title' => 'View All Cases'],
+        );
+        Gate::define('view-all_cases', fn ($user) => $user->hasPermission('view-all_cases'));
+
+        $user = User::factory()->create(['is_administrator' => false]);
+        $user->giveDirectPermission('view-all_cases');
+        $this->actingAs($user);
+
+        $response = $this->get(route('cases-main.index', ['type' => 'all']));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('cases.casesMain');
+    }
+
+    public function testCasesOtherTabsRemainAccessibleWithoutViewAllCasesPermission()
+    {
+        $user = User::factory()->create(['is_administrator' => false]);
+        $this->actingAs($user);
+
+        foreach (['in_progress', 'completed'] as $type) {
+            $response = $this->get(route('cases-main.index', ['type' => $type]));
+            $response->assertStatus(200);
+            $response->assertViewIs('cases.casesMain');
+        }
+
+        // Default `/cases` landing should also work for everyone.
+        $response = $this->get(route('cases-main.index'));
+        $response->assertStatus(200);
+        $response->assertViewIs('cases.casesMain');
     }
 
     public function testShowCaseWithUserAdmin()


### PR DESCRIPTION
# Issue
Ticket: [FOUR-27623](https://processmaker.atlassian.net/browse/FOUR-27623)

Users without the **"View All Cases"** permission can still see every case in the platform by navigating directly to `/cases/all`.

# Solution
### Added permission checks for `view-all-cases`. 
The web check at `ProcessMaker/Http/Controllers/CasesController.php` — `index()` produces the proper "Not Authorized" page. 

`ProcessMaker/Http/Controllers/Api/V1_1/CaseController.php` — `getAllCases` now checks the requested `userId` and only requires `view-all_cases` when the request is **not** scoped to the authenticated user. This protects the data from direct API access while preserving the "My Cases" tab for everyone.

### Added test coverage:
`tests/Feature/CasesControllerTest.php` — three new tests on the web route:
   - `testCasesAllPageReturns403WithoutViewAllCasesPermission` — non-admin without the permission gets a 403 and sees the "Not Authorized" page text.
   - `testCasesAllPageReturns200WithViewAllCasesPermission` — once granted, the user can access `/cases/all` and the `cases.casesMain` view renders.
   - `testCasesOtherTabsRemainAccessibleWithoutViewAllCasesPermission` — regression guard that `/cases`, `/cases/in_progress`, and `/cases/completed` stay accessible for everyone.

`tests/Feature/Api/V1_1/CaseControllerTest.php` — three new tests on the API route:
   - `test_get_all_cases_forbidden_without_view_all_cases_permission` — an unscoped request (the "All cases" tab) returns 403 for a non-admin without the permission, and 200 once granted.
   - `test_get_all_cases_allows_user_to_view_their_own_cases_without_permission`— a self-scoped request (`userId = self`, the "My cases" tab) returns 200 even with no special permission, and other users' cases never leak into the response.
   - `test_get_all_cases_forbids_user_from_viewing_another_users_cases_without_permission` — asking for another user's cases (`userId = other`) returns 403 without the permission, and 200 with it. Locks in the regression that any authenticated user could otherwise iterate userIds to enumerate every user's cases.

# How To Test
1. Run `phpunit tests/Feature/CasesControllerTest.php`
     - Verify `testCasesAllPageReturns403WithoutViewAllCasesPermission` passes
     - Verify `testCasesAllPageReturns200WithViewAllCasesPermission` passes
     - Verify `testCasesOtherTabsRemainAccessibleWithoutViewAllCasesPermission` passes
2. Run `phpunit tests/Feature/Api/V1_1/CaseControllerTest.php`
	- Verify `test_get_all_cases_forbidden_without_view_all_cases_permission` passes
	- Verify `test_get_all_cases_allows_user_to_view_their_own_cases_without_permission` passes
	- Verify `test_get_all_cases_forbids_user_from_viewing_another_users_cases_without_permission` passes
3. Create or modify an existing user.
4. Ensure the user does **not** belong to any group whose membership grants `View All Cases`.
5. Ensure the user does **not** have `View All Cases` granted directly under user permissions (Cases and Requests).
6. Save the user and log in as them.
7. Observe that the **All Cases** menu link is correctly hidden.
8. Observe that the **My Cases** menu link is correctly displayed with the user's cases.
9. Manually navigate to `/cases/all` in the browser.
	- The user should receive an "Unauthorized" message.

ci:deploy

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-27623]: https://processmaker.atlassian.net/browse/FOUR-27623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ