### PR TITLE
FOUR-32743: Handle invalid Process Browser category IDs

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessLaunchpadController.php
@@ -28,8 +28,13 @@ class ProcessLaunchpadController extends Controller
         $category = $request->input('category', null);
         if ($category === 'recent') {
             $processes->orderByRecentRequests();
-        } elseif (!empty($category)) {
-            $processes->processCategory($category);
+        } elseif ($category !== null && $category !== '') {
+            $categoryId = filter_var($category, FILTER_VALIDATE_INT);
+            if ($categoryId === false) {
+                $processes->whereRaw('1 = 0');
+            } else {
+                $processes->processCategory($categoryId);
+            }
         }
         // Filter pmql
         $pmql = $request->input('pmql', '');

--- a/tests/Feature/Api/ProcessLaunchpadTest.php
+++ b/tests/Feature/Api/ProcessLaunchpadTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessCategory;
 use ProcessMaker\Models\ProcessLaunchpad;
 use ProcessMaker\Models\ProcessRequest;
 use Tests\Feature\Shared\RequestHelper;
@@ -15,6 +16,8 @@ class ProcessLaunchpadTest extends TestCase
     use RequestHelper, RefreshDatabase;
 
     const API_TEST_URL = '/process_launchpad';
+
+    const PROCESSES_API_TEST_URL = '/process_bookmarks/processes';
 
     const STRUCTURE = [
         'launchpad',
@@ -47,6 +50,53 @@ class ProcessLaunchpadTest extends TestCase
         // Validate the header status code
         $response->assertStatus(200);
         $this->assertNotEmpty($response);
+    }
+
+    public function testGetProcessesReturnsEmptyCollectionForNonNumericCategory()
+    {
+        Process::factory()->create();
+
+        $response = $this->apiCall('GET', self::PROCESSES_API_TEST_URL, [
+            'category' => 'lorem',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0);
+    }
+
+    public function testGetProcessesReturnsEmptyCollectionForMissingNumericCategory()
+    {
+        Process::factory()->create();
+
+        $response = $this->apiCall('GET', self::PROCESSES_API_TEST_URL, [
+            'category' => '0',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0);
+    }
+
+    public function testGetProcessesFiltersByValidCategory()
+    {
+        $category = ProcessCategory::factory()->create();
+        $otherCategory = ProcessCategory::factory()->create();
+        $process = Process::factory()->create([
+            'process_category_id' => $category->id,
+        ]);
+        Process::factory()->create([
+            'process_category_id' => $otherCategory->id,
+        ]);
+
+        $response = $this->apiCall('GET', self::PROCESSES_API_TEST_URL, [
+            'category' => $category->id,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $process->id)
+            ->assertJsonPath('meta.total', 1);
     }
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Opening the Process Browser with an arbitrary non-existent category ID, such as \`/process-browser/?categoryId=lorem\`, causes the processes API to pass a string to the integer-typed category scope and return a 500 error.

## Solution
- Validate non-empty category filters before applying the category scope.
- Return an empty process collection for invalid category values.
- Preserve the existing behavior for recent, empty, and valid numeric category values.
- Add regression coverage for invalid, missing numeric, and valid category IDs.

## How to Test
- Run \`./vendor/bin/phpunit tests/Feature/Api/ProcessLaunchpadTest.php\`.
- Open \`/process-browser/?categoryId=lorem\`.
- Confirm the processes request returns 200, the empty state is displayed, and no Axios error is logged.

Automated result: 9 tests passed with 25 assertions.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32743

ci:deploy
