### PR TITLE
FOUR-27170: [47742] - Server Performance Issues new index [notifications_notifiable_type_notifiable_id_read_at_index]

### DIFF
--- a/database/migrations/2026_07_13_145000_add_created_at_to_notifications_notifiable_index.php
+++ b/database/migrations/2026_07_13_145000_add_created_at_to_notifications_notifiable_index.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    private const TABLE = 'notifications';
+
+    private const INDEX_NAME = 'notifications_notifiable_type_notifiable_id_read_at_index';
+
+    /**
+     * Run the migrations.
+     *
+     * Prefer running during a low-workload window. Creating this index on a large
+     * notifications table can acquire locks and briefly affect write throughput.
+     */
+    public function up(): void
+    {
+        // Replace the previous 3-column index with an extended one that includes
+        // created_at DESC. Same index name is reused intentionally.
+        if (Schema::hasIndex(self::TABLE, self::INDEX_NAME)) {
+            Schema::table(self::TABLE, function (Blueprint $table) {
+                $table->dropIndex(self::INDEX_NAME);
+            });
+        }
+
+        if (!Schema::hasIndex(self::TABLE, self::INDEX_NAME)) {
+            DB::statement(
+                'CREATE INDEX ' . self::INDEX_NAME . ' ON ' . self::TABLE
+                . ' (notifiable_type, notifiable_id, read_at, created_at DESC)'
+            );
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasIndex(self::TABLE, self::INDEX_NAME)) {
+            Schema::table(self::TABLE, function (Blueprint $table) {
+                $table->dropIndex(self::INDEX_NAME);
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
[47742] - Server Performance Issues new index [notifications_notifiable_type_notifiable_id_read_at_index]

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-27170

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
