### PR TITLE
FOUR-32126: INBOX >> First loading is to slow

### DIFF
--- a/resources/views/auth/newLogin.blade.php
+++ b/resources/views/auth/newLogin.blade.php
@@ -18,6 +18,13 @@
     @include('package-accessibility::userway')
   @endif
 
+  {{-- Prefetch inbox JS while the user is on login (Mix ?id= invalidates on deploy). --}}
+  <link rel="prefetch" href="{{ mix('js/manifest.js') }}" as="script">
+  <link rel="prefetch" href="{{ mix('js/vue-vendor.js') }}" as="script">
+  <link rel="prefetch" href="{{ mix('js/bootstrap-vendor.js') }}" as="script">
+  <link rel="prefetch" href="{{ mix('js/fortawesome-vendor.js') }}" as="script">
+  <link rel="prefetch" href="{{ mix('js/app.js') }}" as="script">
+  <link rel="prefetch" href="{{ mix('js/app-layout.js') }}" as="script">
 </head>
 <body>
   <div class="background-cover">


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
Prefetch heavy inbox JS bundles on the login page so they download before entering the inbox.


https://github.com/user-attachments/assets/99950bf5-290b-42dc-a042-c12da2d54654



## How to Test

1. Open /login with DevTools → Network (Disable cache off after first load).
2. Confirm prefetch for app.js / app-layout.js / vendors.
3. Log in to inbox and confirm those scripts come from prefetch/disk cache, not a full re-download.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32126

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy