### PR TITLE
FOUR-32745: Prevent stored XSS in user directory

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -650,12 +650,11 @@ class UserController extends Controller
      */
     private function normalizeSelfServiceMeta(User $user, array $fields): array
     {
-        if (!array_key_exists('meta', $fields)) {
-            return $fields;
-        }
-
         $meta = (array) $user->meta;
-        if (array_key_exists('disableRecommendations', $fields['meta'])) {
+        if (
+            array_key_exists('meta', $fields)
+            && array_key_exists('disableRecommendations', $fields['meta'])
+        ) {
             if ($fields['meta']['disableRecommendations']) {
                 $meta['disableRecommendations'] = true;
             } else {

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -71,6 +71,15 @@ class UserController extends Controller
     ];
 
     /**
+     * Metadata fields accepted during a self-service profile update.
+     *
+     * @var array<string>
+     */
+    private const SELF_SERVICE_META_FIELDS = [
+        'disableRecommendations',
+    ];
+
+    /**
      * Display a listing of the resource.
      *
      * @return \Illuminate\Http\Response
@@ -491,8 +500,16 @@ class UserController extends Controller
         }
 
         $fields = $request->json()->all();
-        $this->authorizeSelfServiceUpdate($authenticatedUser, $user, $fields);
-        $request->validate(User::rules($user));
+        $isSelfServiceUpdate = $this->authorizeSelfServiceUpdate($authenticatedUser, $user, $fields);
+        $rules = User::rules($user);
+        if ($isSelfServiceUpdate) {
+            $rules['meta'] = ['sometimes', 'array'];
+            $rules['meta.disableRecommendations'] = ['sometimes', 'boolean'];
+        }
+        $request->validate($rules);
+        if ($isSelfServiceUpdate) {
+            $fields = $this->normalizeSelfServiceMeta($user, $fields);
+        }
         if (isset($fields['password'])) {
             $fields['password'] = Hash::make($fields['password']);
             $fields['password_changed_at'] = Carbon::now()->toDateTimeString();
@@ -501,6 +518,7 @@ class UserController extends Controller
             session()->forget('login-error');
         }
         $original = $user->getOriginal();
+        $isLdapUser = $user->meta?->authenticationType === 'ldap';
         $user->fill($fields);
         if (array_key_exists('cell', $fields)) {
             $response = $this->validateCellPhoneNumber($user, $fields['cell']);
@@ -509,28 +527,24 @@ class UserController extends Controller
             }
         }
         if ($fields['email'] !== $original['email']) {
+            $ssoUser = $isLdapUser;
             if (class_exists(SsoUser::class)) {
                 // Check if the user is an SSO user (including SAML)
-                $ssoUser = SsoUser::where('user_id', $user->id)->exists();
-
-                // Check if the user is an LDAP user
-                if (isset($user->meta?->authenticationType) && $user->meta->authenticationType === 'ldap') {
-                    $ssoUser = true;
-                }
-                if ($ssoUser) {
-                    return response([
-                        'message' => __(
-                            "The email can't be edited. This action is only available for SSO-synced users."
-                        ),
-                        'errors' => [
-                            'email' => [
-                                __(
-                                    "The email can't be edited. This action is only available for SSO-synced users."
-                                ),
-                            ],
+                $ssoUser = $ssoUser || SsoUser::where('user_id', $user->id)->exists();
+            }
+            if ($ssoUser) {
+                return response([
+                    'message' => __(
+                        "The email can't be edited. This action is only available for SSO-synced users."
+                    ),
+                    'errors' => [
+                        'email' => [
+                            __(
+                                "The email can't be edited. This action is only available for SSO-synced users."
+                            ),
                         ],
-                    ], 422);
-                }
+                    ],
+                ], 422);
             }
             if (!isset($fields['valpassword'])) {
                 return response([
@@ -602,14 +616,14 @@ class UserController extends Controller
     /**
      * Authorize and constrain self-service profile updates.
      */
-    private function authorizeSelfServiceUpdate(User $authenticatedUser, User $targetUser, array $fields): void
+    private function authorizeSelfServiceUpdate(User $authenticatedUser, User $targetUser, array $fields): bool
     {
         $isSelfServiceUpdate = $authenticatedUser->id === $targetUser->id
             && !$authenticatedUser->is_administrator
             && !$authenticatedUser->hasPermission('edit-users');
 
         if (!$isSelfServiceUpdate) {
-            return;
+            return false;
         }
 
         if (!$authenticatedUser->hasPermission('edit-personal-profile')) {
@@ -620,6 +634,37 @@ class UserController extends Controller
         if ($disallowedFields !== []) {
             throw new AuthorizationException(__('Not authorized to update one or more user fields.'));
         }
+
+        if (isset($fields['meta']) && is_array($fields['meta'])) {
+            $disallowedMetaFields = array_diff(array_keys($fields['meta']), self::SELF_SERVICE_META_FIELDS);
+            if ($disallowedMetaFields !== []) {
+                throw new AuthorizationException(__('Not authorized to update one or more user fields.'));
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Merge self-service metadata into the persisted server-managed values.
+     */
+    private function normalizeSelfServiceMeta(User $user, array $fields): array
+    {
+        if (!array_key_exists('meta', $fields)) {
+            return $fields;
+        }
+
+        $meta = (array) $user->meta;
+        if (array_key_exists('disableRecommendations', $fields['meta'])) {
+            if ($fields['meta']['disableRecommendations']) {
+                $meta['disableRecommendations'] = true;
+            } else {
+                unset($meta['disableRecommendations']);
+            }
+        }
+        $fields['meta'] = $meta ?: null;
+
+        return $fields;
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -35,6 +35,39 @@ class UserController extends Controller
     public $doNotSanitize = [
         'username', // has alpha_dash rule
         'password',
+        'firstname', // validated as plain text by User::rules()
+        'lastname', // validated as plain text by User::rules()
+        'title', // validated as plain text by User::rules()
+    ];
+
+    /**
+     * Fields accepted when a non-administrative user updates their own profile.
+     *
+     * @var array<string>
+     */
+    private const SELF_SERVICE_UPDATE_FIELDS = [
+        'username',
+        'password',
+        'firstname',
+        'lastname',
+        'title',
+        'email',
+        'address',
+        'city',
+        'state',
+        'postal',
+        'country',
+        'phone',
+        'fax',
+        'cell',
+        'timezone',
+        'datetime_format',
+        'status',
+        'avatar',
+        'preferences_2fa',
+        'connected_accounts',
+        'meta',
+        'valpassword',
     ];
 
     /**
@@ -452,12 +485,14 @@ class UserController extends Controller
      */
     public function update(User $user, Request $request)
     {
-        if (!Auth::user()->can('edit', $user)) {
+        $authenticatedUser = Auth::user();
+        if (!$authenticatedUser->can('edit', $user)) {
             throw new AuthorizationException(__('Not authorized to update this user.'));
         }
 
-        $request->validate(User::rules($user));
         $fields = $request->json()->all();
+        $this->authorizeSelfServiceUpdate($authenticatedUser, $user, $fields);
+        $request->validate(User::rules($user));
         if (isset($fields['password'])) {
             $fields['password'] = Hash::make($fields['password']);
             $fields['password_changed_at'] = Carbon::now()->toDateTimeString();
@@ -562,6 +597,29 @@ class UserController extends Controller
         RecommendationEngine::handleUserSettingChanges($user, $original);
 
         return response([], 204);
+    }
+
+    /**
+     * Authorize and constrain self-service profile updates.
+     */
+    private function authorizeSelfServiceUpdate(User $authenticatedUser, User $targetUser, array $fields): void
+    {
+        $isSelfServiceUpdate = $authenticatedUser->id === $targetUser->id
+            && !$authenticatedUser->is_administrator
+            && !$authenticatedUser->hasPermission('edit-users');
+
+        if (!$isSelfServiceUpdate) {
+            return;
+        }
+
+        if (!$authenticatedUser->hasPermission('edit-personal-profile')) {
+            throw new AuthorizationException(__('Not authorized to update this user.'));
+        }
+
+        $disallowedFields = array_diff(array_keys($fields), self::SELF_SERVICE_UPDATE_FIELDS);
+        if ($disallowedFields !== []) {
+            throw new AuthorizationException(__('Not authorized to update one or more user fields.'));
+        }
     }
 
     /**

--- a/ProcessMaker/Http/Middleware/ValidateEditUserAndPasswordPermission.php
+++ b/ProcessMaker/Http/Middleware/ValidateEditUserAndPasswordPermission.php
@@ -15,8 +15,11 @@ class ValidateEditUserAndPasswordPermission
     {
         $user = $request->route('user');
         $fields = $request->json()->all();
-        if (($fields['username'] !== $user->getAttribute('username') || in_array('password', $fields)) &&
-        !Auth::user()->hasPermission('edit-user-and-password') && !Auth::user()->is_administrator) {
+        $usernameChanged = array_key_exists('username', $fields)
+            && $fields['username'] !== $user->getAttribute('username');
+        $passwordChanged = array_key_exists('password', $fields);
+        if (($usernameChanged || $passwordChanged) &&
+            !Auth::user()->hasPermission('edit-user-and-password') && !Auth::user()->is_administrator) {
             throw new AuthorizationException(__('Not authorized to update the username and password.'));
         }
 

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -16,6 +16,7 @@ use Laravel\Passport\HasApiTokens;
 use ProcessMaker\Models\EmptyModel;
 use ProcessMaker\Notifications\ResetPassword as ResetPasswordNotification;
 use ProcessMaker\Query\Traits\PMQL;
+use ProcessMaker\Rules\PlainText;
 use ProcessMaker\Rules\StringHasAtLeastOneUpperCaseCharacter;
 use ProcessMaker\Traits\Exportable;
 use ProcessMaker\Traits\HasAuthorization;
@@ -184,9 +185,10 @@ class User extends Authenticatable implements HasMedia
         return [
             // The following characters where not included in the regexp: & %  ' " ? /
             'username' /****/ => ['required', 'regex:/^[a-zA-Z0-9.!#$*+=^_`|~\-@]+$/', 'min:2', 'max:255', $unique],
-            'firstname' /***/ => ['required', 'max:50'],
-            'lastname' /****/ => ['required', 'max:50'],
+            'firstname' /***/ => ['required', 'max:50', new PlainText()],
+            'lastname' /****/ => ['required', 'max:50', new PlainText()],
             'email' /*******/ => ['required', 'email'],
+            'title' /*******/ => ['nullable', 'max:255', new PlainText()],
             'birthdate' /***/ => ['nullable', 'date'],
             'phone' /*******/ => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],
             'fax' /*********/ => ['nullable', 'regex:/^[+\.0-9x\)\(\-\s\/]*$/'],

--- a/ProcessMaker/Rules/PlainText.php
+++ b/ProcessMaker/Rules/PlainText.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ProcessMaker\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class PlainText implements ValidationRule
+{
+    /**
+     * Validate that the value does not contain HTML markup.
+     *
+     * @param string  $attribute Attribute being validated.
+     * @param mixed   $value     Value being validated.
+     * @param Closure $fail      Validation failure callback.
+     *
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!is_string($value) || strip_tags($value) !== $value) {
+            $fail('The :attribute field must contain plain text only.');
+        }
+    }
+}

--- a/resources/js/admin/groups/components/UsersInGroupListing.vue
+++ b/resources/js/admin/groups/components/UsersInGroupListing.vue
@@ -15,6 +15,9 @@
             >   <template slot="username" slot-scope="props">
                   <span v-uni-id="props.rowData.id.toString()">{{ props.rowData.username }}</span>
                 </template>
+                <template slot="fullname" slot-scope="props">
+                  <span>{{ props.rowData.fullname }}</span>
+                </template>
                 <template slot="actions" slot-scope="props">
                     <div class="actions">
                         <div class="popout">
@@ -44,8 +47,10 @@
 </template>
 
 <script>
-  import datatableMixin from "../../../components/common/mixins/datatable";
+  import escapeHtml from "lodash/escape";
   import { createUniqIdsMixin } from "vue-uniq-ids";
+
+  import datatableMixin from "../../../components/common/mixins/datatable";
   const uniqIdsMixin = createUniqIdsMixin();
 
   export default {
@@ -74,7 +79,7 @@
           },
           {
             title: () => this.$t("Full Name"),
-            name: "fullname",
+            name: "__slot:fullname",
             sortField: "firstname"
           },
           {
@@ -114,7 +119,7 @@
         let that = this;
         ProcessMaker.confirmModal(
           this.$t("Caution!"),
-          this.$t('Are you sure you want to delete {{item}}?', {item: data.fullname}),
+          this.$t('Are you sure you want to delete {{item}}?', {item: escapeHtml(data.fullname)}),
           null,
           function () {
             ProcessMaker.apiClient

--- a/resources/js/admin/users/components/DeletedUsersListing.vue
+++ b/resources/js/admin/users/components/DeletedUsersListing.vue
@@ -23,6 +23,9 @@
         <template slot="username" slot-scope="props">
           <span v-uni-id="props.rowData.id.toString()">{{ props.rowData.username }}</span>
         </template>
+        <template slot="fullname" slot-scope="props">
+          <span>{{ props.rowData.fullname }}</span>
+        </template>
         <template slot="avatar" slot-scope="props">
           <avatar-image size="25" :input-data="props.rowData" hide-name="true"></avatar-image>
         </template>
@@ -93,7 +96,7 @@ export default {
         },
         {
           title: () => this.$t("Full Name"),
-          name: "fullname",
+          name: "__slot:fullname",
           sortField: "fullname"
         },
         {

--- a/resources/js/admin/users/components/DeletedUsersListing.vue
+++ b/resources/js/admin/users/components/DeletedUsersListing.vue
@@ -59,10 +59,12 @@
 
 
 <script>
+import escapeHtml from "lodash/escape";
+import { createUniqIdsMixin } from "vue-uniq-ids";
+
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import AvatarImage from "../../../components/AvatarImage";
-import { createUniqIdsMixin } from "vue-uniq-ids";
 const uniqIdsMixin = createUniqIdsMixin();
 Vue.component("avatar-image", AvatarImage);
 
@@ -172,7 +174,7 @@ export default {
 
       ProcessMaker.confirmModal(
         this.$t('Caution!'),
-        this.$t('Are you sure you want to restore the user {{item}}?', {item: data.fullname}),
+        this.$t('Are you sure you want to restore the user {{item}}?', {item: escapeHtml(data.fullname)}),
         "",
         () => {
           ProcessMaker.apiClient.put('users/restore', $body).then(response => {

--- a/resources/js/admin/users/components/UsersListing.vue
+++ b/resources/js/admin/users/components/UsersListing.vue
@@ -57,12 +57,14 @@
 
 
 <script>
+import escapeHtml from "lodash/escape";
+import { createUniqIdsMixin } from "vue-uniq-ids";
+
 import datatableMixin from "../../../components/common/mixins/datatable";
 import dataLoadingMixin from "../../../components/common/mixins/apiDataLoading";
 import AvatarImage from "../../../components/AvatarImage";
 import AddToBundle from "../../../components/shared/AddToBundle.vue";
 import EllipsisMenu from "../../../components/shared/EllipsisMenu.vue";
-import { createUniqIdsMixin } from "vue-uniq-ids";
 const uniqIdsMixin = createUniqIdsMixin();
 Vue.component("avatar-image", AvatarImage);
 
@@ -184,7 +186,7 @@ export default {
             this.$t("Caution!"),
             this.$t("Are you sure you want to delete the user") +
               " " +
-              data.fullname +
+              escapeHtml(data.fullname) +
               this.$t("?"),
             "",
             () => {

--- a/resources/js/admin/users/components/UsersListing.vue
+++ b/resources/js/admin/users/components/UsersListing.vue
@@ -23,6 +23,9 @@
         <template slot="username" slot-scope="props">
           <span v-uni-id="props.rowData.id.toString()">{{ props.rowData.username }}</span>
         </template>
+        <template slot="fullname" slot-scope="props">
+          <span>{{ props.rowData.fullname }}</span>
+        </template>
         <template slot="avatar" slot-scope="props">
           <avatar-image size="25" :input-data="props.rowData" hide-name="true"></avatar-image>
         </template>
@@ -98,7 +101,7 @@ export default {
         },
         {
           title: () => this.$t("Full Name"),
-          name: "fullname",
+          name: "__slot:fullname",
           sortField: "fullname"
         },
         {

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -128,6 +128,30 @@
                 }
             }
         };
+        const SELF_SERVICE_PROFILE_FIELDS = [
+            'username',
+            'password',
+            'firstname',
+            'lastname',
+            'title',
+            'email',
+            'address',
+            'city',
+            'state',
+            'postal',
+            'country',
+            'phone',
+            'fax',
+            'cell',
+            'timezone',
+            'datetime_format',
+            'status',
+            'avatar',
+            'preferences_2fa',
+            'connected_accounts',
+            'meta',
+            'valpassword',
+        ];
         let formVueInstance = new Vue({
             el: '#editProfile',
             mixins:addons,
@@ -251,6 +275,15 @@
                 closeModal() {
                   $('#validateModal').modal('hide');
                 },
+                profilePayload() {
+                    return SELF_SERVICE_PROFILE_FIELDS.reduce((payload, field) => {
+                        if (Object.prototype.hasOwnProperty.call(this.formData, field)) {
+                            payload[field] = this.formData[field];
+                        }
+
+                        return payload;
+                    }, {});
+                },
                 saveProfileChanges() {
                   this.resetErrors();
                     if (@json($enabled2FA) &&  this.global2FAEnabled.length === 0) {
@@ -270,7 +303,7 @@
                     if (this.image === false) {
                         this.formData.avatar = false;
                     }
-                    ProcessMaker.apiClient.put('users/' + this.formData.id, this.formData)
+                    ProcessMaker.apiClient.put('users/' + this.formData.id, this.profilePayload())
                         .then((response) => {
                             // reset the slack configuration error
                             this.slackConfigurationError = false;

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -149,7 +149,6 @@
             'avatar',
             'preferences_2fa',
             'connected_accounts',
-            'meta',
             'valpassword',
         ];
         let formVueInstance = new Vue({
@@ -276,13 +275,19 @@
                   $('#validateModal').modal('hide');
                 },
                 profilePayload() {
-                    return SELF_SERVICE_PROFILE_FIELDS.reduce((payload, field) => {
+                    const payload = SELF_SERVICE_PROFILE_FIELDS.reduce((payload, field) => {
                         if (Object.prototype.hasOwnProperty.call(this.formData, field)) {
                             payload[field] = this.formData[field];
                         }
 
                         return payload;
                     }, {});
+
+                    payload.meta = {
+                        disableRecommendations: Boolean(this.disableRecommendations),
+                    };
+
+                    return payload;
                 },
                 saveProfileChanges() {
                   this.resetErrors();

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -944,6 +944,168 @@ class UsersTest extends TestCase
         ]);
     }
 
+    public function testSelfServiceUpdateRejectsServerManagedMetadataWithoutPersistingChanges(): void
+    {
+        $this->user = User::factory()->create([
+            'is_administrator' => false,
+            'status' => 'ACTIVE',
+            'meta' => [
+                'authenticationType' => 'ldap',
+                'serverManagedSetting' => 'preserve-me',
+            ],
+        ]);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+        $originalFirstname = $this->user->firstname;
+        $originalEmail = $this->user->email;
+
+        foreach (['authenticationType', 'serverManagedSetting'] as $metaField) {
+            $response = $this->apiCall(
+                'PUT',
+                self::API_TEST_URL . '/' . $this->user->id,
+                $this->getSelfServiceUpdateData($this->user, [
+                    'firstname' => 'Should Not Persist',
+                    'email' => 'changed@example.com',
+                    'valpassword' => 'oneOnlyPassword',
+                    'meta' => [
+                        $metaField => null,
+                        'disableRecommendations' => true,
+                    ],
+                ])
+            );
+
+            $response->assertStatus(403);
+        }
+
+        $user = $this->user->fresh();
+        $this->assertSame($originalFirstname, $user->firstname);
+        $this->assertSame($originalEmail, $user->email);
+        $this->assertSame('ldap', $user->meta->authenticationType);
+        $this->assertSame('preserve-me', $user->meta->serverManagedSetting);
+        $this->assertFalse(property_exists($user->meta, 'disableRecommendations'));
+    }
+
+    public function testSelfServiceUpdateOnlyChangesDisableRecommendationsMetadata(): void
+    {
+        $this->user = User::factory()->create([
+            'is_administrator' => false,
+            'status' => 'ACTIVE',
+            'meta' => [
+                'authenticationType' => 'ldap',
+                'serverManagedSetting' => 'preserve-me',
+            ],
+        ]);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+        $url = self::API_TEST_URL . '/' . $this->user->id;
+
+        $response = $this->apiCall(
+            'PUT',
+            $url,
+            $this->getSelfServiceUpdateData($this->user, [
+                'meta' => ['disableRecommendations' => true],
+            ])
+        );
+
+        $response->assertStatus(204);
+        $user = $this->user->fresh();
+        $this->assertTrue($user->meta->disableRecommendations);
+        $this->assertSame('ldap', $user->meta->authenticationType);
+        $this->assertSame('preserve-me', $user->meta->serverManagedSetting);
+
+        $response = $this->apiCall(
+            'PUT',
+            $url,
+            $this->getSelfServiceUpdateData($user, [
+                'meta' => ['disableRecommendations' => false],
+            ])
+        );
+
+        $response->assertStatus(204);
+        $user = $this->user->fresh();
+        $this->assertFalse(property_exists($user->meta, 'disableRecommendations'));
+        $this->assertSame('ldap', $user->meta->authenticationType);
+        $this->assertSame('preserve-me', $user->meta->serverManagedSetting);
+    }
+
+    public function testSelfServiceUpdateValidatesDisableRecommendationsAsBoolean(): void
+    {
+        $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+
+        $response = $this->apiCall(
+            'PUT',
+            self::API_TEST_URL . '/' . $this->user->id,
+            $this->getSelfServiceUpdateData($this->user, [
+                'meta' => ['disableRecommendations' => 'not-a-boolean'],
+            ])
+        );
+
+        $response->assertStatus(422)->assertJsonValidationErrors('meta.disableRecommendations');
+    }
+
+    public function testLdapUserCannotBypassEmailRestrictionWithAllowedMetadata(): void
+    {
+        $this->user = User::factory()->create([
+            'is_administrator' => false,
+            'status' => 'ACTIVE',
+            'password' => Hash::make('oneOnlyPassword'),
+            'meta' => [
+                'authenticationType' => 'ldap',
+                'serverManagedSetting' => 'preserve-me',
+            ],
+        ]);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+        $originalEmail = $this->user->email;
+
+        $response = $this->apiCall(
+            'PUT',
+            self::API_TEST_URL . '/' . $this->user->id,
+            $this->getSelfServiceUpdateData($this->user, [
+                'email' => 'changed@example.com',
+                'valpassword' => 'oneOnlyPassword',
+                'meta' => ['disableRecommendations' => true],
+            ])
+        );
+
+        $response->assertStatus(422)->assertJsonValidationErrors('email');
+        $user = $this->user->fresh();
+        $this->assertSame($originalEmail, $user->email);
+        $this->assertSame('ldap', $user->meta->authenticationType);
+        $this->assertSame('preserve-me', $user->meta->serverManagedSetting);
+        $this->assertFalse(property_exists($user->meta, 'disableRecommendations'));
+    }
+
+    public function testAdministratorCanUpdateServerManagedMetadata(): void
+    {
+        $targetUser = User::factory()->create([
+            'status' => 'ACTIVE',
+            'meta' => ['authenticationType' => 'ldap'],
+        ]);
+
+        $response = $this->apiCall(
+            'PUT',
+            self::API_TEST_URL . '/' . $targetUser->id,
+            $this->getSelfServiceUpdateData($targetUser, [
+                'meta' => [
+                    'authenticationType' => 'saml',
+                    'serverManagedSetting' => 'updated-by-admin',
+                ],
+            ])
+        );
+
+        $response->assertStatus(204);
+        $targetUser->refresh();
+        $this->assertSame('saml', $targetUser->meta->authenticationType);
+        $this->assertSame('updated-by-admin', $targetUser->meta->serverManagedSetting);
+    }
+
     public function testUsernameUpdateRequiresCredentialPermission(): void
     {
         $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api;
 use Database\Seeders\PermissionSeeder;
 use Faker\Factory as Faker;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Redis;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
@@ -70,6 +71,18 @@ class UsersTest extends TestCase
             'birthdate' => $faker->dateTimeThisCentury()->format('Y-m-d'),
             'password' => $this->makePassword(),
         ];
+    }
+
+    private function getSelfServiceUpdateData(User $user, array $overrides = []): array
+    {
+        return array_merge([
+            'username' => $user->username,
+            'firstname' => $user->firstname,
+            'lastname' => $user->lastname,
+            'title' => $user->title,
+            'email' => $user->email,
+            'status' => $user->status,
+        ], $overrides);
     }
 
     protected function withUserSetup()
@@ -823,14 +836,17 @@ class UsersTest extends TestCase
         // Validate the header status code
         $response->assertStatus(403);
 
-        //  With permission
+        // With both permissions
+        $this->user->giveDirectPermission('edit-personal-profile');
         $this->user->giveDirectPermission('edit-user-and-password');
         $this->user->save();
         $this->user->refresh();
         $this->flushSession();
 
-        $updateData = $this->getUpdatedData();
-        $updateData['email'] = $verify['email'];
+        $updateData = $this->getSelfServiceUpdateData($this->user, [
+            'username' => 'newusername',
+            'firstname' => 'Updated',
+        ]);
 
         // Post saved success
         $response = $this->apiCall('PUT', $url, $updateData);
@@ -843,6 +859,209 @@ class UsersTest extends TestCase
 
         // Check that it has changed
         $this->assertNotEquals($verify, $verifyNew);
+    }
+
+    public function testUserWithoutProfilePermissionCannotUpdateTheirOwnProfile(): void
+    {
+        $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);
+        $this->flushSession();
+        $originalFirstname = $this->user->firstname;
+
+        $response = $this->apiCall(
+            'PUT',
+            self::API_TEST_URL . '/' . $this->user->id,
+            $this->getSelfServiceUpdateData($this->user, ['firstname' => 'Unauthorized'])
+        );
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('users', [
+            'id' => $this->user->id,
+            'firstname' => $originalFirstname,
+        ]);
+    }
+
+    public function testUserWithProfilePermissionCanUpdateAllowedFields(): void
+    {
+        $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+
+        $response = $this->apiCall(
+            'PUT',
+            self::API_TEST_URL . '/' . $this->user->id,
+            $this->getSelfServiceUpdateData($this->user, [
+                'firstname' => 'Éléazar',
+                'lastname' => 'Reséndez',
+                'title' => 'Research & Development',
+            ])
+        );
+
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('users', [
+            'id' => $this->user->id,
+            'firstname' => 'Éléazar',
+            'lastname' => 'Reséndez',
+            'title' => 'Research & Development',
+        ]);
+    }
+
+    public function testSelfServiceUpdateRejectsDisallowedFieldsWithoutPersistingChanges(): void
+    {
+        $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+        $originalFirstname = $this->user->firstname;
+        $disallowedFields = [
+            'manager_id' => User::factory()->create()->id,
+            'delegation_user_id' => User::factory()->create()->id,
+            'schedule' => ['monday' => []],
+            'force_change_password' => true,
+            'is_administrator' => true,
+        ];
+
+        foreach ($disallowedFields as $field => $value) {
+            $response = $this->apiCall(
+                'PUT',
+                self::API_TEST_URL . '/' . $this->user->id,
+                $this->getSelfServiceUpdateData($this->user, [
+                    'firstname' => 'Should Not Persist',
+                    $field => $value,
+                ])
+            );
+
+            $response->assertStatus(403);
+        }
+
+        $this->assertDatabaseHas('users', [
+            'id' => $this->user->id,
+            'firstname' => $originalFirstname,
+            'manager_id' => null,
+            'delegation_user_id' => null,
+            'force_change_password' => false,
+            'is_administrator' => false,
+        ]);
+    }
+
+    public function testUsernameUpdateRequiresCredentialPermission(): void
+    {
+        $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+        $originalUsername = $this->user->username;
+        $payload = $this->getSelfServiceUpdateData($this->user, ['username' => 'four32745-username']);
+
+        $response = $this->apiCall('PUT', self::API_TEST_URL . '/' . $this->user->id, $payload);
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('users', ['id' => $this->user->id, 'username' => $originalUsername]);
+
+        $this->user->giveDirectPermission('edit-user-and-password');
+        $this->user->refresh();
+        $this->flushSession();
+
+        $response = $this->apiCall('PUT', self::API_TEST_URL . '/' . $this->user->id, $payload);
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('users', ['id' => $this->user->id, 'username' => 'four32745-username']);
+    }
+
+    public function testPasswordUpdateRequiresCredentialPermission(): void
+    {
+        $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+        $password = $this->makePassword();
+        $originalPassword = $this->user->password;
+        $payload = $this->getSelfServiceUpdateData($this->user, ['password' => $password]);
+
+        $response = $this->apiCall('PUT', self::API_TEST_URL . '/' . $this->user->id, $payload);
+        $response->assertStatus(403);
+        $this->assertSame($originalPassword, $this->user->fresh()->password);
+
+        $this->user->giveDirectPermission('edit-user-and-password');
+        $this->user->refresh();
+        $this->flushSession();
+
+        $response = $this->apiCall('PUT', self::API_TEST_URL . '/' . $this->user->id, $payload);
+        $response->assertStatus(204);
+        $this->assertTrue(Hash::check($password, $this->user->fresh()->password));
+    }
+
+    public function testUserEditorCanUpdateAnotherUserThroughAdministrativeFlow(): void
+    {
+        $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);
+        $this->user->giveDirectPermission('edit-users');
+        $this->user->refresh();
+        $this->flushSession();
+        $targetUser = User::factory()->create(['status' => 'ACTIVE']);
+
+        $response = $this->apiCall(
+            'PUT',
+            self::API_TEST_URL . '/' . $targetUser->id,
+            $this->getSelfServiceUpdateData($targetUser, [
+                'firstname' => 'Administrative',
+                'manager_id' => $this->user->id,
+            ])
+        );
+
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('users', [
+            'id' => $targetUser->id,
+            'firstname' => 'Administrative',
+            'manager_id' => $this->user->id,
+        ]);
+    }
+
+    public function testUserProfileMarkupIsRejectedWithoutChangingStoredValues(): void
+    {
+        $user = User::factory()->create([
+            'firstname' => 'Original First',
+            'lastname' => 'Original Last',
+            'title' => 'Original Title',
+            'status' => 'ACTIVE',
+        ]);
+        $payloads = [
+            ['firstname', '<<img>img src=x onerror=alert(document.domain)>'],
+            ['lastname', '<script>alert(document.domain)</script>'],
+            ['title', '<svg onload=alert(document.domain)>'],
+            ['title', '<iframe src=javascript:alert(document.domain)>'],
+            ['title', '<img src=x onerror=alert(document.domain)>'],
+        ];
+
+        foreach ($payloads as [$field, $markup]) {
+            $response = $this->apiCall(
+                'PUT',
+                self::API_TEST_URL . '/' . $user->id,
+                $this->getSelfServiceUpdateData($user, [$field => $markup])
+            );
+
+            $response->assertStatus(422)->assertJsonValidationErrors($field);
+        }
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'firstname' => 'Original First',
+            'lastname' => 'Original Last',
+            'title' => 'Original Title',
+        ]);
+    }
+
+    public function testUserCreationRejectsProfileMarkup(): void
+    {
+        $response = $this->apiCall('POST', self::API_TEST_URL, [
+            'username' => 'four32745qa',
+            'firstname' => '<<img>img src=x onerror=alert(document.domain)>',
+            'lastname' => 'FOUR-32745 QA',
+            'title' => '<svg onload=alert(document.domain)>',
+            'email' => 'four32745qa@example.invalid',
+            'status' => 'ACTIVE',
+            'password' => $this->makePassword(),
+        ]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['firstname', 'title']);
+        $this->assertDatabaseMissing('users', ['username' => 'four32745qa']);
     }
 
     public function testDisableRecommendations()

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -1030,6 +1030,53 @@ class UsersTest extends TestCase
         $this->assertSame('preserve-me', $user->meta->serverManagedSetting);
     }
 
+    public function testSelfServiceUpdateWithoutMetaPreservesServerManagedMetadata(): void
+    {
+        $this->user = User::factory()->create([
+            'is_administrator' => false,
+            'status' => 'ACTIVE',
+            'password' => Hash::make('oneOnlyPassword'),
+            'meta' => [
+                'authenticationType' => 'ldap',
+                'serverManagedSetting' => 'preserve-me',
+            ],
+        ]);
+        $this->user->giveDirectPermission('edit-personal-profile');
+        $this->user->refresh();
+        $this->flushSession();
+        $url = self::API_TEST_URL . '/' . $this->user->id;
+        $originalEmail = $this->user->email;
+
+        $response = $this->apiCall(
+            'PUT',
+            $url,
+            $this->getSelfServiceUpdateData($this->user, [
+                'firstname' => 'Updated Without Meta',
+            ])
+        );
+
+        $response->assertStatus(204);
+        $user = $this->user->fresh();
+        $this->assertSame('Updated Without Meta', $user->firstname);
+        $this->assertSame('ldap', $user->meta->authenticationType);
+        $this->assertSame('preserve-me', $user->meta->serverManagedSetting);
+
+        $response = $this->apiCall(
+            'PUT',
+            $url,
+            $this->getSelfServiceUpdateData($user, [
+                'email' => 'changed@example.com',
+                'valpassword' => 'oneOnlyPassword',
+            ])
+        );
+
+        $response->assertStatus(422)->assertJsonValidationErrors('email');
+        $user = $this->user->fresh();
+        $this->assertSame($originalEmail, $user->email);
+        $this->assertSame('ldap', $user->meta->authenticationType);
+        $this->assertSame('preserve-me', $user->meta->serverManagedSetting);
+    }
+
     public function testSelfServiceUpdateValidatesDisableRecommendationsAsBoolean(): void
     {
         $this->user = User::factory()->create(['is_administrator' => false, 'status' => 'ACTIVE']);

--- a/tests/unit/ProcessMaker/Rules/PlainTextTest.php
+++ b/tests/unit/ProcessMaker/Rules/PlainTextTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit\ProcessMaker\Rules;
+
+use Illuminate\Support\Facades\Validator;
+use ProcessMaker\Rules\PlainText;
+use Tests\TestCase;
+
+class PlainTextTest extends TestCase
+{
+    public function testItRejectsHtmlMarkup(): void
+    {
+        $payloads = [
+            '<<img>img src=x onerror=alert(document.domain)>',
+            '<script>alert(document.domain)</script>',
+            '<svg onload=alert(document.domain)>',
+            '<iframe src=javascript:alert(document.domain)>',
+            '<img src=x onerror=alert(document.domain)>',
+            '<!-- comment -->',
+            '<?php echo "unsafe"; ?>',
+        ];
+
+        foreach ($payloads as $payload) {
+            $validator = Validator::make(['value' => $payload], ['value' => [new PlainText()]]);
+
+            $this->assertTrue($validator->fails(), $payload);
+        }
+    }
+
+    public function testItAcceptsPlainText(): void
+    {
+        $values = [
+            'Éléazar Reséndez',
+            'Research & Development',
+            'VP < Sales',
+            '&lt;img src=x&gt;',
+            'javascript:alert(document.domain)',
+        ];
+
+        foreach ($values as $value) {
+            $validator = Validator::make(['value' => $value], ['value' => [new PlainText()]]);
+
+            $this->assertFalse($validator->fails(), $value);
+        }
+    }
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
A low-privilege user can bypass the single-pass profile sanitizer with nested HTML, store executable markup in user profile fields, and trigger it when an authorized user opens `/admin/users`.

1. Update `firstname`, `lastname`, or `title` through `PUT /api/1.0/users/{id}` using a nested HTML payload.
2. Retrieve the stored user and observe that the payload has become executable markup.
3. Open `/admin/users` as a user with directory access.
4. Observe that the stored payload executes in the viewer's session.

## Solution
- Validate `firstname`, `lastname`, and `title` as plain text before persistence.
- Require `edit-personal-profile` and enforce a profile-field allowlist for non-administrative self-service updates.
- Keep username and password changes protected by `edit-user-and-password`.
- Send only profile-editable fields from the profile page.
- Render `fullname` through escaped Vue slots in active and deleted user listings.
- Add regression coverage for markup validation, authorization, atomic rejection, credential permissions, and administrative updates.

## How to Test
- Run `./vendor/bin/phpunit tests/unit/ProcessMaker/Rules/PlainTextTest.php tests/Feature/Api/UsersTest.php tests/Feature/ProfileTest.php`.
- Run `npm run development`.
- Confirm markup payloads return `422`, unauthorized or disallowed self-service updates return `403`, and valid updates return `204`.
- Open both Users and Deleted Users and confirm existing malicious names appear as literal text without creating executable DOM nodes or JavaScript dialogs.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32745

ci:deploy
