### PR TITLE
Fix SMART_EXTRACT_API_HOST env variable for Custom Executor execution

### DIFF
--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -192,6 +192,9 @@ abstract class Base
             $variablesParameter[] = 'HOST_URL=' . config('app.docker_host_url');
         }
 
+        $variablesParameter[] = 'SMART_EXTRACT_API_HOST=' . config('smart-extract.api_host');
+        $variablesParameter[] = 'SMART_EXTRACT_REQUEST_TIMEOUT=' . config('smart-extract.request_timeout');
+
         return $variablesParameter;
     }
 

--- a/ProcessMaker/ScriptRunners/Base.php
+++ b/ProcessMaker/ScriptRunners/Base.php
@@ -188,12 +188,13 @@ abstract class Base
         // Add the url to the host
         if ($useEscape) {
             $variablesParameter[] = 'HOST_URL=' . escapeshellarg(config('app.docker_host_url'));
+            $variablesParameter[] = 'SMART_EXTRACT_API_HOST=' . escapeshellarg(config('smart-extract.api_host'));
+            $variablesParameter[] = 'SMART_EXTRACT_REQUEST_TIMEOUT=' . escapeshellarg((string) config('smart-extract.request_timeout'));
         } else {
             $variablesParameter[] = 'HOST_URL=' . config('app.docker_host_url');
+            $variablesParameter[] = 'SMART_EXTRACT_API_HOST=' . config('smart-extract.api_host');
+            $variablesParameter[] = 'SMART_EXTRACT_REQUEST_TIMEOUT=' . config('smart-extract.request_timeout');
         }
-
-        $variablesParameter[] = 'SMART_EXTRACT_API_HOST=' . config('smart-extract.api_host');
-        $variablesParameter[] = 'SMART_EXTRACT_REQUEST_TIMEOUT=' . config('smart-extract.request_timeout');
 
         return $variablesParameter;
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "processmaker/processmaker",
-    "version": "2026.10.4",
+    "version": "dev-bugfix/FOUR-30560-B",
     "description": "BPM PHP Software",
     "keywords": [
         "php bpm processmaker"
@@ -112,7 +112,7 @@
             "Gmail"
         ],
         "processmaker": {
-            "build": "f8fdfc80",
+            "build": "7ef60f37",
             "cicd-enabled": true,
             "custom": {
                 "package-ellucian-ethos": "1.19.10",

--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,7 @@
                 "package-rpa": "1.1.2",
                 "package-savedsearch": "1.43.13",
                 "package-slideshow": "1.4.3",
-                "package-smart-extract": "0.0.6",
+                "package-smart-extract": "0.0.7",
                 "package-signature": "1.15.5",
                 "package-testing": "1.8.2",
                 "package-translations": "2.14.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@processmaker/processmaker",
-    "version": "2026.10.4",
+    "version": "dev-bugfix/FOUR-30560-B",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@processmaker/processmaker",
-            "version": "2026.10.4",
+            "version": "dev-bugfix/FOUR-30560-B",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@processmaker/processmaker",
-    "version": "2026.10.4",
+    "version": "dev-bugfix/FOUR-30560-B",
     "description": "ProcessMaker 4",
     "author": "DevOps <devops@processmaker.com>",
     "license": "ISC",


### PR DESCRIPTION
This PR resolves an issue where the SMART_EXTRACT_API_HOST environment variable was not being properly returned when CUSTOM_EXECUTOR was enabled and SCRIPT_MICROSERVICE was disabled.

The fix ensures that the SMART_EXTRACT_API_HOST environment variable is correctly injected and available regardless of which executor configuration is being used.

**Root Cause**

The environment variable was only being properly configured for Script Microservice execution paths. When running scripts through the Custom Executor with the Script Microservice disabled, the variable was not available within the execution environment.


## Solution
Updated the environment variable handling to ensure `SMART_EXTRACT_API_HOST` is consistently available for both:

- Script Microservice execution
- Custom Executor execution

## How to Test
1. Enable CUSTOM_EXECUTOR
2. Disable SCRIPT_MICROSERVICE
3. Ensure Smart Extract environment variables are configured in the .env file
4. Run a Script Task with the following code:
    `getenv('SMART_EXTRACT_API_HOST')`
5. Verify that the expected host value is returned successfully.

## Related Tickets & Packages
- [FOUR-30560](https://processmaker.atlassian.net/browse/FOUR-30560)

ci:deploy
ci:package-smart-extract:task/FOUR-31337

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-30560]: https://processmaker.atlassian.net/browse/FOUR-30560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ