### PR TITLE
FOUR-32311: Prevent duplicate DevLink bundle operations

### DIFF
--- a/resources/js/admin/devlink/components/InstallProgress.vue
+++ b/resources/js/admin/devlink/components/InstallProgress.vue
@@ -33,7 +33,20 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, getCurrentInstance } from 'vue';
+import {
+  ref,
+  watch,
+  onMounted,
+  onUnmounted,
+  getCurrentInstance,
+} from "vue";
+
+const props = defineProps({
+  requestError: {
+    type: String,
+    default: "",
+  },
+});
 
 const vue = getCurrentInstance().proxy;
 const progress = ref(0);
@@ -45,8 +58,27 @@ const showSpinner = ref(true);
 const error = ref('');
 const emit = defineEmits(['installation-complete']);
 
+watch(
+  () => props.requestError,
+  (message) => {
+    if (!message) {
+      return;
+    }
+
+    showSpinner.value = false;
+    currentMessage.value = "";
+    error.value = message;
+    done.value = true;
+  },
+  {
+    immediate: true,
+  },
+);
+
 onMounted(() => {
-  currentMessage.value = vue.$t('Initializing') + '...';
+  if (!props.requestError) {
+    currentMessage.value = vue.$t('Initializing') + '...';
+  }
   window.Echo.private(`ProcessMaker.Models.User.${userId}`).listen(
     '.ImportLog',
     (response) => {

--- a/resources/js/admin/devlink/components/UpdateBundle.vue
+++ b/resources/js/admin/devlink/components/UpdateBundle.vue
@@ -7,6 +7,9 @@ const confirmUpdateVersion = ref(null);
 const selected = ref(null);
 const selectedOption = ref('update');
 const showInstallModal = ref(false);
+const installationInProgress = ref(false);
+const installationAttempt = ref(0);
+const requestError = ref("");
 const reinstall = ref(false);
 const title = computed(() => {
   if (reinstall.value) {
@@ -40,6 +43,13 @@ const updateBundleText = computed(() => {
 });
 
 const executeUpdate = (updateType) => {
+  if (installationInProgress.value) {
+    return;
+  }
+
+  installationInProgress.value = true;
+  installationAttempt.value += 1;
+  requestError.value = "";
   showInstallModal.value = true;
   let url;
   if (reinstall.value) {
@@ -52,12 +62,18 @@ const executeUpdate = (updateType) => {
     .post(url, {
       updateType,
     })
-    .then((response) => {
-      // Handle the response as needed
+    .catch((error) => {
+      const message = error?.response?.data?.message || error?.message;
+      requestError.value = typeof message === "string"
+        ? message
+        : vue.$t("Unable to start installation.");
     });
 };
 
 const handleInstallationComplete = () => {
+  installationInProgress.value = false;
+  showInstallModal.value = false;
+  requestError.value = "";
   emit('installation-complete');
 };
 
@@ -98,8 +114,21 @@ const handleInstallationComplete = () => {
       </div>
     </b-modal>
 
-    <b-modal id="install-progress" size="lg" v-model="showInstallModal" :title="$t('Installation Progress')" hide-footer>
-      <install-progress @installation-complete="handleInstallationComplete" />
+    <b-modal
+      id="install-progress"
+      v-model="showInstallModal"
+      size="lg"
+      :title="$t('Installation Progress')"
+      hide-footer
+      hide-header-close
+      no-close-on-backdrop
+      no-close-on-esc
+    >
+      <install-progress
+        :key="installationAttempt"
+        :request-error="requestError"
+        @installation-complete="handleInstallationComplete"
+      />
     </b-modal>
   </div>
 </template>


### PR DESCRIPTION
## Issue & Reproduction Steps
DevLink allows an Update Bundle or Reinstall Bundle progress modal to be dismissed while the operation is still running. This makes the action available again and permits a duplicate job to be submitted, which the backend lock rejects with an "Already running!" error. To reproduce, navigate to Admin > DevLink > Local Bundles, start an Update Bundle or Reinstall Bundle operation, click outside the progress modal before completion, and attempt the same action again. No fixture is required.

## Solution
- Prevent the installation progress modal from being dismissed through the backdrop, Escape key, or header close button while an operation is active.
- Guard against duplicate submissions and reset the progress component for every new installation attempt.
- Display initial API request failures as terminal errors so the operation can be acknowledged and closed safely.
- Release the operation lock in the interface only after the terminal result is closed.

## How to Test
1. Run `npm run development`.
2. Navigate to Admin > DevLink > Local Bundles and start Update Bundle or Reinstall Bundle.
3. Verify the progress modal has no header close button and cannot be dismissed by clicking the backdrop or pressing Escape.
4. Verify only one operation is submitted while the modal is active.
5. Allow the operation to complete and verify the Close button releases the interface.
6. Start another legitimate operation and verify it begins with fresh progress state and completes without an "Already running!" error.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32311
- https://processmaker.atlassian.net/browse/FOUR-32196
- ProcessMaker core only; no package changes.
