### PR TITLE
FOUR-30102: Command to update the timezone for the Anonymous user

### DIFF
--- a/ProcessMaker/Console/Commands/UpdateAnonymousUserTimezone.php
+++ b/ProcessMaker/Console/Commands/UpdateAnonymousUserTimezone.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ProcessMaker\Console\Commands;
+
+use Illuminate\Console\Command;
+use ProcessMaker\Models\AnonymousUser;
+use ProcessMaker\Models\User;
+
+class UpdateAnonymousUserTimezone extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'processmaker:update-anonymous-user-timezone
+                            {--timezone= : Timezone to assign. Defaults to config app.anonymous_user_timezone}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update the anonymous user timezone from config (safe to run multiple times)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $timezone = $this->option('timezone') ?: config('app.anonymous_user_timezone', 'UTC');
+
+        $user = User::where('username', AnonymousUser::ANONYMOUS_USERNAME)->first();
+
+        if (!$user) {
+            $this->error('Anonymous user not found.');
+
+            return self::FAILURE;
+        }
+
+        if ($user->timezone === $timezone) {
+            $this->info("Anonymous user timezone is already set to [{$timezone}].");
+
+            return self::SUCCESS;
+        }
+
+        $previousTimezone = $user->timezone;
+        $user->timezone = $timezone;
+        $user->save();
+
+        $this->info("Anonymous user timezone updated from [{$previousTimezone}] to [{$timezone}].");
+
+        return self::SUCCESS;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -32,6 +32,9 @@ return [
     // The timezone for the application
     'timezone' => env('APP_TIMEZONE', 'America/Los_Angeles'),
 
+    // The timezone for the anonymous user
+    'anonymous_user_timezone' => env('ANONYMOUS_USER_TIMEZONE', 'UTC'),
+
     // The time format for the application
     'dateformat' => env('DATE_FORMAT', 'm/d/Y h:i A'),
 

--- a/tests/Feature/Console/UpdateAnonymousUserTimezoneTest.php
+++ b/tests/Feature/Console/UpdateAnonymousUserTimezoneTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use ProcessMaker\Models\AnonymousUser;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class UpdateAnonymousUserTimezoneTest extends TestCase
+{
+    public function testUpdatesTimezoneFromConfig(): void
+    {
+        $user = User::where('username', AnonymousUser::ANONYMOUS_USERNAME)->firstOrFail();
+        $user->timezone = 'America/Chicago';
+        $user->save();
+
+        config(['app.anonymous_user_timezone' => 'America/New_York']);
+
+        $this->artisan('processmaker:update-anonymous-user-timezone')
+            ->expectsOutput('Anonymous user timezone updated from [America/Chicago] to [America/New_York].')
+            ->assertExitCode(0);
+
+        $this->assertEquals('America/New_York', $user->fresh()->timezone);
+    }
+
+    public function testDoesNothingWhenTimezoneAlreadyMatches(): void
+    {
+        $user = User::where('username', AnonymousUser::ANONYMOUS_USERNAME)->firstOrFail();
+        $user->timezone = 'UTC';
+        $user->save();
+
+        config(['app.anonymous_user_timezone' => 'UTC']);
+
+        $this->artisan('processmaker:update-anonymous-user-timezone')
+            ->expectsOutput('Anonymous user timezone is already set to [UTC].')
+            ->assertExitCode(0);
+
+        $this->assertEquals('UTC', $user->fresh()->timezone);
+    }
+
+    public function testUpdatesTimezoneFromOption(): void
+    {
+        $user = User::where('username', AnonymousUser::ANONYMOUS_USERNAME)->firstOrFail();
+        $user->timezone = 'UTC';
+        $user->save();
+
+        config(['app.anonymous_user_timezone' => 'UTC']);
+
+        $this->artisan('processmaker:update-anonymous-user-timezone', [
+            '--timezone' => 'Europe/Madrid',
+        ])
+            ->expectsOutput('Anonymous user timezone updated from [UTC] to [Europe/Madrid].')
+            ->assertExitCode(0);
+
+        $this->assertEquals('Europe/Madrid', $user->fresh()->timezone);
+    }
+
+    public function testCanBeRunMultipleTimes(): void
+    {
+        $user = User::where('username', AnonymousUser::ANONYMOUS_USERNAME)->firstOrFail();
+        $user->timezone = 'America/Chicago';
+        $user->save();
+
+        config(['app.anonymous_user_timezone' => 'America/Los_Angeles']);
+
+        $this->artisan('processmaker:update-anonymous-user-timezone')->assertExitCode(0);
+        $this->artisan('processmaker:update-anonymous-user-timezone')
+            ->expectsOutput('Anonymous user timezone is already set to [America/Los_Angeles].')
+            ->assertExitCode(0);
+
+        $this->assertEquals('America/Los_Angeles', $user->fresh()->timezone);
+    }
+
+    public function testFailsWhenAnonymousUserDoesNotExist(): void
+    {
+        User::where('username', AnonymousUser::ANONYMOUS_USERNAME)->forceDelete();
+
+        $this->artisan('processmaker:update-anonymous-user-timezone')
+            ->expectsOutput('Anonymous user not found.')
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
## Create a command to update the Users.timezone

1. Set the env ANONYMOUS_USER_TIMEZONE (default UTC)
2. Execute the command `php artisan processmaker:update-anonymous-user-timezone`

## Solution
- List the changes you've introduced to solve the issue.

## How to Test
`php artisan processmaker:update-anonymous-user-timezone`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-30102

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:package-webentry:FOUR-30102
ci:deploy