### PR TITLE
FOUR-31359: Fix clipboard lookup for new users

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/V1_1/ClipboardController.php
+++ b/ProcessMaker/Http/Controllers/Api/V1_1/ClipboardController.php
@@ -30,7 +30,12 @@ class ClipboardController extends Controller
     public function showByUserId(): Resource
     {
         $userId = Auth::id();
-        $clipboard = Clipboard::where('user_id', $userId)->firstOrFail();
+        $clipboard = Clipboard::firstOrCreate(
+            ['user_id' => $userId],
+            ['config' => [], 'type' => 'FORM']
+        );
+        // JsonResource responds with 201 for new models, but this GET should remain 200.
+        $clipboard->wasRecentlyCreated = false;
 
         return new Resource($clipboard);
     }

--- a/tests/Feature/Api/V1_1/ClipboardControllerTest.php
+++ b/tests/Feature/Api/V1_1/ClipboardControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Api\V1_1;
+
+use ProcessMaker\Models\Clipboard;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class ClipboardControllerTest extends TestCase
+{
+    use RequestHelper;
+
+    public function test_get_by_user_creates_empty_clipboard_for_new_user(): void
+    {
+        Clipboard::where('user_id', $this->user->id)->delete();
+
+        $response = $this->apiCall('GET', '/api/1.1/clipboard/get_by_user');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'user_id' => $this->user->id,
+                'type' => 'FORM',
+                'config' => [],
+            ]);
+
+        $this->assertDatabaseHas('clipboards', [
+            'user_id' => $this->user->id,
+            'type' => 'FORM',
+        ]);
+        $this->assertSame(1, Clipboard::where('user_id', $this->user->id)->count());
+    }
+
+    public function test_get_by_user_returns_existing_clipboard_without_creating_duplicate(): void
+    {
+        Clipboard::where('user_id', $this->user->id)->delete();
+
+        $clipboard = Clipboard::factory()->create([
+            'user_id' => $this->user->id,
+            'config' => [
+                [
+                    'component' => 'FormInput',
+                    'config' => ['label' => 'Existing Clipboard Item'],
+                ],
+            ],
+            'type' => 'FORM',
+        ]);
+
+        $response = $this->apiCall('GET', '/api/1.1/clipboard/get_by_user');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'id' => $clipboard->id,
+                'user_id' => $this->user->id,
+                'type' => 'FORM',
+                'config' => $clipboard->config,
+            ]);
+
+        $this->assertSame(1, Clipboard::where('user_id', $this->user->id)->count());
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
A newly created user can hit a `404 Not Found` when opening the Screen Builder because the editor initializes clipboard data with `GET /api/1.1/clipboard/get_by_user`, but new users do not yet have a row in the `clipboards` table.

Reproduction:
1. Create a brand new user.
2. Grant the user permissions to create or design screens.
3. Log in as that user.
4. Navigate to Screens and create or open a screen in Screen Builder.
5. Observe the `GET /api/1.1/clipboard/get_by_user` request returning `404`.

## Solution
- Changed the clipboard lookup endpoint to lazily create an empty clipboard for the authenticated user when one does not exist.
- Preserved the existing response shape while ensuring the GET endpoint returns `200 OK`.
- Added feature coverage for new users without a clipboard row and users with an existing clipboard row.

## How to Test
Automated test run:
- `./vendor/bin/phpunit tests/Feature/Api/V1_1/ClipboardControllerTest.php`

Manual verification:
1. Ensure the authenticated user has no row in `clipboards`.
2. Call `GET /api/1.1/clipboard/get_by_user`.
3. Confirm the response is `200 OK` with `config: []`.
4. Confirm a clipboard row is created for that user.
5. Call the endpoint again and confirm it returns the existing clipboard without creating duplicates.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-31359


ci:deploy
