### PR TITLE
FOUR-32470 DoqMind Speed performance on tasks API

### DIFF
--- a/database/migrations/2026_08_17_000000_add_task_pagination_indexes.php
+++ b/database/migrations/2026_08_17_000000_add_task_pagination_indexes.php
@@ -7,9 +7,9 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     private const TABLE = 'process_request_tokens';
 
-    private const COUNT_INDEX = 'idx_prt_completed_task_count';
+    private const COUNT_INDEX = 'process_request_tokens_prt_completed_task_count';
 
-    private const PAGE_INDEX = 'idx_prt_task_created';
+    private const PAGE_INDEX = 'process_request_tokens_prt_task_created';
 
     /**
      * Add indexes used by completed-task pagination.

--- a/database/migrations/2026_08_17_000000_add_task_pagination_indexes.php
+++ b/database/migrations/2026_08_17_000000_add_task_pagination_indexes.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    private const TABLE = 'process_request_tokens';
+
+    private const COUNT_INDEX = 'idx_prt_completed_task_count';
+
+    private const PAGE_INDEX = 'idx_prt_task_created';
+
+    /**
+     * Add indexes used by completed-task pagination.
+     *
+     * Run this migration during a low-traffic window. Although MySQL builds the
+     * indexes online, it can briefly wait for metadata locks on a large table.
+     */
+    public function up(): void
+    {
+        $clauses = [];
+
+        if (!Schema::hasIndex(self::TABLE, self::COUNT_INDEX)) {
+            $clauses[] = sprintf(
+                'ADD INDEX `%s` (`status`, `is_self_service`, `element_type`, `element_name`)',
+                self::COUNT_INDEX
+            );
+        }
+
+        if (!Schema::hasIndex(self::TABLE, self::PAGE_INDEX)) {
+            $clauses[] = sprintf(
+                'ADD INDEX `%s` (`is_self_service`, `created_at` DESC, `status`, `element_type`, `element_name`)',
+                self::PAGE_INDEX
+            );
+        }
+
+        $this->alterTable($clauses);
+        $this->refreshStatistics();
+    }
+
+    /**
+     * Remove completed-task pagination indexes.
+     */
+    public function down(): void
+    {
+        $clauses = [];
+
+        if (Schema::hasIndex(self::TABLE, self::COUNT_INDEX)) {
+            $clauses[] = sprintf('DROP INDEX `%s`', self::COUNT_INDEX);
+        }
+
+        if (Schema::hasIndex(self::TABLE, self::PAGE_INDEX)) {
+            $clauses[] = sprintf('DROP INDEX `%s`', self::PAGE_INDEX);
+        }
+
+        $this->alterTable($clauses);
+        $this->refreshStatistics();
+    }
+
+    private function alterTable(array $clauses): void
+    {
+        if ($clauses === []) {
+            return;
+        }
+
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` %s, ALGORITHM=INPLACE, LOCK=NONE',
+            self::TABLE,
+            implode(', ', $clauses)
+        ));
+    }
+
+    private function refreshStatistics(): void
+    {
+        DB::statement(sprintf('ANALYZE TABLE `%s`', self::TABLE));
+    }
+};

--- a/tests/Feature/Migrations/AddTaskPaginationIndexesTest.php
+++ b/tests/Feature/Migrations/AddTaskPaginationIndexesTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Migrations;
+
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class AddTaskPaginationIndexesTest extends TestCase
+{
+    private const MIGRATION_PATH = 'database/migrations/2026_08_17_000000_add_task_pagination_indexes.php';
+
+    private const COUNT_INDEX = 'idx_prt_completed_task_count';
+
+    private const PAGE_INDEX = 'idx_prt_task_created';
+
+    protected $connectionsToTransact = [];
+
+    public function testUpCreatesBothIndexesAndRefreshesStatistics(): void
+    {
+        $migration = $this->migration();
+        $migration->down();
+
+        try {
+            $queries = $this->captureQueries(fn () => $migration->up());
+
+            $this->assertTrue(Schema::hasIndex('process_request_tokens', self::COUNT_INDEX));
+            $this->assertTrue(Schema::hasIndex('process_request_tokens', self::PAGE_INDEX));
+            $this->assertStatisticsWereRefreshed($queries);
+        } finally {
+            $migration->up();
+        }
+    }
+
+    public function testUpIsIdempotentAndStillRefreshesStatistics(): void
+    {
+        $migration = $this->migration();
+        $migration->up();
+
+        $queries = $this->captureQueries(fn () => $migration->up());
+
+        $this->assertTrue(Schema::hasIndex('process_request_tokens', self::COUNT_INDEX));
+        $this->assertTrue(Schema::hasIndex('process_request_tokens', self::PAGE_INDEX));
+        $this->assertStatisticsWereRefreshed($queries);
+        $this->assertFalse(collect($queries)->contains(
+            fn (string $query) => str_starts_with($query, 'ALTER TABLE `process_request_tokens`')
+        ));
+    }
+
+    public function testDownRemovesBothIndexesAndRefreshesStatistics(): void
+    {
+        $migration = $this->migration();
+        $migration->up();
+
+        try {
+            $queries = $this->captureQueries(fn () => $migration->down());
+
+            $this->assertFalse(Schema::hasIndex('process_request_tokens', self::COUNT_INDEX));
+            $this->assertFalse(Schema::hasIndex('process_request_tokens', self::PAGE_INDEX));
+            $this->assertStatisticsWereRefreshed($queries);
+        } finally {
+            $migration->up();
+        }
+    }
+
+    private function migration()
+    {
+        return include base_path(self::MIGRATION_PATH);
+    }
+
+    private function captureQueries(callable $callback): array
+    {
+        $queries = [];
+
+        DB::listen(function (QueryExecuted $query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+
+        $callback();
+
+        return $queries;
+    }
+
+    private function assertStatisticsWereRefreshed(array $queries): void
+    {
+        $this->assertContains('ANALYZE TABLE `process_request_tokens`', $queries);
+    }
+}

--- a/tests/Feature/Migrations/AddTaskPaginationIndexesTest.php
+++ b/tests/Feature/Migrations/AddTaskPaginationIndexesTest.php
@@ -11,9 +11,9 @@ class AddTaskPaginationIndexesTest extends TestCase
 {
     private const MIGRATION_PATH = 'database/migrations/2026_08_17_000000_add_task_pagination_indexes.php';
 
-    private const COUNT_INDEX = 'idx_prt_completed_task_count';
+    private const COUNT_INDEX = 'process_request_tokens_prt_completed_task_count';
 
-    private const PAGE_INDEX = 'idx_prt_task_created';
+    private const PAGE_INDEX = 'process_request_tokens_prt_task_created';
 
     protected $connectionsToTransact = [];
 


### PR DESCRIPTION
## Issue & Reproduction Steps

### DoqMind Speed performance on tasks API

## Solution
GET /api/1.0/tasks with completed-task filtering took approximately 16 seconds because Laravel pagination executes an exact COUNT(*). MySQL used the low-selectivity is_self_service index, scanning roughly 4.87 million rows.

- Improves completed-task pagination performance by adding dedicated indexes for count and page queries.
- Add idx_prt_completed_task_count for the pagination count query.
- Add idx_prt_task_created for created_at DESC page retrieval.
- Preserve the existing API response, exact totals, ordering, and pagination metadata.
- Add integration tests covering index creation, idempotency, rollback, and statistics refresh.

## Related Tickets & Packages
[FOUR-32470](https://processmaker.atlassian.net/browse/FOUR-32470)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-32470]: https://processmaker.atlassian.net/browse/FOUR-32470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ