### PR TITLE
Update app.instance configuration for tenant

### DIFF
--- a/ProcessMaker/Multitenancy/SwitchTenant.php
+++ b/ProcessMaker/Multitenancy/SwitchTenant.php
@@ -89,7 +89,7 @@ class SwitchTenant implements SwitchTenantTask
     {
         $this->setEnvironmentVariable('APP_URL', $tenant->config['app.url']);
 
-        $this->setConfig('app.instance', $this->landlordConfig('app.instance') . '_' . $tenant->id);
+        $this->setConfig('app.instance', $tenant->database);
         $this->setConfig('app.url', $tenant->config['app.url']);
 
         // Microservice callback url


### PR DESCRIPTION
The app instance is used for the docker image name for custom executors. We have always set it to the database name so let's do the same thing for tenant executors