### PR TITLE
FOUR-32465: [Octane] CRITICAL Data Leaks Between Requests "$uid2id"

### DIFF
--- a/ProcessMaker/Nayra/Repositories/EntityRepository.php
+++ b/ProcessMaker/Nayra/Repositories/EntityRepository.php
@@ -11,7 +11,7 @@ use ProcessMaker\Nayra\Repositories\ProcessRequestTokenRepository;
 
 abstract class EntityRepository
 {
-    private static $uid2id = ['requests' =>[], 'tokens' =>[]];
+    private $uid2id = ['requests' =>[], 'tokens' =>[]];
 
     abstract public function create(array $transaction): ? Model;
 
@@ -41,16 +41,16 @@ abstract class EntityRepository
         }
 
         // Get record if is not stored previously
-        if (!isset(self::$uid2id[$type][$uid])) {
+        if (!isset($this->uid2id[$type][$uid])) {
             $record = $instance->select('id')->where('uuid', $uid)->first();
             if ($record) {
-                self::$uid2id[$type][$uid] = $record->getKey();
+                $this->uid2id[$type][$uid] = $record->getKey();
             } else {
                 throw new Exception("The uid {$uid} does not exist in the database");
             }
         }
 
-        return self::$uid2id[$type][$uid] ?? 0;
+        return $this->uid2id[$type][$uid] ?? 0;
     }
 
     /**
@@ -71,6 +71,6 @@ abstract class EntityRepository
                 break;
         }
 
-        self::$uid2id[$type][$uid] = $id;
+        $this->uid2id[$type][$uid] = $id;
     }
 }

--- a/tests/unit/ProcessMaker/Nayra/Repositories/EntityRepositoryTest.php
+++ b/tests/unit/ProcessMaker/Nayra/Repositories/EntityRepositoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\ProcessMaker\Nayra\Repositories;
+
+use Illuminate\Database\Eloquent\Model;
+use ProcessMaker\Nayra\Repositories\EntityRepository;
+use ReflectionProperty;
+use Tests\TestCase;
+
+class EntityRepositoryTest extends TestCase
+{
+    /**
+     * Create a concrete implementation of EntityRepository for testing.
+     */
+    private function createRepository(): EntityRepository
+    {
+        return new class extends EntityRepository {
+            public function create(array $transaction): ?Model
+            {
+                return null;
+            }
+
+            public function update(array $transaction): ?Model
+            {
+                return null;
+            }
+
+            public function save(array $transaction): ?Model
+            {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Test that $uid2id is NOT a static property (fix for Octane data leak).
+     *
+     * In Octane, static properties persist across requests. The critical fix
+     * changes $uid2id from "private static" to "private" so that each instance
+     * has its own isolated cache, preventing data leaks between requests.
+     */
+    public function test_uid2id_is_not_static(): void
+    {
+        $reflection = new ReflectionProperty(EntityRepository::class, 'uid2id');
+
+        $this->assertFalse(
+            $reflection->isStatic(),
+            'uid2id must NOT be static to prevent data leaks between requests in Octane'
+        );
+    }
+
+    /**
+     * Test that $uid2id is a private property.
+     */
+    public function test_uid2id_is_private(): void
+    {
+        $reflection = new ReflectionProperty(EntityRepository::class, 'uid2id');
+
+        $this->assertTrue(
+            $reflection->isPrivate(),
+            'uid2id should be private'
+        );
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- Changed `$uid2id` from `private static` to `private` (instance property) in `EntityRepository.php` to prevent Octane data leaks between requests.


## How to Test
```
php vendor/bin/phpunit tests/unit/ProcessMaker/Nayra/Repositories/EntityRepositoryTest.php
```

Verify: `OK (2 tests, 2 assertions)`

- `test_uid2id_is_not_static` — Confirms the fix (property is no longer static)
- `test_uid2id_is_private` — Confirms encapsulation is preserved


## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
