### PR TITLE
FOUR-32760 After install/enable/disable a plugin, should be executed the command: php artisan horizon:terminate

### DIFF
--- a/ProcessMaker/Managers/PluginManager.php
+++ b/ProcessMaker/Managers/PluginManager.php
@@ -92,7 +92,7 @@ class PluginManager
         $this->logRunning('Running plugin install command...', $repoName, $userId);
         $this->runCommand($installCommand, $repoName, $userId);
 
-        $this->rebuildRouteCache($repoName, $userId);
+        $this->refreshRuntimeAfterPluginChange($repoName, $userId);
 
         $this->logDone('Plugin installed successfully', $repoName, $userId);
     }
@@ -127,7 +127,7 @@ class PluginManager
         $this->logRunning('Removing plugin directory...', $pluginName, $userId);
         $this->deleteDirectory($pluginPath, $pluginName, $userId);
 
-        $this->rebuildRouteCache($pluginName, $userId);
+        $this->refreshRuntimeAfterPluginChange($pluginName, $userId);
 
         $this->logDone('Plugin uninstalled successfully', $pluginName, $userId);
     }
@@ -145,16 +145,22 @@ class PluginManager
 
         if (!$result->successful()) {
             if (str_contains($result->output(), 'is not defined')) {
-                \Log::info("Plugin does not have a {$command} command", ['output' => $result->output()]);
                 $this->logRunning("Plugin does not have a {$command} command", $pluginName, $userId);
             } else {
-                \Log::info("Plugin {$command} command failed. Got output:\n\n{$result->output()}", ['output' => $result->output()]);
                 $this->logError("Plugin {$command} command failed. Got output:\n\n{$result->output()}", $pluginName, $userId);
             }
         } else {
-            \Log::info("Plugin {$command} command output:\n\n{$result->output()}", ['output' => $result->output()]);
             $this->logRunning("Plugin {$command} command output:\n\n{$result->output()}", $pluginName, $userId);
         }
+    }
+
+    /**
+     * Refresh routes and queue workers after plugin code changes.
+     */
+    private function refreshRuntimeAfterPluginChange(string $pluginName, ?int $userId = null): void
+    {
+        $this->rebuildRouteCache($pluginName, $userId);
+        $this->terminateHorizon($pluginName, $userId);
     }
 
     /**
@@ -170,6 +176,15 @@ class PluginManager
         $this->logRunning('Rebuilding route cache...', $pluginName, $userId);
         $this->runCommand('route:cache', $pluginName, $userId);
         $this->reloadCachedRoutes();
+    }
+
+    /**
+     * Always stop current Horizon workers so a new process picks up plugin code.
+     */
+    private function terminateHorizon(string $pluginName, ?int $userId = null): void
+    {
+        $this->logRunning('Restarting queue workers...', $pluginName, $userId);
+        $this->runCommand('horizon:terminate', $pluginName, $userId);
     }
 
     /**
@@ -273,7 +288,7 @@ class PluginManager
             $this->logRunning('Running plugin install command...', $repoName, $userId);
             $this->runCommand($installCommand, $repoName, $userId);
 
-            $this->rebuildRouteCache($repoName, $userId);
+            $this->refreshRuntimeAfterPluginChange($repoName, $userId);
 
             $this->logDone('Plugin installed successfully', $repoName, $userId);
         } finally {
@@ -311,7 +326,7 @@ class PluginManager
                 throw new RuntimeException("Failed to disable plugin: {$pluginName}");
             }
 
-            $this->rebuildRouteCache($pluginName, $userId);
+            $this->refreshRuntimeAfterPluginChange($pluginName, $userId);
 
             return false;
         }
@@ -325,7 +340,7 @@ class PluginManager
                 throw new RuntimeException("Failed to enable plugin: {$pluginName}");
             }
 
-            $this->rebuildRouteCache($enabledName, $userId);
+            $this->refreshRuntimeAfterPluginChange($enabledName, $userId);
 
             return true;
         }
@@ -775,16 +790,14 @@ class PluginManager
      */
     protected function log(string $message, string $type, string $pluginName, ?int $userId = null): void
     {
+        if ($type === 'error') {
+            \Log::error($message);
+        } else {
+            \Log::info($message);
+        }
+
         if ($userId) {
             event(new PluginLog($message, $type, $pluginName, $userId));
-        } else {
-            if ($type === 'done') {
-                \Log::info($message);
-            } elseif ($type === 'error') {
-                \Log::error($message);
-            } else {
-                \Log::info($message);
-            }
         }
     }
 }

--- a/tests/Managers/PluginManagerTest.php
+++ b/tests/Managers/PluginManagerTest.php
@@ -2,12 +2,10 @@
 
 namespace Tests\Managers;
 
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Process;
 use ProcessMaker\Events\PluginLog;
 use ProcessMaker\Managers\PluginManager;
-use ProcessMaker\Models\Plugin;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -62,10 +60,6 @@ class PluginManagerTest extends TestCase
             '*' => Process::result('', exitCode: 0),
         ]);
 
-        // Mock Artisan::all() to return empty array (no plugin install command)
-        Artisan::shouldReceive('all')
-            ->andReturn([]);
-
         Event::fake([PluginLog::class]);
 
         $manager = new PluginManager();
@@ -74,6 +68,7 @@ class PluginManagerTest extends TestCase
         Event::assertDispatched(PluginLog::class, function ($event) {
             return str_contains($event->message, 'installed successfully');
         });
+        $this->assertProcessRanCommand('horizon:terminate');
     }
 
     public function testInstallValidatesComposerJsonNamespace()
@@ -127,10 +122,6 @@ class PluginManagerTest extends TestCase
         mkdir($this->tempPluginDir, 0755, true);
         file_put_contents($this->tempPluginDir . '/test.txt', 'test');
 
-        // Mock Artisan::all() to return empty array (no plugin uninstall command)
-        Artisan::shouldReceive('all')
-            ->andReturn([]);
-
         Event::fake([PluginLog::class]);
 
         Process::fake([
@@ -144,6 +135,7 @@ class PluginManagerTest extends TestCase
         Event::assertDispatched(PluginLog::class, function ($event) {
             return str_contains($event->message, 'uninstalled successfully');
         });
+        $this->assertProcessRanCommand('horizon:terminate');
     }
 
     public function testUninstallThrowsExceptionForNonExistentPlugin()
@@ -266,7 +258,7 @@ class PluginManagerTest extends TestCase
         $this->assertSame(['TENANT' => '7'], $environment);
     }
 
-    public function testToggleRebuildsRouteCache()
+    public function testToggleRebuildsRouteCacheAndTerminatesHorizon()
     {
         $this->setUpTestPluginManager();
 
@@ -286,12 +278,55 @@ class PluginManagerTest extends TestCase
         $this->assertFalse(is_dir($pluginPath));
         $this->assertTrue(is_dir($this->pluginsDir . '/_' . $pluginName));
 
-        Process::assertRan(function ($process) {
+        $this->assertProcessRanCommand('route:cache');
+        $this->assertProcessRanCommand('horizon:terminate');
+    }
+
+    public function testToggleEnableTerminatesHorizon()
+    {
+        $this->setUpTestPluginManager();
+
+        $pluginName = 'toggle-plugin';
+        $disabledPath = $this->pluginsDir . '/_' . $pluginName;
+        $this->tempPluginDir = $this->pluginsDir . '/' . $pluginName;
+        mkdir($disabledPath, 0755, true);
+
+        Process::fake([
+            '*' => Process::result('', exitCode: 0),
+        ]);
+
+        $manager = new PluginManager();
+        $enabled = $manager->toggle($pluginName);
+
+        $this->assertTrue($enabled);
+        $this->assertTrue(is_dir($this->pluginsDir . '/' . $pluginName));
+        $this->assertProcessRanCommand('horizon:terminate');
+    }
+
+    public function testRunCommandLogsSuccessfulOutputOnce()
+    {
+        Process::fake([
+            '*' => Process::result("Routes cached successfully.\n", exitCode: 0),
+        ]);
+        Event::fake([PluginLog::class]);
+
+        $method = new \ReflectionMethod(PluginManager::class, 'runCommand');
+        $method->invoke(new PluginManager(), 'route:cache', 'test-plugin', 1);
+
+        Event::assertDispatchedTimes(PluginLog::class, 1);
+        Event::assertDispatched(PluginLog::class, function (PluginLog $event) {
+            return str_contains($event->message, 'Plugin route:cache command output');
+        });
+    }
+
+    private function assertProcessRanCommand(string $artisanCommand): void
+    {
+        Process::assertRan(function ($process) use ($artisanCommand) {
             $command = is_array($process->command)
                 ? implode(' ', $process->command)
                 : (string) $process->command;
 
-            return str_contains($command, 'route:cache');
+            return str_contains($command, $artisanCommand);
         });
     }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

## Solution
Command php artisan horizon:terminate is executed after install/enable/disable a plugin

## How to Test
Install plugin "package-service-task" create a process and add a new service task, configure process and start a new request, a error should be displayed because the worker now found the classes related to the package

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-32760

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
