### PR TITLE
fix(FOUR-21061): Inpute Technologies - Pagination in Forms with Multiple Records Fails

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -791,10 +791,11 @@ class ProcessRequestController extends Controller
      */
     public function screenRequested(Request $httpRequest, ProcessRequest $request)
     {
+        $elementTypes = ['task'];
         $query = ProcessRequestToken::query();
         $query->select('id', 'element_id', 'process_id', 'process_request_id', 'data', 'token_properties')
             ->where('process_request_id', $request->id)
-            ->whereNotIn('element_type', ['end_event', 'scriptTask'])
+            ->whereIn('element_type', $elementTypes)
             ->whereIn('status', ['CLOSED', 'TRIGGERED'])
             ->orderBy('completed_at');
 

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -791,7 +791,7 @@ class ProcessRequestController extends Controller
      */
     public function screenRequested(Request $httpRequest, ProcessRequest $request)
     {
-        $elementTypes = ['task', 'userTask', 'startEvent', 'callActivity'];
+        $elementTypes = ['task', 'userTask', 'startEvent'];
         $query = ProcessRequestToken::query();
         $query->select('id', 'element_id', 'process_id', 'process_request_id', 'data', 'token_properties')
             ->where('process_request_id', $request->id)

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -791,7 +791,7 @@ class ProcessRequestController extends Controller
      */
     public function screenRequested(Request $httpRequest, ProcessRequest $request)
     {
-        $elementTypes = ['task'];
+        $elementTypes = ['task', 'userTask', 'startEvent', 'callActivity'];
         $query = ProcessRequestToken::query();
         $query->select('id', 'element_id', 'process_id', 'process_request_id', 'data', 'token_properties')
             ->where('process_request_id', $request->id)

--- a/tests/Feature/Api/ProcessRequestsTest.php
+++ b/tests/Feature/Api/ProcessRequestsTest.php
@@ -1199,6 +1199,79 @@ class ProcessRequestsTest extends TestCase
     }
 
     /**
+     * Bug #41926: boundary timer tokens must not inflate Forms tab pagination.
+     *
+     * @group process_requests
+     */
+    public function testScreenRequestedPaginatesOnlyTaskTokens()
+    {
+        $screen = Screen::factory()->create();
+        $bpmn = '<?xml version="1.0"?>'
+            . '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"'
+            . ' xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd">'
+            . '<bpmn:process id="ProcessId">'
+            . '<bpmn:task id="node_task" pm:screenRef="' . $screen->id . '" name="Form Task"/>'
+            . '<bpmn:boundaryEvent id="node_event" attachedToRef="node_task"/>'
+            . '</bpmn:process></bpmn:definitions>';
+
+        $process = Process::factory()->create([
+            'bpmn' => $bpmn,
+            'user_id' => $this->user->id,
+        ]);
+
+        $request = ProcessRequest::factory()->create([
+            'process_id' => $process->id,
+            'process_version_id' => $process->getLatestVersion()->id,
+        ]);
+
+        $baseTime = now()->subHours(3);
+        $iterations = 120;
+
+        for ($i = 0; $i < $iterations; $i++) {
+            ProcessRequestToken::factory()->create([
+                'process_id' => $process->id,
+                'process_request_id' => $request->id,
+                'element_id' => 'node_task',
+                'element_type' => 'task',
+                'status' => 'CLOSED',
+                'completed_at' => $baseTime->copy()->addMinutes($i),
+            ]);
+            ProcessRequestToken::factory()->create([
+                'process_id' => $process->id,
+                'process_request_id' => $request->id,
+                'element_id' => 'node_event',
+                'element_type' => 'event',
+                'status' => 'CLOSED',
+                'completed_at' => $baseTime->copy()->addMinutes($iterations + $i),
+            ]);
+        }
+
+        $route = route('api.requests.detail.screen', ['request' => $request->id]);
+        $params = [
+            'page' => 1,
+            'per_page' => 15,
+            'order_by' => 'completed_at',
+            'order_direction' => 'asc',
+        ];
+
+        $response = $this->apiCall('GET', $route, $params);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('meta.total', $iterations);
+        $response->assertJsonPath('meta.total_pages', 8);
+        $this->assertCount(15, $response->json('data'));
+
+        $lastPage = $this->apiCall('GET', $route, array_merge($params, ['page' => 8]));
+        $lastPage->assertStatus(200);
+        $this->assertCount(15, $lastPage->json('data'));
+
+        $beyondLastPage = $this->apiCall('GET', $route, array_merge($params, ['page' => 9]));
+        $beyondLastPage->assertStatus(200);
+        $this->assertCount(0, $beyondLastPage->json('data'));
+        $beyondLastPage->assertJsonPath('meta.total_pages', 8);
+    }
+
+    /**
      * Get a list of Requests by Cases.
      */
     public function testRequestByCase()


### PR DESCRIPTION
…
## Issue & Reproduction Steps
On the request Forms tab, pagination counted all closed tokens (tasks, boundary timers, gateways, etc.), not just tokens with a screen.

In processes with a form task + a looping boundary timer (~120 runs), you get ~120 forms but ~240 tokens. Result: empty pages showing "No Data Available" while pagination still shows more pages.

Reproduce:

Open a request with a form task + boundary timer running many times.
Go to Forms and paginate.
Some pages come back empty.


## Solution

In screenRequested(), filter before pagination: only task tokens (previously it only excluded end_event and scriptTask).

This aligns meta.total and page count with actual forms.


https://github.com/user-attachments/assets/607867ab-ccc5-4abb-92e8-d9b36efdd9f8


## How to Test

`./vendor/bin/phpunit --filter=testScreenRequestedPaginatesOnlyTaskTokens tests/Feature/Api/ProcessRequestsTest.php`

Manual: Open an affected request → Forms → confirm every page has data and total pages matches completed form count.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21061

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
