### PR TITLE
FORU-31151 Fix personal access clients in oauth

### DIFF
--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\URL;
 use Laravel\Horizon\Horizon;
 use Laravel\Horizon\SystemProcessCounter;
 use Laravel\Horizon\WorkerCommandString;
+use Laravel\Passport\Client as PassportClient;
 use Lavary\Menu\Menu;
 use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Analysers\DocBlockAnnotationFactory;
@@ -354,6 +355,24 @@ class ProcessMakerServiceProvider extends ServiceProvider
         Models\ProcessRequestToken::observe(Observers\ProcessRequestTokenObserver::class);
 
         Models\ProcessCollaboration::observe(Observers\ProcessCollaborationObserver::class);
+
+        // Due to this change https://github.com/laravel/passport/blob/ea020190123953426a439f0267c6cfa478f6e6e7/src/Guards/TokenGuard.php#L146
+        // user ID is now required for bearer tokens clients. Any user will work here, the token itself
+        // is what's associated with the real user. For now, we'll use the first administrator user.
+        PassportClient::creating(function (PassportClient $client): void {
+            if (!$client->personal_access_client || $client->user_id !== null) {
+                return;
+            }
+
+            $adminUserId = Models\User::query()
+                ->where('is_administrator', true)
+                ->orderBy('id')
+                ->value('id');
+
+            if ($adminUserId !== null) {
+                $client->user_id = $adminUserId;
+            }
+        });
     }
 
     /**

--- a/upgrades/2026_05_07_212653_set_user_id_on_oauth_client.php
+++ b/upgrades/2026_05_07_212653_set_user_id_on_oauth_client.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use ProcessMaker\Upgrades\UpgradeMigration as Upgrade;
+
+class SetUserIdOnOauthClient extends Upgrade
+{
+    /**
+     * Run any validations/pre-run checks to ensure the environment, settings,
+     * packages installed, etc. are right correct to run this upgrade.
+     *
+     * Throw a \RuntimeException if the conditions are *NOT* correct for this
+     * upgrade migration to run. If this is not a required upgrade, then it
+     * will be skipped. Otherwise the exception thrown will be caught, noted,
+     * and will prevent the remaining migrations from continuing to run.
+     *
+     * Returning void or null denotes the checks were successful.
+     *
+     * @return void
+     *
+     * @throws RuntimeException
+     */
+    public function preflightChecks()
+    {
+        //
+    }
+
+    /**
+     * Run the upgrade migration.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $adminUserId = DB::table('users')
+            ->where('is_administrator', true)
+            ->orderBy('id')
+            ->value('id');
+
+        if ($adminUserId === null) {
+            return;
+        }
+
+        DB::table('oauth_clients')
+            ->where('personal_access_client', true)
+            ->whereNull('user_id')
+            ->update(['user_id' => $adminUserId]);
+    }
+
+    /**
+     * Reverse the upgrade migration.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $adminUserId = DB::table('users')
+            ->where('is_administrator', true)
+            ->orderBy('id')
+            ->value('id');
+
+        if ($adminUserId === null) {
+            return;
+        }
+
+        DB::table('oauth_clients')
+            ->where('personal_access_client', true)
+            ->where('user_id', $adminUserId)
+            ->update(['user_id' => null]);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
If the oauth client id, often 1, is the same as the user attempting to authenticate, also often 1, then it fails.

I tried upgrading the schema to the [new Passport clients schema](https://github.com/laravel/passport/blob/13.x/UPGRADE.md#oauth-client-table-changes) but it [caused too many problems](https://github.com/laravel/passport/pull/1913#issuecomment-4490969579) so I'm keeping it the same for now.

See https://github.com/laravel/passport/blob/ea020190123953426a439f0267c6cfa478f6e6e7/src/Guards/TokenGuard.php#L146
and
https://github.com/laravel/passport/blob/ea020190123953426a439f0267c6cfa478f6e6e7/src/Client.php#L169

## Solution
- Set user id for the client to 1

## How to Test
Describe how to test that this solution works.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-31151

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-31151]: https://processmaker.atlassian.net/browse/FOUR-31151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Original PR https://github.com/ProcessMaker/processmaker/pull/8823