### PR TITLE
FOUR-28729: [48874] Ellucian - Email Notifications to "Assigned User" Are Suppressed When the Same User Initiates the Request or Is Assigned to Consecutive Tasks

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -132,7 +132,7 @@ return [
     // PM Analytics Chart
     'pm_analytics_chart' => env('PM_ANALYTICS_CHART', 'https://localhost'),
 
-    // NOTIFICATIONS_SEND_TO_SAME_USER
+    // When true, email notifications are sent even when the assigned user matches the current user.
     'notifications_send_to_same_user' => env('NOTIFICATIONS_SEND_TO_SAME_USER', 'true'),
 
     // Enable default SSO

--- a/config/app.php
+++ b/config/app.php
@@ -132,6 +132,9 @@ return [
     // PM Analytics Chart
     'pm_analytics_chart' => env('PM_ANALYTICS_CHART', 'https://localhost'),
 
+    // NOTIFICATIONS_SEND_TO_SAME_USER
+    'notifications_send_to_same_user' => env('NOTIFICATIONS_SEND_TO_SAME_USER', 'true'),
+
     // Enable default SSO
     'enable_default_sso' => env('ENABLE_DEFAULT_SSO', 'true'),
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Emails to Assigned User are skipped when the assignee is the same user on consecutive tasks or the request starter. Repro: 2 tasks → both User A → notification on task 2 does not send.

## Solution
- Core: notifications_send_to_same_user config (env NOTIFICATIONS_SEND_TO_SAME_USER).
- Connector-send-email: only skip same-user when config is false.

## How to Test
- NOTIFICATIONS_SEND_TO_SAME_USER=true → email sends on each assigned task.
- false → old skip behavior.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-28729

ci:deploy
ci:connector-send-email:bugfix/FOUR-28729

