### PR TITLE
FOUR-27675 | Email Notifications, Subject By Default Is Not Configured Correctly; Quotation Marks Are Missing

### DIFF
--- a/ProcessMaker/Http/Controllers/Process/ModelerController.php
+++ b/ProcessMaker/Http/Controllers/Process/ModelerController.php
@@ -170,7 +170,7 @@ class ModelerController extends Controller
         $screen = Screen::getScreenByKey('default-email-task-notification');
 
         return [
-            'subject' => 'RE: {{_user.firstname}} assigned you in "{{_task_name}}"',
+            'subject' => 'RE: "{{_user.firstname}}" assigned you in "{{_task_name}}"',
             'type' => 'screen',
             'screenRef' => $screen->id,
             'toRecipients' => [

--- a/tests/Feature/Processes/ModelerTest.php
+++ b/tests/Feature/Processes/ModelerTest.php
@@ -59,4 +59,23 @@ class ModelerTest extends TestCase
         $response = $this->actingAs($user)->get($anotherRoute);
         $response->assertStatus(200);
     }
+
+    public function testModelerShowExposesDefaultEmailNotificationWithQuotedUserFirstName()
+    {
+        $user = User::factory()->admin()->create();
+        $process = Process::factory()->create();
+
+        $route = route('modeler.show', ['process' => $process->id]);
+        $response = $this->actingAs($user)->get($route);
+
+        $response->assertStatus(200);
+        $response->assertViewHas('defaultEmailNotification');
+
+        $defaultEmailNotification = $response->viewData('defaultEmailNotification');
+
+        $this->assertSame(
+            'RE: "{{_user.firstname}}" assigned you in "{{_task_name}}"',
+            $defaultEmailNotification['subject']
+        );
+    }
 }


### PR DESCRIPTION
# Issue
Ticket: [FOUR-27675](https://processmaker.atlassian.net/browse/FOUR-27675)

The default email notification subject seeded by the modeler rendered `{{_user.firstname}}` without quotation marks, causing the user's first name to appear unquoted in task email notifications. This PR wraps the token in quotes so it matches the formatting of "`{{_task_name}}`".

# Solution
- `ProcessMaker/Http/Controllers/Process/ModelerController.php` — Updated `getDefaultEmailNotification()` subject template from `RE: {{_user.firstname}} assigned you in "{{_task_name}}"` to `RE: "{{_user.firstname}}" assigned you in "{{_task_name}}"`.
- `tests/Feature/Processes/ModelerTest.php` — Added `testModelerShowExposesDefaultEmailNotificationWithQuotedUserFirstName` to assert the modeler bootstrap exposes the corrected subject to the task email notification inspector.
  
# How To Test
1. Run `./vendor/bin/phpunit tests/Feature/Processes/ModelerTest.php`
	- Ensure all tests pass.
2. Go to Designer → create a process.
3. Add a Task → open Email Notifications.
5. Ensure subject reads RE: "{{_user.firstname}}" assigned you in "{{_task_name}}".

ci:deploy

.

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to ProcessMaker Coding Guidelines.
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-27675]: https://processmaker.atlassian.net/browse/FOUR-27675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ