### PR TITLE
FOUR-32764 Process Manager gets an unauthorized error when loading the summary screen without the View All request permission

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -200,7 +200,7 @@ class RequestController extends Controller
         $addons = $this->getPluginAddons('edit', compact(['request']));
         $dataActionsAddons = $this->getPluginAddons('edit.dataActions', []);
 
-        $isProcessManager = $request->process?->manager_id === Auth::user()->id;
+        $isProcessManager = in_array(Auth::user()->id, $request->process?->manager_id ?? []);
 
         $eligibleRollbackTask = null;
         $errorTask = RollbackProcessRequest::getErrorTask($request);

--- a/ProcessMaker/Policies/ProcessRequestPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestPolicy.php
@@ -33,6 +33,10 @@ class ProcessRequestPolicy
      */
     public function view(User $user, ProcessRequest $processRequest)
     {
+        if (in_array($user->id, $processRequest->process?->manager_id ?? [])) {
+            return true;
+        }
+
         // Policy defined in ForUserScope
         return ProcessRequest::forUser($user)
             ->where('process_requests.id', $processRequest->id)

--- a/tests/Feature/Api/ProcessRequestPolicyTest.php
+++ b/tests/Feature/Api/ProcessRequestPolicyTest.php
@@ -117,4 +117,159 @@ class ProcessRequestPolicyTest extends TestCase
         $this->apiCall('GET', route('api.requests.end_event_destination', [$unmanagedRequest]))
             ->assertStatus(403);
     }
+
+    public function testProcessManagerAccessIsRevokedWhenRemovedFromProcess()
+    {
+        $process = Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+        ]);
+
+        $this->apiCall('GET', route('api.requests.show', [$request]))
+            ->assertStatus(200);
+
+        $process->manager_id = [];
+        $process->save();
+
+        $this->apiCall('GET', route('api.requests.show', [$request]))
+            ->assertStatus(403);
+    }
+
+    public function testProcessManagerCannotUpdateOrDeleteManagedRequest()
+    {
+        $process = Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+        ]);
+
+        $this->apiCall('PUT', route('api.requests.update', [$request]), [
+            'name' => 'Unauthorized update',
+        ])->assertStatus(403);
+
+        $this->apiCall('DELETE', route('api.requests.destroy', [$request]))
+            ->assertStatus(403);
+    }
+
+    public function testManagedRequestIsNotAddedToRequestListing()
+    {
+        $process = Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+        ]);
+
+        $this->apiCall('GET', route('api.requests.show', [$request]))
+            ->assertStatus(200);
+
+        $this->apiCall('GET', route('api.requests.index'))
+            ->assertStatus(200)
+            ->assertJsonMissing(['id' => $request->id]);
+    }
+
+    public function testScalarProcessManagerValueIsNormalizedForAuthorization()
+    {
+        $process = Process::factory()->create([
+            'manager_id' => $this->user->id,
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+        ]);
+
+        $this->assertSame([$this->user->id], $process->fresh()->manager_id);
+
+        $this->apiCall('GET', route('api.requests.show', [$request]))
+            ->assertStatus(200);
+    }
+
+    public function testProcessManagerReassignmentUpdatesRequestAccess()
+    {
+        $newManager = User::factory()->create();
+        $process = Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+        ]);
+
+        $this->apiCall('GET', route('api.requests.show', [$request]))
+            ->assertStatus(200);
+
+        $process->manager_id = [$newManager->id];
+        $process->save();
+
+        $this->apiCall('GET', route('api.requests.show', [$request]))
+            ->assertStatus(403);
+
+        $this->user = $newManager;
+
+        $this->apiCall('GET', route('api.requests.show', [$request]))
+            ->assertStatus(200);
+    }
+
+    public function testProcessManagerCanViewManagedRequestsInEveryStatus()
+    {
+        $process = Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+
+        foreach (['ACTIVE', 'COMPLETED', 'CANCELED', 'ERROR'] as $status) {
+            $request = ProcessRequest::factory()->create([
+                'process_id' => $process->id,
+                'status' => $status,
+            ]);
+
+            $this->apiCall('GET', route('api.requests.show', [$request]))
+                ->assertStatus(200);
+        }
+    }
+
+    public function testEndEventDestinationReturnsNullWhenManagedRequestHasNoEndEvent()
+    {
+        $process = Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'status' => 'COMPLETED',
+        ]);
+
+        $this->apiCall('GET', route('api.requests.end_event_destination', [$request]))
+            ->assertStatus(200)
+            ->assertJsonPath('data', null);
+    }
+
+    public function testEndEventDestinationReturnsConfiguredExternalUrlForProcessManager()
+    {
+        $bpmn = file_get_contents(__DIR__ . '/../../Fixtures/action_by_email_process_no_require_login.bpmn');
+        $bpmn = str_replace(
+            '{&#34;type&#34;:&#34;summaryScreen&#34;,&#34;value&#34;:null}',
+            '{&#34;type&#34;:&#34;externalURL&#34;,&#34;value&#34;:&#34;https://example.com/summary&#34;}',
+            $bpmn,
+        );
+        $process = Process::factory()->create([
+            'bpmn' => $bpmn,
+            'manager_id' => [$this->user->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'status' => 'COMPLETED',
+        ]);
+        ProcessRequestToken::factory()->create([
+            'element_id' => 'node_18',
+            'element_type' => 'end_event',
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'status' => 'CLOSED',
+        ]);
+
+        $this->apiCall('GET', route('api.requests.end_event_destination', [$request]))
+            ->assertStatus(200)
+            ->assertJsonPath('data.endEventDestination.type', 'externalURL')
+            ->assertJsonPath('data.endEventDestination.value', 'https://example.com/summary');
+    }
 }

--- a/tests/Feature/Api/ProcessRequestPolicyTest.php
+++ b/tests/Feature/Api/ProcessRequestPolicyTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use Database\Seeders\PermissionSeeder;
+use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessRequest;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Models\User;
@@ -71,5 +72,49 @@ class ProcessRequestPolicyTest extends TestCase
 
         $response = $this->apiCall('GET', $route);
         $response->assertStatus(200);
+    }
+
+    public function testProcessManagerCanViewManagedRequestAndEndEventDestination()
+    {
+        $firstManager = User::factory()->create();
+        $process = Process::factory()->create([
+            'bpmn' => file_get_contents(__DIR__ . '/../../Fixtures/action_by_email_process_no_require_login.bpmn'),
+            'manager_id' => [$firstManager->id, $this->user->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'status' => 'COMPLETED',
+        ]);
+        ProcessRequestToken::factory()->create([
+            'element_id' => 'node_18',
+            'element_type' => 'end_event',
+            'process_id' => $process->id,
+            'process_request_id' => $request->id,
+            'status' => 'CLOSED',
+        ]);
+
+        $this->apiCall('GET', route('api.requests.show', [$request]))
+            ->assertStatus(200);
+
+        $this->apiCall('GET', route('api.requests.end_event_destination', [$request]))
+            ->assertStatus(200)
+            ->assertJsonPath('data.endEventDestination.type', 'summaryScreen')
+            ->assertJsonPath('data.endEventDestination.value', null);
+    }
+
+    public function testProcessManagerCannotViewRequestFromUnmanagedProcess()
+    {
+        $managedProcess = Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+        $unmanagedRequest = ProcessRequest::factory()->create();
+
+        $this->assertNotEquals($managedProcess->id, $unmanagedRequest->process_id);
+
+        $this->apiCall('GET', route('api.requests.show', [$unmanagedRequest]))
+            ->assertStatus(403);
+
+        $this->apiCall('GET', route('api.requests.end_event_destination', [$unmanagedRequest]))
+            ->assertStatus(403);
     }
 }

--- a/tests/Feature/CasesControllerTest.php
+++ b/tests/Feature/CasesControllerTest.php
@@ -62,6 +62,31 @@ class CasesControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
+    public function testProcessManagerCanOpenManagedCaseButUnrelatedUserCannot()
+    {
+        $processManager = User::factory()->create();
+        $firstManager = User::factory()->create();
+        $process = Process::factory()->create([
+            'manager_id' => [$firstManager->id, $processManager->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'parent_request_id' => null,
+            'process_id' => $process->id,
+            'status' => 'COMPLETED',
+        ]);
+        $route = route('cases.show', ['case_number' => $request->case_number]);
+
+        $response = $this->actingAs($processManager)->get($route);
+
+        $response->assertStatus(200);
+        $response->assertViewIs('cases.edit');
+        $response->assertViewHas('isProcessManager', true);
+
+        $this->actingAs(User::factory()->create())
+            ->get($route)
+            ->assertStatus(403);
+    }
+
     public function testCasesAllPageReturns403WithoutViewAllCasesPermission()
     {
         Permission::firstOrCreate(

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use Illuminate\Http\Testing\File;
+use Illuminate\Support\Facades\Gate;
+use ProcessMaker\Models\Permission;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessRequest;
@@ -121,6 +123,54 @@ class RequestTest extends TestCase
 
         $response = $this->webCall('GET', '/requests/' . $request_id);
         $response->assertStatus(200);
+    }
+
+    public function testProcessManagerCanViewManagedRequestSummary()
+    {
+        $this->user = User::factory()->create();
+        $firstManager = User::factory()->create();
+        $process = Process::factory()->create([
+            'manager_id' => [$firstManager->id, $this->user->id],
+        ]);
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'status' => 'COMPLETED',
+        ]);
+
+        $response = $this->webCall('GET', route('requests.show', [$request]));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('requests.show');
+        $response->assertViewHas('isProcessManager', true);
+    }
+
+    public function testProcessManagerCannotViewUnmanagedRequestSummary()
+    {
+        $this->user = User::factory()->create();
+        Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+        $unmanagedRequest = ProcessRequest::factory()->create();
+
+        $this->webCall('GET', route('requests.show', [$unmanagedRequest]))
+            ->assertStatus(403);
+    }
+
+    public function testProcessManagerCannotViewAllRequestsWithoutPermission()
+    {
+        Permission::firstOrCreate(
+            ['name' => 'view-all_requests'],
+            ['title' => 'View All Requests'],
+        );
+        Gate::define('view-all_requests', fn ($user) => $user->hasPermission('view-all_requests'));
+
+        $this->user = User::factory()->create();
+        Process::factory()->create([
+            'manager_id' => [$this->user->id],
+        ]);
+
+        $this->webCall('GET', route('requests_by_type', ['type' => 'all']))
+            ->assertStatus(403);
     }
 
     public function testShowRouteWithAdministrator()


### PR DESCRIPTION
## Issue & Reproduction Steps

### Process Manager gets an unauthorized error when loading the summary screen without the View All request permission

## Solution
- Updates request view authorization so all assigned process managers can open managed request summaries and retrieve End Event destinations. Also fixes the request page’s multi-manager detection and adds coverage for authorization boundaries, multiple managers, revocation, reassignment, destination variants, case access, and request-list isolation.

https://github.com/user-attachments/assets/67c195c9-69eb-432d-98e6-a87514c6803a

## Related Tickets & Packages
[FOUR-32764](https://processmaker.atlassian.net/browse/FOUR-32764)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy

..


[FOUR-32764]: https://processmaker.atlassian.net/browse/FOUR-32764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ