### PR TITLE
FOUR-32496 Octane CRITICAL - Data Leaks Between Requests $queryTime

### DIFF
--- a/tests/Feature/ServerTimingMiddlewareTest.php
+++ b/tests/Feature/ServerTimingMiddlewareTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
+use Laravel\Octane\ApplicationGateway;
 use ProcessMaker\Http\Middleware\ServerTimingMiddleware;
 use ProcessMaker\Models\User;
 use ProcessMaker\Providers\ProcessMakerServiceProvider;
@@ -15,11 +18,36 @@ class ServerTimingMiddlewareTest extends TestCase
 {
     use RequestHelper;
 
+    protected function tearDown(): void
+    {
+        ProcessMakerServiceProvider::beginRequestTiming();
+
+        parent::tearDown();
+    }
+
     private function getHeader($response, $header)
     {
         $headers = $response->headers->all();
 
         return $headers[$header];
+    }
+
+    private function getMetricDuration($response, string $metric): float
+    {
+        $serverTiming = implode(',', $this->getHeader($response, 'server-timing'));
+
+        preg_match('/(?:^|,)\\s*' . preg_quote($metric, '/') . ';dur=([\\d.]+)/', $serverTiming, $matches);
+
+        $this->assertArrayHasKey(1, $matches, "The {$metric} metric was not present in the Server-Timing header.");
+
+        return (float) $matches[1];
+    }
+
+    private function recordQueryDuration(float $milliseconds): void
+    {
+        $connection = DB::connection();
+
+        event(new QueryExecuted('SELECT 1', [], $milliseconds, $connection));
     }
 
     public function testServerTimingHeaderIncludesAllMetrics()
@@ -83,6 +111,45 @@ class ServerTimingMiddlewareTest extends TestCase
         $dbTime = $matches[1] ?? 0;
 
         $this->assertGreaterThanOrEqual(200, (float) $dbTime);
+    }
+
+    public function testOctaneGatewayIsolatesQueryTimingAcrossConsecutiveRequests()
+    {
+        Route::middleware(ServerTimingMiddleware::class)->get('/octane-query/slow', function () {
+            $this->recordQueryDuration(5000);
+
+            return response()->json(['request' => 'slow']);
+        });
+
+        Route::middleware(ServerTimingMiddleware::class)->get('/octane-query/fast', function () {
+            $this->recordQueryDuration(10);
+
+            return response()->json(['request' => 'fast']);
+        });
+
+        $gateway = new ApplicationGateway($this->app, $this->app);
+
+        $firstRequest = Request::create('/octane-query/slow');
+        $firstResponse = $gateway->handle($firstRequest);
+        $firstRequestQueryTime = $this->getMetricDuration($firstResponse, 'db');
+
+        $this->assertGreaterThanOrEqual(5000, $firstRequestQueryTime);
+
+        $gateway->terminate($firstRequest, $firstResponse);
+
+        $this->assertSame(0.0, ProcessMakerServiceProvider::getQueryTime());
+
+        $secondRequest = Request::create('/octane-query/fast');
+        $secondResponse = $gateway->handle($secondRequest);
+        $secondRequestQueryTime = $this->getMetricDuration($secondResponse, 'db');
+
+        $this->assertGreaterThanOrEqual(10, $secondRequestQueryTime);
+        $this->assertLessThan(5000, $secondRequestQueryTime);
+        $this->assertLessThan($firstRequestQueryTime, $secondRequestQueryTime);
+
+        $gateway->terminate($secondRequest, $secondResponse);
+
+        $this->assertSame(0.0, ProcessMakerServiceProvider::getQueryTime());
     }
 
     public function testServiceProviderTimeIsMeasured()

--- a/tests/unit/ProcessMaker/Octane/ResetRequestStateTest.php
+++ b/tests/unit/ProcessMaker/Octane/ResetRequestStateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\ProcessMaker\Octane;
 
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
@@ -18,6 +19,20 @@ use Tests\TestCase;
 
 class ResetRequestStateTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        ProcessMakerServiceProvider::beginRequestTiming();
+
+        parent::tearDown();
+    }
+
+    private function recordQueryDuration(float $milliseconds): void
+    {
+        $connection = DB::connection();
+
+        event(new QueryExecuted('SELECT 1', [], $milliseconds, $connection));
+    }
+
     public function test_it_clears_request_timing_before_the_next_request(): void
     {
         DB::select('SELECT 1');
@@ -49,6 +64,13 @@ class ResetRequestStateTest extends TestCase
     {
         Event::fake([RedirectToEvent::class]);
 
+        ProcessMakerServiceProvider::beginRequestTiming();
+        $this->recordQueryDuration(5000);
+
+        $firstRequestQueryTime = ProcessMakerServiceProvider::getQueryTime();
+
+        $this->assertSame(5000.0, $firstRequestQueryTime);
+
         $redirectListener = new RedirectStateProbe();
         $redirectListener->queue(ProcessRequest::factory()->create());
 
@@ -59,9 +81,33 @@ class ResetRequestStateTest extends TestCase
             new Response()
         ));
 
+        $this->assertSame(0.0, ProcessMakerServiceProvider::getQueryTime());
+
         HandleRedirectListener::sendRedirectToEvent();
 
         Event::assertNotDispatched(RedirectToEvent::class);
+
+        $this->recordQueryDuration(10);
+
+        $nextRequestQueryTime = ProcessMakerServiceProvider::getQueryTime();
+
+        $this->assertSame(10.0, $nextRequestQueryTime);
+    }
+
+    public function test_octane_request_termination_resets_timing_after_an_error_response(): void
+    {
+        DB::select('SELECT 1');
+
+        $this->assertGreaterThan(0, ProcessMakerServiceProvider::getQueryTime());
+
+        event(new RequestTerminated(
+            $this->app,
+            $this->app,
+            Request::create('/failed-request'),
+            new Response(status: 500)
+        ));
+
+        $this->assertSame(0.0, ProcessMakerServiceProvider::getQueryTime());
     }
 }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

### Octane CRITICAL - Data Leaks Between Requests $queryTime

## Solution
- The $queryTime leak was already addressed by fixes from [FOUR-32024](https://github.com/ProcessMaker/processmaker/pull/8885) / [FOUR-32353](https://github.com/ProcessMaker/processmaker/pull/8948)
- Reset query timing when each request begins.
- Reset static request state again when Octane emits RequestTerminated.

- Add stronger regression coverage for consecutive Octane requests, error responses, fresh query timing, and test-state cleanup

## Related Tickets & Packages
[FOUR-32496](https://processmaker.atlassian.net/browse/FOUR-32496)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-32024]: https://processmaker.atlassian.net/browse/FOUR-32024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-32353]: https://processmaker.atlassian.net/browse/FOUR-32353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-32496]: https://processmaker.atlassian.net/browse/FOUR-32496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ