### PR TITLE
bugfix/FOUR-26343: Completed tasks can be modified in the task preview pane.

### DIFF
--- a/resources/js/tasks/components/TaskListRowButtons.vue
+++ b/resources/js/tasks/components/TaskListRowButtons.vue
@@ -5,7 +5,7 @@
         <slot name="body">
           <span v-for="(button, index) in buttons" :key="index">
             <b-button :id="button.id + rowIndex"
-                      v-if="button.show"
+                      v-if="shouldShow(button)"
                       aria-label="button.title"
                       @click="onClick(button)"
                       variant="light"
@@ -19,6 +19,7 @@
                    :alt="button.title"/>
             </b-button>
             <b-tooltip
+              v-if="shouldShow(button)"
               :target="button.id + rowIndex"
               :title="button.title"
               custom-class="task-hover-tooltip"
@@ -27,7 +28,7 @@
               boundary="viewport"
               :no-fade="true"
               />
-            <div v-if="index < buttons.length - 1 && button.show"
+            <div v-if="index < buttons.length - 1 && shouldShow(button)"
                  class="task-vertical-separator">
             </div>
           </span>
@@ -51,6 +52,12 @@
       showButtons: null
     },
     methods: {
+      shouldShow(button) {
+        if (typeof button.show === "function") {
+          return button.show(this.row);
+        }
+        return button.show;
+      },
       show() {
         this.triggerFloatingButtons(() => {
           if (!this.showButtons) {

--- a/resources/js/tasks/components/TasksList.vue
+++ b/resources/js/tasks/components/TasksList.vue
@@ -348,7 +348,7 @@ export default {
           click: this.previewTasks,
           icon: "fas fa-eye",
           title: this.$t("Preview"),
-          show: !this.verifyURL("saved-searches") || false,
+          show: (row) => this.shouldShowPreviewButton(row),
         },
         {
           id: "openCaseButton",
@@ -444,6 +444,7 @@ export default {
             record.process_request,
             record,
           );
+          record.task_status = record.status;
           record.status = this.formatStatus(record);
           record.assignee = this.formatAvatar(record.user);
           record.request = this.formatRequest(record);
@@ -758,6 +759,16 @@ export default {
         isInUrl = false;
       }
       return isInUrl;
+    },
+    /**
+     * Hide Preview for completed tasks (API status CLOSED) and on normal saved searches.
+     * Use task_status because status is replaced with badge HTML in the data watcher.
+     */
+    shouldShowPreviewButton(row) {
+      if (this.verifyURL("saved-searches") && !this.processesIManage) {
+        return false;
+      }
+      return row?.task_status !== "CLOSED";
     },
     /**
      * This method is used in PMColumnFilterPopoverCommonMixin.js


### PR DESCRIPTION
## Solution
- Preview pane icon is hidden when Status = "Completed" in /tasks page.

## How to Test
- Go to Tasks
- Filter status with Completed and In Progress Tasks.
- Preview Icon should be hidden in "Completed" tasks

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26343

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:screen-builder:bugfix/FOUR-26343
ci:deploy