### PR TITLE
feat(FOUR-32801): improve Jobs execution when the PUT tasks endpoint is executed

### DIFF
--- a/ProcessMaker/Jobs/GenerateUserRecommendations.php
+++ b/ProcessMaker/Jobs/GenerateUserRecommendations.php
@@ -3,6 +3,7 @@
 namespace ProcessMaker\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -12,15 +13,25 @@ use ProcessMaker\Models\Recommendation;
 use ProcessMaker\Models\User;
 use ProcessMaker\RecommendationEngine;
 
-class GenerateUserRecommendations implements ShouldQueue
+class GenerateUserRecommendations implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Seconds the unique lock is held so duplicate dispatches for the same user are dropped.
+     */
+    public int $uniqueFor = 60;
 
     /**
      * Create a new job instance.
      */
     public function __construct(public int $user_id)
     {
+    }
+
+    public function uniqueId(): string
+    {
+        return (string) $this->user_id;
     }
 
     public function middleware(): array

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -185,6 +185,28 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     }
 
     /**
+     * Determine if the model existed in the search index prior to an update.
+     * Prevents unnecessary RemoveFromSearch jobs when indexed search is disabled.
+     *
+     * @return bool
+     */
+    public function wasSearchableBeforeUpdate()
+    {
+        return $this->shouldBeSearchable();
+    }
+
+    /**
+     * Determine if the model existed in the search index prior to deletion.
+     * Prevents unnecessary RemoveFromSearch jobs when indexed search is disabled.
+     *
+     * @return bool
+     */
+    public function wasSearchableBeforeDelete()
+    {
+        return $this->shouldBeSearchable();
+    }
+
+    /**
      * Get the indexable data array for the model.
      *
      * @return array

--- a/ProcessMaker/Models/ProcessRequestToken.php
+++ b/ProcessMaker/Models/ProcessRequestToken.php
@@ -203,6 +203,28 @@ class ProcessRequestToken extends ProcessMakerModel implements TokenInterface
     }
 
     /**
+     * Determine if the model existed in the search index prior to an update.
+     * Prevents unnecessary RemoveFromSearch jobs when indexed search is disabled.
+     *
+     * @return bool
+     */
+    public function wasSearchableBeforeUpdate()
+    {
+        return $this->shouldBeSearchable();
+    }
+
+    /**
+     * Determine if the model existed in the search index prior to deletion.
+     * Prevents unnecessary RemoveFromSearch jobs when indexed search is disabled.
+     *
+     * @return bool
+     */
+    public function wasSearchableBeforeDelete()
+    {
+        return $this->shouldBeSearchable();
+    }
+
+    /**
      * Boot application as a process instance.
      *
      * @param array $argument

--- a/tests/Feature/Jobs/GenerateUserRecommendationsUniqueTest.php
+++ b/tests/Feature/Jobs/GenerateUserRecommendationsUniqueTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use Illuminate\Support\Facades\Queue;
+use ProcessMaker\Events\ActivityCompleted;
+use ProcessMaker\Jobs\GenerateUserRecommendations;
+use ProcessMaker\Jobs\SmartInbox;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class GenerateUserRecommendationsUniqueTest extends TestCase
+{
+    public function test_duplicate_dispatches_for_the_same_user_are_dropped(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+
+        GenerateUserRecommendations::dispatch($user->id);
+        GenerateUserRecommendations::dispatch($user->id)->onQueue('low');
+
+        Queue::assertPushed(GenerateUserRecommendations::class, 1);
+    }
+
+    public function test_smart_inbox_and_activity_completed_do_not_enqueue_twice_for_the_same_user(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create(['status' => 'ACTIVE']);
+        $token = ProcessRequestToken::factory()->create([
+            'user_id' => $user->id,
+            'element_type' => 'task',
+            'status' => 'CLOSED',
+        ]);
+
+        (new SmartInbox($token->id))->handle();
+        event(new ActivityCompleted($token));
+
+        Queue::assertPushed(GenerateUserRecommendations::class, 1);
+        Queue::assertPushed(GenerateUserRecommendations::class, function (GenerateUserRecommendations $job) use ($user) {
+            return $job->user_id === $user->id;
+        });
+    }
+}

--- a/tests/Feature/Models/IndexedSearchScoutSyncTest.php
+++ b/tests/Feature/Models/IndexedSearchScoutSyncTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use Illuminate\Support\Facades\Queue;
+use Laravel\Scout\Jobs\MakeSearchable;
+use Laravel\Scout\Jobs\RemoveFromSearch;
+use ProcessMaker\Cache\Settings\SettingCacheFactory;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\Setting;
+use Tests\TestCase;
+
+class IndexedSearchScoutSyncTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['scout.queue' => true]);
+    }
+
+    private function setIndexedSearch(bool $enabled): void
+    {
+        $setting = Setting::updateOrCreate(
+            ['key' => 'indexed-search'],
+            ['config' => ['enabled' => $enabled]]
+        );
+
+        $settingCache = SettingCacheFactory::getSettingsCache();
+        $settingKey = $settingCache->createKey(['key' => 'indexed-search']);
+        $settingCache->set($settingKey, $setting->fresh());
+    }
+
+    public function test_was_searchable_hooks_follow_indexed_search_setting(): void
+    {
+        $this->setIndexedSearch(false);
+        $request = ProcessRequest::factory()->create();
+        $token = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'element_type' => 'task',
+        ]);
+
+        $this->assertFalse($request->shouldBeSearchable());
+        $this->assertFalse($request->wasSearchableBeforeUpdate());
+        $this->assertFalse($request->wasSearchableBeforeDelete());
+        $this->assertFalse($token->shouldBeSearchable());
+        $this->assertFalse($token->wasSearchableBeforeUpdate());
+        $this->assertFalse($token->wasSearchableBeforeDelete());
+
+        $this->setIndexedSearch(true);
+
+        $this->assertTrue($request->shouldBeSearchable());
+        $this->assertTrue($request->wasSearchableBeforeUpdate());
+        $this->assertTrue($request->wasSearchableBeforeDelete());
+        $this->assertTrue($token->fresh()->shouldBeSearchable());
+        $this->assertTrue($token->fresh()->wasSearchableBeforeUpdate());
+        $this->assertTrue($token->fresh()->wasSearchableBeforeDelete());
+    }
+
+    public function test_save_does_not_dispatch_remove_from_search_when_indexed_search_is_disabled(): void
+    {
+        $this->setIndexedSearch(false);
+        $request = ProcessRequest::factory()->create();
+        $token = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'element_type' => 'task',
+        ]);
+
+        Queue::fake();
+
+        $request->name = 'Updated request';
+        $request->save();
+        $token->element_name = 'Updated token';
+        $token->save();
+
+        Queue::assertNotPushed(RemoveFromSearch::class);
+        Queue::assertNotPushed(MakeSearchable::class);
+    }
+
+    public function test_save_indexes_when_indexed_search_is_enabled(): void
+    {
+        $this->setIndexedSearch(true);
+        $request = ProcessRequest::factory()->create();
+        $token = ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'element_type' => 'task',
+        ]);
+
+        Queue::fake();
+
+        $request->name = 'Searchable request';
+        $request->save();
+        $token->element_name = 'Searchable token';
+        $token->save();
+
+        Queue::assertPushed(MakeSearchable::class);
+        Queue::assertNotPushed(RemoveFromSearch::class);
+    }
+
+    public function test_delete_still_removes_from_search_when_indexed_search_is_enabled(): void
+    {
+        $this->setIndexedSearch(true);
+        $request = ProcessRequest::factory()->create();
+
+        Queue::fake();
+        $request->delete();
+
+        Queue::assertPushed(RemoveFromSearch::class);
+    }
+
+    public function test_delete_does_not_dispatch_remove_from_search_when_indexed_search_is_disabled(): void
+    {
+        $this->setIndexedSearch(false);
+        $request = ProcessRequest::factory()->create();
+
+        Queue::fake();
+        $request->delete();
+
+        Queue::assertNotPushed(RemoveFromSearch::class);
+    }
+}


### PR DESCRIPTION

## Issue & Reproduction Steps
PUT /api/1.0/tasks/{id} floods Horizon when indexed-search is off.

Open Horizon, clear Completed.
Start a case and complete one task.
Before: 8–12 RemoveFromSearch (same request/token IDs) and two GenerateUserRecommendations (default + low).

Scout still calls unsearchable() because wasSearchableBeforeUpdate() defaults to true. Recommendations are dispatched twice (SmartInbox + ActivityCompleted); WithoutOverlapping does not drop the second enqueue.

## Solution

Core only.

- ProcessRequest / ProcessRequestToken: wasSearchableBeforeUpdate() and wasSearchableBeforeDelete() return shouldBeSearchable(). No Scout jobs when search is off.
- GenerateUserRecommendations implements ShouldBeUnique (uniqueId = user id, uniqueFor = 60s). One job per user.
Does not change PUT wall-clock (JSON persist stays sync).


https://github.com/user-attachments/assets/5c8004ed-181e-4607-951c-69a782b9ffe3


## How to Test
run 
```
DB_CONNECTION=processmaker ./vendor/bin/phpunit \
  tests/Feature/Models/IndexedSearchScoutSyncTest.php \
  tests/Feature/Jobs/GenerateUserRecommendationsUniqueTest.php
```

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32801

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
