### PR TITLE
FOUR-32395: Respect non-filterable request columns

### DIFF
--- a/resources/js/requests/components/RequestsListing.vue
+++ b/resources/js/requests/components/RequestsListing.vue
@@ -34,7 +34,7 @@
         </template>
         <!-- Slot Table Header filter Button -->
         <template v-for="(column, index) in tableHeaders" v-slot:[`filter-${column.field}`]>
-            <PMColumnFilterPopover v-if="column.sortable"
+            <PMColumnFilterPopover v-if="column.sortable && column.filterable !== false"
                                    :key="index"
                                    :id="'pm-table-column-'+index"
                                    :type="getTypeColumnFilter(column.field)"


### PR DESCRIPTION
## Issue & Reproduction Steps
The fixed-scope request trays in Cases / My Requests expose the Status column filter even when saved search metadata marks that column as non-filterable.

Reproduction:
1. Open Started By Me, In Progress, or Completed under Cases / My Requests.
2. Open the Status column menu.
3. Confirm that statuses outside the tray's fixed scope are available.

## Solution
- Update the request listing to respect `filterable: false` when rendering column filter popovers.
- Preserve sorting and filtering for columns whose metadata allows it.

## How to Test
Automated validation:
- The RequestsListing Vue template compiled successfully.
- The companion package `SavedSearchTest.php` suite passed from ProcessMaker core: 10 tests, 32 assertions.

Manual verification:
1. Open Started By Me, In Progress, and Completed under Cases / My Requests and confirm that Status has no filter menu.
2. Open All Requests and confirm that the Status filter remains available.
3. Confirm that other sortable and filterable columns still expose their menus.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32395
- https://github.com/ProcessMaker/package-savedsearch/pull/676

ci:deploy
ci:package-savedsearch:task/FOUR-32395
ci:skip-build