### PR TITLE
FOUR-32416: API base URL keeps the old server when a process watcher is imported

### DIFF
--- a/ProcessMaker/Assets/DataSourcesInProcess.php
+++ b/ProcessMaker/Assets/DataSourcesInProcess.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace ProcessMaker\Assets;
+
+use DOMXPath;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Providers\WorkflowServiceProvider;
+
+class DataSourcesInProcess
+{
+    public $type = 'ProcessMaker\Packages\Connectors\DataSources\Models\DataSource';
+
+    public $owner = Process::class;
+
+    /**
+     * Get the data sources used in a process
+     *
+     * @param Process $process
+     * @param array $dataSources
+     *
+     * @return array
+     */
+    public function referencesToExport(Process $process, array $dataSources = [])
+    {
+        // Data Sources used in BPMN Service Tasks
+        $xpath = new DOMXPath($process->getDefinitions());
+        $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+        
+        // Find all nodes with pm:config
+        $nodes = $xpath->query("//*[@pm:config!='']");
+        foreach ($nodes as $node) {
+            $configString = $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config');
+            $config = json_decode($configString, true);
+            if (isset($config['dataSource']) && is_numeric($config['dataSource'])) {
+                $dataSources[] = [$this->type, (int) $config['dataSource']];
+            }
+        }
+
+        return $dataSources;
+    }
+
+    /**
+     * Update references used in an imported process
+     *
+     * @param Process $process
+     * @param array $references
+     *
+     * @return void
+     */
+    public function updateReferences(Process $process, array $references = [])
+    {
+        $definitions = $process->getDefinitions();
+        $xpath = new DOMXPath($definitions);
+        $xpath->registerNamespace('pm', WorkflowServiceProvider::PROCESS_MAKER_NS);
+
+        $nodes = $xpath->query("//*[@pm:config!='']");
+        foreach ($nodes as $node) {
+            $configString = $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config');
+            $config = json_decode($configString, true);
+            if (isset($config['dataSource']) && is_numeric($config['dataSource'])) {
+                $oldRef = $config['dataSource'];
+                if (isset($references[$this->type][$oldRef])) {
+                    $newRef = $references[$this->type][$oldRef]->getKey();
+                    $config['dataSource'] = $newRef;
+                    $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'config', json_encode($config));
+                }
+            }
+        }
+        $process->bpmn = $definitions->saveXML();
+        $process->save();
+    }
+}

--- a/ProcessMaker/Assets/DataSourcesInScreen.php
+++ b/ProcessMaker/Assets/DataSourcesInScreen.php
@@ -93,12 +93,12 @@ class DataSourcesInScreen
 
         $config = $screen->config;
         if (is_array($config)) {
-            $this->findInArray($config, function ($item, $key) use ($references, &$config) {
+            $this->findInArray($config, function ($item, $keyDotNotation) use ($references, &$config) {
                 if (is_array($item) && isset($item['component']) && $item['component'] === 'FormSelectList' && !empty($item['config']['options']['selectedDataSource'])) {
                     $oldRef = $item['config']['options']['selectedDataSource'];
                     if (isset($references[$this->type][$oldRef])) {
                         $newRef = $references[$this->type][$oldRef]->getKey();
-                        Arr::set($config, "$key.config.options.selectedDataSource", $newRef);
+                        Arr::set($config, "$keyDotNotation.config.options.selectedDataSource", $newRef);
                     }
                 }
             });
@@ -113,17 +113,18 @@ class DataSourcesInScreen
      *
      * @param array $array
      * @param callable $callback
+     * @param array $path
      *
      * @return void
      */
-    private function findInArray(array $array, callable $callback)
+    private function findInArray(array $array, callable $callback, array $path = [])
     {
-        call_user_func($callback, $array);
-        foreach ($array as $item) {
+        call_user_func($callback, $array, implode('.', $path));
+        foreach ($array as $key => $item) {
             if (is_array($item)) {
-                $this->findInArray($item, $callback);
+                $this->findInArray($item, $callback, array_merge($path, [$key]));
             } else {
-                call_user_func($callback, $item);
+                call_user_func($callback, $item, implode('.', array_merge($path, [$key])));
             }
         }
     }

--- a/ProcessMaker/Assets/DataSourcesInScreen.php
+++ b/ProcessMaker/Assets/DataSourcesInScreen.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Assets;
 
 use ProcessMaker\Managers\ExportManager;
 use ProcessMaker\Models\Screen;
+use Illuminate\Support\Arr;
 
 class DataSourcesInScreen
 {

--- a/ProcessMaker/Assets/DataSourcesInScreen.php
+++ b/ProcessMaker/Assets/DataSourcesInScreen.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace ProcessMaker\Assets;
+
+use ProcessMaker\Managers\ExportManager;
+use ProcessMaker\Models\Screen;
+
+class DataSourcesInScreen
+{
+    public $type = 'ProcessMaker\Packages\Connectors\DataSources\Models\DataSource';
+
+    public $owner = Screen::class;
+
+    /**
+     * Get the data sources (ex. watchers) used in a screen
+     *
+     * @param Screen $screen
+     * @param array $dataSources
+     *
+     * @return array
+     */
+    public function referencesToExport(Screen $screen, array $dataSources = [])
+    {
+        $watchers = $screen->watchers;
+        if (is_array($watchers)) {
+            $this->findInArray($watchers, function ($item) use (&$dataSources) {
+                if (is_array($item)) {
+                    $scriptId = (string) ($item['script_id'] ?? '');
+                    $id = (string) ($item['script']['id'] ?? '');
+                    if (str_starts_with($scriptId, 'data_source-') || str_starts_with($id, 'data_source-')) {
+                        $numericId = str_replace('data_source-', '', str_starts_with($scriptId, 'data_source-') ? $scriptId : $id);
+                        if (is_numeric($numericId)) {
+                            $dataSources[] = [$this->type, (int) $numericId];
+                        }
+                    }
+                }
+            });
+        }
+
+        $config = $screen->versionFor(null)->config;
+        if (is_array($config)) {
+            $this->findInArray($config, function ($item) use (&$dataSources) {
+                if (is_array($item) && isset($item['component']) && $item['component'] === 'FormSelectList' && !empty($item['config']['options']['selectedDataSource'])) {
+                    $dataSources[] = [$this->type, (int) $item['config']['options']['selectedDataSource']];
+                }
+            });
+        }
+
+        return $dataSources;
+    }
+
+    /**
+     * Update references used in an imported screen
+     *
+     * @param Screen $screen
+     * @param array $references
+     * @param ExportManager $exportManager
+     *
+     * @return void
+     */
+    public function updateReferences(Screen $screen, array $references, ExportManager $exportManager)
+    {
+        $watches = $screen->watchers;
+        if (is_array($watches)) {
+            foreach ($watches as &$watcher) {
+                $id = (string) ($watcher['script']['id'] ?? '');
+                if (str_starts_with($id, 'data_source-')) {
+                    $oldRef = str_replace('data_source-', '', $id);
+                    if (isset($references[$this->type][$oldRef])) {
+                        $newRef = $references[$this->type][$oldRef]->getKey();
+                    } else {
+                        $newRef = null;
+                        $exportManager->addLogMessage(
+                            'DataSourcesInScreen:references',
+                            __(
+                                'Imported file does not contain the data source #:dataSource assigned to a watcher',
+                                ['dataSource' => $oldRef]
+                            ),
+                            false,
+                            __("Missing watcher's data source")
+                        );
+                    }
+                    if ($newRef) {
+                        $watcher['script_id'] = $newRef;
+                        $watcher['script']['id'] = "data_source-$newRef";
+                        $watcher['script']['title'] = $references[$this->type][$oldRef]->name;
+                    }
+                }
+            }
+        }
+        $screen->watchers = $watches;
+
+        $config = $screen->config;
+        if (is_array($config)) {
+            $this->findInArray($config, function ($item, $key) use ($references, &$config) {
+                if (is_array($item) && isset($item['component']) && $item['component'] === 'FormSelectList' && !empty($item['config']['options']['selectedDataSource'])) {
+                    $oldRef = $item['config']['options']['selectedDataSource'];
+                    if (isset($references[$this->type][$oldRef])) {
+                        $newRef = $references[$this->type][$oldRef]->getKey();
+                        Arr::set($config, "$key.config.options.selectedDataSource", $newRef);
+                    }
+                }
+            });
+            $screen->config = $config;
+        }
+
+        $screen->save();
+    }
+
+    /**
+     * Find recursively in an array
+     *
+     * @param array $array
+     * @param callable $callback
+     *
+     * @return void
+     */
+    private function findInArray(array $array, callable $callback)
+    {
+        call_user_func($callback, $array);
+        foreach ($array as $item) {
+            if (is_array($item)) {
+                $this->findInArray($item, $callback);
+            } else {
+                call_user_func($callback, $item);
+            }
+        }
+    }
+}

--- a/ProcessMaker/Assets/ScriptsInProcess.php
+++ b/ProcessMaker/Assets/ScriptsInProcess.php
@@ -30,7 +30,10 @@ class ScriptsInProcess
         // Used in scriptRef
         $nodes = $xpath->query("//*[@pm:scriptRef!='']");
         foreach ($nodes as $node) {
-            $scripts[] = [Script::class, $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'scriptRef')];
+            $scriptId = $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'scriptRef');
+            if (!str_starts_with((string) $scriptId, 'data_source-')) {
+                $scripts[] = [Script::class, $scriptId];
+            }
         }
 
         return $scripts;
@@ -54,6 +57,9 @@ class ScriptsInProcess
         $nodes = $xpath->query("//*[@pm:scriptRef!='']");
         foreach ($nodes as $node) {
             $oldRef = $node->getAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'scriptRef');
+            if (str_starts_with((string) $oldRef, 'data_source-')) {
+                continue;
+            }
             $newRef = $references[Script::class][$oldRef]->getKey();
             $node->setAttributeNS(WorkflowServiceProvider::PROCESS_MAKER_NS, 'scriptRef', $newRef);
         }

--- a/ProcessMaker/Assets/ScriptsInScreen.php
+++ b/ProcessMaker/Assets/ScriptsInScreen.php
@@ -26,7 +26,11 @@ class ScriptsInScreen
         if (is_array($config)) {
             $this->findInArray($config, function ($item) use (&$scripts) {
                 if (is_array($item) && !empty($item['script_id'])) {
-                    $scripts[] = [Script::class, $item['script_id']];
+                    $scriptId = (string) $item['script_id'];
+                    $id = (string) ($item['script']['id'] ?? '');
+                    if (!str_starts_with($scriptId, 'data_source-') && !str_starts_with($id, 'data_source-')) {
+                        $scripts[] = [Script::class, $item['script_id']];
+                    }
                 }
             });
         }
@@ -47,11 +51,12 @@ class ScriptsInScreen
         $watches = $screen->watchers;
         if (is_array($watches)) {
             foreach ($watches as &$watcher) {
-                $refParts = explode('-', $watcher['script_id']);
-                if ($refParts[0] === 'data_source') {
+                $scriptId = (string) ($watcher['script_id'] ?? '');
+                $id = (string) ($watcher['script']['id'] ?? '');
+                if (str_starts_with($scriptId, 'data_source-') || str_starts_with($id, 'data_source-')) {
                     continue;
                 }
-                $oldRef = $refParts[1];
+                $oldRef = $scriptId;
                 if (isset($references[Script::class][$oldRef])) {
                     $newRef = $references[Script::class][$oldRef]->getKey();
                 } else {

--- a/ProcessMaker/Assets/ScriptsInScreen.php
+++ b/ProcessMaker/Assets/ScriptsInScreen.php
@@ -87,17 +87,18 @@ class ScriptsInScreen
      *
      * @param array $array
      * @param callable $callback
+     * @param array $path
      *
      * @return void
      */
-    private function findInArray(array $array, callable $callback)
+    private function findInArray(array $array, callable $callback, array $path = [])
     {
-        call_user_func($callback, $array);
-        foreach ($array as $item) {
+        call_user_func($callback, $array, implode('.', $path));
+        foreach ($array as $key => $item) {
             if (is_array($item)) {
-                $this->findInArray($item, $callback);
+                $this->findInArray($item, $callback, array_merge($path, [$key]));
             } else {
-                call_user_func($callback, $item);
+                call_user_func($callback, $item, implode('.', array_merge($path, [$key])));
             }
         }
     }

--- a/ProcessMaker/Jobs/ExportProcess.php
+++ b/ProcessMaker/Jobs/ExportProcess.php
@@ -218,6 +218,37 @@ class ExportProcess implements ShouldQueue
     }
 
     /**
+     * Package any data sources referred to in our screen or process.
+     *
+     * @return void
+     */
+    public function packageDataSources()
+    {
+        $this->package['data_sources'] = [];
+        $dataSourceClass = 'ProcessMaker\Packages\Connectors\DataSources\Models\DataSource';
+
+        if (!class_exists($dataSourceClass)) {
+            return;
+        }
+
+        if (!isset($this->screen)) {
+            $dataSourceIds = $this->manager->getDependenciesOfType($dataSourceClass, $this->process, []);
+        } else {
+            $dataSourceIds = $this->manager->getDependenciesOfType($dataSourceClass, $this->screen, []);
+        }
+
+        if (count($dataSourceIds)) {
+            $dataSources = $dataSourceClass::whereIn('id', $dataSourceIds)->get();
+
+            $dataSources->each(function ($dataSource) {
+                $dataSourceArray = $dataSource->toArray();
+                $dataSourceArray['categories'] = $dataSource->categories->toArray();
+                $this->package['data_sources'][] = $dataSourceArray;
+            });
+        }
+    }
+
+    /**
      * Package the metadata (NOT THE VALUE) of any environment variables
      * referred to in our scripts.
      *
@@ -253,6 +284,7 @@ class ExportProcess implements ShouldQueue
         $this->packageProcessCategory();
         $this->packageScreens();
         $this->packageScripts();
+        $this->packageDataSources();
         $this->packageEnvironmentVariables();
     }
 

--- a/ProcessMaker/Jobs/ExportScreen.php
+++ b/ProcessMaker/Jobs/ExportScreen.php
@@ -38,6 +38,7 @@ class ExportScreen extends ExportProcess
         $this->package['version'] = '2';
         $this->packageScreens();
         $this->packageScripts();
+        $this->packageDataSources();
     }
 
     /**

--- a/ProcessMaker/Jobs/ImportProcess.php
+++ b/ProcessMaker/Jobs/ImportProcess.php
@@ -990,7 +990,7 @@ class ImportProcess implements ShouldQueue
         $watcherList = [];
         foreach ($screen->watchers as $watcher) {
             $script = $watcher->script;
-            $watcher->script_id = $script->id;
+            $watcher->script_id = str_replace(['script-', 'data_source-'], '', $script->id);
             $watcher->script->title = $script->title;
             $watcherList[] = $watcher;
         }

--- a/ProcessMaker/Providers/WorkflowServiceProvider.php
+++ b/ProcessMaker/Providers/WorkflowServiceProvider.php
@@ -9,6 +9,8 @@ use ProcessMaker\Assets\ScreensInProcess;
 use ProcessMaker\Assets\ScreensInScreen;
 use ProcessMaker\Assets\ScriptsInProcess;
 use ProcessMaker\Assets\ScriptsInScreen;
+use ProcessMaker\Assets\DataSourcesInScreen;
+use ProcessMaker\Assets\DataSourcesInProcess;
 use ProcessMaker\Bpmn\MustacheOptions;
 use ProcessMaker\BpmnEngine;
 use ProcessMaker\Contracts\TimerExpressionInterface;
@@ -195,6 +197,8 @@ class WorkflowServiceProvider extends ServiceProvider
             $instance->addDependencyManager(ScreensInScreen::class);
             $instance->addDependencyManager(ScriptsInProcess::class);
             $instance->addDependencyManager(ScriptsInScreen::class);
+            $instance->addDependencyManager(DataSourcesInScreen::class);
+            $instance->addDependencyManager(DataSourcesInProcess::class);
 
             return $instance;
         });

--- a/tests/Feature/ImportExport/Exporters/ProcessExporterWithScreenDataSourceTest.php
+++ b/tests/Feature/ImportExport/Exporters/ProcessExporterWithScreenDataSourceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\ImportExport\Exporters;
+
+use ProcessMaker\Jobs\ExportProcess;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\Script;
+use Tests\TestCase;
+
+class ProcessExporterWithScreenDataSourceTest extends TestCase
+{
+    /**
+     * Test that Process export with a Screen using a Data Source
+     * correctly identifies the Data Source and not as a Script.
+     */
+    public function testProcessExportWithScreenDataSource()
+    {
+        $dataSourceClass = 'ProcessMaker\Packages\Connectors\DataSources\Models\DataSource';
+        $dataSourceCategoryClass = 'ProcessMaker\Packages\Connectors\DataSources\Models\DataSourceCategory';
+        if (!class_exists($dataSourceClass) || !class_exists($dataSourceCategoryClass)) {
+            $this->markTestSkipped('DataSource package not installed');
+        }
+
+        // Create a script first to consume some IDs
+        $script = Script::factory()->create(['title' => 'A Script']);
+        
+        $category = new $dataSourceCategoryClass();
+        $category->name = 'Test Category ' . uniqid();
+        $category->save();
+
+        $dataSource = new $dataSourceClass();
+        $dataSource->name = 'Test Data Source ' . uniqid();
+        $dataSource->description = 'Description';
+        $dataSource->data_source_category_id = $category->id;
+        $dataSource->save();
+
+        // Let's try to make a script with the same ID as the data source
+        // This might be tricky due to auto-increment, but we can try to force it or just use a high ID
+        $duplicateScript = null;
+        try {
+            $duplicateScript = Script::factory()->create(['id' => $dataSource->id, 'title' => 'Duplicate ID Script']);
+        } catch (\Exception $e) {
+            // If ID is already taken, just create one normally
+            $duplicateScript = Script::factory()->create(['title' => 'Other Script']);
+        }
+
+        $screen = Screen::factory()->create([
+            'title' => 'Screen with data source watcher',
+            'watchers' => [
+                [
+                    'name' => 'Data Source Watcher',
+                    'script_id' => 'data_source-' . $dataSource->id,
+                    'script' => [
+                        'id' => 'data_source-' . $dataSource->id,
+                        'title' => 'My Data Source',
+                    ],
+                ],
+            ],
+        ]);
+
+        $bpmn = '<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" pm:screenRef="' . $screen->id . '" />
+  </bpmn:process>
+</bpmn:definitions>';
+
+        $process = Process::factory()->create([
+            'name' => 'Process with screen using data source',
+            'bpmn' => $bpmn
+        ]);
+
+        $exportJob = new ExportProcess($process);
+        $exportJob->handle();
+        
+        // Access private package property via reflection
+        $reflection = new \ReflectionClass($exportJob);
+        $property = $reflection->getProperty('package');
+        $property->setAccessible(true);
+        $package = $property->getValue($exportJob);
+
+        // Check if data source is in package
+        $this->assertArrayHasKey('data_sources', $package);
+        $this->assertCount(1, $package['data_sources']);
+        $this->assertEquals($dataSource->id, $package['data_sources'][0]['id']);
+
+        // Check that it is NOT in scripts
+        foreach ($package['scripts'] as $script) {
+            $this->assertNotEquals('data_source-' . $dataSource->id, $script['id']);
+            $this->assertNotEquals($dataSource->id, $script['id']);
+            // Also check that it's not present as a numeric ID if it's the same
+            if (is_numeric($script['id']) && (int)$script['id'] === $dataSource->id) {
+                $this->fail('Data source ID ' . $dataSource->id . ' found in scripts section');
+            }
+        }
+    }
+}

--- a/tests/Feature/ImportExport/Exporters/ScriptsInScreenDataSourceTest.php
+++ b/tests/Feature/ImportExport/Exporters/ScriptsInScreenDataSourceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature\ImportExport\Exporters;
+
+use ProcessMaker\Assets\DataSourcesInScreen;
+use ProcessMaker\Assets\ScriptsInScreen;
+use ProcessMaker\Models\Screen;
+use ProcessMaker\Models\Script;
+use ProcessMaker\Jobs\ExportScreen;
+use Tests\TestCase;
+
+class ScriptsInScreenDataSourceTest extends TestCase
+{
+    /**
+     * Test that ScriptsInScreen does not identify data_source- prefixed IDs as scripts.
+     */
+    public function testReferencesToExportWithDataSource()
+    {
+        $screen = Screen::factory()->create([
+            'title' => 'Screen with data source watcher',
+            'watchers' => [
+                [
+                    'name' => 'Data Source Watcher',
+                    'script_id' => 'data_source-3',
+                    'script' => [
+                        'id' => 'data_source-3',
+                        'title' => 'My Data Source',
+                    ],
+                ],
+            ],
+        ]);
+
+        $scriptsInScreen = new ScriptsInScreen();
+        $scripts = $scriptsInScreen->referencesToExport($screen);
+
+        // After the fix, this should be 0 because the only watcher is a data source
+        $this->assertCount(0, $scripts, 'Should not identify data_source as a script');
+    }
+
+    /**
+     * Test that DataSourcesInScreen identifies data_source- prefixed IDs as data sources.
+     */
+    public function testReferencesToExportWithDataSourceAsset()
+    {
+        $screen = Screen::factory()->create([
+            'title' => 'Screen with data source watcher',
+            'watchers' => [
+                [
+                    'name' => 'Data Source Watcher',
+                    'script_id' => 'data_source-3',
+                    'script' => [
+                        'id' => 'data_source-3',
+                        'title' => 'My Data Source',
+                    ],
+                ],
+            ],
+        ]);
+
+        $dataSourcesInScreen = new DataSourcesInScreen();
+        $dataSources = $dataSourcesInScreen->referencesToExport($screen);
+
+        $this->assertCount(1, $dataSources);
+        $this->assertEquals('ProcessMaker\Packages\Connectors\DataSources\Models\DataSource', $dataSources[0][0]);
+        $this->assertEquals(3, $dataSources[0][1]);
+    }
+
+    /**
+     * Test that ExportScreen includes data sources in the package.
+     */
+    public function testExportScreenIncludesDataSources()
+    {
+        $dataSourceClass = 'ProcessMaker\Packages\Connectors\DataSources\Models\DataSource';
+        $dataSourceCategoryClass = 'ProcessMaker\Packages\Connectors\DataSources\Models\DataSourceCategory';
+        if (!class_exists($dataSourceClass) || !class_exists($dataSourceCategoryClass)) {
+            $this->markTestSkipped('DataSource package not installed');
+        }
+
+        $category = new $dataSourceCategoryClass();
+        $category->name = 'Test Category';
+        $category->save();
+
+        $dataSource = new $dataSourceClass();
+        $dataSource->name = 'Test Data Source';
+        $dataSource->description = 'Description';
+        $dataSource->data_source_category_id = $category->id;
+        $dataSource->save();
+
+        $screen = Screen::factory()->create([
+            'title' => 'Screen with data source watcher',
+            'watchers' => [
+                [
+                    'name' => 'Data Source Watcher',
+                    'script_id' => 'data_source-' . $dataSource->id,
+                    'script' => [
+                        'id' => 'data_source-' . $dataSource->id,
+                        'title' => 'My Data Source',
+                    ],
+                ],
+            ],
+        ]);
+
+        $exportJob = new ExportScreen($screen);
+        $exportJob->handle();
+        
+        // Access private package property via reflection
+        $reflection = new \ReflectionClass($exportJob);
+        // package is protected in ExportProcess
+        $property = $reflection->getParentClass()->getProperty('package');
+        $property->setAccessible(true);
+        $package = $property->getValue($exportJob);
+
+        $this->assertArrayHasKey('data_sources', $package);
+        $this->assertCount(1, $package['data_sources']);
+        $this->assertEquals($dataSource->id, $package['data_sources'][0]['id']);
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps

- Issue resolving dependency of DataSource inside a Screen
- DataSource is hardcoding Collection api base.

## Solution
- Fix dependency resolution
- Replace hardcoded app URL with placeholder in DataSourceExporter

https://github.com/user-attachments/assets/c22beb7b-117e-4f1d-9963-8ef1e7c92aad

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32416

ci:package-collections:FOUR-32416
ci:package-data-sources:FOUR-32416

ci:deploy

.