### PR TITLE
FOUR-32474 [Octane] CRITICAL Data Leaks Between Requests "$landlordVa…

### DIFF
--- a/ProcessMaker/Multitenancy/SwitchTenant.php
+++ b/ProcessMaker/Multitenancy/SwitchTenant.php
@@ -6,6 +6,7 @@ use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\Context;
 use Monolog\Handler\RotatingFileHandler;
 use ProcessMaker\Application;
 use ProcessMaker\Multitenancy\Broadcasting\TenantAwareBroadcastManager;
@@ -17,7 +18,7 @@ class SwitchTenant implements SwitchTenantTask
 {
     use UsesMultitenancyConfig;
 
-    public static $landlordValues = null;
+    private const LANDLORD_VALUES_CONTEXT_KEY = 'multitenancy.landlord_values';
 
     /**
      * Make the given tenant current.
@@ -31,9 +32,8 @@ class SwitchTenant implements SwitchTenantTask
 
         \Log::debug('SwitchTenant: ' . $tenant->id, ['domain' => request()->getHost()]);
 
-        // Save the landlord values for later use
-        if (!self::$landlordValues) {
-            self::$landlordValues = $app->make('config')->all();
+        if (!Context::has(self::LANDLORD_VALUES_CONTEXT_KEY)) {
+            Context::add(self::LANDLORD_VALUES_CONTEXT_KEY, $app->make('config')->all());
         }
 
         // Set the tenant's domain in the request headers. Used for things like the global url() helper.
@@ -70,7 +70,7 @@ class SwitchTenant implements SwitchTenantTask
 
     private function landlordConfig($key)
     {
-        return Arr::get(self::$landlordValues, $key);
+        return Arr::get(Context::get(self::LANDLORD_VALUES_CONTEXT_KEY), $key);
     }
 
     private function setConfig($key, $value)

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -75,9 +75,6 @@ class ProcessMakerServiceProvider extends ServiceProvider
     // Track the query time for each request
     private static $queryTime = 0;
 
-    // Track the landlord values for multitenancy
-    private static $landlordValues = null;
-
     public function boot(): void
     {
         // Track the start time for service providers boot

--- a/tests/unit/ProcessMaker/Multitenancy/SwitchTenantTest.php
+++ b/tests/unit/ProcessMaker/Multitenancy/SwitchTenantTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Multitenancy;
+
+use Illuminate\Support\Facades\Context;
+use ProcessMaker\Multitenancy\SwitchTenant;
+use Tests\TestCase;
+
+class SwitchTenantTest extends TestCase
+{
+    private const LANDLORD_VALUES_KEY = 'multitenancy.landlord_values';
+
+    protected function tearDown(): void
+    {
+        Context::forget(self::LANDLORD_VALUES_KEY);
+
+        parent::tearDown();
+    }
+
+    public function test_landlord_snapshot_persists_during_same_request(): void
+    {
+        config(['app.url' => 'https://landlord.example.com']);
+        Context::add(self::LANDLORD_VALUES_KEY, config()->all());
+
+        config(['app.url' => 'https://tenant-modified.example.com']);
+
+        $this->assertSame(
+            'https://landlord.example.com',
+            $this->landlordConfig('app.url')
+        );
+    }
+
+    public function test_landlord_values_are_not_reused_across_requests(): void
+    {
+        Context::add(self::LANDLORD_VALUES_KEY, ['app' => ['url' => 'https://tenant-a.example.com']]);
+        Context::forget(self::LANDLORD_VALUES_KEY);
+
+        config(['app.url' => 'https://tenant-b.example.com']);
+        Context::add(self::LANDLORD_VALUES_KEY, config()->all());
+
+        $this->assertSame(
+            'https://tenant-b.example.com',
+            Context::get(self::LANDLORD_VALUES_KEY)['app']['url']
+        );
+    }
+
+    private function landlordConfig(string $key): mixed
+    {
+        $method = new \ReflectionMethod(SwitchTenant::class, 'landlordConfig');
+
+        return $method->invoke(new SwitchTenant(), $key);
+    }
+}


### PR DESCRIPTION
…lues"

Description:
Fix Octane data leak by storing landlord config in request-scoped Context

Replace SwitchTenant static $landlordValues with Laravel Context to prevent tenant config snapshots from persisting across Octane requests. Remove unused duplicate property from ProcessMakerServiceProvider.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-32474
