### PR TITLE
feat(FOUR-31831): review Improve Task page loading

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -109,15 +109,6 @@ class TaskController extends Controller
         $task = $task->loadTokenInstance();
         $dataManager = new DataManager();
 
-        // $userHasComments = Comment::where('commentable_type', ProcessRequestToken::class)
-        //                             ->where('commentable_id', $task->id)
-        //                             ->where('body', 'like', '%{{' . \Auth::user()->id . '}}%')
-        //                             ->count() > 0;
-
-        // if (!\Auth::user()->can('update', $task) && !$userHasComments) {
-        //     $this->authorize('update', $task);
-        // }
-
         if (!\Auth::user()->can('update', $task)) {
             $userHasComments = Comment::where('commentable_type', ProcessRequestToken::class)
                                         ->where('commentable_id', $task->id)
@@ -190,7 +181,6 @@ class TaskController extends Controller
                 ]);
             }
 
-            // UserResourceView::setViewed(Auth::user(), $task);
             dispatch(function () use ($task) {
                 UserResourceView::setViewed(Auth::user(), $task);
             })->afterResponse();

--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -108,13 +108,25 @@ class TaskController extends Controller
     {
         $task = $task->loadTokenInstance();
         $dataManager = new DataManager();
-        $userHasComments = Comment::where('commentable_type', ProcessRequestToken::class)
-                                    ->where('commentable_id', $task->id)
-                                    ->where('body', 'like', '%{{' . \Auth::user()->id . '}}%')
-                                    ->count() > 0;
 
-        if (!\Auth::user()->can('update', $task) && !$userHasComments) {
-            $this->authorize('update', $task);
+        // $userHasComments = Comment::where('commentable_type', ProcessRequestToken::class)
+        //                             ->where('commentable_id', $task->id)
+        //                             ->where('body', 'like', '%{{' . \Auth::user()->id . '}}%')
+        //                             ->count() > 0;
+
+        // if (!\Auth::user()->can('update', $task) && !$userHasComments) {
+        //     $this->authorize('update', $task);
+        // }
+
+        if (!\Auth::user()->can('update', $task)) {
+            $userHasComments = Comment::where('commentable_type', ProcessRequestToken::class)
+                                        ->where('commentable_id', $task->id)
+                                        ->where('body', 'like', '%{{' . \Auth::user()->id . '}}%')
+                                        ->count() > 0;
+
+            if (!$userHasComments) {
+                $this->authorize('update', $task);
+            }
         }
 
         //Mark notification as read
@@ -178,7 +190,10 @@ class TaskController extends Controller
                 ]);
             }
 
-            UserResourceView::setViewed(Auth::user(), $task);
+            // UserResourceView::setViewed(Auth::user(), $task);
+            dispatch(function () use ($task) {
+                UserResourceView::setViewed(Auth::user(), $task);
+            })->afterResponse();
             $currentUser = Auth::user()->only([
                 'id',
                 'username',
@@ -189,7 +204,8 @@ class TaskController extends Controller
                 'timezone',
                 'datetime_format',
             ]);
-            $userConfiguration = (new UserConfigurationController())->index();
+            //$userConfiguration = (new UserConfigurationController())->index();
+            $userConfiguration = app(UserConfigurationController::class)->index();
             $hitlEnabled = config('smart-extract.hitl_enabled', false) && $isSmartExtractTask;
 
             // Build the iframe source
@@ -209,9 +225,11 @@ class TaskController extends Controller
                     $iframeSrc = $dashboardUrl . '?' . $queryParams;
                 }
             }
+            $canUpdateTask = Auth::user()->can('update', $task);
 
             return view('tasks.edit', [
                 'task' => $task,
+                'canUpdateTask' => $canUpdateTask,
                 'dueLabels' => self::$dueLabels,
                 'manager' => $manager,
                 'submitUrl' => $submitUrl,

--- a/resources/js/tasks/edit.js
+++ b/resources/js/tasks/edit.js
@@ -64,6 +64,10 @@ const main = new Vue({
     userConfiguration,
     urlConfiguration: "users/configuration",
     showTabs: true,
+    loadedTabs: {
+      form: true,
+      data: false,
+    },
   },
   computed: {
     taskDefinitionConfig() {
@@ -172,6 +176,14 @@ const main = new Vue({
     this.setAllowReassignment();
   },
   methods: {
+    openDataTab() {
+      if (!this.loadedTabs.data) {
+        this.loadedTabs.data = true;
+      }
+      this.$nextTick(() => {
+        this.resizeMonaco();
+      });
+    },
     defineUserConfiguration() {
       this.userConfiguration = JSON.parse(this.userConfiguration.ui_configuration);
       this.showMenu = this.userConfiguration.tasks.isMenuCollapse;
@@ -288,8 +300,13 @@ const main = new Vue({
     },
     resizeMonaco() {
       this.showTree = false;
-      const editor = this.$refs.monaco.getMonaco();
-      editor.layout({ height: window.innerHeight * 0.65 });
+      const editor = this.$refs.monaco?.getMonaco?.();
+      if (!editor) {
+        return;
+      }
+      editor.layout({
+        height: window.innerHeight * 0.65,
+      });
     },
     prepareData() {
       this.updateRequestData = debounce(this.updateRequestData, 1000);

--- a/resources/views/layouts/layoutnext.blade.php
+++ b/resources/views/layouts/layoutnext.blade.php
@@ -95,6 +95,7 @@
         {!! config('global_header') !!}
         <!-- End Global Header -->
     @endif
+    @stack('preload')
 </head>
 <body>
 <a class="skip-navigation alert alert-info" role="link" href="#main" tabindex="1">@{{ __('Skip to Content') }}</a>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -27,6 +27,14 @@
       ], 'attributes' => 'v-cloak'])
 @endsection
 @section('content')
+@push('preload')
+  <link rel="preload" href="{{ mix('js/manifest.js') }}" as="script">
+  <link rel="preload" href="{{ mix('js/vue-vendor.js') }}" as="script">
+  <link rel="preload" href="{{ mix('js/bootstrap-vendor.js') }}" as="script">
+  <link rel="preload" href="{{ mix('js/fortawesome-vendor.js') }}" as="script">
+  <link rel="preload" href="{{ mix('js/tasks/loaderEdit.js') }}" as="script">
+  <link rel="preload" href="{{ mix('js/tasks/edit.js') }}" as="script">
+@endpush
 <div
   id="task"
   v-cloak
@@ -77,7 +85,7 @@
                     role="tab"
                     aria-controls="tab-data"
                     aria-selected="false"
-                    @click="resizeMonaco"
+                    @click="openDataTab"
                     class="nav-link">
                     {{__('Data')}}
                   </a>
@@ -86,7 +94,7 @@
             @endcan
             <div id="tabContent" class="tab-content tw-flex tw-flex-col tw-grow tw-overflow-y-scroll">
               <div id="tab-form" role="tabpanel" aria-labelledby="tab-form" class="tab-pane active show">
-                @can('update', $task)
+                @if($canUpdateTask)
                   @unless($hitlEnabled)
                   <span v-if="tceEnableCaseNumberScreen" class="tw-block tw-gap-2 tw-mb-0 tw-px-2 tw-bg-white tw-border-l tw-border-l-[#d7dde5] tw-border-r tw-border-r-[#d7dde5]" v-cloak>
                     <span class="tw-font-medium tw-text-[#728092] tw-text-xs">Case #:</span> <span class="tw-font-normal tw-text-[#9fa8b5] tw-text-xs">{{ $caseNumber }}</span>
@@ -113,7 +121,7 @@
                   @else
                     @include('tasks.partials.hitl-iframe', ['iframeSrc' => $iframeSrc ?? null])
                   @endunless
-                @endcan
+                @endif
                 <div v-if="taskHasComments">
                   <timeline :commentable_id="task.id"
                     commentable_type="ProcessMaker\Models\ProcessRequestToken"
@@ -126,6 +134,7 @@
               <div v-if="task.process_request.status === 'ACTIVE'" id="tab-data" role="tabpanel" aria-labelledby="tab-data" class="card card-body border-top-0 tab-pane p-3">
                 <!-- data edit -->
                   <monaco-editor
+                      v-if="loadedTabs.data"
                       v-show="!showTree"
                       ref="monaco"
                       data-cy="editorViewFrame"
@@ -437,8 +446,11 @@
     );
 
     const task = @json($task);
+    //const task = @json($taskForFrontend);
+    
     let draftTask = task.draft;
-    const userHasAccessToTask = {{ Auth::user()->can('update', $task) ? "true": "false" }};
+    // const userHasAccessToTask = {{ Auth::user()->can('update', $task) ? "true": "false" }};
+    const userHasAccessToTask = @json($canUpdateTask);
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
     const userIsProcessManager = {{ in_array(Auth::user()->id, $task->process?->manager_id ?? []) ? "true": "false" }};
     const caseNumber = @json($caseNumber);

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -446,10 +446,8 @@
     );
 
     const task = @json($task);
-    //const task = @json($taskForFrontend);
     
     let draftTask = task.draft;
-    // const userHasAccessToTask = {{ Auth::user()->can('update', $task) ? "true": "false" }};
     const userHasAccessToTask = @json($canUpdateTask);
     const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
     const userIsProcessManager = {{ in_array(Auth::user()->id, $task->process?->manager_id ?? []) ? "true": "false" }};


### PR DESCRIPTION
## Issue & Reproduction Steps
Implemented lazy loading for the Data tab in Task Details. The Monaco Editor is now initialized only when the user opens the Data tab, reducing the initial rendering workload and improving page responsiveness.
## Solution
- Added lazy loading for the Data tab.
- Deferred Monaco Editor initialization until the tab is opened.
- Improved initial task page load performance by reducing unnecessary component rendering.

https://github.com/user-attachments/assets/2728601f-07ea-4581-893c-645fb0e0f4c5


## How to Test
- Create a process with a large screen
- Run a case and run a task
- Review that all is working as expected and fast

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-31831

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
