### PR TITLE
FOUR-32357 REGRESSION>> Intermediate Signal Throw Event is not working

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -250,7 +250,11 @@ if (!function_exists('packTemporalData')) {
     function packTemporalData($data)
     {
         $uid = uniqid('data_', true);
-        $path = storage_path('app/private/' . $uid);
+        $directory = storage_path('app/private');
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+        $path = $directory . '/' . $uid;
 
         file_put_contents($path, json_encode($data));
 


### PR DESCRIPTION
Description:
Fix intermediate signal throw when storage/app/private is missing

ThrowSignalEvent calls packTemporalData() in its constructor; that helper wrote to storage_path('app/private') without ensuring the directory exists. On develop-qa the folder was absent, causing file_put_contents to fail and blocking the signal before CatchSignalEventRequest could run.

Create the directory with mkdir(..., 0755, true) before writing. Uses the current storage_path(), so tenant and landlord contexts are unchanged.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-32357
