### PR TITLE
fix(FOUR-29427): Menu Style Discrepancy Between Homepage and Request  View

### DIFF
--- a/resources/js/Mobile/FilterMobile.vue
+++ b/resources/js/Mobile/FilterMobile.vue
@@ -269,7 +269,7 @@ export default {
   },
 };
 </script>
-<style>
+<style scoped>
   .has-search .form-control {
     padding-left: 2.375rem;
   }


### PR DESCRIPTION

## Issue & Reproduction Steps

Dropdowns in /tasks render with smaller text and extra spacing compared to /requests because FilterMobile.vue use global selectors (.dropdown-toggle, .dropdown-item) that leak into other menus.

Repro:

Open /tasks.
Open a top navigation dropdown.
Compare with /requests → /tasks looks smaller/taller.

## Solution
- Scoped FilterMobile styles to .dropdown-status-style and .mobile-dropdown-menu.


https://github.com/user-attachments/assets/710350ad-6e87-4b8b-80c1-51ba8e60df5d


## How to Test

1. Rebuild JS (npm run dev).
2. Open /tasks and /requests.
3. Confirm both dropdowns look identical.
4. Verify the mobile filter and image carousel dropdowns still work.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-29427

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy