### PR TITLE
Fix duplicate script modal validation error persisting after close

### DIFF
--- a/resources/js/processes/designer/RecentAssetsList.vue
+++ b/resources/js/processes/designer/RecentAssetsList.vue
@@ -406,6 +406,7 @@ export default {
      */
     showModal() {
       this.$refs.duplicateScriptModalRef.show();
+      this.errors = {};
     },
     hideDuplicateScriptModal() {
       this.$refs.duplicateScriptModalRef.hide();


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR fixes an issue in the Copy Script modal where the "name already exists" validation error would remain visible after closing and reopening the modal.

The error state was not being cleared when the modal was reopened, causing old validation messages to persist even before attempting another duplicate action.

## Solution
- Added `this.errors = {}` to `showModal()` to reset the modal state before displaying it.


## How to Test
Follow the testing steps provided in the ticket.

## Related Tickets & Packages
- [FOUR-30054](https://processmaker.atlassian.net/browse/FOUR-30054)

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-30054]: https://processmaker.atlassian.net/browse/FOUR-30054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ