### PR TITLE
FOUR-31721 | Rename "IMAP Server" Column to "Server" in Email Listener Logs Table

### DIFF
--- a/resources/js/admin/logs/components/Logs/LogTable/LogTable.vue
+++ b/resources/js/admin/logs/components/Logs/LogTable/LogTable.vue
@@ -145,7 +145,7 @@ export default {
       const emailColumns = {
         errors: [
           { key: 'id', label: this.$t('ID') },
-          { key: 'imap_server', label: this.$t('IMAP Server') },
+          { key: 'server', label: this.$t('Server') },
           { key: 'email', label: this.$t('User Email') },
           { key: 'from.email', label: this.$t('Email From') },
           { key: 'error_code', label: this.$t('Error Code') },
@@ -154,7 +154,7 @@ export default {
         ],
         matched: [
           { key: 'id', label: this.$t('ID') },
-          { key: 'imap_server', label: this.$t('IMAP Server') },
+          { key: 'server', label: this.$t('Server') },
           { key: 'email', label: this.$t('User Email') },
           { key: 'from.email', label: this.$t('Email From') },
           { key: 'subject', label: this.$t('Subject') },
@@ -168,7 +168,7 @@ export default {
         ],
         total: [
           { key: 'execution_id', label: this.$t('ID') },
-          { key: 'imap_server', label: this.$t('IMAP Server') },
+          { key: 'server', label: this.$t('Server') },
           { key: 'email', label: this.$t('User Email') },
           { key: 'total_emails', label: this.$t('Total Emails') },
           { key: 'total_matched', label: this.$t('Total Matches') },


### PR DESCRIPTION
## Issue
Ticket: [FOUR-31721](https://processmaker.atlassian.net/browse/FOUR-31721)

This PR renames the label `IMAP Server` → `Server` in all three views of the Email Listener Logs table (errors, matched, total). This is the front-end follow-up to the prior `imap_server` → `server` rename in `package-email-start-event`, generalizing the column so it can display server info for both IMAP and Azure email listeners.

## Changes
- `resources/js/admin/logs/components/Logs/LogTable/LogTable.vue` — update the column definition in the `errors`, `matched`, and `total` column sets.

## How to Test
1. In ProcessMaker, go to Admin → Logs
2. Under the Email Listener Logs, verify that each tab (Errors, Matched, Total) renders a `Server` column.
3. Run an Email Listener process to ensure that the logs are listed and the `Server` column populates correctly.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-31721]: https://processmaker.atlassian.net/browse/FOUR-31721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ