### PR TITLE
feat(FOUR-32734): allow ProcessMaker login in cross-site iframes

### DIFF
--- a/ProcessMaker/Http/Middleware/HideServerHeaders.php
+++ b/ProcessMaker/Http/Middleware/HideServerHeaders.php
@@ -72,7 +72,42 @@ class HideServerHeaders
             $response->headers->set('Server', 'ProcessMaker Server');
         }
 
+        $this->allowIframeEmbedding($response);
+
         return $response;
+    }
+
+    private function allowIframeEmbedding(Response $response): void
+    {
+        $origins = trim((string) env('IFRAME_EMBEDDING_ALLOWED_ORIGINS', ''));
+        if (!filter_var(env('IFRAME_EMBEDDING_ENABLED', false), FILTER_VALIDATE_BOOLEAN) || $origins === '') {
+            return;
+        }
+
+        $response->headers->remove('X-Frame-Options');
+
+        $ancestors = "'self'";
+        foreach (explode(',', $origins) as $origin) {
+            $origin = rtrim(trim($origin), '/');
+            if ($origin === '' || !preg_match('#^https?://[^\s/]+$#i', $origin)) {
+                continue;
+            }
+            if (app()->environment('production') && str_starts_with(strtolower($origin), 'http://')) {
+                continue;
+            }
+            $ancestors .= ' ' . $origin;
+        }
+
+        $csp = $response->headers->get('Content-Security-Policy', '');
+        if ($csp !== '' && str_contains(strtolower($csp), 'frame-ancestors')) {
+            return;
+        }
+
+        $directive = 'frame-ancestors ' . $ancestors;
+        $response->headers->set(
+            'Content-Security-Policy',
+            $csp === '' ? $directive : trim($csp) . '; ' . $directive
+        );
     }
 
     /**

--- a/config/session.php
+++ b/config/session.php
@@ -2,6 +2,9 @@
 
 use Illuminate\Support\Str;
 
+$iframeEmbedding = filter_var(env('IFRAME_EMBEDDING_ENABLED', false), FILTER_VALIDATE_BOOLEAN)
+    && trim((string) env('IFRAME_EMBEDDING_ALLOWED_ORIGINS', '')) !== '';
+
 return [
 
     /*
@@ -170,7 +173,11 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE', false),
+    'secure' => $iframeEmbedding
+        ? (env('SESSION_SECURE_COOKIE') !== null
+            ? filter_var(env('SESSION_SECURE_COOKIE'), FILTER_VALIDATE_BOOLEAN)
+            : true)
+        : env('SESSION_SECURE_COOKIE', false),
 
     /*
     |--------------------------------------------------------------------------
@@ -198,6 +205,8 @@ return [
     |
     */
 
-    'same_site' => env('SESSION_SAME_SITE', 'lax'),
+    'same_site' => $iframeEmbedding ? 'none' : env('SESSION_SAME_SITE', 'lax'),
+
+    'partitioned' => $iframeEmbedding,
 
 ];


### PR DESCRIPTION
Set CSP frame-ancestors and relax session cookies (SameSite=None, Secure, partitioned) when IFRAME_EMBEDDING_ENABLED=true and IFRAME_EMBEDDING_ALLOWED_ORIGINS lists parent origins (e.g. http://localhost:8093).

Example: pmList embeds PM login via
<iframe src="https://127.0.0.5:8092/login" ...></iframe>.

Security notes:
- Only enable when cross-site embedding is required; disable when not in use.
- IFRAME_EMBEDDING_ALLOWED_ORIGINS must list explicit parent origins; empty allowlist does not activate relaxed cookies or CSP.
- SameSite=None increases cross-site cookie exposure; CSRF risk is higher—restrict allowed origins to trusted domains only.
- In production, only https:// origins are accepted for frame-ancestors (http:// entries are ignored).
- Third-party cookie blocking in browsers may still break iframe login; test target browsers and prefer HTTPS on both parent and PM.
- Do not use as a substitute for SSO; treat as a narrow integration option.

https://processmaker.atlassian.net/browse/FOUR-32734

