### PR TITLE
FOUR-32613 - Realtime (or at least faster) script executor

### DIFF
--- a/ProcessMaker/Enums/ScriptExecutorType.php
+++ b/ProcessMaker/Enums/ScriptExecutorType.php
@@ -7,4 +7,10 @@ enum ScriptExecutorType:string
     case System = 'system';
     case Custom = 'custom';
     case Duplicate = 'duplicate';
+    case Realtime = 'realtime';
+
+    public function isCustomOrRealtime(): bool
+    {
+        return $this === self::Custom || $this === self::Realtime;
+    }
 }

--- a/ProcessMaker/Events/ScriptResponseEvent.php
+++ b/ProcessMaker/Events/ScriptResponseEvent.php
@@ -25,18 +25,21 @@ class ScriptResponseEvent implements ShouldBroadcastNow
 
     public $nonce;
 
+    public $duration;
+
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct(User $user, $status, array $response, $watcher = null, $nonce = null)
+    public function __construct(User $user, $status, array $response, $watcher = null, $nonce = null, $duration = null)
     {
         $this->userId = $user->id;
         $this->status = $status;
         $this->response = $response;
         $this->watcher = $watcher;
         $this->nonce = $nonce;
+        $this->duration = $duration;
     }
 
     /**
@@ -75,6 +78,7 @@ class ScriptResponseEvent implements ShouldBroadcastNow
             'watcher' => $this->watcher,
             'response' => $response,
             'nonce' => $this->nonce,
+            'duration' => $this->duration,
         ];
     }
 }

--- a/ProcessMaker/Http/Controllers/Admin/ScriptExecutorController.php
+++ b/ProcessMaker/Http/Controllers/Admin/ScriptExecutorController.php
@@ -8,15 +8,20 @@ use ProcessMaker\Services\ScriptMicroserviceService;
 
 class ScriptExecutorController extends Controller
 {
-    public function index(Request $request)
+    public function index(Request $request, ScriptMicroserviceService $service)
     {
         if (!config('app.custom_executors')) {
             abort(404);
         }
 
+        $scriptMicroserviceEnabled = config('script-runner-microservice.enabled');
+
         return view('admin.script-executors.index',
             [
-                'script_microservice_enabled' => config('script-runner-microservice.enabled'),
+                'script_microservice_enabled' => $scriptMicroserviceEnabled,
+                'script_microservice_tenant_id' => $scriptMicroserviceEnabled
+                    ? $service->getInstanceUuid()
+                    : null,
             ]);
     }
 }

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -21,6 +21,7 @@ use ProcessMaker\Models\User;
 use ProcessMaker\Query\SyntaxError;
 use ProcessMaker\Services\ScriptMicroserviceService;
 use ProcessMaker\Traits\ProjectAssetTrait;
+use Throwable;
 
 class ScriptController extends Controller
 {
@@ -192,11 +193,22 @@ class ScriptController extends Controller
         $nonce = $request->get('nonce');
 
         if ($script->scriptExecutor->type === ScriptExecutorType::Realtime) {
-            // Set the preview code without persisting it and wait for the realtime
-            // executor to return its response in this request.
-            $script->code = $code;
+            return $this->realtimePreview($data, $config, $code, $nonce, $request, $script);
+        }
 
-            return $script->runScript(
+        TestScript::dispatch($script, $request->user(), $code, $data, $config, $nonce)->onQueue('bpmn');
+
+        return ['status' => 'success'];
+    }
+
+    private function realtimePreview(array $data, array $config, string $code, string $nonce, Request $request, Script $script)
+    {
+        // Set the preview code without persisting it and wait for the realtime
+        // executor to return its response in this request.
+        $script->code = $code;
+
+        try {
+            $response = $script->runScript(
                 $data,
                 $config,
                 '',
@@ -207,11 +219,22 @@ class ScriptController extends Controller
                     'current_user' => $request->user()?->id,
                 ]
             );
+            \Log::debug('Response from realtime preview: ' . print_r($response, true));
+
+            if (isset($response['metadata']['start_time'])) {
+                $response['metadata']['duration'] = microtime(true) - $response['metadata']['start_time'];
+            }
+
+            return $response;
+        } catch (Throwable $exception) {
+            \Log::debug('Realtime preview failed: ' . $exception->getMessage());
+
+            return response([
+                'status' => 'error',
+                'exception' => get_class($exception),
+                'message' => $exception->getMessage(),
+            ], 500);
         }
-
-        TestScript::dispatch($script, $request->user(), $code, $data, $config, $nonce)->onQueue('bpmn');
-
-        return ['status' => 'success'];
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -21,7 +21,6 @@ use ProcessMaker\Models\User;
 use ProcessMaker\Query\SyntaxError;
 use ProcessMaker\Services\ScriptMicroserviceService;
 use ProcessMaker\Traits\ProjectAssetTrait;
-use Throwable;
 
 class ScriptController extends Controller
 {
@@ -192,49 +191,14 @@ class ScriptController extends Controller
         $code = $request->get('code');
         $nonce = $request->get('nonce');
 
+        $job = TestScript::dispatch($script, $request->user(), $code, $data, $config, $nonce);
         if ($script->scriptExecutor->type === ScriptExecutorType::Realtime) {
-            return $this->realtimePreview($data, $config, $code, $nonce, $request, $script);
+            $job->onConnection('redis-realtime')->onQueue('realtime');
+        } else {
+            $job->onQueue('bpmn');
         }
-
-        TestScript::dispatch($script, $request->user(), $code, $data, $config, $nonce)->onQueue('bpmn');
 
         return ['status' => 'success'];
-    }
-
-    private function realtimePreview(array $data, array $config, string $code, string $nonce, Request $request, Script $script)
-    {
-        // Set the preview code without persisting it and wait for the realtime
-        // executor to return its response in this request.
-        $script->code = $code;
-
-        try {
-            $response = $script->runScript(
-                $data,
-                $config,
-                '',
-                $request->get('timeout'),
-                0,
-                [
-                    'nonce' => $nonce,
-                    'current_user' => $request->user()?->id,
-                ]
-            );
-            \Log::debug('Response from realtime preview: ' . print_r($response, true));
-
-            if (isset($response['metadata']['start_time'])) {
-                $response['metadata']['duration'] = microtime(true) - $response['metadata']['start_time'];
-            }
-
-            return $response;
-        } catch (Throwable $exception) {
-            \Log::debug('Realtime preview failed: ' . $exception->getMessage());
-
-            return response([
-                'status' => 'error',
-                'exception' => get_class($exception),
-                'message' => $exception->getMessage(),
-            ], 500);
-        }
     }
 
     /**
@@ -291,7 +255,12 @@ class ScriptController extends Controller
         if ($request->get('sync') === true) {
             return (new ExecuteScript($script, $request->user(), $code, $data, $watcher, $config, true))->handle();
         } else {
-            ExecuteScript::dispatch($script, $request->user(), $code, $data, $watcher, $config)->onQueue('bpmn');
+            $job = ExecuteScript::dispatch($script, $request->user(), $code, $data, $watcher, $config);
+            if ($script->scriptExecutor->type === ScriptExecutorType::Realtime) {
+                $job->onConnection('redis-realtime')->onQueue('realtime');
+            } else {
+                $job->onQueue('bpmn');
+            }
         }
 
         return ['status' => 'success', 'key' => $watcher];

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use ProcessMaker\Enums\ScriptExecutorType;
 use ProcessMaker\Events\ScriptCreated;
 use ProcessMaker\Events\ScriptDeleted;
 use ProcessMaker\Events\ScriptDuplicated;
@@ -178,7 +179,7 @@ class ScriptController extends Controller
      *
      *     @OA\Response(
      *         response=200,
-     *         description="success if the script was queued",
+     *         description="The queued status or realtime execution response",
      *         ),
      *     ),
      * )
@@ -189,6 +190,24 @@ class ScriptController extends Controller
         $config = $this->getRequestArray($request->get('config'));
         $code = $request->get('code');
         $nonce = $request->get('nonce');
+
+        if ($script->scriptExecutor->type === ScriptExecutorType::Realtime) {
+            // Set the preview code without persisting it and wait for the realtime
+            // executor to return its response in this request.
+            $script->code = $code;
+
+            return $script->runScript(
+                $data,
+                $config,
+                '',
+                $request->get('timeout'),
+                0,
+                [
+                    'nonce' => $nonce,
+                    'current_user' => $request->user()?->id,
+                ]
+            );
+        }
 
         TestScript::dispatch($script, $request->user(), $code, $data, $config, $nonce)->onQueue('bpmn');
 

--- a/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
@@ -4,6 +4,7 @@ namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use ProcessMaker\Enums\ScriptExecutorType;
@@ -124,7 +125,15 @@ class ScriptExecutorController extends Controller
             ScriptExecutorCreated::dispatch($scriptExecutor->getAttributes());
             BuildScriptExecutor::dispatch($scriptExecutor->id, $request->user()->id);
         } else {
-            $service->createCustomExecutor($scriptExecutor);
+            try {
+                $service->createCustomExecutor($scriptExecutor);
+            } catch (RequestException $e) {
+                // The remote executor was rejected, so keeping the local record would leave
+                // an executor that can never be built.
+                $scriptExecutor->delete();
+
+                $this->throwMicroserviceError($e);
+            }
         }
 
         return ['status' => 'started', 'uuid' => $scriptExecutor->uuid, 'id' => $scriptExecutor->id];
@@ -189,7 +198,11 @@ class ScriptExecutorController extends Controller
         );
 
         if (config('script-runner-microservice.enabled') && $scriptExecutor->type == ScriptExecutorType::Custom) {
-            $service->updateCustomExecutor($scriptExecutor);
+            try {
+                $service->updateCustomExecutor($scriptExecutor);
+            } catch (RequestException $e) {
+                $this->throwMicroserviceError($e);
+            }
         } else {
             if (!empty($scriptExecutor->getChanges())) {
                 ScriptExecutorUpdated::dispatch($scriptExecutor->id, $original, $scriptExecutor->getChanges());
@@ -272,6 +285,28 @@ class ScriptExecutorController extends Controller
         }
 
         return ['status' => 'done'];
+    }
+
+    /**
+     * Report a script microservice rejection on the form, since the build itself
+     * is only reported over the websocket channel.
+     *
+     * @param RequestException $e Failed script microservice response
+     *
+     * @return never
+     *
+     * @throws ValidationException|RequestException
+     */
+    private function throwMicroserviceError(RequestException $e): never
+    {
+        if (!$e->response->clientError()) {
+            throw $e;
+        }
+
+        $detail = $e->response->json('detail');
+        $message = is_string($detail) && $detail !== '' ? $detail : $e->getMessage();
+
+        throw ValidationException::withMessages(['language' => [$message]]);
     }
 
     private function checkAuth($request)

--- a/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
@@ -197,7 +197,7 @@ class ScriptExecutorController extends Controller
             $request->only($scriptExecutor->getFillable())
         );
 
-        if (config('script-runner-microservice.enabled') && $scriptExecutor->type == ScriptExecutorType::Custom) {
+        if (config('script-runner-microservice.enabled') && $scriptExecutor->type?->isCustomOrRealtime()) {
             try {
                 $service->updateCustomExecutor($scriptExecutor);
             } catch (RequestException $e) {
@@ -416,9 +416,28 @@ class ScriptExecutorController extends Controller
                 $languages[] = [
                     'value' => $key,
                     'text' => $config['name'],
+                    'language' => $key,
+                    'realtime' => false,
                     'initDockerfile' => ScriptExecutor::initDockerfile($key),
+                    'configExample' => '',
                 ];
             }
+        }
+
+        foreach (['php', 'python', 'javascript'] as $language) {
+            $dockerfilePath = resource_path("script-executors/realtime/{$language}.Dockerfile");
+            if (!file_exists($dockerfilePath)) {
+                continue;
+            }
+            $label = $language === 'javascript' ? 'nodejs (realtime)' : "{$language} (realtime)";
+            $languages[] = [
+                'value' => "{$language}-realtime",
+                'text' => $label,
+                'language' => $language,
+                'realtime' => true,
+                'initDockerfile' => '',
+                'configExample' => file_get_contents($dockerfilePath),
+            ];
         }
 
         return ['languages' => $languages];

--- a/ProcessMaker/Jobs/ErrorHandling.php
+++ b/ProcessMaker/Jobs/ErrorHandling.php
@@ -83,7 +83,8 @@ class ErrorHandling
             );
         }
         $newJob->delay($this->retryWaitTime());
-        $newJob->onQueue('bpmn');
+        $newJob->onConnection($job->connection);
+        $newJob->onQueue($job->queue ?? 'bpmn');
         dispatch($newJob);
     }
 

--- a/ProcessMaker/Jobs/TestScript.php
+++ b/ProcessMaker/Jobs/TestScript.php
@@ -58,24 +58,26 @@ class TestScript implements ShouldQueue
      */
     public function handle()
     {
+        $startTime = microtime(true);
         try {
             // Just set the code but do not save the object (preview only)
             $this->script->code = $this->code;
             $metadata = [
                 'nonce' => $this->nonce,
                 'current_user' => $this->current_user?->id,
+                'start_time' => microtime(true),
             ];
             $response = $this->script->runScript($this->data, $this->configuration, '', null, 0, $metadata);
             \Log::debug('Response from runScript: ' . print_r($response, true));
 
             if (!config('script-runner-microservice.enabled')) {
-                $this->sendResponse(200, $response);
+                $this->sendResponse(200, $response, (microtime(true) - $startTime));
             }
         } catch (Throwable $exception) {
             $this->sendResponse(500, [
                 'exception' => get_class($exception),
                 'message' => $exception->getMessage(),
-            ]);
+            ], (microtime(true) - $startTime));
         }
     }
 
@@ -85,8 +87,8 @@ class TestScript implements ShouldQueue
      * @param int $status
      * @param array $response
      */
-    private function sendResponse($status, array $response)
+    private function sendResponse($status, array $response, float $duration)
     {
-        event(new ScriptResponseEvent($this->current_user, $status, $response, null, $this->nonce));
+        event(new ScriptResponseEvent($this->current_user, $status, $response, null, $this->nonce, $duration));
     }
 }

--- a/ProcessMaker/Jobs/TestScript.php
+++ b/ProcessMaker/Jobs/TestScript.php
@@ -7,10 +7,12 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 use ProcessMaker\Enums\ScriptExecutorType;
 use ProcessMaker\Events\ScriptResponseEvent;
 use ProcessMaker\Models\Script;
 use ProcessMaker\Models\User;
+use ProcessMaker\Services\ScriptMicroserviceService;
 use Throwable;
 
 class TestScript implements ShouldQueue
@@ -35,8 +37,8 @@ class TestScript implements ShouldQueue
     /**
      * Create a new job instance to execute a script.
      *
-     * @param ProcessMaker\Models\Script $script
-     * @param ProcessMaker\Models\User $current_user
+     * @param Script $script
+     * @param User $current_user
      * @param string $code
      * @param array $data
      * @param array $configuration
@@ -68,9 +70,14 @@ class TestScript implements ShouldQueue
                 'start_time' => microtime(true),
             ];
             $response = $this->script->runScript($this->data, $this->configuration, '', null, 0, $metadata);
-            \Log::debug('Response from runScript: ' . print_r($response, true));
+            Log::debug('Response from runScript: ' . print_r($response, true));
 
-            if (!config('script-runner-microservice.enabled')) {
+            if ($this->script->scriptExecutor->type === ScriptExecutorType::Realtime) {
+                // Realtime executors return the microservice payload synchronously rather than
+                // posting back to the callback endpoint, so format it the same way here.
+                $formatted = (new ScriptMicroserviceService())->formatPreviewResponse($response);
+                $this->sendResponse($formatted['status'], $formatted['output'], (microtime(true) - $startTime));
+            } elseif (!config('script-runner-microservice.enabled')) {
                 $this->sendResponse(200, $response, (microtime(true) - $startTime));
             }
         } catch (Throwable $exception) {

--- a/ProcessMaker/Models/Script.php
+++ b/ProcessMaker/Models/Script.php
@@ -179,6 +179,7 @@ class Script extends ProcessMakerModel implements ScriptInterface
         if (!$user) {
             throw new ConfigurationException('A user is required to run scripts');
         }
+        $metadata['start_time'] = microtime(true);
 
         return $runner->run($this->code, $data, $config, $timeout, $user, $sync, $metadata);
     }

--- a/ProcessMaker/Models/ScriptExecutor.php
+++ b/ProcessMaker/Models/ScriptExecutor.php
@@ -32,6 +32,7 @@ use ProcessMaker\Traits\HideSystemResources;
  *   @OA\Property(property="language", type="string"),
  *   @OA\Property(property="config", type="string"),
  *   @OA\Property(property="is_system", type="boolean"),
+ *   @OA\Property(property="type", type="string"),
  * ),
  * @OA\Schema(
  *   schema="scriptExecutors",
@@ -176,6 +177,12 @@ class ScriptExecutor extends ProcessMakerModel
                 return !in_array($language, Script::deprecatedLanguages);
             });
         }
+
+        // Realtime executors may use php/python/javascript even if a package is not installed
+        $allowedLanguages = array_values(array_unique(array_merge(
+            $allowedLanguages,
+            ['php', 'python', 'javascript']
+        )));
 
         return [
             'title' => 'required',

--- a/ProcessMaker/Nayra/Managers/WorkflowManagerDefault.php
+++ b/ProcessMaker/Nayra/Managers/WorkflowManagerDefault.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Validator;
 use ProcessMaker\BpmnEngine;
 use ProcessMaker\Contracts\ServiceTaskImplementationInterface;
 use ProcessMaker\Contracts\WorkflowManagerInterface;
+use ProcessMaker\Enums\ScriptExecutorType;
 use ProcessMaker\Jobs\BoundaryEvent;
 use ProcessMaker\Jobs\CallProcess;
 use ProcessMaker\Jobs\CatchEvent;
@@ -23,6 +24,7 @@ use ProcessMaker\Models\FormalExpression;
 use ProcessMaker\Models\Process as Definitions;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken as Token;
+use ProcessMaker\Models\Script;
 use ProcessMaker\Nayra\Contracts\Bpmn\BoundaryEventInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EntityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\EventDefinitionInterface;
@@ -231,7 +233,14 @@ class WorkflowManagerDefault implements WorkflowManagerInterface
 
         $instance = $token->processRequest;
         $process = $instance->process;
-        RunScriptTask::dispatch($process, $instance, $token, [])->onQueue('bpmn');
+        $job = new RunScriptTask($process, $instance, $token, []);
+        $script = Script::find($scriptTask->getProperty('scriptRef'));
+
+        if ($script?->scriptExecutor?->type === ScriptExecutorType::Realtime) {
+            $job->onConnection('redis-realtime')->onQueue('realtime');
+        }
+
+        dispatch($job);
     }
 
     /**

--- a/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
+++ b/ProcessMaker/ScriptRunners/ScriptMicroserviceRunner.php
@@ -40,7 +40,7 @@ class ScriptMicroserviceRunner
         $scriptRunner = $this->service->getScriptRunner(
             $this->language,
             $this->script->scriptExecutor->uuid,
-            $this->script->scriptExecutor->type === ScriptExecutorType::Custom
+            $this->script->scriptExecutor->type?->isCustomOrRealtime()
         );
 
         if (!$scriptRunner) {
@@ -62,7 +62,8 @@ class ScriptMicroserviceRunner
             'callback_token' => $environmentVariables['API_TOKEN'],
             'debug' => true,
             'timeout' => $timeout,
-            'sync' => $sync,
+            // Realtime executors always run synchronously (service ignores sync too)
+            'sync' => $this->script->scriptExecutor->type === ScriptExecutorType::Realtime ? true : $sync,
         ];
 
         Log::debug('Payload: ' . print_r($payload, true));

--- a/ProcessMaker/Services/ScriptMicroserviceService.php
+++ b/ProcessMaker/Services/ScriptMicroserviceService.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use ProcessMaker\Enums\ScriptExecutorType;
 use ProcessMaker\Events\ScriptResponseEvent;
 use ProcessMaker\Exception\ScriptException;
 use ProcessMaker\Jobs\CompleteActivity;
@@ -87,6 +88,7 @@ class ScriptMicroserviceService
             'language' => strtolower($scriptExecutor->language),
             'version' => config('script-runner-microservice.version'),
             'config' => $scriptExecutor->config,
+            'realtime' => $scriptExecutor->type === ScriptExecutorType::Realtime,
         ];
         Log::debug('Payload: ', $payload);
 
@@ -114,6 +116,7 @@ class ScriptMicroserviceService
             'language' => strtolower($scriptExecutor->language),
             'version' => config('script-runner-microservice.version'),
             'config' => $scriptExecutor->config,
+            'realtime' => $scriptExecutor->type === ScriptExecutorType::Realtime,
         ];
         Log::debug('Payload: ', $payload);
 
@@ -195,6 +198,7 @@ class ScriptMicroserviceService
 
         if (Cache::has($cacheKey)) {
             Log::debug('Cache hit for script runner', ['cacheKey' => $cacheKey]);
+
             return Cache::get($cacheKey);
         }
 
@@ -211,7 +215,9 @@ class ScriptMicroserviceService
                 return isset($item['language'], $item['id']) && $item['language'] === $language && $item['id'] === $executorUuid;
             })->first();
 
-        if (!empty($result)) Cache::put($cacheKey, $result, now()->addHour());
+        if (!empty($result)) {
+            Cache::put($cacheKey, $result, now()->addHour());
+        }
 
         return $result;
     }

--- a/ProcessMaker/Services/ScriptMicroserviceService.php
+++ b/ProcessMaker/Services/ScriptMicroserviceService.php
@@ -272,10 +272,10 @@ class ScriptMicroserviceService
      * @param array $response
      * @return array{status: int, output: array}
      */
-    private function formatPreviewResponse(array $response): array
+    public function formatPreviewResponse(array $response): array
     {
         // Simple status determination: success = 200, others = 500
-        $status = $response['status'] === 'success' ? 200 : 500;
+        $status = ($response['status'] ?? '') === 'success' ? 200 : 500;
 
         return [
             'status' => $status,
@@ -294,7 +294,7 @@ class ScriptMicroserviceService
         $output = $response;
         if (($response['status'] ?? '') === 'success') {
             $output = ['output' => $response['output']];
-        } elseif ($response['status'] === 'error') {
+        } elseif (($response['status'] ?? '') === 'error') {
             $output = [
                 'exception' => $response['exception'] ?? ScriptException::class,
                 'message' => $response['error'],

--- a/ProcessMaker/Services/ScriptMicroserviceService.php
+++ b/ProcessMaker/Services/ScriptMicroserviceService.php
@@ -241,6 +241,9 @@ class ScriptMicroserviceService
     {
         $response = $request->all();
         Log::debug('Response microservice executor: ' . print_r($response, true));
+
+        $duration = isset($response['metadata']['start_time']) ? (microtime(true) - $response['metadata']['start_time']) : null;
+
         // If the call is from preview
         if (!empty($response['metadata']['nonce'])) {
             $formattedResponse = $this->formatPreviewResponse($response);
@@ -249,7 +252,8 @@ class ScriptMicroserviceService
                 $formattedResponse['status'],
                 $formattedResponse['output'],
                 null,
-                $response['metadata']['nonce']));
+                $response['metadata']['nonce'],
+                $duration));
         }
         if (!empty($response['metadata']['script_task'])) {
             $script = Script::find($response['metadata']['script_task']['script_id']);

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -231,6 +231,16 @@ return [
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MAX_PROCESSES', 1),
                 'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
+            'supervisor-realtime' => [
+                'connection' => 'redis-realtime',
+                'queue' => ['realtime'],
+                'balance' => env('PM4_HORIZON_SUPERVISOR_REALTIME_BALANCE', 'auto'),
+                'tries' => env('PM4_HORIZON_SUPERVISOR_REALTIME_TRIES', 3),
+                'timeout' => env('PM4_HORIZON_SUPERVISOR_REALTIME_TIMEOUT', 600),
+                'minProcesses' => env('PM4_HORIZON_SUPERVISOR_REALTIME_MIN_PROCESSES', 2),
+                'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_REALTIME_MAX_PROCESSES', 20),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
+            ],
         ],
     ],
 ];

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -163,6 +163,16 @@ return [
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MAX_PROCESSES', 1),
                 'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
+            'supervisor-realtime' => [
+                'connection' => 'redis-realtime',
+                'queue' => ['realtime'],
+                'balance' => env('PM4_HORIZON_SUPERVISOR_REALTIME_BALANCE', 'auto'), // auto: dynamically adjust the number of processes based on the load
+                'tries' => env('PM4_HORIZON_SUPERVISOR_REALTIME_TRIES', 3),
+                'timeout' => env('PM4_HORIZON_SUPERVISOR_REALTIME_TIMEOUT', 600),
+                'minProcesses' => env('PM4_HORIZON_SUPERVISOR_REALTIME_MIN_PROCESSES', 2),
+                'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_REALTIME_MAX_PROCESSES', 20),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
+            ],
         ],
 
         'local' => [
@@ -185,6 +195,16 @@ return [
                 'timeout' => env('PM4_HORIZON_SUPERVISOR_1_TIMEOUT', 600),
                 'minProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MIN_PROCESSES', 1),
                 'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_1_MAX_PROCESSES', 1),
+                'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
+            ],
+            'supervisor-realtime' => [
+                'connection' => 'redis-realtime',
+                'queue' => ['realtime'],
+                'balance' => env('PM4_HORIZON_SUPERVISOR_REALTIME_BALANCE', 'auto'), // auto: dynamically adjust the number of processes based on the load
+                'tries' => env('PM4_HORIZON_SUPERVISOR_REALTIME_TRIES', 3),
+                'timeout' => env('PM4_HORIZON_SUPERVISOR_REALTIME_TIMEOUT', 600),
+                'minProcesses' => env('PM4_HORIZON_SUPERVISOR_REALTIME_MIN_PROCESSES', 2),
+                'maxProcesses' => env('PM4_HORIZON_SUPERVISOR_REALTIME_MAX_PROCESSES', 20),
                 'memory' => env('PM4_HORIZON_WORKER_MEMORY_LIMIT', 512),
             ],
         ],

--- a/config/queue.php
+++ b/config/queue.php
@@ -71,6 +71,15 @@ return [
             'after_commit' => false,
         ],
 
+        'redis-realtime' => [
+            'driver' => 'redis',
+            'connection' => 'default',
+            'queue' => 'realtime',
+            'retry_after' => 86400,
+            'block_for' => 10,
+            'after_commit' => false,
+        ],
+
     ],
 
     /*

--- a/resources/js/admin/script-executors/ScriptExecutors.vue
+++ b/resources/js/admin/script-executors/ScriptExecutors.vue
@@ -252,6 +252,7 @@ export default {
     "filter",
     "permission",
     "script_microservice_enabled",
+    "script_microservice_tenant_id",
   ],
   data() {
     return {
@@ -271,7 +272,8 @@ export default {
       exitCode: 0,
       showDockerfile: false,
       loading: true,
-      script_microservice_broadcast_uui: null,
+      activeBuildUuid: null,
+      pendingBuildEvents: [],
 
       localLoadOnStart: true,
       orderBy: "language",
@@ -356,15 +358,14 @@ export default {
         }
       );
     }
+
+    if (this.script_microservice_enabled && this.script_microservice_tenant_id) {
+      this.subscribeToTenantBuildChannel();
+    }
   },
   watch: {
     commandOutput() {
       this.scrollToBottom();
-    },
-    script_microservice_broadcast_uui(newVal) {
-      if (newVal) {
-        this.subscribeToScriptMicroserviceChannel(newVal);
-      }
     },
   },
   computed: {
@@ -434,7 +435,13 @@ export default {
     },
     setErrors(errors) {
       this.status = "error";
-      this.errors = errors.response.data.errors;
+      this.errors = _.get(errors, "response.data.errors", {});
+      const messages = Object.values(this.errors)
+        .flat()
+        .filter((message) => typeof message === "string" && message !== "");
+      if (messages.length) {
+        this.output(messages.join("\n") + "\n");
+      }
     },
     doNotHideIfRunning(e) {
       if (this.isRunning) {
@@ -472,13 +479,15 @@ export default {
     save() {
       this.resetProcessInfo();
       this.status = "saving";
+      this.activeBuildUuid = this.formData.uuid || null;
+      this.pendingBuildEvents = [];
       if (this.formData.id) {
         const path = "/script-executors/" + this.formData.id;
         ProcessMaker.apiClient
           .put(path, this.formData)
           .then((result) => {
             this.status = _.get(result, "data.status", "error");
-            this.script_microservice_broadcast_uui = result.data.uuid;
+            this.setActiveBuildUuid(_.get(result, "data.uuid", this.formData.uuid));
           })
           .catch((e) => {
             this.setErrors(e);
@@ -489,9 +498,10 @@ export default {
           .post(path, this.formData)
           .then((result) => {
             this.status = _.get(result, "data.status", "error");
-            this.script_microservice_broadcast_uui = result.data.uuid;
+            this.setActiveBuildUuid(_.get(result, "data.uuid"));
             if (this.status === "started") {
               this.formData.id = result.data.id;
+              this.formData.uuid = result.data.uuid;
               this.fetch(); // refresh the table (beneath the modal)
             }
           })
@@ -505,13 +515,17 @@ export default {
     },
     edit(row) {
       this.formData = _.cloneDeep(row);
+      this.activeBuildUuid = row.uuid || null;
       this.$refs.edit.show();
     },
     reset() {
       this.formData = _.cloneDeep(this.emptyFormData);
       this.errors = {};
       this.showDockerfile = false;
-      (this.status = "idle"), this.resetProcessInfo();
+      this.status = "idle";
+      this.activeBuildUuid = null;
+      this.pendingBuildEvents = [];
+      this.resetProcessInfo();
     },
     resetProcessInfo() {
       this.commandOutput = "";
@@ -550,31 +564,72 @@ export default {
     onAddToBundle(data) {
       this.$root.$emit('add-to-bundle', data);
     },
-    subscribeToScriptMicroserviceChannel(name) {
-      const channel = `build-image-${name}`;
-      if (this.script_microservice_enabled) {
-      // Subscribe to new channel
-        window.ScriptMicroserviceEcho
-          .channel(channel)
-          .listenToAll((eventName, data) => {
-            this.status = this.status === "idle" ? "starting" : this.status;
-            switch (eventName) {
-              case ".build-image":
-                this.output(`${data}\n`);
-                break;
-              case ".build-finished":
-                this.pidFile = null;
-                this.exitCode = 0;
-                this.status = "done";
-                break;
-              case ".build-error":
-                this.output(data);
-                this.pidFile = null;
-                this.exitCode = 1;
-                this.status = "done";
-                break;
-            }
-          });
+    subscribeToTenantBuildChannel() {
+      if (!window.ScriptMicroserviceEcho) {
+        return;
+      }
+      const channel = `tenant-${this.script_microservice_tenant_id}-builds`;
+      window.ScriptMicroserviceEcho.channel(channel).listen(
+        ".executor-build",
+        (data) => {
+          this.handleExecutorBuildEvent(data);
+        }
+      );
+    },
+    setActiveBuildUuid(uuid) {
+      if (!uuid) {
+        return;
+      }
+      this.activeBuildUuid = uuid;
+      const pending = this.pendingBuildEvents.filter(
+        (event) => event.executor_id === uuid
+      );
+      this.pendingBuildEvents = [];
+      pending.forEach((event) => this.applyExecutorBuildEvent(event));
+    },
+    handleExecutorBuildEvent(data) {
+      if (!data || typeof data !== "object") {
+        return;
+      }
+      if (!this.isRunning) {
+        return;
+      }
+      if (!this.activeBuildUuid) {
+        this.pendingBuildEvents.push(data);
+        return;
+      }
+      if (data.executor_id !== this.activeBuildUuid) {
+        return;
+      }
+      this.applyExecutorBuildEvent(data);
+    },
+    applyExecutorBuildEvent(data) {
+      if (this.status === "saving") {
+        this.status = "starting";
+      } else if (this.status === "idle") {
+        this.status = "starting";
+      }
+
+      if (data.type === "status") {
+        this.output(`[${data.phase}] ${data.message || ""}\n`);
+      } else if (data.message) {
+        const message = data.message.endsWith("\n")
+          ? data.message
+          : `${data.message}\n`;
+        this.output(message);
+      }
+
+      if (data.phase === "completed" && data.type === "status") {
+        this.pidFile = null;
+        this.exitCode = 0;
+        this.status = "done";
+        return;
+      }
+
+      if (data.phase === "error" || data.type === "error") {
+        this.pidFile = null;
+        this.exitCode = 1;
+        this.status = "done";
       }
     },
   },

--- a/resources/js/admin/script-executors/ScriptExecutors.vue
+++ b/resources/js/admin/script-executors/ScriptExecutors.vue
@@ -32,7 +32,7 @@
           <span v-uni-id="props.rowData.id.toString()">{{ props.rowData.title }}</span>
         </template>
         <template slot="type" slot-scope="props">
-          {{ (props.rowData.type === "custom") ? "Custom" : "Base" }}
+          {{ typeLabel(props.rowData.type) }}
         </template>
 
         <template slot="actions" slot-scope="props">
@@ -49,7 +49,7 @@
               </b-btn>
               <b-btn
                 variant="link"
-                :disabled="props.rowData.type !== 'custom'"
+                :disabled="!isEditableType(props.rowData.type)"
                 @click="deleteExecutor(props.rowData)"
                 v-b-tooltip.hover
                 :title="$t('Delete')"
@@ -110,7 +110,7 @@
                   required
                   v-model="formData.title"
                   name="title"
-                  :disabled="formData.type !== 'custom'"
+                  :disabled="!isEditableType(formData.type)"
                 ></b-input>
               </b-form-group>
               <b-form-group
@@ -121,10 +121,11 @@
               >
               <b-form-select
                 required
-                v-model="formData.language"
+                v-model="selectedLanguage"
                 :options="languagesSelect"
                 name="language"
-                :disabled="formData.type !== 'custom'"
+                :disabled="!isEditableType(formData.type)"
+                @change="onLanguageChange"
               >
               </b-form-select>
               </b-form-group>
@@ -137,7 +138,7 @@
               v-model="formData.description"
               class="flex-grow-1"
               name="description"
-              :disabled="formData.type !== 'custom'"
+              :disabled="!isEditableType(formData.type)"
             ></b-textarea>
           </b-col>
         </b-row>
@@ -145,7 +146,7 @@
 
       <p class="mb-0">{{ $t("Docker file") }}</p>
 
-      <div class="d-flex flex-row mb-1">
+      <div v-if="formData.type !== 'realtime'" class="d-flex flex-row mb-1">
         <div class="mr-1">
           <a
             @click="showDockerfile = !showDockerfile"
@@ -177,7 +178,7 @@
       <b-form-textarea
         v-model="formData.config"
         class="mb-3 dockerfile"
-        :disabled="isRunning || formData.type !== 'custom'"
+        :disabled="isRunning || !isEditableType(formData.type)"
       >
       </b-form-textarea>
 
@@ -215,7 +216,7 @@
         </b-button>
 
         <b-button
-          v-if="showCancel && formData.type === 'custom'"
+          v-if="showCancel && isEditableType(formData.type)"
           :disabled="pidFile === null"
           variant="secondary"
           @click="cancel"
@@ -224,7 +225,7 @@
         </b-button>
 
         <b-button
-          v-if="showSave && formData.type === 'custom'"
+          v-if="showSave && isEditableType(formData.type)"
           :disabled="isRunning"
           variant="primary"
           @click="save()"
@@ -259,6 +260,7 @@ export default {
       commandOutput: "",
       languages: [],
       formData: null,
+      selectedLanguage: null,
       emptyFormData: {
         name: "",
         description: "",
@@ -390,19 +392,24 @@ export default {
     languagesSelect() {
       return [
         { value: null, text: this.$t("Select a language") },
-        ...this.languages,
+        ...this.languages.map((lang) => ({
+          value: lang.value,
+          text: lang.text,
+        })),
       ];
+    },
+    selectedLanguageOption() {
+      if (!this.selectedLanguage) {
+        return null;
+      }
+      return this.languages.find((l) => l.value === this.selectedLanguage) || null;
     },
     initDockerfile() {
       let content = "";
-      if (this.formData.language) {
-        content = _.get(
-          this.languages.find((l) => l.value === this.formData.language),
-          "initDockerfile",
-          ""
-        );
+      if (this.selectedLanguageOption) {
+        content = _.get(this.selectedLanguageOption, "initDockerfile", "");
       }
-      return content;
+      return content || "";
     },
   },
   methods: {
@@ -515,17 +522,50 @@ export default {
     },
     edit(row) {
       this.formData = _.cloneDeep(row);
+      this.selectedLanguage = row.type === "realtime"
+        ? `${row.language}-realtime`
+        : row.language;
       this.activeBuildUuid = row.uuid || null;
       this.$refs.edit.show();
     },
     reset() {
       this.formData = _.cloneDeep(this.emptyFormData);
+      this.selectedLanguage = null;
       this.errors = {};
       this.showDockerfile = false;
       this.status = "idle";
       this.activeBuildUuid = null;
       this.pendingBuildEvents = [];
       this.resetProcessInfo();
+    },
+    onLanguageChange(value) {
+      const option = this.languages.find((l) => l.value === value);
+      if (!option) {
+        this.formData.language = null;
+        this.formData.type = "custom";
+        return;
+      }
+      this.formData.language = option.language || option.value;
+      this.formData.type = option.realtime ? "realtime" : "custom";
+      if (!this.formData.id) {
+        this.formData.config = option.realtime
+          ? (option.configExample || "")
+          : "";
+      } else if (option.realtime && !this.formData.config && option.configExample) {
+        this.formData.config = option.configExample;
+      }
+    },
+    isEditableType(type) {
+      return type === "custom" || type === "realtime";
+    },
+    typeLabel(type) {
+      if (type === "realtime") {
+        return "Realtime";
+      }
+      if (type === "custom") {
+        return "Custom";
+      }
+      return "Base";
     },
     resetProcessInfo() {
       this.commandOutput = "";

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -299,7 +299,7 @@
                             {{ preview.error.exception }}
                           </div>
                           <pre class="text-light text-monospace small">{{
-                            preview.error.message
+                            formatErrorMessage(preview.error.message)
                           }}</pre>
                         </div>
                       </div>
@@ -357,6 +357,7 @@
           <span class="text-uppercase">{{ language }}</span>
         </span>
         <span class="ml-auto">
+          <span v-if="displayDuration" class="text-secondary text-sm">{{ displayDuration }}</span>
           <i
             v-if="preview.executing"
             class="fas fa-spinner fa-spin"
@@ -506,6 +507,7 @@ export default {
       lineContext: null,
       isDiffEditor: false,
       currentNonce: null,
+      duration: null,
       progress: {
         progress: 0,
       },
@@ -539,6 +541,25 @@ export default {
     };
   },
   computed: {
+    displayDuration() {
+      if (this.preview.executing) {
+        return null;
+      }
+
+      if (!this.preview.success && !this.preview.failure) {
+        return null;
+      }
+      
+      if (!this.duration && this.duration !== 0) return null;
+
+      if (this.duration < 1) {
+        // less than a second, show ms
+        return `${Math.round(this.duration * 1000)}ms`;
+      }
+      // 1s or more, show s with 2 decimals
+      return `${this.duration.toFixed(2)}s`;
+ 
+    },
     previewChanges() {
       return this.showDiffEditor || this.showExplainEditor;
     },
@@ -798,10 +819,33 @@ export default {
       }
       this.stringifyJson = JSON.stringify(output, null, 2);
     },
+    formatErrorMessage(value) {
+      if (value == null || value === "") {
+        return "";
+      }
+      if (typeof value === "string") {
+        return value;
+      }
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch (e) {
+        return String(value);
+      }
+    },
+    setPreviewFailure(exception, message) {
+      this.preview.executing = false;
+      this.preview.success = false;
+      this.preview.failure = true;
+      this.preview.error.exception = exception;
+      this.preview.error.message = message;
+      this.outputOpen = true;
+    },
     outputResponse(response) {
       if (response.nonce !== this.nonce) {
         return;
       }
+
+      this.duration = response.duration;
 
       if (this.executionKey && this.executionKey !== response.data.watcher) {
         return;
@@ -842,27 +886,28 @@ export default {
         nonce: this.nonce,
       }).then((response) => {
         if (isRealtime) {
-          this.preview.executing = false;
+          this.duration = response.data.metadata?.duration || null;
           if (response.data.status === "error") {
-            this.preview.failure = true;
-            this.preview.error.exception = response.data.exception || "ScriptException";
-            this.preview.error.message = response.data.error_message
-              || response.data.error?.error
-              || response.data.error
-              || response.data.message;
-          } else {
-            this.preview.success = true;
-            this.preview.output = response.data.output;
+            this.setPreviewFailure(
+              response.data.error_message,
+              response.data.error,
+            );
+            return;
           }
+          this.preview.executing = false;
+          this.preview.success = true;
+          // The extra "output" key is actually the result of fetching srn cache for the non-realtime system
+          // But people are use to seeing it, so we'll add it here.
+          this.preview.output = { output: response.data.output };
           return;
         }
 
         this.executionKey = response.data.key;
       }).catch((error) => {
-        this.preview.executing = false;
-        this.preview.failure = true;
-        this.preview.error.exception = error.response?.data?.exception || error.response?.status || "Error";
-        this.preview.error.message = error.response?.data?.message || error.message;
+        this.setPreviewFailure(
+          error.response?.data?.exception || error.response?.status || "Error",
+          error.response?.data || error.message,
+        );
       });
     },
     save(onSuccess, onError, shouldRedirect = false) {

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -833,6 +833,7 @@ export default {
       this.preview.output = undefined;
       // Attempt to execute a script, using our temp variables
       this.nonce = Math.random().toString(36);
+      const isRealtime = this.scriptExecutor.type === "realtime";
       ProcessMaker.apiClient.post(`scripts/${this.script.id}/preview`, {
         code: this.code,
         data: this.preview.data,
@@ -840,7 +841,28 @@ export default {
         timeout: this.script.timeout,
         nonce: this.nonce,
       }).then((response) => {
+        if (isRealtime) {
+          this.preview.executing = false;
+          if (response.data.status === "error") {
+            this.preview.failure = true;
+            this.preview.error.exception = response.data.exception || "ScriptException";
+            this.preview.error.message = response.data.error_message
+              || response.data.error?.error
+              || response.data.error
+              || response.data.message;
+          } else {
+            this.preview.success = true;
+            this.preview.output = response.data.output;
+          }
+          return;
+        }
+
         this.executionKey = response.data.key;
+      }).catch((error) => {
+        this.preview.executing = false;
+        this.preview.failure = true;
+        this.preview.error.exception = error.response?.data?.exception || error.response?.status || "Error";
+        this.preview.error.message = error.response?.data?.message || error.message;
       });
     },
     save(onSuccess, onError, shouldRedirect = false) {

--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -877,7 +877,6 @@ export default {
       this.preview.output = undefined;
       // Attempt to execute a script, using our temp variables
       this.nonce = Math.random().toString(36);
-      const isRealtime = this.scriptExecutor.type === "realtime";
       ProcessMaker.apiClient.post(`scripts/${this.script.id}/preview`, {
         code: this.code,
         data: this.preview.data,
@@ -885,23 +884,6 @@ export default {
         timeout: this.script.timeout,
         nonce: this.nonce,
       }).then((response) => {
-        if (isRealtime) {
-          this.duration = response.data.metadata?.duration || null;
-          if (response.data.status === "error") {
-            this.setPreviewFailure(
-              response.data.error_message,
-              response.data.error,
-            );
-            return;
-          }
-          this.preview.executing = false;
-          this.preview.success = true;
-          // The extra "output" key is actually the result of fetching srn cache for the non-realtime system
-          // But people are use to seeing it, so we'll add it here.
-          this.preview.output = { output: response.data.output };
-          return;
-        }
-
         this.executionKey = response.data.key;
       }).catch((error) => {
         this.setPreviewFailure(

--- a/resources/script-executors/realtime/javascript.Dockerfile
+++ b/resources/script-executors/realtime/javascript.Dockerfile
@@ -1,28 +1,23 @@
 # syntax=docker/dockerfile:1
-# Experiment: warm Node.js container blocked on stdin
+# Realtime Node.js executor: fresh container per request via `docker run --rm -i`.
 #
-# Same idea as the PHP/Python variants: keep a container running with the
-# interpreter already loaded and blocked on stdin. A client attaches, writes
-# one JSON payload; bootstrap.js runs the script, prints the result, and exits.
-#
-# Usage:
-#   ./warm.sh          # build + start warm container (foreground via docker wait)
-#   ./run.sh           # attach, send payload.json, print result
+# The service pipes one JSON payload on stdin. bootstrap.js runs the script,
+# prints the JSON result on stdout, and exits. The container is removed on exit.
 
 FROM node:22-alpine
 
 COPY <<'EOF' /bootstrap.js
 #!/usr/bin/env node
 /**
- * Wait for one JSON payload on stdin, run the script, print result, exit.
+ * Read one JSON payload from stdin, run the script, print result, exit.
  *
- * Expected payload shape (see ../../payload.schema.json):
+ * Expected payload shape:
  *   { "script": "...", "data": {}, "config": {}, "env": {} }
  */
 
 'use strict';
 
-const readline = require('readline');
+const fs = require('fs');
 
 function writeError(error, { code = 0, file = '', line = 0, trace = '' } = {}) {
   process.stderr.write(
@@ -41,76 +36,63 @@ function locationFromError(e) {
   return { file: '', line: 0 };
 }
 
-async function readLine() {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    crlfDelay: Infinity,
+let raw = '';
+try {
+  raw = fs.readFileSync(0, 'utf8');
+} catch (e) {
+  process.stderr.write('No input on stdin\n');
+  process.exit(1);
+}
+
+if (!raw || !raw.trim()) {
+  process.stderr.write('No input on stdin\n');
+  process.exit(1);
+}
+
+let payload;
+try {
+  payload = JSON.parse(raw.trim());
+} catch (e) {
+  writeError(`Invalid JSON: ${e.message}`);
+  process.exit(1);
+}
+
+const script = payload.script;
+if (script === undefined || script === null || script === '') {
+  writeError('Missing "script" field');
+  process.exit(1);
+}
+
+// Available to the evaluated script (mirrors the PHP/Python convention).
+const data = payload.data ?? {};
+const config = payload.config ?? {};
+
+for (const [key, value] of Object.entries(payload.env ?? {})) {
+  if (value === null || value === undefined) {
+    process.env[key] = '';
+  } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    process.env[key] = String(value);
+  } else {
+    process.env[key] = JSON.stringify(value);
+  }
+}
+
+try {
+  // new Function so the user script can `return` a value, like PHP eval.
+  const fn = new Function('data', 'config', script);
+  const result = fn(data, config);
+  process.stdout.write(JSON.stringify(result) + '\n');
+  process.exit(0);
+} catch (e) {
+  const { file, line: errLine } = locationFromError(e);
+  writeError(e.message || String(e), {
+    code: typeof e.code === 'number' ? e.code : 0,
+    file,
+    line: errLine,
+    trace: typeof e.stack === 'string' ? e.stack : '',
   });
-  try {
-    for await (const line of rl) {
-      return line;
-    }
-    return null;
-  } finally {
-    rl.close();
-  }
+  process.exit(1);
 }
-
-async function main() {
-  const line = await readLine();
-  if (line === null || line === undefined) {
-    process.stderr.write('No input on stdin\n');
-    return 1;
-  }
-
-  let payload;
-  try {
-    payload = JSON.parse(line.trim());
-  } catch (e) {
-    writeError(`Invalid JSON: ${e.message}`);
-    return 1;
-  }
-
-  const script = payload.script;
-  if (script === undefined || script === null || script === '') {
-    writeError('Missing "script" field');
-    return 1;
-  }
-
-  // Available to the evaluated script (mirrors the PHP/Python convention).
-  const data = payload.data ?? {};
-  const config = payload.config ?? {};
-
-  // Apply per-request env before eval (warm containers can't use docker run -e).
-  for (const [key, value] of Object.entries(payload.env ?? {})) {
-    if (value === null || value === undefined) {
-      process.env[key] = '';
-    } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-      process.env[key] = String(value);
-    } else {
-      process.env[key] = JSON.stringify(value);
-    }
-  }
-
-  try {
-    // new Function so the user script can `return` a value, like PHP eval.
-    const fn = new Function('data', 'config', script);
-    const result = fn(data, config);
-    process.stdout.write(JSON.stringify(result) + '\n');
-    return 0;
-  } catch (e) {
-    const { file, line: errLine } = locationFromError(e);
-    writeError(e.message || String(e), {
-      code: typeof e.code === 'number' ? e.code : 0,
-      file,
-      line: errLine,
-      trace: typeof e.stack === 'string' ? e.stack : '',
-    });
-    return 1;
-  }
-}
-
-main().then((code) => process.exit(code));
 EOF
 
 CMD ["node", "/bootstrap.js"]

--- a/resources/script-executors/realtime/javascript.Dockerfile
+++ b/resources/script-executors/realtime/javascript.Dockerfile
@@ -1,0 +1,116 @@
+# syntax=docker/dockerfile:1
+# Experiment: warm Node.js container blocked on stdin
+#
+# Same idea as the PHP/Python variants: keep a container running with the
+# interpreter already loaded and blocked on stdin. A client attaches, writes
+# one JSON payload; bootstrap.js runs the script, prints the result, and exits.
+#
+# Usage:
+#   ./warm.sh          # build + start warm container (foreground via docker wait)
+#   ./run.sh           # attach, send payload.json, print result
+
+FROM node:22-alpine
+
+COPY <<'EOF' /bootstrap.js
+#!/usr/bin/env node
+/**
+ * Wait for one JSON payload on stdin, run the script, print result, exit.
+ *
+ * Expected payload shape (see ../../payload.schema.json):
+ *   { "script": "...", "data": {}, "config": {}, "env": {} }
+ */
+
+'use strict';
+
+const readline = require('readline');
+
+function writeError(error, { code = 0, file = '', line = 0, trace = '' } = {}) {
+  process.stderr.write(
+    JSON.stringify({ error, code, file, line, trace }) + '\n'
+  );
+}
+
+/** Best-effort line/file from a Function/eval stack frame. */
+function locationFromError(e) {
+  const stack = typeof e.stack === 'string' ? e.stack : '';
+  // new Function bodies show up as <anonymous>:LINE:COL
+  const anon = stack.match(/<anonymous>:(\d+):(\d+)/);
+  if (anon) {
+    return { file: '<anonymous>', line: Number(anon[1]) || 0 };
+  }
+  return { file: '', line: 0 };
+}
+
+async function readLine() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
+  try {
+    for await (const line of rl) {
+      return line;
+    }
+    return null;
+  } finally {
+    rl.close();
+  }
+}
+
+async function main() {
+  const line = await readLine();
+  if (line === null || line === undefined) {
+    process.stderr.write('No input on stdin\n');
+    return 1;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(line.trim());
+  } catch (e) {
+    writeError(`Invalid JSON: ${e.message}`);
+    return 1;
+  }
+
+  const script = payload.script;
+  if (script === undefined || script === null || script === '') {
+    writeError('Missing "script" field');
+    return 1;
+  }
+
+  // Available to the evaluated script (mirrors the PHP/Python convention).
+  const data = payload.data ?? {};
+  const config = payload.config ?? {};
+
+  // Apply per-request env before eval (warm containers can't use docker run -e).
+  for (const [key, value] of Object.entries(payload.env ?? {})) {
+    if (value === null || value === undefined) {
+      process.env[key] = '';
+    } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      process.env[key] = String(value);
+    } else {
+      process.env[key] = JSON.stringify(value);
+    }
+  }
+
+  try {
+    // new Function so the user script can `return` a value, like PHP eval.
+    const fn = new Function('data', 'config', script);
+    const result = fn(data, config);
+    process.stdout.write(JSON.stringify(result) + '\n');
+    return 0;
+  } catch (e) {
+    const { file, line: errLine } = locationFromError(e);
+    writeError(e.message || String(e), {
+      code: typeof e.code === 'number' ? e.code : 0,
+      file,
+      line: errLine,
+      trace: typeof e.stack === 'string' ? e.stack : '',
+    });
+    return 1;
+  }
+}
+
+main().then((code) => process.exit(code));
+EOF
+
+CMD ["node", "/bootstrap.js"]

--- a/resources/script-executors/realtime/php.Dockerfile
+++ b/resources/script-executors/realtime/php.Dockerfile
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1
+# Experiment: warm PHP container blocked on stdin
+#
+# Instead of starting a fresh container per request (cold start), we keep a
+# container running with PHP already loaded and blocked on fgets(STDIN). A
+# separate client attaches and writes one JSON payload; bootstrap.php evals
+# the script, prints the result on stdout, and exits so the container stops.
+# Eventually a pool of these warm containers could sit ready for fast attach.
+#
+# Usage:
+#   ./warm.sh          # build + start warm container (foreground via docker wait)
+#   ./run.sh           # attach, send payload.json, print result
+
+FROM php:8.3-cli-alpine
+
+COPY <<'EOF' /bootstrap.php
+<?php
+/**
+ * Wait for one JSON payload on stdin, eval the script, print result, exit.
+ *
+ * Expected payload shape (see ../../payload.schema.json):
+ *   { "script": "...", "data": {}, "config": {}, "env": {} }
+ */
+
+stream_set_blocking(STDIN, true);
+
+$line = fgets(STDIN);
+if ($line === false) {
+    fwrite(STDERR, "No input on stdin\n");
+    exit(1);
+}
+
+$payload = json_decode(trim($line), true);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    fwrite(STDERR, json_encode([
+        'error' => 'Invalid JSON: ' . json_last_error_msg(),
+        'code' => 0,
+        'file' => '',
+        'line' => 0,
+        'trace' => '',
+    ], JSON_UNESCAPED_UNICODE) . "\n");
+    fflush(STDERR);
+    exit(1);
+}
+
+$script = $payload['script'] ?? null;
+if ($script === null || $script === '') {
+    fwrite(STDERR, json_encode([
+        'error' => 'Missing "script" field',
+        'code' => 0,
+        'file' => '',
+        'line' => 0,
+        'trace' => '',
+    ], JSON_UNESCAPED_UNICODE) . "\n");
+    fflush(STDERR);
+    exit(1);
+}
+
+// Available to the evaluated script (matches executor-php convention).
+$data = $payload['data'] ?? [];
+$config = $payload['config'] ?? [];
+
+// Apply per-request env before eval (warm containers can't use docker run -e).
+foreach (($payload['env'] ?? []) as $key => $value) {
+    $stringValue = is_scalar($value) || $value === null ? (string) $value : json_encode($value);
+    putenv($key . '=' . $stringValue);
+    $_ENV[$key] = $stringValue;
+    $_SERVER[$key] = $stringValue;
+}
+
+// eval() does not accept opening tags.
+$script = preg_replace('/^<\?php\s*/i', '', trim($script));
+
+try {
+    $result = eval($script);
+    fwrite(STDOUT, json_encode($result, JSON_UNESCAPED_UNICODE) . "\n");
+    fflush(STDOUT);
+    exit(0);
+} catch (Throwable $e) {
+    fwrite(STDERR, json_encode([
+        'error' => $e->getMessage(),
+        'code' => $e->getCode(),
+        'file' => $e->getFile(),
+        'line' => $e->getLine(),
+        'trace' => $e->getTraceAsString(),
+    ], JSON_UNESCAPED_UNICODE) . "\n");
+    fflush(STDERR);
+    exit(1);
+}
+EOF
+
+CMD ["php", "/bootstrap.php"]

--- a/resources/script-executors/realtime/php.Dockerfile
+++ b/resources/script-executors/realtime/php.Dockerfile
@@ -1,36 +1,27 @@
 # syntax=docker/dockerfile:1
-# Experiment: warm PHP container blocked on stdin
+# Realtime PHP executor: fresh container per request via `docker run --rm -i`.
 #
-# Instead of starting a fresh container per request (cold start), we keep a
-# container running with PHP already loaded and blocked on fgets(STDIN). A
-# separate client attaches and writes one JSON payload; bootstrap.php evals
-# the script, prints the result on stdout, and exits so the container stops.
-# Eventually a pool of these warm containers could sit ready for fast attach.
-#
-# Usage:
-#   ./warm.sh          # build + start warm container (foreground via docker wait)
-#   ./run.sh           # attach, send payload.json, print result
+# The service pipes one JSON payload on stdin. bootstrap.php evals the script,
+# prints the JSON result on stdout, and exits. The container is removed on exit.
 
 FROM php:8.3-cli-alpine
 
 COPY <<'EOF' /bootstrap.php
 <?php
 /**
- * Wait for one JSON payload on stdin, eval the script, print result, exit.
+ * Read one JSON payload from stdin, eval the script, print result, exit.
  *
- * Expected payload shape (see ../../payload.schema.json):
+ * Expected payload shape:
  *   { "script": "...", "data": {}, "config": {}, "env": {} }
  */
 
-stream_set_blocking(STDIN, true);
-
-$line = fgets(STDIN);
-if ($line === false) {
+$raw = file_get_contents('php://stdin');
+if ($raw === false || trim($raw) === '') {
     fwrite(STDERR, "No input on stdin\n");
     exit(1);
 }
 
-$payload = json_decode(trim($line), true);
+$payload = json_decode($raw, true);
 if (json_last_error() !== JSON_ERROR_NONE) {
     fwrite(STDERR, json_encode([
         'error' => 'Invalid JSON: ' . json_last_error_msg(),
@@ -60,7 +51,6 @@ if ($script === null || $script === '') {
 $data = $payload['data'] ?? [];
 $config = $payload['config'] ?? [];
 
-// Apply per-request env before eval (warm containers can't use docker run -e).
 foreach (($payload['env'] ?? []) as $key => $value) {
     $stringValue = is_scalar($value) || $value === null ? (string) $value : json_encode($value);
     putenv($key . '=' . $stringValue);
@@ -70,6 +60,9 @@ foreach (($payload['env'] ?? []) as $key => $value) {
 
 // eval() does not accept opening tags.
 $script = preg_replace('/^<\?php\s*/i', '', trim($script));
+// ProcessMaker encodes ' as &#39; (classic executor shell quoting). Restore
+// before eval so `return ['x' => ...]` is not parsed as `return [&` + comment.
+$script = str_replace('&#39;', "'", $script);
 
 try {
     $result = eval($script);

--- a/resources/script-executors/realtime/python.Dockerfile
+++ b/resources/script-executors/realtime/python.Dockerfile
@@ -1,21 +1,16 @@
 # syntax=docker/dockerfile:1
-# Experiment: warm Python container blocked on stdin
+# Realtime Python executor: fresh container per request via `docker run --rm -i`.
 #
-# Same idea as the PHP variant: keep a container running with the interpreter
-# already loaded and blocked on stdin.readline(). A client attaches, writes one
-# JSON payload; bootstrap.py execs the script, prints the result, and exits.
-#
-# Usage:
-#   ./warm.sh          # build + start warm container (foreground via docker wait)
-#   ./run.sh           # attach, send payload.json, print result
+# The service pipes one JSON payload on stdin. bootstrap.py execs the script,
+# prints the JSON result on stdout, and exits. The container is removed on exit.
 
 FROM python:3.12-alpine
 
 COPY <<'EOF' /bootstrap.py
 #!/usr/bin/env python3
-"""Wait for one JSON payload on stdin, exec the script, print result, exit.
+"""Read one JSON payload from stdin, exec the script, print result, exit.
 
-Expected payload shape (see ../../payload.schema.json):
+Expected payload shape:
   { "script": "...", "data": {}, "config": {}, "env": {} }
 """
 
@@ -53,13 +48,13 @@ def write_error(
 
 
 def main() -> int:
-    line = sys.stdin.readline()
-    if not line:
+    raw = sys.stdin.read()
+    if not raw or not raw.strip():
         print("No input on stdin", file=sys.stderr)
         return 1
 
     try:
-        payload = json.loads(line.strip())
+        payload = json.loads(raw.strip())
     except json.JSONDecodeError as e:
         write_error(f"Invalid JSON: {e}")
         return 1
@@ -73,7 +68,6 @@ def main() -> int:
     data = payload.get("data") or {}
     config = payload.get("config") or {}
 
-    # Apply per-request env before exec (warm containers can't use docker run -e).
     for key, value in (payload.get("env") or {}).items():
         if value is None or isinstance(value, (str, int, float, bool)):
             os.environ[str(key)] = "" if value is None else str(value)

--- a/resources/script-executors/realtime/python.Dockerfile
+++ b/resources/script-executors/realtime/python.Dockerfile
@@ -1,0 +1,128 @@
+# syntax=docker/dockerfile:1
+# Experiment: warm Python container blocked on stdin
+#
+# Same idea as the PHP variant: keep a container running with the interpreter
+# already loaded and blocked on stdin.readline(). A client attaches, writes one
+# JSON payload; bootstrap.py execs the script, prints the result, and exits.
+#
+# Usage:
+#   ./warm.sh          # build + start warm container (foreground via docker wait)
+#   ./run.sh           # attach, send payload.json, print result
+
+FROM python:3.12-alpine
+
+COPY <<'EOF' /bootstrap.py
+#!/usr/bin/env python3
+"""Wait for one JSON payload on stdin, exec the script, print result, exit.
+
+Expected payload shape (see ../../payload.schema.json):
+  { "script": "...", "data": {}, "config": {}, "env": {} }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import textwrap
+import traceback
+
+
+def write_error(
+    error: str,
+    *,
+    code: int = 0,
+    file: str = "",
+    line: int = 0,
+    trace: str = "",
+) -> None:
+    print(
+        json.dumps(
+            {
+                "error": error,
+                "code": code,
+                "file": file,
+                "line": line,
+                "trace": trace,
+            },
+            ensure_ascii=False,
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def main() -> int:
+    line = sys.stdin.readline()
+    if not line:
+        print("No input on stdin", file=sys.stderr)
+        return 1
+
+    try:
+        payload = json.loads(line.strip())
+    except json.JSONDecodeError as e:
+        write_error(f"Invalid JSON: {e}")
+        return 1
+
+    script = payload.get("script")
+    if not script:
+        write_error('Missing "script" field')
+        return 1
+
+    # Available to the evaluated script (mirrors the PHP convention).
+    data = payload.get("data") or {}
+    config = payload.get("config") or {}
+
+    # Apply per-request env before exec (warm containers can't use docker run -e).
+    for key, value in (payload.get("env") or {}).items():
+        if value is None or isinstance(value, (str, int, float, bool)):
+            os.environ[str(key)] = "" if value is None else str(value)
+        else:
+            os.environ[str(key)] = json.dumps(value)
+
+    # Wrap so the user script can `return` a value, like PHP eval.
+    # Leading "def" line shifts user line numbers by +1; we subtract it when reporting.
+    wrapped = "def __user_script__():\n" + textwrap.indent(script.strip(), "    ")
+    namespace: dict = {"data": data, "config": config}
+
+    try:
+        compiled = compile(wrapped, "<script>", "exec")
+        exec(compiled, namespace)
+        result = namespace["__user_script__"]()
+        print(json.dumps(result, ensure_ascii=False), flush=True)
+        return 0
+    except Exception as e:
+        file = ""
+        err_line = 0
+        if isinstance(e, SyntaxError):
+            file = e.filename or "<script>"
+            err_line = max(0, (e.lineno or 0) - 1)
+        else:
+            frames = traceback.extract_tb(e.__traceback__)
+            for frame in reversed(frames):
+                if frame.filename == "<script>":
+                    file = frame.filename
+                    err_line = (
+                        max(0, frame.lineno - 1)
+                        if frame.name == "__user_script__"
+                        else frame.lineno
+                    )
+                    break
+            else:
+                if frames:
+                    file = frames[-1].filename
+                    err_line = frames[-1].lineno
+        write_error(
+            str(e),
+            file=file,
+            line=err_line,
+            trace=traceback.format_exc(),
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+EOF
+
+CMD ["python", "-u", "/bootstrap.py"]

--- a/resources/views/admin/script-executors/index.blade.php
+++ b/resources/views/admin/script-executors/index.blade.php
@@ -19,6 +19,7 @@
         <div class="card card-body">
             <script-executors
                     :script_microservice_enabled="@json($script_microservice_enabled)"
+                    script_microservice_tenant_id="{{$script_microservice_tenant_id}}"
             ></script-executors>
         </div>
     </div>

--- a/resources/views/processes/scripts/builder.blade.php
+++ b/resources/views/processes/scripts/builder.blade.php
@@ -22,7 +22,7 @@
   <div id="script-container">
     <script-editor 
       :script="{{ $script }}" 
-      :script-executor='{!! json_encode($script->scriptExecutor) !!}'
+      :script-executor='{!! json_encode(Arr::except($script->scriptExecutor, 'config')) !!}'
       test-data="{{ json_encode($testData, JSON_PRETTY_PRINT) }}" 
       :auto-save-delay="{{ $autoSaveDelay }}"
       :is-versions-installed="@json($isVersionsInstalled)" 

--- a/resources/views/processes/scripts/preview.blade.php
+++ b/resources/views/processes/scripts/preview.blade.php
@@ -12,7 +12,7 @@
             <div class="col-12">
                 <script-preview
                         :script="{{ $script }}"
-                        :script-executor='{!! json_encode($script->scriptExecutor) !!}'
+                        :script-executor='{!! json_encode(Arr::except($script->scriptExecutor, 'config')) !!}'
                         test-data="{{ json_encode($testData, JSON_PRETTY_PRINT) }}"
                         :auto-save-delay="{{ $autoSaveDelay }}"
                         :is-versions-installed="@json($isVersionsInstalled)"

--- a/tests/Feature/Api/ScriptsTest.php
+++ b/tests/Feature/Api/ScriptsTest.php
@@ -6,10 +6,13 @@ use Database\Seeders\PermissionSeeder;
 use Faker\Factory as Faker;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use ProcessMaker\Enums\ScriptExecutorType;
 use ProcessMaker\Events\ScriptResponseEvent;
 use ProcessMaker\Exception\ScriptLanguageNotSupported;
 use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Jobs\ImportProcess;
+use ProcessMaker\Jobs\TestScript;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\Screen;
@@ -393,6 +396,31 @@ class ScriptsTest extends TestCase
             $nonce = $event->nonce;
 
             return $response['output'] === ['response' => 1] && $nonce === '123abc';
+        });
+    }
+
+    public function testRealtimePreviewUsesRealtimeQueue()
+    {
+        Queue::fake();
+        $executor = ScriptExecutor::factory()->create([
+            'language' => 'php',
+            'type' => ScriptExecutorType::Realtime,
+        ]);
+        $script = Script::factory()->create([
+            'run_as_user_id' => $this->user->id,
+            'language' => 'php',
+            'script_executor_id' => $executor->id,
+        ]);
+
+        $response = $this->apiCall('POST', route('api.scripts.preview', $script), [
+            'data' => '{}',
+            'code' => '<?php return ["response" => 1];',
+            'nonce' => '123abc',
+        ]);
+
+        $response->assertOk()->assertJson(['status' => 'success']);
+        Queue::assertPushed(TestScript::class, function (TestScript $job) {
+            return $job->connection === 'redis-realtime' && $job->queue === 'realtime';
         });
     }
 

--- a/tests/Jobs/RunScriptTaskTest.php
+++ b/tests/Jobs/RunScriptTaskTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Queue;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ProcessMaker\Enums\ScriptExecutorType;
 use ProcessMaker\Facades\WorkflowManager;
 use ProcessMaker\Jobs\ErrorHandling;
 use ProcessMaker\Jobs\RunNayraScriptTask;
@@ -14,11 +15,45 @@ use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\Script;
+use ProcessMaker\Models\ScriptExecutor;
 use ProcessMaker\Models\User;
+use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
+use ProcessMaker\Nayra\Managers\WorkflowManagerDefault;
 use Tests\TestCase;
 
 class RunScriptTaskTest extends TestCase
 {
+    public function testRealtimeScriptTaskUsesRealtimeQueue()
+    {
+        Queue::fake();
+        $process = Process::factory()->create();
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+        ]);
+        $token = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+        ]);
+        $executor = ScriptExecutor::factory()->create([
+            'language' => 'php',
+            'type' => ScriptExecutorType::Realtime,
+        ]);
+        $script = Script::factory()->create([
+            'script_executor_id' => $executor->id,
+        ]);
+        $scriptTask = Mockery::mock(ScriptTaskInterface::class);
+        $scriptTask->shouldReceive('getId')->once()->andReturn('script-task');
+        $scriptTask->shouldReceive('getProperty')
+            ->once()
+            ->with('scriptRef')
+            ->andReturn($script->id);
+
+        (new WorkflowManagerDefault())->runScripTask($scriptTask, $token);
+
+        Queue::assertPushed(RunScriptTask::class, function (RunScriptTask $job) {
+            return $job->connection === 'redis-realtime' && $job->queue === 'realtime';
+        });
+    }
+
     #[DataProvider('jobTypes')]
     public function testScriptNotSet($class)
     {

--- a/tests/Jobs/TestScriptTest.php
+++ b/tests/Jobs/TestScriptTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Jobs;
+
+use Illuminate\Support\Facades\Event;
+use ProcessMaker\Enums\ScriptExecutorType;
+use ProcessMaker\Events\ScriptResponseEvent;
+use ProcessMaker\Jobs\TestScript;
+use ProcessMaker\Models\Script;
+use ProcessMaker\Models\ScriptExecutor;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class TestScriptTest extends TestCase
+{
+    public function testRealtimeExecutorBroadcastsOnlyTheScriptOutput()
+    {
+        config(['script-runner-microservice.enabled' => true]);
+        Event::fake([ScriptResponseEvent::class]);
+
+        $script = $this->realtimeScript([
+            'status' => 'success',
+            'metadata' => ['script_id' => 24, 'executor_type' => 'realtime'],
+            'output' => ['response' => 1],
+        ]);
+
+        (new TestScript($script, $this->previewUser(), 'return [];', [], [], '123abc'))->handle();
+
+        Event::assertDispatched(ScriptResponseEvent::class, function (ScriptResponseEvent $event) {
+            return $event->status === 200
+                && $event->response === ['output' => ['response' => 1]]
+                && $event->nonce === '123abc';
+        });
+    }
+
+    public function testRealtimeExecutorBroadcastsFailureAsException()
+    {
+        config(['script-runner-microservice.enabled' => true]);
+        Event::fake([ScriptResponseEvent::class]);
+
+        $script = $this->realtimeScript([
+            'status' => 'error',
+            'metadata' => ['script_id' => 24],
+            'error' => 'Syntax error, unexpected token',
+        ]);
+
+        (new TestScript($script, $this->previewUser(), 'return [];', [], [], '123abc'))->handle();
+
+        Event::assertDispatched(ScriptResponseEvent::class, function (ScriptResponseEvent $event) {
+            return $event->status === 500
+                && $event->response['message'] === 'Syntax error, unexpected token'
+                && !array_key_exists('metadata', $event->response);
+        });
+    }
+
+    private function realtimeScript(array $microserviceResponse): Script
+    {
+        return new class($microserviceResponse) extends Script {
+            private array $microserviceResponse;
+
+            public function __construct(array $microserviceResponse = [])
+            {
+                parent::__construct();
+                $this->microserviceResponse = $microserviceResponse;
+            }
+
+            public function getScriptExecutorAttribute()
+            {
+                return new ScriptExecutor([
+                    'type' => ScriptExecutorType::Realtime,
+                ]);
+            }
+
+            public function runScript(array $data, array $config, $tokenId = '', $timeout = null, $sync = 1, $metadata = [])
+            {
+                return $this->microserviceResponse;
+            }
+        };
+    }
+
+    private function previewUser(): User
+    {
+        $user = new User();
+        $user->id = 123;
+
+        return $user;
+    }
+}

--- a/tests/unit/ProcessMaker/Services/ScriptMicroserviceServiceTest.php
+++ b/tests/unit/ProcessMaker/Services/ScriptMicroserviceServiceTest.php
@@ -87,7 +87,9 @@ class ScriptMicroserviceServiceTest extends TestCase
                 && isset($request->data()['id'])
                 && $request->data()['name'] === 'Test Executor'
                 && $request->data()['language'] === 'php'
-                && $request->data()['version'] === '1.0.0';
+                && $request->data()['version'] === '1.0.0'
+                && array_key_exists('realtime', $request->data())
+                && $request->data()['realtime'] === false;
         });
 
         $this->assertEquals('test-executor-uuid', $result['id']);
@@ -130,7 +132,8 @@ class ScriptMicroserviceServiceTest extends TestCase
                 && $request->hasHeader('Authorization', 'Bearer ' . $this->accessToken)
                 && $request->data()['name'] === 'Updated Executor'
                 && $request->data()['language'] === 'javascript'
-                && $request->data()['version'] === '1.0.0';
+                && $request->data()['version'] === '1.0.0'
+                && array_key_exists('realtime', $request->data());
         });
 
         $this->assertEquals('test-executor-uuid', $result['id']);


### PR DESCRIPTION
Requires: https://github.com/ProcessMaker/script-executor-service/pull/420

ProcessMaker counterpart to SES realtime executors. New executor type **Realtime**: customer-owned Dockerfile, dedicated Horizon queue, synchronous SES call, result shown in the script editor (with duration).

Pairs with **script-executor-service** `spike/FOUR-32613-C`.

### Why

Same as SES: faster script runs, customers own the base image and can customize freely. SES does `docker run --rm -i` with JSON on stdin; PM just has to create the executor, route jobs, and treat the HTTP response as the result (no callback wait).

### Executor type + admin UI

`ScriptExecutorType::Realtime`. Creating one sends `realtime: true` to SES with the full Dockerfile in `config`.

Admin language list adds **php / python / javascript (realtime)** with example Dockerfiles from `resources/script-executors/realtime/*.Dockerfile` (bootstrap reads stdin, evals/execs, prints JSON, exits). Customers edit that Dockerfile however they want.

### Queue

New Redis connection `redis-realtime` and Horizon supervisor `supervisor-realtime` (`auto` balance, 2–20 processes). Preview, Execute, and BPMN `RunScriptTask` all `onConnection('redis-realtime')->onQueue('realtime')` when the executor is realtime.

The runner always sends `sync: true` to SES. `TestScript` formats the microservice payload locally (no callback) and broadcasts via Echo, including duration.

### Other

- Keycloak access tokens for SES were already cached; that matters more now that every preview/run is a sync HTTP call.
- Script editor shows run duration.

## Test plan

- [ ] Create a realtime executor from an example Dockerfile; SES build succeeds
- [ ] Script editor Test runs on the `realtime` queue and shows output + duration
- [ ] A process script task with a realtime executor also uses that queue
- [ ] Classic custom/system executors still use `bpmn` and the callback path