### PR TITLE
FOUR-31279: Custom columns are not displayed in the HOME page

### DIFF
--- a/resources/js/tasks/components/ListMixin.js
+++ b/resources/js/tasks/components/ListMixin.js
@@ -83,10 +83,12 @@ const ListMixin = {
         }
         this.previousAdvancedFilter = advancedFilter;
         let includeString = "process,processRequest,processRequest.user,user,data";
-        // If columns are default (isDefaultColumns = true), don't include data
-        // If columns are NOT default (isDefaultColumns = false), include data
+        // Omit data only for default columns without form fields (FOUR-24946 payload optimization)
         const isDefaultColumns = window.ProcessMaker?.isDefaultColumns ?? false;
-        if (isDefaultColumns) {
+        const hasDataColumns = (this.columns || []).some(
+          (column) => String(column.field || "").startsWith("data."),
+        );
+        if (isDefaultColumns && !hasDataColumns) {
           includeString = "process,processRequest,processRequest.user,user";
         }
         const include = includeString.split(",");


### PR DESCRIPTION
## Issue & Reproduction Steps
All custom columns are empty when the user select Home menu.

## Solution
- add data param
<img width="1728" height="965" alt="image" src="https://github.com/user-attachments/assets/92c121b1-9480-4d00-8c80-461308abffb7" />


## How to Test
detailed in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-31279
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy
