### PR TITLE
feat(FOUR-32024): review and fix the calculation of DB timing when loaded by octane

### DIFF
--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -28,6 +28,8 @@ class ServerTimingMiddleware
             return $next($request);
         }
 
+        ProcessMakerServiceProvider::beginRequestTiming();
+
         // Start time for controller execution
         $startController = microtime(true);
 

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -509,6 +509,14 @@ class ProcessMakerServiceProvider extends ServiceProvider
     }
 
     /**
+     * Reset per-request query timing metrics.
+     */
+    public static function beginRequestTiming(): void
+    {
+        self::$queryTime = 0;
+    }
+
+    /**
      * Get the query time for the request.
      *
      * @return float

--- a/tests/Feature/ServerTimingMiddlewareTest.php
+++ b/tests/Feature/ServerTimingMiddlewareTest.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use ProcessMaker\Http\Middleware\ServerTimingMiddleware;
 use ProcessMaker\Models\User;
+use ProcessMaker\Providers\ProcessMakerServiceProvider;
+use ReflectionClass;
 use Tests\Feature\Shared\RequestHelper;
 use Tests\TestCase;
 
@@ -39,6 +41,28 @@ class ServerTimingMiddlewareTest extends TestCase
         $this->assertStringContainsString('provider;dur=', $serverTiming[0]);
         $this->assertStringContainsString('controller;dur=', $serverTiming[1]);
         $this->assertStringContainsString('db;dur=', $serverTiming[2]);
+    }
+
+    public function testBeginRequestTimingClearsAccumulatedQueryTime()
+    {
+        $reflection = new ReflectionClass(ProcessMakerServiceProvider::class);
+        $property = $reflection->getProperty('queryTime');
+        $property->setAccessible(true);
+        $property->setValue(null, 500);
+
+        Route::middleware(ServerTimingMiddleware::class)->get('/timing-reset-test', function () {
+            DB::select('SELECT 1');
+
+            return response()->json(['message' => 'Timing reset test']);
+        });
+
+        $response = $this->get('/timing-reset-test');
+        $serverTiming = $this->getHeader($response, 'server-timing');
+
+        preg_match('/db;dur=([\d.]+)/', implode(',', $serverTiming), $matches);
+        $dbTime = (float) ($matches[1] ?? 500);
+
+        $this->assertLessThan(500, $dbTime);
     }
 
     public function testQueryTimeIsMeasured()


### PR DESCRIPTION

## Issue & Reproduction Steps
_bd:dur_ accumulates requests because $queryTime is static and never reset. Under Octane _bd:dur_ grows on everey call to the same end point.
## Solution
Reset $queryTime at the start of each request via beginRequestTiming() in ServerTimingMiddleware.
<img width="1711" height="985" alt="image" src="https://github.com/user-attachments/assets/75a98114-0923-47fb-87fe-6dde4f7d0372" />

## How to Test
./vendor/bin/phpunit tests/Feature/ServerTimingMiddlewareTest.php --testdox

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32024

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
