### PR TITLE
fix(FOUR-32481): enforce password policy on password reset flow

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
@@ -4,7 +4,6 @@ namespace ProcessMaker\Http\Controllers\Auth;
 
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Models\User;
@@ -108,7 +107,10 @@ class ResetPasswordController extends Controller
             'token' => 'required',
             'email' => 'required|email',
             'username' => 'required|string',
-            'password' => ['required', 'confirmed', Password::defaults()],
+            'password' => array_merge(
+                array_filter(User::passwordRules()),
+                ['confirmed']
+            ),
         ];
     }
 

--- a/resources/views/auth/partials/password-requirements.blade.php
+++ b/resources/views/auth/partials/password-requirements.blade.php
@@ -1,0 +1,17 @@
+<div class="alert alert-primary mb-3">{{ __('Password Requirements') }}:
+  <ul class="mb-0">
+    <li>{{ __('Minimum of :length characters in length', ['length' => (int) config('password-policies.minimum_length', 8)]) }}</li>
+    @if (config('password-policies.maximum_length'))
+    <li>{{ __('Maximum of :length characters in length', ['length' => (int) config('password-policies.maximum_length')]) }}</li>
+    @endif
+    @if (config('password-policies.uppercase', true))
+    <li>{{ __('Passwords must contain minimum one uppercase character.') }}</li>
+    @endif
+    @if (config('password-policies.numbers', true))
+    <li>{{ __('Passwords must contain minimum one numeric character.') }}</li>
+    @endif
+    @if (config('password-policies.special', true))
+    <li>{{ __('Passwords must contain minimum one special character.') }}</li>
+    @endif
+  </ul>
+</div>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -9,6 +9,8 @@
   <h1 class="auth-card-title">{{ __('Reset Your Password') }}</h1>
 </div>
 
+@include('auth.partials.password-requirements')
+
 <form role="form" class="form" method="POST" action="{{ url('/password/reset') }}">
   @csrf
   <input type="hidden" name="token" value="{{ $token }}">

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -182,6 +182,77 @@ class PasswordResetTest extends TestCase
         $this->assertTrue(Hash::check('oneOnlyPassword', $user->password));
     }
 
+    public function testResetPasswordRejectsPasswordThatDoesNotMeetPolicy(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'weak-password-reset@example.com',
+            'status' => 'ACTIVE',
+        ]);
+
+        /** @var ConcretePasswordBroker $broker */
+        $broker = Password::broker();
+        $token = $broker->createToken($user);
+
+        $response = $this->from(route('password.reset', ['token' => $token]))->post('/password/reset', [
+            'token' => $token,
+            'email' => $user->email,
+            'username' => $user->username,
+            'password' => '12345678',
+            'password_confirmation' => '12345678',
+        ]);
+
+        $response->assertSessionHasErrors('password');
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('oneOnlyPassword', $user->password));
+    }
+
+    public function testResetPasswordRejectsPasswordBelowConfiguredMinimumLength(): void
+    {
+        config(['password-policies.minimum_length' => 10]);
+
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'short-password-reset@example.com',
+            'status' => 'ACTIVE',
+        ]);
+
+        /** @var ConcretePasswordBroker $broker */
+        $broker = Password::broker();
+        $token = $broker->createToken($user);
+
+        $response = $this->from(route('password.reset', ['token' => $token]))->post('/password/reset', [
+            'token' => $token,
+            'email' => $user->email,
+            'username' => $user->username,
+            'password' => 'Abcd1234!',
+            'password_confirmation' => 'Abcd1234!',
+        ]);
+
+        $response->assertSessionHasErrors('password');
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('oneOnlyPassword', $user->password));
+    }
+
+    public function testShowResetFormDisplaysPasswordRequirements(): void
+    {
+        config(['password-policies.minimum_length' => 10]);
+
+        $user = User::factory()->create([
+            'email' => 'requirements-reset-form@example.com',
+            'status' => 'ACTIVE',
+        ]);
+
+        $url = route('password.reset', ['token' => 'some-token']);
+        $response = $this->get($url . '?email=' . urlencode($user->email));
+
+        $response->assertOk();
+        $response->assertSee(__('Password Requirements'), false);
+        $response->assertSee(__('Minimum of :length characters in length', ['length' => 10]), false);
+    }
+
     public function testResetPasswordUpdatesPasswordForActiveUser(): void
     {
         /** @var User $user */


### PR DESCRIPTION
Replace Password::defaults() with User::passwordRules() in ResetPasswordController so reset uses the same Login Options policies as change password (minimum length, uppercase, numbers, special characters, and maximum length when configured).

Display dynamic password requirements on the reset page via a shared partial aligned with backend validation rules.

Add feature tests to reject weak passwords and passwords below the configured minimum length.

https://processmaker.atlassian.net/browse/FOUR-32481

ci:deploy
