### PR TITLE
feat(FOUR-32662): additional init config for octane

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -138,7 +138,6 @@ return [
         ProcessMaker\Managers\MenuManager::class,
         ProcessMaker\Managers\PackageManager::class,
         ProcessMaker\Managers\IndexManager::class,
-        ProcessMaker\Managers\ModelerManager::class,
         ProcessMaker\Managers\ScreenBuilderManager::class,
         ProcessMaker\Managers\ScriptBuilderManager::class,
         ProcessMaker\Managers\DockerManager::class,
@@ -155,6 +154,7 @@ return [
     'flush' => [
         // Services with mutable state that must be recreated per request
         ProcessMaker\Managers\LoginManager::class,
+        ProcessMaker\Managers\ModelerManager::class,
         Lavary\Menu\Menu::class,
     ],
 

--- a/config/octane.php
+++ b/config/octane.php
@@ -132,17 +132,11 @@ return [
 
     'warm' => [
         ...Octane::defaultServicesToWarm(),
-
-    ],
-
-    'flush' => [
-        // Services with mutable state that must be recreated per request
         ProcessMaker\Models\AnonymousUser::class,
         ProcessMaker\ImportExport\Extension::class,
         ProcessMaker\ImportExport\SignalHelper::class,
         ProcessMaker\Managers\MenuManager::class,
         ProcessMaker\Managers\PackageManager::class,
-        ProcessMaker\Managers\LoginManager::class,
         ProcessMaker\Managers\IndexManager::class,
         ProcessMaker\Managers\ModelerManager::class,
         ProcessMaker\Managers\ScreenBuilderManager::class,
@@ -152,11 +146,16 @@ return [
         ProcessMaker\Helpers\PmHash::class,
         ProcessMaker\Models\RequestDevice::class,
         ProcessMaker\PolicyExtension::class,
-        Lavary\Menu\Menu::class,
         Illuminate\Foundation\PackageManifest::class,
         'compiledscreen',
         'setting.cache',
         'currentTenant',
+    ],
+
+    'flush' => [
+        // Services with mutable state that must be recreated per request
+        ProcessMaker\Managers\LoginManager::class,
+        Lavary\Menu\Menu::class,
     ],
 
     /*

--- a/config/octane.php
+++ b/config/octane.php
@@ -38,7 +38,7 @@ return [
     |
     */
 
-    'server' => env('OCTANE_SERVER', 'roadrunner'),
+    'server' => env('OCTANE_SERVER', 'frankenphp'),
 
     /*
     |--------------------------------------------------------------------------
@@ -132,10 +132,7 @@ return [
 
     'warm' => [
         ...Octane::defaultServicesToWarm(),
-        // Services to pre-resolve on worker start
-        ProcessMaker\Managers\PackageManager::class,
-        ProcessMaker\Managers\LoginManager::class,
-        ProcessMaker\Managers\IndexManager::class,
+
     ],
 
     'flush' => [
@@ -144,6 +141,22 @@ return [
         ProcessMaker\ImportExport\Extension::class,
         ProcessMaker\ImportExport\SignalHelper::class,
         ProcessMaker\Managers\MenuManager::class,
+        ProcessMaker\Managers\PackageManager::class,
+        ProcessMaker\Managers\LoginManager::class,
+        ProcessMaker\Managers\IndexManager::class,
+        ProcessMaker\Managers\ModelerManager::class,
+        ProcessMaker\Managers\ScreenBuilderManager::class,
+        ProcessMaker\Managers\ScriptBuilderManager::class,
+        ProcessMaker\Managers\DockerManager::class,
+        ProcessMaker\Managers\GlobalScriptsManager::class,
+        ProcessMaker\Helpers\PmHash::class,
+        ProcessMaker\Models\RequestDevice::class,
+        ProcessMaker\PolicyExtension::class,
+        Lavary\Menu\Menu::class,
+        Illuminate\Foundation\PackageManifest::class,
+        'compiledscreen',
+        'setting.cache',
+        'currentTenant',
     ],
 
     /*


### PR DESCRIPTION
## Additional init config for octane

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32662

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
