### PR TITLE
FOUR-32191 [52344] Clear Text Submission of Login Password in Process…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /public/js
 /public/css
 /storage/*.key
+/storage/app/keys/
 /storage/*.index
 /storage/tenant_*
 /vendor

--- a/ProcessMaker/Console/Commands/GenerateLoginKeys.php
+++ b/ProcessMaker/Console/Commands/GenerateLoginKeys.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use ProcessMaker\Services\LoginCredentialEncryption;
+
+class GenerateLoginKeys extends Command
+{
+    protected $signature = 'login:generate-keys
+                            {--force : Overwrite existing key files}';
+
+    protected $description = 'Generate RSA key pair for encrypted login credentials';
+
+    public function handle(LoginCredentialEncryption $encryption): int
+    {
+        if ($encryption->hasKeyPair() && !$this->option('force')) {
+            $this->error('Login encryption keys already exist. Use --force to overwrite them.');
+
+            return self::FAILURE;
+        }
+
+        $encryption->generateKeyPair();
+        $this->info('Login encryption keys generated successfully.');
+
+        return self::SUCCESS;
+    }
+}

--- a/ProcessMaker/Console/Commands/GenerateLoginKeys.php
+++ b/ProcessMaker/Console/Commands/GenerateLoginKeys.php
@@ -9,8 +9,7 @@ use ProcessMaker\Services\LoginCredentialEncryption;
 
 class GenerateLoginKeys extends Command
 {
-    protected $signature = 'login:generate-keys
-                            {--force : Overwrite existing key files}';
+    protected $signature = 'login:generate-keys {--force : Overwrite existing key files}';
 
     protected $description = 'Generate RSA key pair for encrypted login credentials';
 

--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -116,12 +116,7 @@ class LoginController extends Controller
             false,
             $this->sessionSameSite()
         );
-        $loginEncryption = app(LoginCredentialEncryption::class);
-        $loginPublicKey = null;
-        if ($loginEncryption->isEnabled()) {
-            $loginEncryption->ensureKeyPair();
-            $loginPublicKey = $loginEncryption->getPublicKeyPem();
-        }
+        $loginPublicKey = app(LoginCredentialEncryption::class)->publicKeyForLogin();
 
         $loginView = empty(config('app.login_view')) ? 'auth.login' : config('app.login_view');
         $response = response(view($loginView, compact('addons', 'block', 'loginPublicKey')));
@@ -202,7 +197,7 @@ class LoginController extends Controller
 
     public function loginWithIntendedCheck(Request $request)
     {
-        if (!$this->decryptLoginCredentialsIfNeeded($request)) {
+        if (!app(LoginCredentialEncryption::class)->mergeDecryptedCredentials($request)) {
             $this->sendFailedLoginResponse($request);
         }
 
@@ -448,29 +443,5 @@ class LoginController extends Controller
     private function sessionSameSite(): string
     {
         return config('session.same_site') ?: 'lax';
-    }
-
-    private function decryptLoginCredentialsIfNeeded(Request $request): bool
-    {
-        if (!$request->boolean('encrypted')) {
-            return true;
-        }
-
-        $encryption = app(LoginCredentialEncryption::class);
-        if (!$encryption->isEnabled() || !$encryption->hasKeyPair()) {
-            return false;
-        }
-
-        $credentials = $encryption->decryptCredentials((string) $request->input('encrypted_credentials', ''));
-        if ($credentials === null) {
-            return false;
-        }
-
-        $request->merge([
-            'username' => $credentials['username'],
-            'password' => $credentials['password'],
-        ]);
-
-        return true;
     }
 }

--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -17,6 +17,7 @@ use ProcessMaker\Managers\LoginManager;
 use ProcessMaker\Models\Setting;
 use ProcessMaker\Models\User;
 use ProcessMaker\Package\Auth\Database\Seeds\AuthDefaultSeeder;
+use ProcessMaker\Services\LoginCredentialEncryption;
 use ProcessMaker\Services\PermissionCacheService;
 use ProcessMaker\Traits\HasControllerAddons;
 
@@ -115,8 +116,15 @@ class LoginController extends Controller
             false,
             $this->sessionSameSite()
         );
+        $loginEncryption = app(LoginCredentialEncryption::class);
+        $loginPublicKey = null;
+        if ($loginEncryption->isEnabled()) {
+            $loginEncryption->ensureKeyPair();
+            $loginPublicKey = $loginEncryption->getPublicKeyPem();
+        }
+
         $loginView = empty(config('app.login_view')) ? 'auth.login' : config('app.login_view');
-        $response = response(view($loginView, compact('addons', 'block')));
+        $response = response(view($loginView, compact('addons', 'block', 'loginPublicKey')));
         $response->withCookie($cookie);
 
         // Remove 'password_hash_web' from session
@@ -194,6 +202,10 @@ class LoginController extends Controller
 
     public function loginWithIntendedCheck(Request $request)
     {
+        if (!$this->decryptLoginCredentialsIfNeeded($request)) {
+            $this->sendFailedLoginResponse($request);
+        }
+
         $intended = Cookie::get('processmaker_intended');
         if ($intended) {
             // Check if the route is a fallback, meaning it's invalid (like favicon.ico)
@@ -436,5 +448,29 @@ class LoginController extends Controller
     private function sessionSameSite(): string
     {
         return config('session.same_site') ?: 'lax';
+    }
+
+    private function decryptLoginCredentialsIfNeeded(Request $request): bool
+    {
+        if (!$request->boolean('encrypted')) {
+            return true;
+        }
+
+        $encryption = app(LoginCredentialEncryption::class);
+        if (!$encryption->isEnabled() || !$encryption->hasKeyPair()) {
+            return false;
+        }
+
+        $credentials = $encryption->decryptCredentials((string) $request->input('encrypted_credentials', ''));
+        if ($credentials === null) {
+            return false;
+        }
+
+        $request->merge([
+            'username' => $credentials['username'],
+            'password' => $credentials['password'],
+        ]);
+
+        return true;
     }
 }

--- a/ProcessMaker/Services/LoginCredentialEncryption.php
+++ b/ProcessMaker/Services/LoginCredentialEncryption.php
@@ -14,6 +14,10 @@ class LoginCredentialEncryption
 
     private const PUBLIC_KEY = 'login_public.pem';
 
+    private const HYBRID_VERSION = 2;
+
+    private const GCM_TAG_LENGTH = 16;
+
     public function isEnabled(): bool
     {
         return (bool) config('auth.login_encrypt_credentials', true);
@@ -55,19 +59,17 @@ class LoginCredentialEncryption
      */
     public function decryptCredentials(string $cipherTextBase64): ?array
     {
-        $privateKey = openssl_pkey_get_private((string) file_get_contents($this->path(self::PRIVATE_KEY)));
-        $cipher = base64_decode($cipherTextBase64, true);
-        $plain = '';
-
-        if ($privateKey === false || $cipher === false) {
+        $decoded = base64_decode($cipherTextBase64, true);
+        if ($decoded === false) {
             return null;
         }
 
-        if (!openssl_private_decrypt($cipher, $plain, $privateKey, OPENSSL_PKCS1_OAEP_PADDING)) {
-            return null;
+        $bundle = json_decode($decoded, true);
+        if (is_array($bundle) && (int) ($bundle['v'] ?? 0) === self::HYBRID_VERSION) {
+            return $this->decryptHybridBundle($bundle);
         }
 
-        return $this->parsePayload($plain);
+        return $this->decryptLegacyRsaPayload($cipherTextBase64);
     }
 
     public function encryptCredentials(string $username, string $password, ?int $timestamp = null): string
@@ -80,14 +82,29 @@ class LoginCredentialEncryption
             't' => $timestamp ?? time(),
         ], JSON_THROW_ON_ERROR);
 
-        $publicKey = openssl_pkey_get_public((string) file_get_contents($this->path(self::PUBLIC_KEY)));
-        $encrypted = '';
-
-        if ($publicKey === false || !openssl_public_encrypt($payload, $encrypted, $publicKey, OPENSSL_PKCS1_OAEP_PADDING)) {
+        $aesKey = random_bytes(32);
+        $iv = random_bytes(12);
+        $tag = '';
+        $ciphertext = openssl_encrypt($payload, 'aes-256-gcm', $aesKey, OPENSSL_RAW_DATA, $iv, $tag);
+        if ($ciphertext === false) {
             throw new \RuntimeException('Unable to encrypt login credentials.');
         }
 
-        return base64_encode($encrypted);
+        $publicKey = openssl_pkey_get_public((string) file_get_contents($this->path(self::PUBLIC_KEY)));
+        $encryptedKey = '';
+        if (
+            $publicKey === false
+            || !openssl_public_encrypt($aesKey, $encryptedKey, $publicKey, OPENSSL_PKCS1_OAEP_PADDING)
+        ) {
+            throw new \RuntimeException('Unable to encrypt login credentials key.');
+        }
+
+        return base64_encode(json_encode([
+            'v' => self::HYBRID_VERSION,
+            'k' => base64_encode($encryptedKey),
+            'i' => base64_encode($iv),
+            'd' => base64_encode($ciphertext . $tag),
+        ], JSON_THROW_ON_ERROR));
     }
 
     public function generateKeyPair(): void
@@ -130,6 +147,60 @@ class LoginCredentialEncryption
         if (!$this->hasKeyPair()) {
             $this->generateKeyPair();
         }
+    }
+
+    /**
+     * @param array<string, mixed> $bundle
+     * @return array{username: string, password: string}|null
+     */
+    private function decryptHybridBundle(array $bundle): ?array
+    {
+        if (!isset($bundle['k'], $bundle['i'], $bundle['d'])) {
+            return null;
+        }
+
+        $privateKey = openssl_pkey_get_private((string) file_get_contents($this->path(self::PRIVATE_KEY)));
+        $encryptedKey = base64_decode((string) $bundle['k'], true);
+        $iv = base64_decode((string) $bundle['i'], true);
+        $payload = base64_decode((string) $bundle['d'], true);
+        $aesKey = '';
+
+        if (
+            $privateKey === false
+            || $encryptedKey === false
+            || $iv === false
+            || $payload === false
+            || strlen($payload) <= self::GCM_TAG_LENGTH
+            || !openssl_private_decrypt($encryptedKey, $aesKey, $privateKey, OPENSSL_PKCS1_OAEP_PADDING)
+        ) {
+            return null;
+        }
+
+        $tag = substr($payload, -self::GCM_TAG_LENGTH);
+        $ciphertext = substr($payload, 0, -self::GCM_TAG_LENGTH);
+        $plain = openssl_decrypt($ciphertext, 'aes-256-gcm', $aesKey, OPENSSL_RAW_DATA, $iv, $tag);
+
+        return is_string($plain) ? $this->parsePayload($plain) : null;
+    }
+
+    /**
+     * @return array{username: string, password: string}|null
+     */
+    private function decryptLegacyRsaPayload(string $cipherTextBase64): ?array
+    {
+        $privateKey = openssl_pkey_get_private((string) file_get_contents($this->path(self::PRIVATE_KEY)));
+        $cipher = base64_decode($cipherTextBase64, true);
+        $plain = '';
+
+        if ($privateKey === false || $cipher === false) {
+            return null;
+        }
+
+        if (!openssl_private_decrypt($cipher, $plain, $privateKey, OPENSSL_PKCS1_OAEP_PADDING)) {
+            return null;
+        }
+
+        return $this->parsePayload($plain);
     }
 
     /**

--- a/ProcessMaker/Services/LoginCredentialEncryption.php
+++ b/ProcessMaker/Services/LoginCredentialEncryption.php
@@ -4,36 +4,50 @@ declare(strict_types=1);
 
 namespace ProcessMaker\Services;
 
+use Illuminate\Http\Request;
+
 class LoginCredentialEncryption
 {
-    private const PRIVATE_KEY_FILE = 'login_private.pem';
+    private const KEYS_DIR = 'app/keys';
 
-    private const PUBLIC_KEY_FILE = 'login_public.pem';
+    private const PRIVATE_KEY = 'login_private.pem';
+
+    private const PUBLIC_KEY = 'login_public.pem';
 
     public function isEnabled(): bool
     {
         return (bool) config('auth.login_encrypt_credentials', true);
     }
 
-    public function hasKeyPair(): bool
+    public function publicKeyForLogin(): ?string
     {
-        return is_readable($this->privateKeyPath()) && is_readable($this->publicKeyPath());
-    }
-
-    public function ensureKeyPair(): void
-    {
-        if (!$this->hasKeyPair()) {
-            $this->generateKeyPair();
-        }
-    }
-
-    public function getPublicKeyPem(): ?string
-    {
-        if (!$this->hasKeyPair()) {
+        if (!$this->isEnabled()) {
             return null;
         }
 
-        return trim((string) file_get_contents($this->publicKeyPath()));
+        $this->ensureKeyPair();
+
+        return trim((string) file_get_contents($this->path(self::PUBLIC_KEY)));
+    }
+
+    public function mergeDecryptedCredentials(Request $request): bool
+    {
+        if (!$request->boolean('encrypted')) {
+            return true;
+        }
+
+        if (!$this->isEnabled() || !$this->hasKeyPair()) {
+            return false;
+        }
+
+        $credentials = $this->decryptCredentials((string) $request->input('encrypted_credentials', ''));
+        if ($credentials === null) {
+            return false;
+        }
+
+        $request->merge($credentials);
+
+        return true;
     }
 
     /**
@@ -41,19 +55,15 @@ class LoginCredentialEncryption
      */
     public function decryptCredentials(string $cipherTextBase64): ?array
     {
-        $privateKey = openssl_pkey_get_private((string) file_get_contents($this->privateKeyPath()));
-        if ($privateKey === false) {
-            return null;
-        }
-
+        $privateKey = openssl_pkey_get_private((string) file_get_contents($this->path(self::PRIVATE_KEY)));
         $cipher = base64_decode($cipherTextBase64, true);
-        if ($cipher === false) {
+        $plain = '';
+
+        if ($privateKey === false || $cipher === false) {
             return null;
         }
 
-        $plain = '';
-        $success = openssl_private_decrypt($cipher, $plain, $privateKey, OPENSSL_PKCS1_OAEP_PADDING);
-        if (!$success) {
+        if (!openssl_private_decrypt($cipher, $plain, $privateKey, OPENSSL_PKCS1_OAEP_PADDING)) {
             return null;
         }
 
@@ -70,14 +80,10 @@ class LoginCredentialEncryption
             't' => $timestamp ?? time(),
         ], JSON_THROW_ON_ERROR);
 
-        $publicKey = openssl_pkey_get_public((string) file_get_contents($this->publicKeyPath()));
-        if ($publicKey === false) {
-            throw new \RuntimeException('Unable to load login public key.');
-        }
-
+        $publicKey = openssl_pkey_get_public((string) file_get_contents($this->path(self::PUBLIC_KEY)));
         $encrypted = '';
-        $success = openssl_public_encrypt($payload, $encrypted, $publicKey, OPENSSL_PKCS1_OAEP_PADDING);
-        if (!$success) {
+
+        if ($publicKey === false || !openssl_public_encrypt($payload, $encrypted, $publicKey, OPENSSL_PKCS1_OAEP_PADDING)) {
             throw new \RuntimeException('Unable to encrypt login credentials.');
         }
 
@@ -86,7 +92,7 @@ class LoginCredentialEncryption
 
     public function generateKeyPair(): void
     {
-        $directory = $this->keysDirectory();
+        $directory = storage_path(self::KEYS_DIR);
         if (!is_dir($directory)) {
             mkdir($directory, 0755, true);
         }
@@ -100,7 +106,8 @@ class LoginCredentialEncryption
             throw new \RuntimeException('Unable to generate login RSA key pair.');
         }
 
-        if (!openssl_pkey_export_to_file($key, $this->privateKeyPath())) {
+        $privatePath = $this->path(self::PRIVATE_KEY);
+        if (!openssl_pkey_export_to_file($key, $privatePath)) {
             throw new \RuntimeException('Unable to write login private key.');
         }
 
@@ -109,8 +116,20 @@ class LoginCredentialEncryption
             throw new \RuntimeException('Unable to extract login public key.');
         }
 
-        file_put_contents($this->publicKeyPath(), $details['key']);
-        chmod($this->privateKeyPath(), 0600);
+        file_put_contents($this->path(self::PUBLIC_KEY), $details['key']);
+        chmod($privatePath, 0600);
+    }
+
+    public function hasKeyPair(): bool
+    {
+        return is_readable($this->path(self::PRIVATE_KEY)) && is_readable($this->path(self::PUBLIC_KEY));
+    }
+
+    private function ensureKeyPair(): void
+    {
+        if (!$this->hasKeyPair()) {
+            $this->generateKeyPair();
+        }
     }
 
     /**
@@ -123,9 +142,7 @@ class LoginCredentialEncryption
             return null;
         }
 
-        $ttl = (int) config('auth.login_encrypt_ttl', 300);
-        $timestamp = (int) $data['t'];
-        if (abs(time() - $timestamp) > $ttl) {
+        if (abs(time() - (int) $data['t']) > (int) config('auth.login_encrypt_ttl', 300)) {
             return null;
         }
 
@@ -135,18 +152,8 @@ class LoginCredentialEncryption
         ];
     }
 
-    private function keysDirectory(): string
+    private function path(string $file): string
     {
-        return storage_path('app/keys');
-    }
-
-    private function privateKeyPath(): string
-    {
-        return $this->keysDirectory() . '/' . self::PRIVATE_KEY_FILE;
-    }
-
-    private function publicKeyPath(): string
-    {
-        return $this->keysDirectory() . '/' . self::PUBLIC_KEY_FILE;
+        return storage_path(self::KEYS_DIR . '/' . $file);
     }
 }

--- a/ProcessMaker/Services/LoginCredentialEncryption.php
+++ b/ProcessMaker/Services/LoginCredentialEncryption.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProcessMaker\Services;
+
+class LoginCredentialEncryption
+{
+    private const PRIVATE_KEY_FILE = 'login_private.pem';
+
+    private const PUBLIC_KEY_FILE = 'login_public.pem';
+
+    public function isEnabled(): bool
+    {
+        return (bool) config('auth.login_encrypt_credentials', true);
+    }
+
+    public function hasKeyPair(): bool
+    {
+        return is_readable($this->privateKeyPath()) && is_readable($this->publicKeyPath());
+    }
+
+    public function ensureKeyPair(): void
+    {
+        if (!$this->hasKeyPair()) {
+            $this->generateKeyPair();
+        }
+    }
+
+    public function getPublicKeyPem(): ?string
+    {
+        if (!$this->hasKeyPair()) {
+            return null;
+        }
+
+        return trim((string) file_get_contents($this->publicKeyPath()));
+    }
+
+    /**
+     * @return array{username: string, password: string}|null
+     */
+    public function decryptCredentials(string $cipherTextBase64): ?array
+    {
+        $privateKey = openssl_pkey_get_private((string) file_get_contents($this->privateKeyPath()));
+        if ($privateKey === false) {
+            return null;
+        }
+
+        $cipher = base64_decode($cipherTextBase64, true);
+        if ($cipher === false) {
+            return null;
+        }
+
+        $plain = '';
+        $success = openssl_private_decrypt($cipher, $plain, $privateKey, OPENSSL_PKCS1_OAEP_PADDING);
+        if (!$success) {
+            return null;
+        }
+
+        return $this->parsePayload($plain);
+    }
+
+    public function encryptCredentials(string $username, string $password, ?int $timestamp = null): string
+    {
+        $this->ensureKeyPair();
+
+        $payload = json_encode([
+            'u' => $username,
+            'p' => $password,
+            't' => $timestamp ?? time(),
+        ], JSON_THROW_ON_ERROR);
+
+        $publicKey = openssl_pkey_get_public((string) file_get_contents($this->publicKeyPath()));
+        if ($publicKey === false) {
+            throw new \RuntimeException('Unable to load login public key.');
+        }
+
+        $encrypted = '';
+        $success = openssl_public_encrypt($payload, $encrypted, $publicKey, OPENSSL_PKCS1_OAEP_PADDING);
+        if (!$success) {
+            throw new \RuntimeException('Unable to encrypt login credentials.');
+        }
+
+        return base64_encode($encrypted);
+    }
+
+    public function generateKeyPair(): void
+    {
+        $directory = $this->keysDirectory();
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        $key = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        if ($key === false) {
+            throw new \RuntimeException('Unable to generate login RSA key pair.');
+        }
+
+        if (!openssl_pkey_export_to_file($key, $this->privateKeyPath())) {
+            throw new \RuntimeException('Unable to write login private key.');
+        }
+
+        $details = openssl_pkey_get_details($key);
+        if ($details === false || empty($details['key'])) {
+            throw new \RuntimeException('Unable to extract login public key.');
+        }
+
+        file_put_contents($this->publicKeyPath(), $details['key']);
+        chmod($this->privateKeyPath(), 0600);
+    }
+
+    /**
+     * @return array{username: string, password: string}|null
+     */
+    private function parsePayload(string $json): ?array
+    {
+        $data = json_decode($json, true);
+        if (!is_array($data) || !isset($data['u'], $data['p'], $data['t'])) {
+            return null;
+        }
+
+        $ttl = (int) config('auth.login_encrypt_ttl', 300);
+        $timestamp = (int) $data['t'];
+        if (abs(time() - $timestamp) > $ttl) {
+            return null;
+        }
+
+        return [
+            'username' => (string) $data['u'],
+            'password' => (string) $data['p'],
+        ];
+    }
+
+    private function keysDirectory(): string
+    {
+        return storage_path('app/keys');
+    }
+
+    private function privateKeyPath(): string
+    {
+        return $this->keysDirectory() . '/' . self::PRIVATE_KEY_FILE;
+    }
+
+    private function publicKeyPath(): string
+    {
+        return $this->keysDirectory() . '/' . self::PUBLIC_KEY_FILE;
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -111,6 +111,10 @@ return [
 
     'log_auth_events' => env('LOG_AUTH_EVENTS', true),
 
+    'login_encrypt_credentials' => env('LOGIN_ENCRYPT_CREDENTIALS', true),
+
+    'login_encrypt_ttl' => env('LOGIN_ENCRYPT_TTL', 300),
+
     /*
     |--------------------------------------------------------------------------
     | Password Confirmation Timeout

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -14,7 +14,8 @@ Login
     <div class="col-md-8 offset-md-2 col-lg-6 offset-lg-3">
       <div class="card card-body p-3">
         @if (! $block)
-          <form method="POST" class="form" action="{{ route('login') }}">
+          <form method="POST" class="form login-form" action="{{ route('login') }}">
+            @csrf
             @if (session()->has('timeout'))
               <div class="alert alert-danger">{{ __("Your account has been timed out for security.") }}</div>
             @endif

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -82,6 +82,7 @@ Login
 @endsection
 
 @section('js')
+    @include('auth.partials.login-credential-encryption')
     <script>
         const browser = navigator.userAgent;
         const isMobileDevice  = /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(browser);

--- a/resources/views/auth/newLogin.blade.php
+++ b/resources/views/auth/newLogin.blade.php
@@ -8,7 +8,6 @@
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
   <meta name="settings-translations-enabled" content="{{ config('translations.enabled') ? 'true' : 'false' }}">
-  @include('auth.partials.login-credential-encryption')
   <title>{{ __('Login') }} - {{ __('ProcessMaker') }}</title>
   <link href="{{ mix('css/app.css') }}" rel="stylesheet">
   @include('auth.partials.login-critical-styles')
@@ -35,7 +34,8 @@
                 @endcomponent
               </div>
               @if (! $block)
-              <form method="POST" class="form" action="{{ route('login') }}">
+              <form method="POST" class="form login-form" action="{{ route('login') }}">
+                @csrf
                 @if (session()->has('timeout'))
                 <div class="alert alert-danger">{{ __("Your account has been timed out for security.") }}</div>
                 @endif
@@ -140,8 +140,7 @@
       @endif
     </div>
   </div>
-</body>
-<script>
+  <script>
   const browser = navigator.userAgent;
   const isMobileDevice  = /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(browser);
   document.cookie = "isMobile=false"
@@ -174,6 +173,8 @@
       capsLockWarning.hidden = true;
     });
   }
-</script>
-@include('auth.partials.auth-language-scripts')
+  </script>
+  @include('auth.partials.auth-language-scripts')
+  @include('auth.partials.login-credential-encryption')
+</body>
 </html>

--- a/resources/views/auth/newLogin.blade.php
+++ b/resources/views/auth/newLogin.blade.php
@@ -8,6 +8,7 @@
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
   <meta name="settings-translations-enabled" content="{{ config('translations.enabled') ? 'true' : 'false' }}">
+  @include('auth.partials.login-credential-encryption')
   <title>{{ __('Login') }} - {{ __('ProcessMaker') }}</title>
   <link href="{{ mix('css/app.css') }}" rel="stylesheet">
   @include('auth.partials.login-critical-styles')

--- a/resources/views/auth/partials/login-credential-encryption.blade.php
+++ b/resources/views/auth/partials/login-credential-encryption.blade.php
@@ -1,0 +1,109 @@
+@if (!empty($loginPublicKey))
+<meta name="login-public-key" content="{{ $loginPublicKey }}">
+<script>
+  (function () {
+    const publicKeyMeta = document.querySelector('meta[name="login-public-key"]');
+    const form = document.querySelector('form.form[action="{{ route('login') }}"]');
+
+    if (!publicKeyMeta || !form || !window.crypto || !window.crypto.subtle) {
+      return;
+    }
+
+    const usernameInput = form.querySelector('#username');
+    const passwordInput = form.querySelector('#password');
+
+    if (!usernameInput || !passwordInput) {
+      return;
+    }
+
+    function pemToArrayBuffer(pem) {
+      const contents = pem
+        .replace('-----BEGIN PUBLIC KEY-----', '')
+        .replace('-----END PUBLIC KEY-----', '')
+        .replace(/\s/g, '');
+      const binary = atob(contents);
+      const bytes = new Uint8Array(binary.length);
+
+      for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+
+      return bytes.buffer;
+    }
+
+    async function importPublicKey(pem) {
+      return window.crypto.subtle.importKey(
+        'spki',
+        pemToArrayBuffer(pem),
+        { name: 'RSA-OAEP', hash: 'SHA-1' },
+        false,
+        ['encrypt']
+      );
+    }
+
+    async function encryptCredentials(publicKeyPem, username, password) {
+      const key = await importPublicKey(publicKeyPem);
+      const payload = JSON.stringify({
+        u: username,
+        p: password,
+        t: Math.floor(Date.now() / 1000),
+      });
+      const encoded = new TextEncoder().encode(payload);
+      const encrypted = await window.crypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        key,
+        encoded
+      );
+      const bytes = new Uint8Array(encrypted);
+      let binary = '';
+
+      bytes.forEach(function (byte) {
+        binary += String.fromCharCode(byte);
+      });
+
+      return btoa(binary);
+    }
+
+    function ensureHiddenField(name) {
+      let field = form.querySelector('[name="' + name + '"]');
+
+      if (!field) {
+        field = document.createElement('input');
+        field.type = 'hidden';
+        field.name = name;
+        form.appendChild(field);
+      }
+
+      return field;
+    }
+
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+
+      const submit = async function () {
+        const encryptedCredentials = await encryptCredentials(
+          publicKeyMeta.content,
+          usernameInput.value,
+          passwordInput.value
+        );
+
+        usernameInput.removeAttribute('name');
+        passwordInput.removeAttribute('name');
+        usernameInput.value = '';
+        passwordInput.value = '';
+
+        ensureHiddenField('encrypted_credentials').value = encryptedCredentials;
+        ensureHiddenField('encrypted').value = '1';
+
+        form.submit();
+      };
+
+      submit().catch(function () {
+        usernameInput.setAttribute('name', 'username');
+        passwordInput.setAttribute('name', 'password');
+        window.alert(@json(__('Unable to submit login credentials securely. Please try again.')));
+      });
+    });
+  })();
+</script>
+@endif

--- a/resources/views/auth/partials/login-credential-encryption.blade.php
+++ b/resources/views/auth/partials/login-credential-encryption.blade.php
@@ -14,7 +14,9 @@
         return;
       }
 
-      const importKey = () => subtle.importKey(
+      const toBase64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+
+      const importRsaKey = () => subtle.importKey(
         'spki',
         Uint8Array.from(atob(pem.replace(/-----BEGIN PUBLIC KEY-----|-----END PUBLIC KEY-----|\s/g, '')), (c) => c.charCodeAt(0)),
         { name: 'RSA-OAEP', hash: 'SHA-1' },
@@ -22,27 +24,40 @@
         ['encrypt']
       );
 
+      const encryptCredentials = async function () {
+        const payload = new TextEncoder().encode(JSON.stringify({
+          u: username.value,
+          p: password.value,
+          t: Math.floor(Date.now() / 1000),
+        }));
+        const aesKey = await subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt']);
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const encrypted = await subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, payload);
+        const encryptedKey = await subtle.encrypt(
+          { name: 'RSA-OAEP' },
+          await importRsaKey(),
+          await subtle.exportKey('raw', aesKey)
+        );
+
+        return toBase64(JSON.stringify({
+          v: 2,
+          k: toBase64(encryptedKey),
+          i: toBase64(iv),
+          d: toBase64(encrypted),
+        }));
+      };
+
       form.addEventListener('submit', async function (event) {
         event.preventDefault();
 
         try {
-          const encrypted = await subtle.encrypt(
-            { name: 'RSA-OAEP' },
-            await importKey(),
-            new TextEncoder().encode(JSON.stringify({
-              u: username.value,
-              p: password.value,
-              t: Math.floor(Date.now() / 1000),
-            }))
-          );
-
           username.removeAttribute('name');
           password.removeAttribute('name');
 
           const credentials = document.createElement('input');
           credentials.type = 'hidden';
           credentials.name = 'encrypted_credentials';
-          credentials.value = btoa(String.fromCharCode(...new Uint8Array(encrypted)));
+          credentials.value = await encryptCredentials();
           form.appendChild(credentials);
 
           const flag = document.createElement('input');
@@ -53,6 +68,8 @@
 
           form.submit();
         } catch (error) {
+          username.setAttribute('name', 'username');
+          password.setAttribute('name', 'password');
           window.alert(alertMessage);
         }
       });

--- a/resources/views/auth/partials/login-credential-encryption.blade.php
+++ b/resources/views/auth/partials/login-credential-encryption.blade.php
@@ -1,107 +1,60 @@
 @if (!empty($loginPublicKey))
-<meta name="login-public-key" content="{{ $loginPublicKey }}">
 <script>
   (function () {
-    const publicKeyMeta = document.querySelector('meta[name="login-public-key"]');
-    const form = document.querySelector('form.form[action="{{ route('login') }}"]');
+    const pem = @json($loginPublicKey);
+    const alertMessage = @json(__('Unable to submit login credentials securely. Please try again.'));
 
-    if (!publicKeyMeta || !form || !window.crypto || !window.crypto.subtle) {
-      return;
-    }
+    window.addEventListener('load', function () {
+      const form = document.querySelector('form.login-form');
+      const username = form?.querySelector('#username');
+      const password = form?.querySelector('#password');
+      const subtle = window.crypto?.subtle;
 
-    const usernameInput = form.querySelector('#username');
-    const passwordInput = form.querySelector('#password');
-
-    if (!usernameInput || !passwordInput) {
-      return;
-    }
-
-    function pemToArrayBuffer(pem) {
-      const contents = pem
-        .replace('-----BEGIN PUBLIC KEY-----', '')
-        .replace('-----END PUBLIC KEY-----', '')
-        .replace(/\s/g, '');
-      const binary = atob(contents);
-      const bytes = new Uint8Array(binary.length);
-
-      for (let index = 0; index < binary.length; index += 1) {
-        bytes[index] = binary.charCodeAt(index);
+      if (!pem || !form || !username || !password || !subtle) {
+        return;
       }
 
-      return bytes.buffer;
-    }
-
-    async function importPublicKey(pem) {
-      return window.crypto.subtle.importKey(
+      const importKey = () => subtle.importKey(
         'spki',
-        pemToArrayBuffer(pem),
+        Uint8Array.from(atob(pem.replace(/-----BEGIN PUBLIC KEY-----|-----END PUBLIC KEY-----|\s/g, '')), (c) => c.charCodeAt(0)),
         { name: 'RSA-OAEP', hash: 'SHA-1' },
         false,
         ['encrypt']
       );
-    }
 
-    async function encryptCredentials(publicKeyPem, username, password) {
-      const key = await importPublicKey(publicKeyPem);
-      const payload = JSON.stringify({
-        u: username,
-        p: password,
-        t: Math.floor(Date.now() / 1000),
-      });
-      const encoded = new TextEncoder().encode(payload);
-      const encrypted = await window.crypto.subtle.encrypt(
-        { name: 'RSA-OAEP' },
-        key,
-        encoded
-      );
-      const bytes = new Uint8Array(encrypted);
-      let binary = '';
+      form.addEventListener('submit', async function (event) {
+        event.preventDefault();
 
-      bytes.forEach(function (byte) {
-        binary += String.fromCharCode(byte);
-      });
+        try {
+          const encrypted = await subtle.encrypt(
+            { name: 'RSA-OAEP' },
+            await importKey(),
+            new TextEncoder().encode(JSON.stringify({
+              u: username.value,
+              p: password.value,
+              t: Math.floor(Date.now() / 1000),
+            }))
+          );
 
-      return btoa(binary);
-    }
+          username.removeAttribute('name');
+          password.removeAttribute('name');
 
-    function ensureHiddenField(name) {
-      let field = form.querySelector('[name="' + name + '"]');
+          const credentials = document.createElement('input');
+          credentials.type = 'hidden';
+          credentials.name = 'encrypted_credentials';
+          credentials.value = btoa(String.fromCharCode(...new Uint8Array(encrypted)));
+          form.appendChild(credentials);
 
-      if (!field) {
-        field = document.createElement('input');
-        field.type = 'hidden';
-        field.name = name;
-        form.appendChild(field);
-      }
+          const flag = document.createElement('input');
+          flag.type = 'hidden';
+          flag.name = 'encrypted';
+          flag.value = '1';
+          form.appendChild(flag);
 
-      return field;
-    }
-
-    form.addEventListener('submit', function (event) {
-      event.preventDefault();
-
-      const submit = async function () {
-        const encryptedCredentials = await encryptCredentials(
-          publicKeyMeta.content,
-          usernameInput.value,
-          passwordInput.value
-        );
-
-        usernameInput.removeAttribute('name');
-        passwordInput.removeAttribute('name');
-        usernameInput.value = '';
-        passwordInput.value = '';
-
-        ensureHiddenField('encrypted_credentials').value = encryptedCredentials;
-        ensureHiddenField('encrypted').value = '1';
-
-        form.submit();
-      };
-
-      submit().catch(function () {
-        usernameInput.setAttribute('name', 'username');
-        passwordInput.setAttribute('name', 'password');
-        window.alert(@json(__('Unable to submit login credentials securely. Please try again.')));
+          form.submit();
+        } catch (error) {
+          window.alert(alertMessage);
+        }
       });
     });
   })();

--- a/resources/views/auth/partials/login-credential-encryption.blade.php
+++ b/resources/views/auth/partials/login-credential-encryption.blade.php
@@ -14,7 +14,18 @@
         return;
       }
 
-      const toBase64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+      const toBase64 = function (input) {
+        const bytes = typeof input === 'string'
+          ? new TextEncoder().encode(input)
+          : new Uint8Array(input);
+        let binary = '';
+
+        bytes.forEach(function (byte) {
+          binary += String.fromCharCode(byte);
+        });
+
+        return btoa(binary);
+      };
 
       const importRsaKey = () => subtle.importKey(
         'spki',
@@ -51,13 +62,15 @@
         event.preventDefault();
 
         try {
+          const encryptedCredentials = await encryptCredentials();
+
           username.removeAttribute('name');
           password.removeAttribute('name');
 
           const credentials = document.createElement('input');
           credentials.type = 'hidden';
           credentials.name = 'encrypted_credentials';
-          credentials.value = await encryptCredentials();
+          credentials.value = encryptedCredentials;
           form.appendChild(credentials);
 
           const flag = document.createElement('input');

--- a/tests/Feature/LoginEncryptionTest.php
+++ b/tests/Feature/LoginEncryptionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Hash;
+use ProcessMaker\Models\User;
+use ProcessMaker\Services\LoginCredentialEncryption;
+use Tests\TestCase;
+
+class LoginEncryptionTest extends TestCase
+{
+    private LoginCredentialEncryption $encryption;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'auth.login_encrypt_credentials' => true,
+            'auth.login_encrypt_ttl' => 300,
+        ]);
+
+        $this->encryption = app(LoginCredentialEncryption::class);
+        $this->encryption->generateKeyPair();
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink(storage_path('app/keys/login_private.pem'));
+        @unlink(storage_path('app/keys/login_public.pem'));
+
+        parent::tearDown();
+    }
+
+    public function test_login_with_encrypted_credentials(): void
+    {
+        User::factory()->create([
+            'username' => 'encrypted-user',
+            'password' => Hash::make('encrypted-password'),
+            'status' => 'ACTIVE',
+        ]);
+
+        $cipher = $this->encryption->encryptCredentials('encrypted-user', 'encrypted-password');
+
+        $response = $this->post('login', [
+            'encrypted' => 1,
+            'encrypted_credentials' => $cipher,
+        ]);
+
+        $response->assertRedirect('/');
+        $response->assertSessionHasNoErrors();
+        $this->assertAuthenticated();
+    }
+
+    public function test_login_rejects_invalid_encrypted_credentials(): void
+    {
+        User::factory()->create([
+            'username' => 'encrypted-user',
+            'password' => Hash::make('encrypted-password'),
+            'status' => 'ACTIVE',
+        ]);
+
+        $response = $this->post('login', [
+            'encrypted' => 1,
+            'encrypted_credentials' => 'invalid-cipher-text',
+        ]);
+
+        $response->assertRedirect('/');
+        $response->assertSessionHasErrors('username');
+        $this->assertGuest();
+    }
+
+    public function test_login_page_exposes_public_key_when_encryption_is_enabled(): void
+    {
+        $response = $this->get(route('login'));
+
+        $response->assertOk();
+        $response->assertSee('login-public-key', false);
+        $response->assertSee($this->encryption->getPublicKeyPem(), false);
+    }
+}

--- a/tests/Feature/LoginEncryptionTest.php
+++ b/tests/Feature/LoginEncryptionTest.php
@@ -6,31 +6,22 @@ namespace Tests\Feature;
 
 use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\User;
-use ProcessMaker\Services\LoginCredentialEncryption;
+use Tests\Support\InteractsWithLoginEncryptionKeys;
 use Tests\TestCase;
 
 class LoginEncryptionTest extends TestCase
 {
-    private LoginCredentialEncryption $encryption;
+    use InteractsWithLoginEncryptionKeys;
 
     protected function setUp(): void
     {
         parent::setUp();
-
-        config([
-            'auth.login_encrypt_credentials' => true,
-            'auth.login_encrypt_ttl' => 300,
-        ]);
-
-        $this->encryption = app(LoginCredentialEncryption::class);
-        $this->encryption->generateKeyPair();
+        $this->setUpLoginEncryptionKeys();
     }
 
     protected function tearDown(): void
     {
-        @unlink(storage_path('app/keys/login_private.pem'));
-        @unlink(storage_path('app/keys/login_public.pem'));
-
+        $this->tearDownLoginEncryptionKeys();
         parent::tearDown();
     }
 
@@ -42,11 +33,9 @@ class LoginEncryptionTest extends TestCase
             'status' => 'ACTIVE',
         ]);
 
-        $cipher = $this->encryption->encryptCredentials('encrypted-user', 'encrypted-password');
-
         $response = $this->post('login', [
             'encrypted' => 1,
-            'encrypted_credentials' => $cipher,
+            'encrypted_credentials' => $this->loginEncryption->encryptCredentials('encrypted-user', 'encrypted-password'),
         ]);
 
         $response->assertRedirect('/');
@@ -77,7 +66,7 @@ class LoginEncryptionTest extends TestCase
         $response = $this->get(route('login'));
 
         $response->assertOk();
-        $response->assertSee('login-public-key', false);
-        $response->assertSee($this->encryption->getPublicKeyPem(), false);
+        $response->assertSee('BEGIN PUBLIC KEY', false);
+        $response->assertSee('login-form', false);
     }
 }

--- a/tests/Support/InteractsWithLoginEncryptionKeys.php
+++ b/tests/Support/InteractsWithLoginEncryptionKeys.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use ProcessMaker\Services\LoginCredentialEncryption;
+
+trait InteractsWithLoginEncryptionKeys
+{
+    protected LoginCredentialEncryption $loginEncryption;
+
+    protected function setUpLoginEncryptionKeys(): void
+    {
+        config([
+            'auth.login_encrypt_credentials' => true,
+            'auth.login_encrypt_ttl' => 300,
+        ]);
+
+        $this->loginEncryption = app(LoginCredentialEncryption::class);
+        $this->loginEncryption->generateKeyPair();
+    }
+
+    protected function tearDownLoginEncryptionKeys(): void
+    {
+        @unlink(storage_path('app/keys/login_private.pem'));
+        @unlink(storage_path('app/keys/login_public.pem'));
+    }
+}

--- a/tests/unit/ProcessMaker/Services/LoginCredentialEncryptionTest.php
+++ b/tests/unit/ProcessMaker/Services/LoginCredentialEncryptionTest.php
@@ -44,4 +44,17 @@ class LoginCredentialEncryptionTest extends TestCase
     {
         $this->assertNull($this->loginEncryption->decryptCredentials('not-valid-base64-cipher'));
     }
+
+    public function test_it_encrypts_long_credentials_with_hybrid_encryption(): void
+    {
+        $cipher = $this->loginEncryption->encryptCredentials(
+            str_repeat('u', 255),
+            str_repeat('p', 200)
+        );
+
+        $credentials = $this->loginEncryption->decryptCredentials($cipher);
+
+        $this->assertSame(str_repeat('u', 255), $credentials['username']);
+        $this->assertSame(str_repeat('p', 200), $credentials['password']);
+    }
 }

--- a/tests/unit/ProcessMaker/Services/LoginCredentialEncryptionTest.php
+++ b/tests/unit/ProcessMaker/Services/LoginCredentialEncryptionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\ProcessMaker\Services;
+
+use ProcessMaker\Services\LoginCredentialEncryption;
+use Tests\TestCase;
+
+class LoginCredentialEncryptionTest extends TestCase
+{
+    private LoginCredentialEncryption $encryption;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'auth.login_encrypt_credentials' => true,
+            'auth.login_encrypt_ttl' => 300,
+        ]);
+
+        $this->encryption = new LoginCredentialEncryption();
+        $this->encryption->generateKeyPair();
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink(storage_path('app/keys/login_private.pem'));
+        @unlink(storage_path('app/keys/login_public.pem'));
+
+        parent::tearDown();
+    }
+
+    public function test_it_encrypts_and_decrypts_login_credentials(): void
+    {
+        $cipher = $this->encryption->encryptCredentials('test-user', 'secret-password');
+
+        $credentials = $this->encryption->decryptCredentials($cipher);
+
+        $this->assertSame('test-user', $credentials['username']);
+        $this->assertSame('secret-password', $credentials['password']);
+    }
+
+    public function test_it_rejects_expired_credentials(): void
+    {
+        $cipher = $this->encryption->encryptCredentials('test-user', 'secret-password', time() - 301);
+
+        $this->assertNull($this->encryption->decryptCredentials($cipher));
+    }
+
+    public function test_it_rejects_invalid_cipher_text(): void
+    {
+        $this->assertNull($this->encryption->decryptCredentials('not-valid-base64-cipher'));
+    }
+}

--- a/tests/unit/ProcessMaker/Services/LoginCredentialEncryptionTest.php
+++ b/tests/unit/ProcessMaker/Services/LoginCredentialEncryptionTest.php
@@ -5,38 +5,29 @@ declare(strict_types=1);
 namespace Tests\Unit\ProcessMaker\Services;
 
 use ProcessMaker\Services\LoginCredentialEncryption;
+use Tests\Support\InteractsWithLoginEncryptionKeys;
 use Tests\TestCase;
 
 class LoginCredentialEncryptionTest extends TestCase
 {
-    private LoginCredentialEncryption $encryption;
+    use InteractsWithLoginEncryptionKeys;
 
     protected function setUp(): void
     {
         parent::setUp();
-
-        config([
-            'auth.login_encrypt_credentials' => true,
-            'auth.login_encrypt_ttl' => 300,
-        ]);
-
-        $this->encryption = new LoginCredentialEncryption();
-        $this->encryption->generateKeyPair();
+        $this->setUpLoginEncryptionKeys();
     }
 
     protected function tearDown(): void
     {
-        @unlink(storage_path('app/keys/login_private.pem'));
-        @unlink(storage_path('app/keys/login_public.pem'));
-
+        $this->tearDownLoginEncryptionKeys();
         parent::tearDown();
     }
 
     public function test_it_encrypts_and_decrypts_login_credentials(): void
     {
-        $cipher = $this->encryption->encryptCredentials('test-user', 'secret-password');
-
-        $credentials = $this->encryption->decryptCredentials($cipher);
+        $cipher = $this->loginEncryption->encryptCredentials('test-user', 'secret-password');
+        $credentials = $this->loginEncryption->decryptCredentials($cipher);
 
         $this->assertSame('test-user', $credentials['username']);
         $this->assertSame('secret-password', $credentials['password']);
@@ -44,13 +35,13 @@ class LoginCredentialEncryptionTest extends TestCase
 
     public function test_it_rejects_expired_credentials(): void
     {
-        $cipher = $this->encryption->encryptCredentials('test-user', 'secret-password', time() - 301);
+        $cipher = $this->loginEncryption->encryptCredentials('test-user', 'secret-password', time() - 301);
 
-        $this->assertNull($this->encryption->decryptCredentials($cipher));
+        $this->assertNull($this->loginEncryption->decryptCredentials($cipher));
     }
 
     public function test_it_rejects_invalid_cipher_text(): void
     {
-        $this->assertNull($this->encryption->decryptCredentials('not-valid-base64-cipher'));
+        $this->assertNull($this->loginEncryption->decryptCredentials('not-valid-base64-cipher'));
     }
 }


### PR DESCRIPTION
…Maker

Description:
When the login button is clicked, the payload shows that the username and password are visible in clear text in the request body.
- Expected Behavior Login credentials should be Encrypted and transmitted over the network, and not exposed in request body.
- Notes to QA This was also tested on an intercepting site called Burp Suite

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-32191

For test:
php artisan view:clear

ci:deploy