### PR TITLE
perf(FOUR-32947): reduce N+1 queries on requests listing (FOUR-32947)

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -37,7 +37,7 @@ use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\CatchEventInterface;
 use ProcessMaker\Notifications\ProcessCanceledNotification;
 use ProcessMaker\Query\SyntaxError;
-use ProcessMaker\RetryProcessRequest;
+use ProcessMaker\Repositories\ProcessRequestListingRawRepository;
 use ProcessMaker\Traits\ProcessMapTrait;
 use Symfony\Component\HttpFoundation\IpUtils;
 use Throwable;
@@ -117,7 +117,7 @@ class ProcessRequestController extends Controller
         $query = ProcessRequest::forUser($user);
         $includes = $request->input('include', '');
         foreach (array_filter(explode(',', $includes)) as $include) {
-            if (in_array($include, ProcessRequest::$allowedIncludes)) {
+            if (in_array($include, ProcessRequest::$allowedIncludes) && $include !== 'process') {
                 $query->with($include);
             }
         }
@@ -176,6 +176,7 @@ class ProcessRequestController extends Controller
                     ->withAggregate('processVersion', 'alternative')
                     ->paginate($request->input('per_page', 10));
                 $total = $response->total();
+                app(ProcessRequestListingRawRepository::class)->hydrate($response, $includes);
             }
         } catch (QueryException $e) {
             throw $e;
@@ -899,7 +900,14 @@ class ProcessRequestController extends Controller
 
         // Apply ordering only if a valid order_by field is provided
         $query->applyOrdering($request);
-        $response = $query->applyPagination($request);
+        $response = $query
+            ->select('process_requests.*')
+            ->withAggregate('processVersion', 'alternative')
+            ->applyPagination($request);
+        app(ProcessRequestListingRawRepository::class)->hydrate(
+            $response,
+            $request->input('include', '')
+        );
 
         // Get activeTasks and participants
         $response = $response->map(function ($processRequest) use ($request) {

--- a/ProcessMaker/Http/Resources/ProcessRequests.php
+++ b/ProcessMaker/Http/Resources/ProcessRequests.php
@@ -22,11 +22,13 @@ class ProcessRequests extends ApiResource
             $array['participants'] = $this->participants;
         }
         if (in_array('activeTasks', $include)) {
-            $array['active_tasks'] = $this->tokens()
-                ->select(['id', 'element_name', 'status', 'user_id'])
-                ->where('status', 'ACTIVE')
-                ->where('element_type', 'task')
-                ->get();
+            $array['active_tasks'] = $this->relationLoaded('activeTasks')
+                ? $this->activeTasks
+                : $this->tokens()
+                    ->select(['id', 'element_name', 'status', 'user_id'])
+                    ->where('status', 'ACTIVE')
+                    ->where('element_type', 'task')
+                    ->get();
         }
         if (in_array('user', $include)) {
             $array['user'] = new Users($this->user);

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -1613,6 +1613,10 @@ class Process extends ProcessMakerModel implements HasMedia, ProcessModelInterfa
      */
     public function getProcessCategoryIdAttribute($value)
     {
+        if ($this->relationLoaded('categories')) {
+            return implode(',', $this->categories->pluck('pivot.category_id')->toArray()) ?: $value;
+        }
+
         return implode(',', $this->categories()->pluck('category_id')->toArray()) ?: $value;
     }
 

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -404,6 +404,17 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
     }
 
     /**
+     * Active task tokens for this request.
+     */
+    public function activeTasks()
+    {
+        return $this->hasMany(ProcessRequestToken::class)
+            ->select(['id', 'element_name', 'status', 'user_id', 'process_request_id'])
+            ->where('status', 'ACTIVE')
+            ->where('element_type', 'task');
+    }
+
+    /**
      * Get the creator/author of this request.
      */
     public function user()
@@ -1088,6 +1099,10 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
 
     public function getProcessVersionAlternativeAttribute(): string | null
     {
+        if (array_key_exists('process_version_alternative', $this->attributes)) {
+            return $this->attributes['process_version_alternative'] ?? 'A';
+        }
+
         return $this->processVersion?->alternative ?? 'A';
     }
 

--- a/ProcessMaker/Repositories/ProcessRequestListingRawRepository.php
+++ b/ProcessMaker/Repositories/ProcessRequestListingRawRepository.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProcessMaker\Repositories;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequestToken;
+
+class ProcessRequestListingRawRepository
+{
+    public function hydrate(LengthAwarePaginator|Collection $requests, string $includes): void
+    {
+        $includeList = array_filter(explode(',', $includes));
+        $collection = $requests instanceof LengthAwarePaginator
+            ? $requests->getCollection()
+            : $requests;
+
+        if ($collection->isEmpty()) {
+            return;
+        }
+
+        $requestIds = $collection->pluck('id')->all();
+
+        if (in_array('activeTasks', $includeList, true)) {
+            $this->hydrateActiveTasks($collection, $requestIds);
+        }
+
+        if (in_array('process', $includeList, true)) {
+            $processIds = $collection->pluck('process_id')->unique()->filter()->values()->all();
+            $this->hydrateProcesses($collection, $processIds);
+        }
+    }
+
+    private function hydrateActiveTasks(Collection $requests, array $requestIds): void
+    {
+        $placeholders = implode(',', array_fill(0, count($requestIds), '?'));
+        $rows = DB::select(
+            "SELECT id, process_request_id, element_name, status, user_id
+             FROM process_request_tokens
+             WHERE process_request_id IN ({$placeholders})
+               AND status = 'ACTIVE'
+               AND element_type = 'task'",
+            $requestIds
+        );
+
+        $grouped = collect($rows)->groupBy('process_request_id');
+
+        foreach ($requests as $request) {
+            $tasks = $grouped->get($request->id, collect())->map(function ($row) {
+                $token = new ProcessRequestToken();
+                $token->setRawAttributes([
+                    'id' => $row->id,
+                    'element_name' => $row->element_name,
+                    'status' => $row->status,
+                    'user_id' => $row->user_id,
+                ], true);
+                $token->exists = true;
+
+                return $token;
+            });
+
+            $request->setRelation('activeTasks', $tasks);
+        }
+    }
+
+    private function hydrateProcesses(Collection $requests, array $processIds): void
+    {
+        if ($processIds === []) {
+            return;
+        }
+
+        $projectsByProcessId = $this->loadProjectsJsonByProcessIds($processIds);
+
+        $processesById = Process::query()
+            ->whereIn('id', $processIds)
+            ->with('categories')
+            ->get()
+            ->keyBy('id');
+
+        foreach ($processesById as $process) {
+            if (isset($projectsByProcessId[$process->id])) {
+                $attributes = $process->getAttributes();
+                $attributes['projects'] = $projectsByProcessId[$process->id];
+                $process->setRawAttributes($attributes, true);
+            }
+        }
+
+        foreach ($requests as $request) {
+            if ($processesById->has($request->process_id)) {
+                $request->setRelation('process', $processesById->get($request->process_id));
+            }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function loadProjectsJsonByProcessIds(array $processIds): array
+    {
+        $projectAssetClass = 'ProcessMaker\Package\Projects\Models\ProjectAsset';
+
+        if (!class_exists($projectAssetClass)) {
+            return array_fill_keys($processIds, json_encode([]));
+        }
+
+        $projectAssets = $projectAssetClass::query()
+            ->whereIn('asset_id', $processIds)
+            ->where('asset_type', Process::class)
+            ->with('project')
+            ->get()
+            ->groupBy('asset_id');
+
+        $result = [];
+
+        foreach ($processIds as $processId) {
+            $result[$processId] = json_encode(
+                ($projectAssets->get($processId) ?? collect())->map(function ($projectAsset) {
+                    return $projectAsset->project;
+                })
+            );
+        }
+
+        return $result;
+    }
+}

--- a/ProcessMaker/Traits/ProjectAssetTrait.php
+++ b/ProcessMaker/Traits/ProjectAssetTrait.php
@@ -77,6 +77,10 @@ trait ProjectAssetTrait
 
     public function getProjectsAttribute()
     {
+        if (array_key_exists('projects', $this->attributes) && is_string($this->attributes['projects'])) {
+            return $this->attributes['projects'];
+        }
+
         if (class_exists(self::PROJECT_ASSET_MODEL_CLASS)) {
             $projectAssets = self::PROJECT_ASSET_MODEL_CLASS::where('asset_id', $this->id)
                 ->where('asset_type', get_class($this))

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -6,6 +6,7 @@ use Faker\Factory as Faker;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use ProcessMaker\Http\Controllers\Api\ProcessRequestController;
 use ProcessMaker\Managers\DataManager;
@@ -1303,5 +1304,56 @@ class ProcessRequestsTest extends TestCase
         // Check if the response is successful and contains the expected tasks
         $response = $this->apiCall('GET', $url);
         $this->assertCount(2, $response->json('data'));
+    }
+
+    public function testIndexListingUsesBoundedQueryCountWithIncludes(): void
+    {
+        ProcessRequest::query()->delete();
+        $this->user->is_administrator = true;
+        $this->user->save();
+
+        $process = Process::factory()->create();
+        $version = $process->getLatestVersion();
+
+        $requests = ProcessRequest::factory()->count(15)->create([
+            'process_id' => $process->id,
+            'process_version_id' => $version->id,
+            'user_id' => $this->user->id,
+            'data' => ['foo' => 'bar'],
+        ]);
+
+        foreach ($requests as $request) {
+            ProcessRequestToken::factory()->create([
+                'process_request_id' => $request->id,
+                'process_id' => $process->id,
+                'status' => 'ACTIVE',
+                'element_type' => 'task',
+                'element_name' => 'Review Task',
+            ]);
+        }
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $response = $this->apiCall(
+            'GET',
+            self::API_TEST_URL . '?include=process,participants,activeTasks,data&per_page=15'
+        );
+
+        $queryCount = count(DB::getQueryLog());
+
+        $response->assertStatus(200);
+        $this->assertCount(15, $response->json('data'));
+        $this->assertLessThanOrEqual(
+            12,
+            $queryCount,
+            'Listing with includes should not scale linearly with page size. Query count: ' . $queryCount
+        );
+
+        $first = $response->json('data.0');
+        $this->assertSame($process->id, $first['process']['id']);
+        $this->assertNotEmpty($first['active_tasks']);
+        $this->assertSame('bar', $first['data']['foo']);
+        $this->assertArrayHasKey('process_version_alternative', $first);
     }
 }


### PR DESCRIPTION
Batch-load listing relations after pagination to avoid per-row queries for process version alternative, active tasks, process categories, and project assets while preserving the existing API response shape.

- Add ProcessRequestListingRawRepository to hydrate activeTasks (raw SQL) and process data (Eloquent + batched projects/categories)
- Use withAggregate for process_version_alternative and read it without lazy-loading ProcessVersion
- Add activeTasks relation and use preloaded data in ProcessRequests
- Preload projects JSON and reuse loaded categories in Process accessors
- Apply hydration in index and getRequestsByCase
- Add bounded query-count feature test

https://processmaker.atlassian.net/browse/FOUR-32947

ci:deploy