### PR TITLE
feat(FOUR-33062): apply Decisions branding to 2FA views

### DIFF
--- a/resources/views/auth/2fa/auth_app_qr.blade.php
+++ b/resources/views/auth/2fa/auth_app_qr.blade.php
@@ -1,68 +1,39 @@
-<!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}">
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'none';">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-    <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
-    <title>{{ __('Configure the authenticator app') }}</title>
-    <link href="{{ mix('css/app.css') }}" rel="stylesheet">
-    <link rel="icon" href="{{ \ProcessMaker\Models\Setting::getFavicon() }}">
-</head>
-<body>
-<div class="content" id="app">
-    <div class="d-flex flex-column" style="min-height: 100vh">
-        <div class="flex-fill">
-            <div class="row" align-v="center">
-                <div class="col-md-6 col-lg-7">
-                    @php
-                        $isMobile = (
-                          isset($_SERVER['HTTP_USER_AGENT'])
-                          && \ProcessMaker\Helpers\MobileHelper::isMobile($_SERVER['HTTP_USER_AGENT'])
-                        ) ? true : false;
-                    @endphp
-                    @if (!$isMobile)
-                        <div class="slogan">
-                            <img src="/img/slogan.svg" alt="ProcessMaker" />
-                            <img class="sub_logo" src="/img/processmaker_do_more.svg" alt="ProcessMaker" />
-                        </div>
-                    @endif
-                </div>
-                <div class="col-md-6 col-lg-4">
-                    <div class="card card-body p-3">
-                        <div style="text-align:center;" class="p-5">
-                            @component('components.logo')
-                            @endcomponent
-                            <p />
-                            <div class="row justify-content-between mb-3">
-                                <div class="form-group">
-                                    {{__('Configure the authenticator app')}}
-                                </div>
-                                <div class="form-group">
-                                    {{__('1.- Download the Google Authenticator App')}}
-                                </div>
-                                <div class="form-group">
-                                    {{__('2.- On the Google Authenticator app click on the + icon')}}
-                                </div>
-                                <div class="form-group">
-                                    {{__('3.- Select "Scan QR code" option')}}
-                                </div>
-                            </div>
-                            <img src="data:image/svg+xml;base64,{{$qrCode}}" alt="QR" />
-                        </div>
-                        <div class="row justify-content-between mb-3">
-                            <button type="button" name="next" class="btn btn-primary btn-block text-capitalize"
-                                    dusk="next" onclick="next()">{{ __('Next') }}</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+@extends('auth.layouts.two-factor')
+
+@section('title')
+{{ __('Configure the authenticator app') }}
+@endsection
+
+@section('content')
+<div class="row justify-content-between mb-3">
+    <div class="form-group">
+        {{__('Configure the authenticator app')}}
+    </div>
+    <div class="form-group">
+        {{__('1.- Download the Google Authenticator App')}}
+    </div>
+    <div class="form-group">
+        {{__('2.- On the Google Authenticator app click on the + icon')}}
+    </div>
+    <div class="form-group">
+        {{__('3.- Select "Scan QR code" option')}}
     </div>
 </div>
-</body>
+<img src="data:image/svg+xml;base64,{{$qrCode}}" alt="QR" />
+<div class="row justify-content-end mb-3">
+    <div class="form-group text-right">
+        <a href="{{ route('logout') }}" dusk="login-as-another-user">
+            {{ __('Log in as another user') }}
+        </a>
+    </div>
+</div>
+<div class="row justify-content-between mb-3">
+    <button type="button" name="next" class="btn btn-primary btn-block text-capitalize"
+            dusk="next" onclick="next()">{{ __('Next') }}</button>
+</div>
+@endsection
+
+@push('scripts')
 <script>
     const browser = navigator.userAgent;
     const isMobileDevice  = /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(browser);
@@ -74,40 +45,4 @@
         window.location.href = '/2fa';
     };
 </script>
-<style>
-    .row {
-        display: flex;
-        flex-wrap: wrap;
-        margin-right: 0;
-        margin-left: 0;
-    }
-    .card {
-        top: 20%;
-        position: relative;
-        border-radius: 16px;
-    }
-    body {
-        background-image: url("/img/new_background.png");
-        background-repeat: no-repeat;
-        background-size: cover;
-    }
-    .slogan {
-        top: 30%;
-        position: fixed;
-        margin-left: 10%;
-        width: 700px;
-        font-family: Poppins, sans-serif;
-        display: inline-flex;
-        flex-direction: column;
-        align-items: flex-start;
-    }
-    .display {
-        color: #FFC107;
-        font-size: 61.987px;
-        font-weight: 600;
-    }
-    .sub_logo {
-        margin-top: 7%;
-    }
-</style>
-</html>
+@endpush

--- a/resources/views/auth/2fa/otp.blade.php
+++ b/resources/views/auth/2fa/otp.blade.php
@@ -1,101 +1,85 @@
-<!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}">
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'none';">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-    <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
-    <title>{{ __('Enter Security Code') }}</title>
-    <link href="{{ mix('css/app.css') }}" rel="stylesheet">
-    <link rel="icon" href="{{ \ProcessMaker\Models\Setting::getFavicon() }}">
-</head>
-<body>
-<div class="content" id="app">
-    <div class="d-flex flex-column" style="min-height: 100vh">
-        <div class="flex-fill">
-            <div class="row" align-v="center">
-                <div class="col-md-6 col-lg-8">
-                    @php
-                        $isMobile = (
-                          isset($_SERVER['HTTP_USER_AGENT'])
-                          && \ProcessMaker\Helpers\MobileHelper::isMobile($_SERVER['HTTP_USER_AGENT'])
-                        ) ? true : false;
-                    @endphp
-                    @if (!$isMobile)
-                        <div class="slogan">
-                            <img src="/img/slogan.svg" alt="ProcessMaker" />
-                            <img class="sub_logo" src="/img/processmaker_do_more.svg" alt="ProcessMaker" />
-                        </div>
-                    @endif
-                </div>
-                <div class="col-md-6 col-lg-3">
-                    <div class="card card-body p-3">
-                        <div style="text-align:center;" class="p-5">
-                            @component('components.logo')
-                            @endcomponent
-                        </div>
-                            <form method="POST" class="form" action="{{ route('2fa.validate') }}">
-                                @if (session()->has('2fa-message') && !session()->has('2fa-error'))
-                                    <div class="alert alert-success">{{ session()->get('2fa-message')}}</div>
-                                @endif
-                                    @if (session()->has('2fa-error'))
-                                        <div class="alert alert-danger">{{ session()->get('2fa-error')}}</div>
-                                    @endif
+@extends('auth.layouts.two-factor')
 
-                                <div class="form-group">
-                                    <label for="code">{{ __('Enter Security Code') }}</label>
-                                    <div class="code-container">
-                                        <input
-                                            id="code"
-                                            type="password"
-                                            class="form-control{{ $errors->has('code') ? ' is-invalid' : '' }}"
-                                            name="code"
-                                            placeholder="{{__('Enter your security code')}}"
-                                            required
-                                        >
-                                        <i class="fa fa-eye" id="toggleCode"></i>
-                                        @if ($errors->has('code'))
-                                            <span class="invalid-feedback" role="alert">
-                                                <strong>{{ $errors->first('code') }}</strong>
-                                            </span>
-                                        @endif
-                                    </div>
-                                </div>
-                                <div class="row justify-content-between mb-3">
-                                    <div class="form-group">
-                                        <a href="{{ route('2fa.send_again') }}">
-                                            {{ __('Send Again') }}
-                                        </a>
-                                    </div>
-                                    @if (in_array(\ProcessMaker\TwoFactorAuthentication::AUTH_APP,
-                                        config('password-policies.2fa_method', [])))
-                                    <div class="form-group">
-                                        <a href="{{ route('2fa.auth_app_qr') }}">
-                                            {{ __('Authenticator app') }}
-                                        </a>
-                                    </div>
-                                    @endif
-                                </div>
-                                <div class="form-group">
-                                    <button
-                                        type="submit"
-                                        name="continue"
-                                        class="btn btn-primary btn-block text-uppercase"
-                                        dusk="continue"
-                                    >
-                                        {{ __('Continue') }}
-                                    </button>
-                                </div>
-                            </form>
-                    </div>
-                </div>
-            </div>
+@section('title')
+{{ __('Enter Security Code') }}
+@endsection
+
+@section('css')
+<style>
+    #toggleCode{
+        position: absolute;
+        top: 28%;
+        right: 4%;
+        cursor: pointer;
+        color: #51585E;
+    }
+    .code-container {
+        position: relative;
+    }
+</style>
+@endsection
+
+@section('content')
+<form method="POST" class="form" action="{{ route('2fa.validate') }}">
+    @if (session()->has('2fa-message') && !session()->has('2fa-error'))
+        <div class="alert alert-success">{{ session()->get('2fa-message')}}</div>
+    @endif
+        @if (session()->has('2fa-error'))
+            <div class="alert alert-danger">{{ session()->get('2fa-error')}}</div>
+        @endif
+
+    <div class="form-group">
+        <label for="code">{{ __('Enter Security Code') }}</label>
+        <div class="code-container">
+            <input
+                id="code"
+                type="password"
+                class="form-control{{ $errors->has('code') ? ' is-invalid' : '' }}"
+                name="code"
+                placeholder="{{__('Enter your security code')}}"
+                required
+            >
+            <i class="fa fa-eye" id="toggleCode"></i>
+            @if ($errors->has('code'))
+                <span class="invalid-feedback" role="alert">
+                    <strong>{{ $errors->first('code') }}</strong>
+                </span>
+            @endif
         </div>
     </div>
-</div>
-</body>
+    <div class="row justify-content-between mb-3">
+        <div class="form-group">
+            <a href="{{ route('2fa.send_again') }}">
+                {{ __('Send Again') }}
+            </a>
+        </div>
+        <div class="form-group text-right">
+            @if (in_array(\ProcessMaker\TwoFactorAuthentication::AUTH_APP,
+                config('password-policies.2fa_method', [])))
+            <a href="{{ route('2fa.auth_app_qr') }}">
+                {{ __('Authenticator app') }}
+            </a>
+            <br>
+            @endif
+            <a href="{{ route('logout') }}" dusk="login-as-another-user">
+                {{ __('Log in as another user') }}
+            </a>
+        </div>
+    </div>
+    <div class="form-group">
+        <button
+            type="submit"
+            name="continue"
+            class="btn btn-primary btn-block text-uppercase"
+            dusk="continue"
+        >
+            {{ __('Continue') }}
+        </button>
+    </div>
+</form>
+@endsection
+
+@push('scripts')
 <script>
     const browser = navigator.userAgent;
     const isMobileDevice  = /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(browser);
@@ -113,86 +97,4 @@
         this.classList.toggle('fa-eye-slash');
     });
 </script>
-<style>
-    .row {
-        display: flex;
-        flex-wrap: wrap;
-        margin-right: 0;
-        margin-left: 0;
-    }
-    .card {
-        top: 50%;
-        position: relative;
-        border-radius: 16px;
-    }
-    .login-logo-custom,
-    .login-logo-default {
-        width: 100%;
-    }
-    .form {
-        padding: 0 17px 17px 17px;
-    }
-    .formContainer {
-        width: 504px;
-    }
-    .formContainer .form {
-        margin-top: 85px;
-        text-align: left
-    }
-    body {
-        background-image: url("/img/new_background.png");
-        background-repeat: no-repeat;
-        background-size: cover;
-    }
-    .slogan {
-        top: 30%;
-        position: fixed;
-        margin-left: 10%;
-        width: 700px;
-        font-family: Poppins, sans-serif;
-        display: inline-flex;
-        flex-direction: column;
-        align-items: flex-start;
-    }
-    .footer {
-        margin-left: 10%;
-    }
-    #toggleCode{
-        position: absolute;
-        top: 28%;
-        right: 4%;
-        cursor: pointer;
-        color: #51585E;
-    }
-    .code-container {
-        position: relative;
-    }
-    .head-text {
-        color: #FFF;
-        font-size: 46.067px;
-        font-weight: 600;
-        font-family: Poppins, sans-serif;
-    }
-    .display {
-        color: #FFC107;
-        font-size: 61.987px;
-        font-weight: 600;
-    }
-    .superscript {
-        color: #FFF;
-        position: relative;
-        top: -1.5em;
-        font-weight: 600;
-        font-family: Poppins, sans-serif;
-    }
-    .subtext {
-        width: 60%;
-        color: #FFF;
-        font-size: 24.017px;
-        font-family: Poppins, sans-serif;
-    }
-    .sub_logo {
-        margin-top: 7%;
-    }
-</style>
-</html>
+@endpush

--- a/resources/views/auth/layouts/two-factor.blade.php
+++ b/resources/views/auth/layouts/two-factor.blade.php
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval'; object-src 'none';">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
+  <meta name="i18n-mdate" content='{!! json_encode(ProcessMaker\i18nHelper::mdates()) !!}'>
+  <title>@yield('title')</title>
+  <link href="{{ mix('css/app.css') }}" rel="stylesheet">
+  @include('auth.partials.login-critical-styles')
+  @include('auth.partials.auth-styles')
+  <link rel="icon" href="{{ \ProcessMaker\Models\Setting::getFavicon() }}">
+  @yield('css')
+</head>
+<body>
+  <div class="background-cover"></div>
+  <div class="content" id="app">
+    <div class="d-flex flex-column" style="min-height: 100vh">
+      <div class="flex-fill small-screen">
+        <div class="login-layout h-100-vh">
+          <div class="login-panel small-screen">
+            <div class="card card-body login-container">
+              <div class="login-logo">
+                @component('components.logo')
+                @endcomponent
+              </div>
+              @yield('content')
+            </div>
+          </div>
+          @php
+            $isMobile = (
+              isset($_SERVER['HTTP_USER_AGENT'])
+              && \ProcessMaker\Helpers\MobileHelper::isMobile($_SERVER['HTTP_USER_AGENT'])
+            ) ? true : false;
+          @endphp
+          @if (!$isMobile)
+          <div class="slogan-panel d-none d-lg-flex">
+            <div class="slogan">
+              <div class="head-text">{{ __("INTELLIGENT BUSINESS ORCHESTRATION") }}</div>
+              <div class="display">
+                <span class="display-line">{{ __("Built to Master") }}</span>
+                <span class="display-line display-complexity">{{ __("Complexity") }}</span>
+              </div>
+              <div class="subtext">
+                {{ __("Orchestrate workflows, systems, and AI at a moment’s notice. Turn constant change into your greatest competitive advantage by giving your team the freedom to build, test, and iterate in real time.") }}
+              </div>
+            </div>
+          </div>
+          @endif
+        </div>
+      </div>
+      @php
+        $loginFooterSetting = \ProcessMaker\Models\Setting::byKey('login-footer');
+      @endphp
+      @if ($loginFooterSetting)
+        <div class="footer">{!! $loginFooterSetting->config['html'] !!}</div>
+      @endif
+    </div>
+  </div>
+  @stack('scripts')
+</body>
+</html>


### PR DESCRIPTION
Replace legacy ProcessMaker layout in the two-step authentication screens with the shared Decisions auth styling.

- Add auth/layouts/two-factor.blade.php with Decisions background, slogan panel, and auth partials without app-login.js
- Refactor auth/2fa/otp.blade.php to extend the new layout while preserving existing form behavior, links, and scripts
- Refactor auth/2fa/auth_app_qr.blade.php to use the same layout
- Remove legacy assets and inline CSS (new_background.png, slogan.svg, processmaker_do_more.svg)

https://processmaker.atlassian.net/browse/FOUR-33062
