### PR TITLE
fix(FOUR-28543): add log in as another user link on 2FA screens

### DIFF
--- a/resources/views/auth/2fa/auth_app_qr.blade.php
+++ b/resources/views/auth/2fa/auth_app_qr.blade.php
@@ -52,6 +52,13 @@
                             </div>
                             <img src="data:image/svg+xml;base64,{{$qrCode}}" alt="QR" />
                         </div>
+                        <div class="row justify-content-end mb-3">
+                            <div class="form-group text-right">
+                                <a href="{{ route('logout') }}" dusk="login-as-another-user">
+                                    {{ __('Log in as another user') }}
+                                </a>
+                            </div>
+                        </div>
                         <div class="row justify-content-between mb-3">
                             <button type="button" name="next" class="btn btn-primary btn-block text-capitalize"
                                     dusk="next" onclick="next()">{{ __('Next') }}</button>

--- a/resources/views/auth/2fa/otp.blade.php
+++ b/resources/views/auth/2fa/otp.blade.php
@@ -69,14 +69,18 @@
                                             {{ __('Send Again') }}
                                         </a>
                                     </div>
-                                    @if (in_array(\ProcessMaker\TwoFactorAuthentication::AUTH_APP,
-                                        config('password-policies.2fa_method', [])))
-                                    <div class="form-group">
+                                    <div class="form-group text-right">
+                                        @if (in_array(\ProcessMaker\TwoFactorAuthentication::AUTH_APP,
+                                            config('password-policies.2fa_method', [])))
                                         <a href="{{ route('2fa.auth_app_qr') }}">
                                             {{ __('Authenticator app') }}
                                         </a>
+                                        <br>
+                                        @endif
+                                        <a href="{{ route('logout') }}" dusk="login-as-another-user">
+                                            {{ __('Log in as another user') }}
+                                        </a>
                                     </div>
-                                    @endif
                                 </div>
                                 <div class="form-group">
                                     <button


### PR DESCRIPTION
Add a "Log in as another user" link on the two-step authentication views so users stuck on /2fa can clear the previous session without clearing cookies or using a private browser window.

- otp.blade.php: show link on the right of "Send Again" (logout route)
- auth_app_qr.blade.php: show the same link on the authenticator setup view

https://processmaker.atlassian.net/browse/FOUR-28543

ci:deploy
