### PR TITLE
FOUR-33050: Fix updates for users without authentication metadata

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -518,7 +518,8 @@ class UserController extends Controller
             session()->forget('login-error');
         }
         $original = $user->getOriginal();
-        $isLdapUser = $user->meta?->authenticationType === 'ldap';
+        $isLdapUser = isset($user->meta?->authenticationType)
+            && $user->meta->authenticationType === 'ldap';
         $user->fill($fields);
         if (array_key_exists('cell', $fields)) {
             $response = $this->validateCellPhoneNumber($user, $fields['cell']);

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -459,6 +459,51 @@ class UsersTest extends TestCase
         $this->assertNotEquals($verify, $verify_new);
     }
 
+    public function testAdministratorCanUpdateNewNonSsoUserMoreThanOnce(): void
+    {
+        $response = $this->apiCall('POST', self::API_TEST_URL, [
+            'username' => 'new-non-sso-user',
+            'firstname' => 'New',
+            'lastname' => 'User',
+            'email' => Faker::create()->email(),
+            'status' => 'ACTIVE',
+            'password' => $this->makePassword(),
+        ]);
+
+        $response->assertStatus(201);
+        $user = User::findOrFail($response->json('id'));
+        $this->assertNull($user->meta);
+        $url = self::API_TEST_URL . '/' . $user->id;
+        $metadata = ['customProfileProperty' => null];
+
+        $response = $this->apiCall(
+            'PUT',
+            $url,
+            $this->getSelfServiceUpdateData($user, ['meta' => $metadata])
+        );
+
+        $response->assertStatus(204);
+        $user->refresh();
+        $this->assertNotNull($user->meta);
+        $this->assertTrue(property_exists($user->meta, 'customProfileProperty'));
+        $this->assertFalse(property_exists($user->meta, 'authenticationType'));
+
+        $response = $this->apiCall(
+            'PUT',
+            $url,
+            $this->getSelfServiceUpdateData($user, [
+                'title' => 'Updated Twice',
+                'meta' => $metadata,
+            ])
+        );
+
+        $response->assertStatus(204);
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'title' => 'Updated Twice',
+        ]);
+    }
+
     /**
      * Update user in process
      */


### PR DESCRIPTION
## Issue & Reproduction Steps

FOUR-32745 introduced an LDAP metadata check in the user update flow. When a user has a non-empty `meta` object without the optional `authenticationType` property, PHP raises an undefined-property error and the update endpoint returns HTTP 500.

1. Create or edit a user whose metadata does not contain `authenticationType`.
2. Save the user so the form persists other metadata.
3. Save the same user again.

The second update fails before this fix. Jira comment 518756 confirms the same sequence for a newly created user without SSO.

## Solution

- Guard the optional `authenticationType` property before checking whether the user is LDAP-backed.
- Keep the LDAP check before model filling so the email restrictions from FOUR-32745 remain unchanged.
- Add API regression coverage for creating a non-SSO user and updating it twice after metadata without `authenticationType` is persisted.

## How to Test

- Verified locally with an existing user whose metadata only contains `pinnedControls`: repeated saves succeeded and the metadata remained intact.
- Verified locally with a newly created non-SSO user whose metadata only contains `disableRecommendations`: three consecutive saves succeeded without new console errors.
- PHP syntax checks and `git diff --check` passed.
- PHPUnit was not run locally because the required safe wrapper rejected the checkout without `.env.testing`; PR CI should run `tests/Feature/Api/UsersTest.php`.

## Related Tickets & Packages

- https://processmaker.atlassian.net/browse/FOUR-33050
- https://processmaker.atlassian.net/browse/FOUR-32745
- https://processmaker.atlassian.net/browse/FOUR-32981 (separate change; not included in this PR)

ci:deploy
.