### PR TITLE
FOUR-26340 | ”about:blank” Displays From the Preview Pane of a Manual Task Using a List Table

### DIFF
--- a/ProcessMaker/Http/Controllers/TaskController.php
+++ b/ProcessMaker/Http/Controllers/TaskController.php
@@ -155,6 +155,17 @@ class TaskController extends Controller
             return redirect(route('requests.show', ['request' => $task->processRequest->getKey()]));
         } else {
             if (!empty($preview)) {
+                $currentUser = Auth::user()->only([
+                    'id',
+                    'username',
+                    'fullname',
+                    'firstname',
+                    'lastname',
+                    'avatar',
+                    'timezone',
+                    'datetime_format',
+                ]);
+
                 return view('tasks.preview', [
                     'task' => $task,
                     'dueLabels' => self::$dueLabels,
@@ -165,6 +176,7 @@ class TaskController extends Controller
                     'assignedToAddons' => $this->getPluginAddons('edit.assignedTo', []),
                     'dataActionsAddons' => $this->getPluginAddons('edit.dataActions', []),
                     'screenFields' => $screenFields,
+                    'currentUser' => $currentUser,
                 ]);
             }
 

--- a/resources/views/tasks/preview.blade.php
+++ b/resources/views/tasks/preview.blade.php
@@ -137,9 +137,16 @@
   const userIsAdmin = {{ Auth::user()->is_administrator ? "true": "false" }};
   const userIsProcessManager = {{ in_array(Auth::user()->id, $task->process?->manager_id ?? []) ? "true": "false" }};
   const screenFields = @json($screenFields);
+  window.Processmaker.user = @json($currentUser);
 </script>
 <script src="{{ mix('js/tasks/loaderPreview.js')}}"></script>
 <script>
+  window.ProcessMaker.user = Object.assign(
+    {},
+    window.ProcessMaker.user || {},
+    @json($currentUser)
+  );
+
   window.ProcessMaker.EventBus.$on("screen-renderer-init", (screen) => {
     if (screen.watchers_config) {
       screen.watchers_config.api.execute = @json(route('api.scripts.execute', ['script_id' => 'script_id', 'script_key' => 'script_key']));

--- a/tests/Feature/TasksTest.php
+++ b/tests/Feature/TasksTest.php
@@ -83,4 +83,29 @@ class TasksTest extends TestCase
         $response = $this->webGet(self::TASKS_URL . '/' . $task['id'] . '/edit', []);
         $response->assertStatus(200);
     }
+
+    /**
+     * Manual-task modeler preview must bootstrap the current user so List Table
+     * (cases/requests) can build PMQL and emit a real /cases navigation URL.
+     */
+    public function testPreviewBootstrapsCurrentUserForListTable()
+    {
+        $process = $this->createTestProcess();
+        $route = route('api.process_events.trigger', [$process->id, 'event' => 'StartEventUID']);
+        $response = $this->apiCall('POST', $route, []);
+        $response->assertStatus(201);
+
+        $task = $this->apiCall('GET', route('api.tasks.index'))->json('data')[0];
+
+        $response = $this->webGet(self::TASKS_URL . '/' . $task['id'] . '/edit/preview', []);
+        $response->assertStatus(200);
+        $response->assertViewIs('tasks.preview');
+        $response->assertViewHas('currentUser', function ($currentUser) {
+            return ($currentUser['id'] ?? null) === $this->user->id
+                && ($currentUser['username'] ?? null) === $this->user->username;
+        });
+        $response->assertSee('window.Processmaker.user =', false);
+        $response->assertSee('"username":"' . $this->user->username . '"', false);
+        $response->assertSee('window.ProcessMaker.user = Object.assign', false);
+    }
 }


### PR DESCRIPTION
# Issue
Ticket: [FOUR-26340](https://processmaker.atlassian.net/browse/FOUR-26340)

When a manual task used a display screen with a List Table configured for cases/requests, opening the task from the modeler preview and clicking the cases navigation control opened a blank `about:blank` page.

Root cause: preview set `window.Processmaker` metadata but not `user`, while `form-requests.vue` read `Processmaker.user.username` during `mounted()`. That threw before `dataControls` were emitted, so `form-list-table.vue` called `window.open(undefined)` → `about:blank`.

# Solution
- Bootstraped the current user in the manual-task modeler preview shell (`tasks.preview`) so List Table / cases screens can resolve `ProcessMaker.user` / `Processmaker.user`.
- Hardened screen-builder List Table requests rendering: safely read user context, always emit `dataControls` with `url: "/cases"`, and guard external-link opens when no URL is available.
- Added regression coverage for preview user bootstrap and List Table preview navigation behavior.

# How To Test

- Run `tests/Feature/TasksTest.php --filter testPreviewBootstrapsCurrentUserForListTable`
- Run screen-builder `FormListTablePreview.spec.js`
- Create a process with a manual task and a display screen containing a List Table set to cases.
- From the modeler, open task preview and confirm the table renders without JS errors.
- Click the cases navigation control and confirm it opens `/cases` (not `about:blank`).
- Confirm the same screen still works in normal screen preview and standard runtime task pages.
- Confirm Start New Case / My Tasks / My Cases List Table behaviors remain intact.

ci:screen-builder:bugfix/FOUR-26340
ci:deploy

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to ProcessMaker Coding Guidelines.
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-26340]: https://processmaker.atlassian.net/browse/FOUR-26340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ