### PR TITLE
FOUR-31357: Fix boolean bindings for process template modal

### DIFF
--- a/resources/views/processes/list.blade.php
+++ b/resources/views/processes/list.blade.php
@@ -28,12 +28,12 @@
                             :type="__('Process')"
                             :count-categories="@json($config->countCategories)"
                             :package-ai="{{ hasPackage('package-ai') ? '1' : '0' }}"
-                            is-projects-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(
+                            :is-projects-installed="@json(\ProcessMaker\PackageHelper::isPackageInstalled(
                                 \ProcessMaker\PackageHelper::PM_PACKAGE_PROJECTS
-                            )}}"
-                            is-ab-testing-installed="{{\ProcessMaker\PackageHelper::isPackageInstalled(
+                            ))"
+                            :is-ab-testing-installed="@json(\ProcessMaker\PackageHelper::isPackageInstalled(
                                 \ProcessMaker\PackageHelper::PM_PACKAGE_AB_TESTING
-                            )}}"
+                            ))"
                             >
                             </select-template-modal>
                     @endcan


### PR DESCRIPTION
## Issue & Reproduction Steps
FOUR-31357 reports a Vue console warning when opening the process template selection modal. To reproduce, log in with valid credentials, open DevTools Console, navigate to the Processes section, and click the button to create a new process or otherwise trigger the template selection modal. Vue warns that `SelectTemplateModal` expects `isAbTestingInstalled` to be a Boolean but receives the String value `"1"`.

## Solution
- Updated the Processes Blade view to pass `is-ab-testing-installed` as a Vue-bound JSON boolean instead of an HTML string.
- Updated the adjacent `is-projects-installed` package flag the same way to avoid the same string-boolean behavior in the Project selector condition.
- Kept the change scoped to core Blade rendering; no package or Vue prop contract changes were introduced.

## How to Test
- Visit `/processes` as a user with `create-processes`.
- Open DevTools Console.
- Click `+ Process` to open the template selection modal.
- Confirm the `Invalid prop: type check failed for prop "isAbTestingInstalled"` warning no longer appears.
- Confirm the Project selector still appears when `package-projects` is installed and does not appear when it is not installed.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-31357

ci:deploy
.
