### PR TITLE
Include File Attachments in Microsoft Graph Emails

### DIFF
--- a/ProcessMaker/Mail/MicrosoftGraphMessageConverter.php
+++ b/ProcessMaker/Mail/MicrosoftGraphMessageConverter.php
@@ -31,6 +31,11 @@ class MicrosoftGraphMessageConverter
             $message['bccRecipients'] = $bccRecipients;
         }
 
+        $attachments = self::convertAttachments($email);
+        if ($attachments) {
+            $message['attachments'] = $attachments;
+        }
+
         return [
             'message' => $message,
             'saveToSentItems' => true,
@@ -51,5 +56,21 @@ class MicrosoftGraphMessageConverter
 
             return ['emailAddress' => $emailAddress];
         }, $addresses);
+    }
+
+    private static function convertAttachments(Email $email): array
+    {
+        $attachments = [];
+
+        foreach ($email->getAttachments() as $attachment) {
+            $attachments[] = [
+                '@odata.type' => '#microsoft.graph.fileAttachment',
+                'name' => $attachment->getFilename() ?: 'attachment',
+                'contentType' => $attachment->getMediaType() . '/' . $attachment->getMediaSubtype(),
+                'contentBytes' => base64_encode($attachment->getBody()),
+            ];
+        }
+
+        return $attachments;
     }
 }

--- a/tests/unit/ProcessMaker/Mail/MicrosoftGraphMessageConverterTest.php
+++ b/tests/unit/ProcessMaker/Mail/MicrosoftGraphMessageConverterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Mail;
+
+use ProcessMaker\Mail\MicrosoftGraphMessageConverter;
+use Symfony\Component\Mime\Email;
+use Tests\TestCase;
+
+class MicrosoftGraphMessageConverterTest extends TestCase
+{
+    public function testToSendMailPayloadIncludesFileAttachments()
+    {
+        $email = (new Email())
+            ->to('recipient@example.com')
+            ->subject('With attachment')
+            ->html('<p>Hello</p>')
+            ->attach('file-contents', 'report.txt', 'text/plain');
+
+        $payload = MicrosoftGraphMessageConverter::toSendMailPayload($email);
+
+        $this->assertSame('With attachment', $payload['message']['subject']);
+        $this->assertSame('HTML', $payload['message']['body']['contentType']);
+        $this->assertCount(1, $payload['message']['attachments']);
+        $this->assertSame([
+            '@odata.type' => '#microsoft.graph.fileAttachment',
+            'name' => 'report.txt',
+            'contentType' => 'text/plain',
+            'contentBytes' => base64_encode('file-contents'),
+        ], $payload['message']['attachments'][0]);
+    }
+
+    public function testToSendMailPayloadOmitsAttachmentsKeyWhenNonePresent()
+    {
+        $email = (new Email())
+            ->to('recipient@example.com')
+            ->subject('No attachment')
+            ->text('Hello');
+
+        $payload = MicrosoftGraphMessageConverter::toSendMailPayload($email);
+
+        $this->assertArrayNotHasKey('attachments', $payload['message']);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR resolves an issue where emails sent using the Microsoft Graph mail driver did not include file attachments.

The solution adds support for converting Symfony Email attachments into Microsoft Graph `fileAttachment` objects and includes them in the `sendMail` payload.

## Solution
- Added `convertAttachments()` to `MicrosoftGraphMessageConverter`.
- Maps Symfony Email attachments to Microsoft Graph `fileAttachment` objects.
- Includes the following attachment properties in the Graph payload:
      - `name`
      - `contentType`
      -` contentBytes` (Base64 encoded)
- Updated `toSendMailPayload()` to include attachments when they are present on the email.

## How to Test

1. Create an Email Server using the Microsoft Graph driver.
2. Create a process with the following flow:
       - Start Event
       - File Upload Task
       - Send Email Connector
3. Configure the Send Email connector to use the Microsoft Graph Email Server.
4. Configure the attachment to use the file upload variable from the File Upload Task.
5. Save and run the process.
6. Verify the received email contains the uploaded file as an attachment.

## Related Tickets & Packages
- [FOUR-32274](https://processmaker.atlassian.net/browse/FOUR-32274)

ci:connector-send-email:epic/FOUR-32115
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-32274]: https://processmaker.atlassian.net/browse/FOUR-32274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ