### PR TITLE
fix(FOUR-33061): replace gettext _() with Laravel __()

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptExecutorController.php
@@ -257,7 +257,7 @@ class ScriptExecutorController extends Controller
             exec($cmd, $out, $return);
 
             if ($return !== 0) {
-                throw ValidationException::withMessages(['delete' => _('Error removing image.') . " {$cmd} " . implode("\n", $out)]);
+                throw ValidationException::withMessages(['delete' => __('Error removing image.') . " {$cmd} " . implode("\n", $out)]);
             }
         }
 

--- a/ProcessMaker/Http/Controllers/Auth/LoginController.php
+++ b/ProcessMaker/Http/Controllers/Auth/LoginController.php
@@ -415,7 +415,7 @@ class LoginController extends Controller
     protected function throwLockedLoginResponse()
     {
         throw ValidationException::withMessages([
-            $this->username() => [_('Account locked after too many failed attempts. Contact administrator.')],
+            $this->username() => [__('Account locked after too many failed attempts. Contact administrator.')],
         ]);
     }
 

--- a/ProcessMaker/Http/Controllers/Auth/TwoFactorAuthController.php
+++ b/ProcessMaker/Http/Controllers/Auth/TwoFactorAuthController.php
@@ -76,7 +76,7 @@ class TwoFactorAuthController extends Controller
         // If empty code return error message
         if (empty($code)) {
             // Set error message
-            session()->put(self::TFA_ERROR, _('Invalid code.'));
+            session()->put(self::TFA_ERROR, __('Invalid code.'));
 
             // Return to 2fa page
             return redirect()->route('2fa');
@@ -98,7 +98,7 @@ class TwoFactorAuthController extends Controller
             $route = 'login';
         } else {
             // Set error message
-            session()->put(self::TFA_ERROR, _('Invalid code.'));
+            session()->put(self::TFA_ERROR, __('Invalid code.'));
 
             // Return to 2fa page
             $route = '2fa';
@@ -153,7 +153,7 @@ class TwoFactorAuthController extends Controller
         if (count($enabled) === 0) {
             $message = [
                 'status' => 'error',
-                'message' => __('The two-step method must be selected.')
+                'message' => __('The two-step method must be selected.'),
             ];
             $status = 500;
         }
@@ -237,6 +237,7 @@ class TwoFactorAuthController extends Controller
     {
         try {
             $user = Auth::user();
+
             return $user->in2FAGroupOrIndependent();
         } catch (Exception $e) {
             session()->put(self::TFA_ERROR, $e->getMessage());

--- a/ProcessMaker/Http/Middleware/VerifyChangePasswordNeeded.php
+++ b/ProcessMaker/Http/Middleware/VerifyChangePasswordNeeded.php
@@ -12,7 +12,7 @@ class VerifyChangePasswordNeeded
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param  Closure  $next
      * @return mixed
      */
     public function handle($request, Closure $next)
@@ -23,7 +23,7 @@ class VerifyChangePasswordNeeded
 
         if ($this->checkPasswordExpiration()) {
             // Set the error message
-            session()->put('login-error', _('Your password has expired.'));
+            session()->put('login-error', __('Your password has expired.'));
 
             // Redirect to change password screen
             return redirect()->route('password.change');

--- a/ProcessMaker/Notifications/TwoFactorAuthNotification.php
+++ b/ProcessMaker/Notifications/TwoFactorAuthNotification.php
@@ -19,7 +19,7 @@ class TwoFactorAuthNotification extends Notification
     /**
      * Create a new notification instance.
      *
-     * @param \ProcessMaker\Models\User $user
+     * @param User $user
      * @param string $code
      */
     public function __construct(User $user, string $code)
@@ -43,12 +43,12 @@ class TwoFactorAuthNotification extends Notification
      * Get the mail representation of the notification.
      *
      * @param mixed $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->subject(_('Security Code'))
+            ->subject(__('Security Code'))
             ->greeting($this->user->username)
             ->line(__('This is your security code: :code', ['code' => $this->code]));
     }


### PR DESCRIPTION
Avoid php-fpm SIGSEGV on macOS in 2FA, login, and password-expiry flows.

https://processmaker.atlassian.net/browse/FOUR-33061
