### PR TITLE
FOUR-32114 / FOUR-32202: Correct user signals on restore and delete

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -160,8 +160,8 @@ class User extends Authenticatable implements HasMedia
         });
 
         static::restoring(function ($user) {
+            // SoftDeletes::restore() saves this with deleted_at=null; avoid a second updated event.
             $user->status = 'ACTIVE';
-            $user->save();
         });
 
         static::deleted(function ($user) {

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -156,7 +156,8 @@ class User extends Authenticatable implements HasMedia
 
         static::deleting(function ($user) {
             $user->status = 'INACTIVE';
-            $user->save();
+            // Persist the inactive status without treating the delete as a user update.
+            $user->saveQuietly();
         });
 
         static::restoring(function ($user) {

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -5,7 +5,9 @@ namespace Tests\Feature\Api;
 use Database\Seeders\PermissionSeeder;
 use Faker\Factory as Faker;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Redis;
+use ProcessMaker\Jobs\ThrowSignalEvent;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Process;
@@ -642,6 +644,44 @@ class UsersTest extends TestCase
         // Assert that the user is listed
         $response = $this->apiCall('GET', self::API_TEST_URL);
         $response->assertJsonFragment(['id' => $id]);
+    }
+
+    public function testRestoreSoftDeletedUserDispatchesOneUserUpdateSignal()
+    {
+        config(['user-signal.update' => true]);
+
+        Bus::fake([
+            ThrowSignalEvent::class,
+        ]);
+
+        $deletedUser = null;
+        User::withoutEvents(function () use (&$deletedUser) {
+            $deletedUser = User::factory()->create([
+                'deleted_at' => now(),
+                'status' => 'INACTIVE',
+            ]);
+        });
+
+        $response = $this->apiCall('PUT', self::API_TEST_URL . '/restore', [
+            'id' => $deletedUser->id,
+        ]);
+
+        $response->assertStatus(200);
+
+        $restoredUser = User::find($deletedUser->id);
+        $this->assertSame('ACTIVE', $restoredUser->status);
+        $this->assertNull($restoredUser->deleted_at);
+        $this->assertFalse($restoredUser->trashed());
+
+        $userUpdateSignalCount = 0;
+        Bus::assertDispatched(ThrowSignalEvent::class, function (ThrowSignalEvent $job) use (&$userUpdateSignalCount) {
+            if ($job->signalRef === 'user_update') {
+                $userUpdateSignalCount++;
+            }
+
+            return true;
+        });
+        $this->assertSame(1, $userUpdateSignalCount);
     }
 
     public function testCreateWithoutPassword()

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -5,9 +5,7 @@ namespace Tests\Feature\Api;
 use Database\Seeders\PermissionSeeder;
 use Faker\Factory as Faker;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Redis;
-use ProcessMaker\Jobs\ThrowSignalEvent;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Process;
@@ -646,20 +644,19 @@ class UsersTest extends TestCase
         $response->assertJsonFragment(['id' => $id]);
     }
 
-    public function testRestoreSoftDeletedUserDispatchesOneUserUpdateSignal()
+    public function testRestoreSoftDeletedUserDispatchesOneUpdatedEvent()
     {
-        config(['user-signal.update' => true]);
-
-        Bus::fake([
-            ThrowSignalEvent::class,
-        ]);
-
         $deletedUser = null;
         User::withoutEvents(function () use (&$deletedUser) {
             $deletedUser = User::factory()->create([
                 'deleted_at' => now(),
                 'status' => 'INACTIVE',
             ]);
+        });
+
+        $updatedEventCount = 0;
+        User::updated(function () use (&$updatedEventCount) {
+            $updatedEventCount++;
         });
 
         $response = $this->apiCall('PUT', self::API_TEST_URL . '/restore', [
@@ -672,16 +669,40 @@ class UsersTest extends TestCase
         $this->assertSame('ACTIVE', $restoredUser->status);
         $this->assertNull($restoredUser->deleted_at);
         $this->assertFalse($restoredUser->trashed());
+        $this->assertSame(1, $updatedEventCount);
+    }
 
-        $userUpdateSignalCount = 0;
-        Bus::assertDispatched(ThrowSignalEvent::class, function (ThrowSignalEvent $job) use (&$userUpdateSignalCount) {
-            if ($job->signalRef === 'user_update') {
-                $userUpdateSignalCount++;
-            }
+    public function testDeleteUserDispatchesDeletedWithoutUpdatedEvent()
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create();
+        $user->groups()->attach($group->id);
 
-            return true;
+        $updatedEventCount = 0;
+        $deletedEventCount = 0;
+        User::updated(function () use (&$updatedEventCount) {
+            $updatedEventCount++;
         });
-        $this->assertSame(1, $userUpdateSignalCount);
+        User::deleted(function () use (&$deletedEventCount) {
+            $deletedEventCount++;
+        });
+
+        $response = $this->apiCall('DELETE', self::API_TEST_URL . '/' . $user->id);
+
+        $response->assertStatus(204);
+
+        $deletedUser = User::withTrashed()->findOrFail($user->id);
+        $this->assertSame('INACTIVE', $deletedUser->status);
+        $this->assertNotNull($deletedUser->deleted_at);
+        $this->assertTrue($deletedUser->trashed());
+        $this->assertSame(0, $updatedEventCount);
+        $this->assertSame(1, $deletedEventCount);
+
+        $this->assertDatabaseMissing('group_members', [
+            'group_id' => $group->id,
+            'member_id' => $user->id,
+            'member_type' => User::class,
+        ]);
     }
 
     public function testCreateWithoutPassword()


### PR DESCRIPTION
## Issue & Reproduction Steps
User lifecycle actions could emit redundant user signals when `package-advanced-user-manager` is installed:

- FOUR-32114: Restoring a soft-deleted user emitted two `user_update` events because the model callback saved once and Laravel SoftDeletes saved again.
- FOUR-32202: Deleting a user emitted `user_update` before `user_delete` because the `deleting` callback saved `status = INACTIVE` with normal model events.

To reproduce the delete issue:
1. Enable `user-signal.update` and `user-signal.delete`.
2. Configure processes that listen for `user_update` and `user_delete`.
3. Delete a user through Admin > Users or `DELETE /api/1.0/users/{user}`.
4. Observe both signals instead of only `user_delete`.

## Solution
- Removed the extra `save()` from `User::restoring` and let Laravel persist `status = ACTIVE` with `deleted_at = null` in its restore save.
- Changed `User::deleting` to `saveQuietly()`, preserving `status = INACTIVE` without emitting an `updated` event before deletion.
- Kept the normal `deleted` event so `package-advanced-user-manager` still emits `user_delete`.
- Made the core regression tests self-contained by asserting Eloquent lifecycle events instead of requiring an optional package.

No routes, payloads, configuration, database schema, or public APIs were changed.

## How to Test
Automated checks run:
- `php -l ProcessMaker/Models/User.php`
- `php -l tests/Feature/Api/UsersTest.php`
- `vendor/bin/phpunit tests/Feature/Api/UsersTest.php --filter=testRestoreSoftDeletedUserDispatchesOneUpdatedEvent`
- `vendor/bin/phpunit tests/Feature/Api/UsersTest.php --filter=testDeleteUserDispatchesDeletedWithoutUpdatedEvent`
- `vendor/bin/phpunit tests/Feature/Api/UsersTest.php`
- `git diff --check`

Result: 29 tests passed with 370 assertions in `UsersTest.php`.

Manual QA:
1. Restore a soft-deleted user and confirm exactly one `user_update`.
2. Delete a user and confirm no `user_update` and exactly one `user_delete`.
3. Confirm the deleted user remains soft-deleted with `status = INACTIVE` and is removed from its groups.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32114
- https://processmaker.atlassian.net/browse/FOUR-32202
- Signal mapping remains owned by `package-advanced-user-manager`; no package changes are required.
- The core fix also applies to callers such as the SCIM delete endpoint in `package-auth`.

ci:deploy

.