### PR TITLE
FOUR-31341: Respect non-filterable task columns

### DIFF
--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -56,7 +56,7 @@
           #[`filter-${column.field}`]
         >
           <PMColumnFilterPopover
-            v-if="column.sortable"
+            v-if="column.sortable && column.filterable !== false"
             :id="'pm-table-column-' + index"
             :key="index"
             type="Field"


### PR DESCRIPTION
## Issue & Reproduction Steps
The To Do task saved search allows users to open the Status column filter and select statuses such as Completed or Self Service. Applying those filters changes the result set away from the fixed To Do status scope.

Reproduction:
1. Open a default To Do task saved search at `/tasks/saved-searches/{id}`.
2. Open the Status column filter.
3. Select Completed or Self Service and apply the filter.
4. The table returns tasks outside the To Do status scope.

## Solution
- Updated the task list column filter rendering to respect `filterable: false`.
- This lets saved search column metadata disable filtering without disabling the column itself.

## How to Test
Automated tests run:
- `./vendor/bin/phpunit vendor/processmaker/package-savedsearch/tests/Models/SavedSearchTest.php`
- `./vendor/bin/phpunit tests/Feature/Api/TasksTest.php --filter 'AdvancedStatusFilter|SelfServiceFilter'`

Manual test:
1. Open a fixed-status task saved search such as To Do, Completed, or Self Service.
2. Confirm the Status column no longer exposes the filter popover.
3. Confirm other sortable/filterable columns still expose their filters.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-31341
- Related package PR: https://github.com/ProcessMaker/package-savedsearch/pull/625

ci:deploy
ci:package-savedsearch:bugfix/FOUR-31341
.