### PR TITLE
FOUR-30940: Bump package-smart-extract to 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,7 @@
                 "package-rpa": "1.1.2",
                 "package-savedsearch": "1.43.13",
                 "package-slideshow": "1.4.3",
-                "package-smart-extract": "0.0.7",
+                "package-smart-extract": "1.0.0",
                 "package-signature": "1.15.5",
                 "package-testing": "1.8.2",
                 "package-translations": "2.14.6",


### PR DESCRIPTION
## Issue & Reproduction Steps
The TCE 2026.3 upgrade needs Core enterprise package metadata to reference the Smart Extract release that includes the latest HITL work.

## Solution
- Updated `extra.processmaker.enterprise.package-smart-extract` from `0.0.7` to `1.0.0`.
- `processmaker/package-smart-extract v1.0.0` already exists and was created from the package `develop` branch.
- This is a metadata-only Core change; `composer.lock` is not updated because this entry is not a direct Composer dependency.

## How to Test
- `node -e "JSON.parse(require('fs').readFileSync('composer.json','utf8')); console.log('composer.json ok')"`
- Confirmed `extra.processmaker.enterprise.package-smart-extract` resolves to `1.0.0`.
- Confirmed remote tag `processmaker/package-smart-extract v1.0.0` exists.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-30940
- https://github.com/ProcessMaker/package-smart-extract/releases/tag/v1.0.0
