### PR TITLE
feat(FOUR-32405): add Database Indexes to Improve Saved Searches Performance

### DIFF
--- a/database/migrations/2026_07_27_000000_add_saved_search_indexes.php
+++ b/database/migrations/2026_07_27_000000_add_saved_search_indexes.php
@@ -1,0 +1,101 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Add performance indexes for Saved Search queries.
+     */
+    public function up(): void
+    {
+        $this->addIndex(
+            'process_request_tokens',
+            'process_request_tokens_prt_task_name_id',
+            ['element_type', 'element_name', 'process_id', 'user_id', 'process_request_id']
+        );
+        $this->addIndex(
+            'process_request_tokens',
+            'process_request_tokens_prt_type_id_proc',
+            ['element_type', 'process_id', 'user_id', 'process_request_id']
+        );
+        $this->addIndex(
+            'process_request_tokens',
+            'process_request_tokens_prt_self_service_status_user',
+            ['is_self_service', 'status', 'user_id', 'id']
+        );
+        $this->addIndex(
+            'process_request_tokens',
+            'process_request_tokens_processid_elem_stat_self_user_elname',
+            ['process_id', 'element_type', 'status', 'is_self_service', 'user_id', 'element_name']
+        );
+
+        $this->addIndex(
+            'category_assignments',
+            'category_assignments_assignabletyid_categorytyid',
+            ['assignable_type', 'assignable_id', 'category_type', 'category_id']
+        );
+
+        $this->addIndex(
+            'process_versions',
+            'process_versions_processid_draft',
+            ['process_id', 'draft']
+        );
+
+        // Leading `id` removed from the original proposal because the primary key
+        // already covers it and InnoDB secondary indexes include it automatically.
+        $this->addIndex(
+            'processes',
+            'process_idx_proc_deletedat_categoryid',
+            ['deleted_at', 'process_category_id']
+        );
+
+        // Tail `id` removed for the same reason.
+        $this->addIndex(
+            'process_categories',
+            'process_categories_issystem_id',
+            ['is_system']
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $this->dropIndex('process_request_tokens', 'process_request_tokens_prt_task_name_id');
+        $this->dropIndex('process_request_tokens', 'process_request_tokens_prt_type_id_proc');
+        $this->dropIndex('process_request_tokens', 'process_request_tokens_prt_self_service_status_user');
+        $this->dropIndex('process_request_tokens', 'process_request_tokens_processid_elem_stat_self_user_elname');
+        $this->dropIndex('category_assignments', 'category_assignments_assignabletyid_categorytyid');
+        $this->dropIndex('process_versions', 'process_versions_processid_draft');
+        $this->dropIndex('processes', 'process_idx_proc_deletedat_categoryid');
+        $this->dropIndex('process_categories', 'process_categories_issystem_id');
+    }
+
+    private function addIndex(string $table, string $name, array $columns): void
+    {
+        if (Schema::hasIndex($table, $name)) {
+            return;
+        }
+
+        Schema::table($table, function (Blueprint $table) use ($name, $columns) {
+            $table->index($columns, $name);
+        });
+    }
+
+    private function dropIndex(string $table, string $name): void
+    {
+        if (!Schema::hasIndex($table, $name)) {
+            return;
+        }
+
+        try {
+            DB::statement("ALTER TABLE `{$table}` DROP INDEX `{$name}`");
+        } catch (Exception $e) {
+            // Ignore so rollback continues (e.g. index required by a foreign key).
+        }
+    }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps
Saved Search queries slow down on large datasets because process_request_tokens and related tables lack indexes for common filter columns.

Repro:

- Run a Saved Search filter on a large instance.
- EXPLAIN the query → full table scan or filesort.
- Response time exceeds acceptable thresholds.

## Solution

- Added database/migrations/2026_07_27_000000_add_saved_search_indexes.php.
- Added composite indexes on process_request_tokens, category_assignments, process_versions, processes, and process_categories.
- Optimized column order by removing redundant id columns from the middle of composites.
- Made up() idempotent and down() tolerant to foreign-key constraints.

## How to Test
php artisan migrate --path=database/migrations/2026_07_27_000000_add_saved_search_indexes.php

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32405

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
