### PR TITLE
FOUR-32507 [Octane] MEDIUM — Accumulating State "ServerTimingMiddleware"

### DIFF
--- a/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
+++ b/ProcessMaker/Http/Middleware/ServerTimingMiddleware.php
@@ -9,18 +9,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ServerTimingMiddleware
 {
-    // Minimum time in ms to include a package in the Server-Timing header
-    private static $minPackageTime;
-
-    public function __construct()
-    {
-        self::$minPackageTime = config('app.server_timing.min_package_time');
-    }
-
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
@@ -56,12 +48,13 @@ class ServerTimingMiddleware
         }
 
         $packageTimes = ProcessMakerServiceProvider::getPackageBootTiming();
+        $minPackageTime = config('app.server_timing.min_package_time');
 
         foreach ($packageTimes as $package => $timing) {
             $time = ($timing['end'] - $timing['start']) * 1000;
 
             // Only include packages that took more than MIN_PACKAGE_TIME ms
-            if ($time > self::$minPackageTime) {
+            if ($time > $minPackageTime) {
                 $serverTiming[] = "{$package};dur={$time}";
             }
         }

--- a/tests/Feature/ServerTimingMiddlewareTest.php
+++ b/tests/Feature/ServerTimingMiddlewareTest.php
@@ -22,6 +22,11 @@ class ServerTimingMiddlewareTest extends TestCase
         return $headers[$header];
     }
 
+    private function getServerTimingHeaderValue($response): string
+    {
+        return implode(',', $this->getHeader($response, 'server-timing'));
+    }
+
     public function testServerTimingHeaderIncludesAllMetrics()
     {
         Route::middleware(ServerTimingMiddleware::class)->get('/test', function () {
@@ -160,6 +165,54 @@ class ServerTimingMiddlewareTest extends TestCase
         $this->assertStringContainsString('provider;dur=', $serverTiming[0]);
         $this->assertStringContainsString('controller;dur=', $serverTiming[1]);
         $this->assertStringContainsString('db;dur=', $serverTiming[2]);
+    }
+
+    public function testPackageTimingRespectsMinPackageTimeThreshold()
+    {
+        config([
+            'app.server_timing.enabled' => true,
+            'app.server_timing.min_package_time' => 5,
+        ]);
+
+        ProcessMakerServiceProvider::setPackageBootStart('foour32507-fast-package', 0.0);
+        ProcessMakerServiceProvider::setPackageBootedTime('foour32507-fast-package', 0.002);
+
+        ProcessMakerServiceProvider::setPackageBootStart('foour32507-slow-package', 0.0);
+        ProcessMakerServiceProvider::setPackageBootedTime('foour32507-slow-package', 0.010);
+
+        Route::middleware(ServerTimingMiddleware::class)->get('/package-threshold-test', function () {
+            return response()->json(['message' => 'Package threshold test']);
+        });
+
+        $response = $this->get('/package-threshold-test');
+        $response->assertHeader('Server-Timing');
+
+        $serverTiming = $this->getServerTimingHeaderValue($response);
+
+        $this->assertStringNotContainsString('foour32507-fast-package;dur=', $serverTiming);
+        $this->assertStringContainsString('foour32507-slow-package;dur=', $serverTiming);
+    }
+
+    public function testMinPackageTimeReadsConfigPerRequest()
+    {
+        config(['app.server_timing.enabled' => true]);
+
+        ProcessMakerServiceProvider::setPackageBootStart('foour32507-octane-package', 0.0);
+        ProcessMakerServiceProvider::setPackageBootedTime('foour32507-octane-package', 0.008);
+
+        Route::middleware(ServerTimingMiddleware::class)->get('/octane-min-package-test', function () {
+            return response()->json(['message' => 'Octane min package test']);
+        });
+
+        config(['app.server_timing.min_package_time' => 10]);
+        $responseAboveThreshold = $this->get('/octane-min-package-test');
+        $serverTimingAboveThreshold = $this->getServerTimingHeaderValue($responseAboveThreshold);
+        $this->assertStringNotContainsString('foour32507-octane-package;dur=', $serverTimingAboveThreshold);
+
+        config(['app.server_timing.min_package_time' => 5]);
+        $responseBelowThreshold = $this->get('/octane-min-package-test');
+        $serverTimingBelowThreshold = $this->getServerTimingHeaderValue($responseBelowThreshold);
+        $this->assertStringContainsString('foour32507-octane-package;dur=', $serverTimingBelowThreshold);
     }
 
     public function testServerTimingIfIsDisabled()


### PR DESCRIPTION
Description:
Fix Octane state leak in ServerTimingMiddleware by reading min_package_time from config per request instead of a static property. Add tests for package timing threshold and config refresh between requests.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-32507
