### PR TITLE
FOUR-25291 SCS - Participants Filter Fails to Return Results When Combined with Other Filters in Client Environment

### DIFF
--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -746,8 +746,7 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
             return function ($query) use ($user, $expression) {
                 $query->whereIn('id', function ($subquery) use ($user, $expression) {
                     $subquery->select('process_request_id')->from('process_request_tokens')
-                        ->where('user_id', $expression->operator, $user->id)
-                        ->whereIn('element_type', ['task', 'userTask', 'startEvent']);
+                        ->where('user_id', $expression->operator, $user->id);
                 });
             };
         } else {
@@ -769,8 +768,7 @@ class ProcessRequest extends ProcessMakerModel implements ExecutionInstanceInter
                         $subquery->select('id')
                             ->from('users')
                             ->whereRaw("CONCAT(firstname, ' ', lastname) " . $expression->operator . ' ?', [$value]);
-                    })
-                    ->whereIn('element_type', ['task', 'userTask', 'startEvent']);
+                    });
             });
         };
     }

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -220,17 +220,136 @@ class ProcessRequestsTest extends TestCase
 
         $token = ProcessRequestToken::factory()->create([
             'process_request_id' => $request->id,
+            'element_type' => 'task',
             'user_id' => $participant->id,
         ]);
 
         $otherToken = ProcessRequestToken::factory()->create([
             'process_request_id' => $otherRequest->id,
+            'element_type' => 'task',
             'user_id' => $otherUser->id,
         ]);
 
         $response = $this->apiCall('GET', self::API_TEST_URL, ['pmql' => "participant = \"{$participant->username}\""]);
         $this->assertEquals(1, $response->json()['meta']['total']);
         $this->assertEquals($request->id, $response->json()['data'][0]['id']);
+    }
+
+    public function testFilterByParticipantIncludesNonTaskTokens()
+    {
+        $participant = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $request = ProcessRequest::factory()->create(['status' => 'ACTIVE']);
+        $otherRequest = ProcessRequest::factory()->create(['status' => 'ACTIVE']);
+
+        ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'process_id' => $request->process_id,
+            'element_type' => 'callActivity',
+            'user_id' => $participant->id,
+        ]);
+
+        ProcessRequestToken::factory()->create([
+            'process_request_id' => $otherRequest->id,
+            'process_id' => $otherRequest->process_id,
+            'element_type' => 'callActivity',
+            'user_id' => $otherUser->id,
+        ]);
+
+        $response = $this->apiCall('GET', self::API_TEST_URL, ['pmql' => "participant = \"{$participant->username}\""]);
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $response->json()['meta']['total']);
+        $this->assertEquals($request->id, $response->json()['data'][0]['id']);
+    }
+
+    public function testAdvancedFilterByParticipantFullNameIncludesNonTaskTokens()
+    {
+        $participant = User::factory()->create([
+            'firstname' => 'D150',
+            'lastname' => 'workshop',
+        ]);
+        $otherUser = User::factory()->create();
+
+        $request = ProcessRequest::factory()->create([
+            'name' => 'Create-Update records in collections',
+            'status' => 'ACTIVE',
+        ]);
+        $taskRequest = ProcessRequest::factory()->create([
+            'name' => 'Create-Update records in collections',
+            'status' => 'ACTIVE',
+        ]);
+        $otherRequest = ProcessRequest::factory()->create([
+            'name' => 'Create-Update records in collections',
+            'status' => 'ACTIVE',
+        ]);
+        $request->update(['case_title' => 'Inspection Report']);
+        $otherRequest->update(['case_title' => 'Inspection Report']);
+
+        ProcessRequestToken::factory()->create([
+            'process_request_id' => $request->id,
+            'process_id' => $request->process_id,
+            'element_type' => 'callActivity',
+            'user_id' => $participant->id,
+        ]);
+        ProcessRequestToken::factory()->create([
+            'process_request_id' => $taskRequest->id,
+            'process_id' => $taskRequest->process_id,
+            'element_type' => 'task',
+            'user_id' => $participant->id,
+        ]);
+        ProcessRequestToken::factory()->create([
+            'process_request_id' => $otherRequest->id,
+            'process_id' => $otherRequest->process_id,
+            'element_type' => 'callActivity',
+            'user_id' => $otherUser->id,
+        ]);
+
+        $participantFilter = [
+            'subject' => ['type' => 'ParticipantsFullName', 'value' => 'participants'],
+            'operator' => 'contains',
+            'value' => 'D150 workshop',
+        ];
+
+        $response = $this->apiCall('GET', self::API_TEST_URL, [
+            'advanced_filter' => json_encode([$participantFilter]),
+            'include' => 'participants',
+        ]);
+        $json = $response->json();
+
+        $response->assertStatus(200);
+        $this->assertEquals(2, $json['meta']['total']);
+        $this->assertEqualsCanonicalizing(
+            [$request->id, $taskRequest->id],
+            collect($json['data'])->pluck('id')->all()
+        );
+        $requestData = collect($json['data'])->firstWhere('id', $request->id);
+        $this->assertEquals($participant->id, $requestData['participants'][0]['id']);
+
+        $combinedFilter = [
+            [
+                'subject' => ['type' => 'Field', 'value' => 'case_title'],
+                'operator' => '=',
+                'value' => 'Inspection Report',
+            ],
+            [
+                'subject' => ['type' => 'Field', 'value' => 'name'],
+                'operator' => '=',
+                'value' => 'Create-Update records in collections',
+            ],
+            $participantFilter,
+        ];
+
+        $response = $this->apiCall('GET', self::API_TEST_URL, [
+            'advanced_filter' => json_encode($combinedFilter),
+            'include' => 'participants',
+        ]);
+        $json = $response->json();
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $json['meta']['total']);
+        $this->assertEquals($request->id, $json['data'][0]['id']);
     }
 
     /**

--- a/tests/unit/ProcessMaker/FilterTest.php
+++ b/tests/unit/ProcessMaker/FilterTest.php
@@ -254,9 +254,9 @@ class FilterTest extends TestCase
 
         $this->assertEquals(
             'select * from `process_requests` where (((' .
-                "`id` in (select `process_request_id` from `process_request_tokens` where `user_id` = {$user1->id} and `element_type` in ('task', 'userTask', 'startEvent'))) " .
-                "or (`id` in (select `process_request_id` from `process_request_tokens` where `user_id` = {$user2->id} and `element_type` in ('task', 'userTask', 'startEvent'))) " .
-                "or ((`id` in (select `process_request_id` from `process_request_tokens` where `user_id` = {$user3->id} and `element_type` in ('task', 'userTask', 'startEvent'))))))",
+                "`id` in (select `process_request_id` from `process_request_tokens` where `user_id` = {$user1->id})) " .
+                "or (`id` in (select `process_request_id` from `process_request_tokens` where `user_id` = {$user2->id})) " .
+                "or ((`id` in (select `process_request_id` from `process_request_tokens` where `user_id` = {$user3->id})))))",
             $sql
         );
     }


### PR DESCRIPTION
## Issue & Reproduction Steps

### SCS - Participants Filter Fails to Return Results When Combined with Other Filters in Client Environment

## Solution
- Aligns Participants filtering with the Participants column by including users associated with any request token type.
- Adds regression coverage for users associated through callActivity tokens.
- Verifies Participants-only, username PMQL, and combined Case Title + Process + Participants filtering.

## Related Tickets & Packages
[FOUR-25291](https://processmaker.atlassian.net/browse/FOUR-25291)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

[FOUR-25291]: https://processmaker.atlassian.net/browse/FOUR-25291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ