### PR TITLE
FOUR-32502 [Octane] MEDIUM — Accumulating State "Manifest"

### DIFF
--- a/ProcessMaker/ImportExport/Manifest.php
+++ b/ProcessMaker/ImportExport/Manifest.php
@@ -21,6 +21,12 @@ class Manifest
 
     private static $logger = null;
 
+    public static function resetRequestState(): void
+    {
+        self::$parents = null;
+        self::$logger = null;
+    }
+
     public function has(string $uuid)
     {
         return array_key_exists($uuid, $this->manifest);

--- a/ProcessMaker/Octane/ResetRequestState.php
+++ b/ProcessMaker/Octane/ResetRequestState.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ProcessMaker\Octane;
 
+use ProcessMaker\ImportExport\Manifest;
 use ProcessMaker\Providers\ProcessMakerServiceProvider;
 use ProcessMaker\Services\RedirectToEventService;
 
@@ -17,6 +18,7 @@ final class ResetRequestState
     public function handle(): void
     {
         ProcessMakerServiceProvider::beginRequestTiming();
+        Manifest::resetRequestState();
         $this->redirectToEventService->reset();
     }
 }

--- a/tests/Feature/ImportExport/ManifestTest.php
+++ b/tests/Feature/ImportExport/ManifestTest.php
@@ -22,6 +22,13 @@ class ManifestTest extends TestCase
 {
     use HelperTrait;
 
+    protected function tearDown(): void
+    {
+        Manifest::resetRequestState();
+
+        parent::tearDown();
+    }
+
     private function mockExporter($dependents)
     {
         return $this->mock(ScreenExporter::class, function ($mock) use ($dependents) {

--- a/tests/unit/ProcessMaker/Octane/ResetRequestStateTest.php
+++ b/tests/unit/ProcessMaker/Octane/ResetRequestStateTest.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Laravel\Octane\Events\RequestTerminated;
 use ProcessMaker\Events\RedirectToEvent;
+use ProcessMaker\ImportExport\Manifest;
+use ProcessMaker\ImportExport\Options;
 use ProcessMaker\Listeners\HandleRedirectListener;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Octane\ResetRequestState;
@@ -23,6 +25,7 @@ class ResetRequestStateTest extends TestCase
     protected function tearDown(): void
     {
         ProcessMakerServiceProvider::beginRequestTiming();
+        Manifest::resetRequestState();
 
         parent::tearDown();
     }
@@ -32,6 +35,30 @@ class ResetRequestStateTest extends TestCase
         $connection = DB::connection();
 
         event(new QueryExecuted('SELECT 1', [], $milliseconds, $connection));
+    }
+
+    public function test_octane_request_termination_resets_manifest_request_state(): void
+    {
+        Manifest::buildParentModeMap([
+            'parent-uuid' => [
+                'dependents' => [
+                    ['uuid' => 'child-uuid'],
+                ],
+            ],
+        ], new Options([
+            'parent-uuid' => ['mode' => 'update'],
+        ]));
+
+        $this->assertNotNull(Manifest::$parents);
+
+        event(new RequestTerminated(
+            $this->app,
+            $this->app,
+            Request::create('/import-request'),
+            new Response()
+        ));
+
+        $this->assertNull(Manifest::$parents);
     }
 
     public function test_it_clears_request_timing_before_the_next_request(): void


### PR DESCRIPTION
Description:
Reset request-scoped Manifest statics ($parents, $logger) in ResetRequestState after each Octane request. Keep $tableColumns as a schema cache.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-32502
