### PR TITLE
FOUR-32290 Login page layout is not responsive – elements overlap and…

### DIFF
--- a/resources/views/auth/partials/auth-styles.blade.php
+++ b/resources/views/auth/partials/auth-styles.blade.php
@@ -365,11 +365,51 @@
     .small-screen {
       border: 0;
       background: transparent;
+      flex: 0 0 auto;
+    }
+
+    .login-layout,
+    .login-layout.h-100-vh {
+      align-items: flex-start;
+      height: auto;
+      min-height: auto;
+      padding: 1rem 1rem 4.5rem;
+    }
+
+    .h-100-vh {
+      height: auto;
+    }
+
+    .login-panel {
+      width: 100%;
+    }
+
+    .login-logo {
+      margin-bottom: 1.5rem;
+    }
+
+    .login-logo-custom,
+    .login-logo-default {
+      max-width: 240px;
     }
 
     .login-container {
       max-width: 100%;
+      padding: 1.5rem 1.25rem 1.75rem;
       box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
+    }
+
+    .password-field-header {
+      flex-wrap: wrap;
+    }
+
+    .caps-lock-warning {
+      white-space: normal;
+    }
+
+    .footer {
+      margin-left: 0;
+      padding: 0 1rem 1rem;
     }
   }
 </style>

--- a/resources/views/auth/partials/login-extra-styles.blade.php
+++ b/resources/views/auth/partials/login-extra-styles.blade.php
@@ -103,5 +103,13 @@
     .login-remember {
       width: 100%;
     }
+
+    .forgot-password-link {
+      white-space: normal;
+    }
+
+    .login-addons {
+      margin-top: 0.5rem;
+    }
   }
 </style>


### PR DESCRIPTION
… truncate on mobile devices

Description:
The login page (/login) does not render correctly on mobile screen sizes (width < 768px). UI elements overlap, text is cut off, and the "Login" button is partially hidden, making it impossible for users to complete the login flow on mobile devices.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-32290

ci:deploy