### PR TITLE
FOUR-31810 Only output stack traces for debug logs

### DIFF
--- a/ProcessMaker/Jobs/RunServiceTask.php
+++ b/ProcessMaker/Jobs/RunServiceTask.php
@@ -36,9 +36,9 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param \ProcessMaker\Models\Process $definitions
-     * @param \ProcessMaker\Models\ProcessRequest $instance
-     * @param \ProcessMaker\Models\ProcessRequestToken $token
+     * @param Definitions $definitions
+     * @param ProcessRequest $instance
+     * @param ProcessRequestToken $token
      * @param array $data
      */
     public function __construct(Definitions $definitions, ProcessRequest $instance, ProcessRequestToken $token, array $data, $attemptNum = 1)
@@ -136,7 +136,7 @@ class RunServiceTask extends BpmnAction implements ShouldQueue
             $token->logError($modifiedException, $element);
 
             Log::error('Service task failed: ' . $implementation . ' - ' . $message);
-            Log::error($exception->getTraceAsString());
+            Log::debug($exception->getTraceAsString());
         }
     }
 

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -586,7 +586,8 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
         $errors[] = $error;
         $this->errors = $errors;
         $this->status = 'ERROR';
-        Log::error($exception);
+        Log::error($exception->getMessage());
+        Log::debug($exception->getTraceAsString());
         if (!$this->isNonPersistent()) {
             $this->save();
             // Update Case status


### PR DESCRIPTION
## Issue & Reproduction Steps
Logs have too much info and they are taking up a ton of space

Requires
- https://github.com/ProcessMaker/connector-send-email/pull/369
- https://github.com/ProcessMaker/connector-slack/pull/54

ci:connector-send-email:task/FOUR-31810
ci:connector-slack:task/FOUR-31810

## Solution
- Only output traces when log level is debug

## How to Test
https://processmaker.atlassian.net/browse/FOUR-31810

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-31810

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
