### PR TITLE
FOUR-32617: variable to disable the sendEmail by task

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -139,6 +139,9 @@ return [
     // PM Analytics Chart
     'pm_analytics_chart' => env('PM_ANALYTICS_CHART', 'https://localhost'),
 
+    // When is true, task email notifications per defaulta are sent.
+    'email_tasks_default_enabled' => env('EMAIL_TASKS_DEFAULT_ENABLED', 'true'),
+
     // When true, email notifications are sent even when the assigned user matches the current user.
     'notifications_send_to_same_user' => env('NOTIFICATIONS_SEND_TO_SAME_USER', 'true'),
 


### PR DESCRIPTION
## Create a variable to turn off notifications by defaultthe steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32617

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:connector-send-email:FOUR-32617