### PR TITLE
Remove Microsoft Graph Configuration Caching

### DIFF
--- a/ProcessMaker/Mail/MicrosoftGraphTokenProvider.php
+++ b/ProcessMaker/Mail/MicrosoftGraphTokenProvider.php
@@ -3,7 +3,6 @@
 namespace ProcessMaker\Mail;
 
 use GuzzleHttp\Client;
-use Illuminate\Support\Facades\Cache;
 use RuntimeException;
 
 class MicrosoftGraphTokenProvider
@@ -15,17 +14,13 @@ class MicrosoftGraphTokenProvider
     public function __construct(
         private array $config,
         private int|string $serverIndex = 0,
-        private ?Client $httpClient = null
+        private ?Client $httpClient = null,
     ) {
     }
 
     public function getAccessToken(): string
     {
-        $cacheKey = 'microsoft_graph_access_token_' . ($this->serverIndex ?: 'default');
-
-        return Cache::remember($cacheKey, now()->addMinutes(50), function () {
-            return $this->requestAccessToken();
-        });
+        return $this->requestAccessToken();
     }
 
     private function requestAccessToken(): string

--- a/tests/unit/ProcessMaker/Mail/MicrosoftGraphTokenProviderTest.php
+++ b/tests/unit/ProcessMaker/Mail/MicrosoftGraphTokenProviderTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit\ProcessMaker\Mail;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Support\Facades\Cache;
 use Mockery;
 use ProcessMaker\Mail\MicrosoftGraphTokenProvider;
 use RuntimeException;
@@ -34,8 +33,6 @@ class MicrosoftGraphTokenProviderTest extends TestCase
 
     public function testGetAccessTokenRequestsTokenFromMicrosoft()
     {
-        Cache::flush();
-
         $tokenResponse = new Response(200, [], json_encode(['access_token' => 'token-from-azure']));
 
         $guzzle = Mockery::mock(Client::class);
@@ -59,7 +56,6 @@ class MicrosoftGraphTokenProviderTest extends TestCase
             'secret' => 'client-secret-123',
         ], 1, $guzzle);
 
-        $this->assertSame('token-from-azure', $provider->getAccessToken());
         $this->assertSame('token-from-azure', $provider->getAccessToken());
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves an issue where Send Test Email continued to succeed even after the required Microsoft Graph configuration values (Tenant ID, Client ID, and Client Secret) were cleared.

The issue was caused by cached Microsoft Graph configuration values being used instead of the current Email Server configuration. This PR removes the configuration caching so the latest values are always used when sending emails.

## Solution
- Removed configuration caching for Microsoft Graph.
- Updated the Microsoft Graph mail transport to always use the current Email Server configuration.
- Ensures missing or invalid credentials are detected immediately rather than falling back to previously cached values.

## How to Test

1. Create a new Email Server using the Microsoft Graph driver.
2. Configure all required Microsoft Graph settings.
3. Send a Test Email.
4. Verify the email is sent successfully.
5. Clear the Client ID, Tenant ID, and Client Secret fields.
6. Save the Email Server configuration.
7. Send another Test Email.
8. Verify an error is displayed indicating the Microsoft Graph configuration is invalid or incomplete.

## Related Tickets & Packages
- [FOUR-32273](https://processmaker.atlassian.net/browse/FOUR-32273)

ci:connector-send-email:epic/FOUR-32115
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-32273]: https://processmaker.atlassian.net/browse/FOUR-32273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ