### PR TITLE
FOUR-32981: Show job title validation errors

### DIFF
--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -263,6 +263,7 @@
               username: null,
               firstname: null,
               lastname: null,
+              title: null,
               email: null,
               password: null,
               status: null,
@@ -444,6 +445,7 @@
               username: null,
               firstname: null,
               lastname: null,
+              title: null,
               email: null,
               password: null,
               status: null

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -168,6 +168,7 @@
                     username: null,
                     firstname: null,
                     lastname: null,
+                    title: null,
                     email: null,
                     password: null,
                     status: null
@@ -240,6 +241,7 @@
                         username: null,
                         firstname: null,
                         lastname: null,
+                        title: null,
                         email: null,
                         password: null,
                         status: null

--- a/resources/views/shared/users/profile.blade.php
+++ b/resources/views/shared/users/profile.blade.php
@@ -27,10 +27,14 @@
               id="title"
               class="mb-2"
               v-model="formData.title"
+              :state="errors.title ? false : null"
               type="text"
               required
               placeholder="Job Title"
             ></b-form-input>
+            <div class="invalid-feedback" role="alert" v-if="errors.title">
+                @{{errors.title[0]}}
+            </div>
         </div>
 <hr>
     <h5 class="mt-1 mb-3">{{__('Contact Information')}}</h5>

--- a/tests/Feature/Admin/UserTest.php
+++ b/tests/Feature/Admin/UserTest.php
@@ -76,4 +76,18 @@ class UserTest extends TestCase
         $response->assertViewIs('profile.edit');
         $response->assertDontSee('Additional Information');
     }
+
+    public function testJobTitleValidationFeedbackIsRenderedInUserEditForms(): void
+    {
+        $userId = User::factory()->create()->id;
+
+        foreach (["/admin/users/{$userId}/edit", '/profile/edit'] as $url) {
+            $response = $this->webCall('GET', $url);
+
+            $response->assertStatus(200);
+            $response->assertSee(':state="errors.title ? false : null"', false);
+            $response->assertSee('v-if="errors.title"', false);
+            $response->assertSee('@{{errors.title[0]}}', false);
+        }
+    }
 }

--- a/tests/Feature/Admin/UserTest.php
+++ b/tests/Feature/Admin/UserTest.php
@@ -87,7 +87,7 @@ class UserTest extends TestCase
             $response->assertStatus(200);
             $response->assertSee(':state="errors.title ? false : null"', false);
             $response->assertSee('v-if="errors.title"', false);
-            $response->assertSee('@{{errors.title[0]}}', false);
+            $response->assertSee('{{errors.title[0]}}', false);
         }
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Editing a user with HTML markup in the Job Title field returns a 422 validation response, but the form does not display the `errors.title` message. The save appears to fail without identifying the invalid field.

1. Open an existing user in Admin > Users.
2. Enter HTML markup in Job Title while keeping the other fields valid.
3. Save the user.
4. Observe the 422 response and the missing field-level validation feedback.

## Solution
- Bind the Job Title input to the API's `errors.title` state.
- Render the first Job Title validation message below the input.
- Initialize and reset the title error in both the administrator and personal profile edit flows.
- Add feature coverage confirming both edit views render the validation contract.

## How to Test
Manual validation confirmed that an invalid Job Title on the administrator user edit page is highlighted and displays `The title field must contain plain text only.`

1. Open `/admin/users/{id}/edit`, enter HTML markup only in Job Title, and save.
2. Confirm Job Title is marked invalid and shows the API validation message.
3. Replace the markup with plain text and confirm the user saves successfully.
4. Repeat the same invalid and valid cases on `/profile/edit`.
5. Confirm First Name and Last Name validation feedback remains unchanged.

The focused automated test was not run because the safe Laravel test wrapper rejected this checkout: `.env.testing` is missing. Run `tests/Feature/Admin/UserTest.php` through the repository's isolated SQLite test environment.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32981
- ProcessMaker core only; no package changes are required.

ci:deploy
