### PR TITLE
fix(FOUR-33134): use dynamic password requirements on change password…

### DIFF
--- a/resources/views/auth/passwords/change.blade.php
+++ b/resources/views/auth/passwords/change.blade.php
@@ -16,13 +16,7 @@
     <div class="auth-card-header">
       <h1 class="auth-card-title">{{ __('Please change your account password') }}</h1>
     </div>
-    <div class="alert alert-primary mb-3">{{ __('Password Requirements') }}:
-      <ul class="mb-0">
-        <li>{{ __('Minimum of 8 characters in length') }}</li>
-        <li>{{ __('Contains an uppercase letter') }}</li>
-        <li>{{ __('Contains a number or symbol') }}</li>
-      </ul>
-    </div>
+    @include('auth.partials.password-requirements')
     @if (session()->has('timeout'))
     <div class="alert alert-danger mb-3">{{ __("Your account has been timed out for security.") }}</div>
     @endif

--- a/tests/Feature/Auth/ChangePasswordTest.php
+++ b/tests/Feature/Auth/ChangePasswordTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use Illuminate\Support\Facades\Auth;
+use ProcessMaker\Models\User;
+use Tests\TestCase;
+
+class ChangePasswordTest extends TestCase
+{
+    public function testShowChangeFormDisplaysPasswordRequirements(): void
+    {
+        config(['password-policies.minimum_length' => 10]);
+
+        $user = User::factory()->create([
+            'force_change_password' => 1,
+        ]);
+
+        Auth::login($user);
+
+        $response = $this->get(route('password.change'));
+
+        $response->assertOk();
+        $response->assertViewIs('auth.passwords.change');
+        $response->assertSee(__('Password Requirements'), false);
+        $response->assertSee(__('Minimum of :length characters in length', ['length' => 10]), false);
+    }
+}


### PR DESCRIPTION
… page

Replace hardcoded password validation messages on /password/change with the shared auth.partials.password-requirements partial so requirements reflect Log-in options settings (minimum/maximum length, uppercase, numbers, special characters), consistent with the reset password page.

Add feature test to verify the change password form displays configured password policy requirements.

https://processmaker.atlassian.net/browse/FOUR-33134

ci:deploy