### PR TITLE
FOUR-32475 [Octane] CRITICAL Data Leaks Between Requests "AnonymousUs…

### DIFF
--- a/ProcessMaker/Models/AnonymousUser.php
+++ b/ProcessMaker/Models/AnonymousUser.php
@@ -12,6 +12,12 @@ class AnonymousUser extends User
 
     protected $table = 'users';
 
+    public static function resolve(): self
+    {
+        return static::where('username', '=', static::ANONYMOUS_USERNAME)
+            ->firstOrFail();
+    }
+
     public $isAnonymous = true;
 
     public function receivesBroadcastNotificationsOn($notification)

--- a/ProcessMaker/Providers/ProcessMakerServiceProvider.php
+++ b/ProcessMaker/Providers/ProcessMakerServiceProvider.php
@@ -188,9 +188,8 @@ class ProcessMakerServiceProvider extends ServiceProvider
             return new Managers\GlobalScriptsManager();
         });
 
-        $this->app->singleton(Models\AnonymousUser::class, function ($app) {
-            return Models\AnonymousUser::where('username', '=', Models\AnonymousUser::ANONYMOUS_USERNAME)
-                                       ->firstOrFail();
+        $this->app->scoped(Models\AnonymousUser::class, function ($app) {
+            return Models\AnonymousUser::resolve();
         });
 
         $this->app->singleton(PolicyExtension::class, function ($app) {

--- a/tests/unit/ProcessMaker/Models/AnonymousUserTest.php
+++ b/tests/unit/ProcessMaker/Models/AnonymousUserTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Models;
+
+use ProcessMaker\Models\AnonymousUser;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class AnonymousUserTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->app->forgetScopedInstances();
+
+        parent::tearDown();
+    }
+
+    public function test_resolve_returns_anonymous_user_from_database(): void
+    {
+        $user = AnonymousUser::resolve();
+
+        $this->assertInstanceOf(AnonymousUser::class, $user);
+        $this->assertSame(AnonymousUser::ANONYMOUS_USERNAME, $user->username);
+    }
+
+    public function test_container_binding_returns_same_instance_within_request(): void
+    {
+        $first = app(AnonymousUser::class);
+        $second = app(AnonymousUser::class);
+
+        $this->assertSame($first, $second);
+    }
+
+    public function test_container_binding_is_not_reused_across_requests(): void
+    {
+        $first = app(AnonymousUser::class);
+
+        $this->app->forgetScopedInstances();
+
+        $second = app(AnonymousUser::class);
+
+        $this->assertNotSame($first, $second);
+        $this->assertSame($first->id, $second->id);
+    }
+
+    public function test_container_binding_reflects_database_changes_after_flush(): void
+    {
+        $original = app(AnonymousUser::class);
+        $originalEmail = $original->email;
+
+        User::where('username', AnonymousUser::ANONYMOUS_USERNAME)
+            ->update(['email' => 'updated-anon@example.com']);
+
+        $this->app->forgetScopedInstances();
+
+        $refreshed = app(AnonymousUser::class);
+
+        $this->assertSame('updated-anon@example.com', $refreshed->email);
+        $this->assertNotSame($originalEmail, $refreshed->email);
+
+        User::where('username', AnonymousUser::ANONYMOUS_USERNAME)
+            ->update(['email' => $originalEmail]);
+    }
+}


### PR DESCRIPTION
…er::class"

Description:
Replace AnonymousUser singleton with a scoped binding and add resolve() to load the user from the database per request. Prevents stale anonymous user data from leaking across Octane requests while keeping the same behavior in PHP-FPM and queue workers.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-32475
